### PR TITLE
feat: fast timeline scrubbing via pre-generated preview proxy

### DIFF
--- a/docs-site/docs/configuration/environment-reference.md
+++ b/docs-site/docs/configuration/environment-reference.md
@@ -52,6 +52,21 @@ See [Motion & Detection](/motion/) for the mechanism this configures.
 | `MOTION_CACHE_DIR` | `/cache/motion` | only change alongside the compose tmpfs target |
 | `MOTION_RECORDING_SHADOW` | `0` | `1` records everything as before but stamps each segment with the keep/discard verdict the buffer would have made, for validating before flipping a camera live |
 
+## Timeline previews (scrubbing)
+
+See [Timeline scrubbing](/playback/scrubbing) for what these do. All optional; the defaults work.
+
+| Key | Default | Notes |
+|---|---|---|
+| `THUMB_PREGEN_ENABLED` | `false` | build scrub previews in the background so the *first* drag is instant too; costs some ongoing CPU + disk |
+| `THUMB_PREGEN_LOOKBACK_HOURS` | `2` | how far back to build previews when the worker starts |
+| `THUMB_PREGEN_SCAN_SECS` | `60` | how often to build previews for newly-recorded footage |
+| `THUMB_PREGEN_WIDTH` | `160` | preview width in pixels |
+| `THUMB_CACHE_DIR` | (`EXPORT_DIR`) | where the preview cache lives; point at an SSD/NVMe mount to keep scrubbing fast on a spinning-disk system |
+| `THUMB_EXTRACT_MAX_CONCURRENCY` | scales with cores | how many previews Crumb builds at once; default is roughly half the CPU cores |
+| `THUMB_CACHE_MAX_BYTES` | `21474836480` (20 GiB) | preview cache size budget; oldest previews are dropped past this |
+| `THUMB_CACHE_TTL_SECONDS` | `2592000` (30 days) | preview cache age budget |
+
 ## Storage
 
 | Key | Default | Notes |

--- a/docs-site/docs/playback/scrubbing.md
+++ b/docs-site/docs/playback/scrubbing.md
@@ -1,0 +1,85 @@
+---
+title: Timeline scrubbing & previews
+sidebar_label: Timeline scrubbing
+slug: /playback/scrubbing
+---
+
+# Timeline scrubbing & previews
+
+When you drag along the timeline to find a moment in recorded footage, Crumb
+shows a small preview image that updates as you move, so you can spot the right
+frame without playing through everything. It works the same in the desktop app,
+the mobile apps, and the web console.
+
+## It just works, and gets faster as you go
+
+You don't have to turn anything on. The first time you drag to a spot, Crumb
+grabs a preview frame from the recording; after that, that spot is remembered,
+so dragging back and forth over a region you've already looked at is instant.
+Scrubbing a whole wall of cameras at the same moment works the same way.
+
+Two optional settings can make it even better on larger systems. Most people
+never need either one.
+
+## Make the *first* drag instant too (background previews)
+
+By default, the very first time you scrub to a brand-new spot, Crumb builds that
+preview on the spot, a brief moment of work before the image appears. If you'd
+rather have previews ready in advance so even the first drag is instant, turn on
+background pre-generation. Crumb then quietly builds previews for recent footage
+as it records.
+
+The trade-off is honest: it uses some ongoing CPU and a little disk space
+whether or not you scrub much, which is why it's off by default (a small box
+shouldn't do work nobody asked for). Turn it on if you review footage often and
+want it to feel instant everywhere.
+
+In your `.env`:
+
+```bash
+THUMB_PREGEN_ENABLED=true
+```
+
+Then apply it:
+
+```bash
+docker compose up -d api
+```
+
+The fine-tuning knobs (how far back to build, how often, what size) are in the
+[environment reference](/configuration/environment-reference); the defaults are
+sensible.
+
+## Keep it snappy on a busy hard-drive system (put previews on an SSD)
+
+Previews are tiny images, and on most setups it makes no difference where they
+live. But if you run **a lot of cameras for weeks on a regular spinning hard
+drive**, reading all those small scattered files can get slow, exactly when
+you're trying to scrub. If you have a spare SSD or NVMe drive, point the preview
+cache at it so scrubbing stays snappy while your footage stays on the big, cheap
+drive.
+
+This is completely safe. Previews are just cached copies of frames Crumb can
+always rebuild. If that SSD fills up, fails, or you wipe it, no footage is lost:
+Crumb regenerates previews from the recordings as needed.
+
+1. Mount the fast drive into the `api` container (a compose volume, for example
+   at `/mnt/thumbs`).
+2. In your `.env`:
+
+   ```bash
+   THUMB_CACHE_DIR=/mnt/thumbs
+   ```
+
+3. Apply it:
+
+   ```bash
+   docker compose up -d api
+   ```
+
+## You don't have to manage the cache
+
+Crumb keeps the preview cache from growing forever on its own: once it passes a
+size or age limit, the oldest previews are dropped, and any preview that's
+missing is simply rebuilt the next time it's needed. If you ever want to change
+those limits, they're in the [environment reference](/configuration/environment-reference).

--- a/docs-site/sidebars.js
+++ b/docs-site/sidebars.js
@@ -55,6 +55,14 @@ const sidebars = {
     },
     {
       type: 'category',
+      label: 'Playback',
+      link: { type: 'doc', id: 'playback/scrubbing' },
+      items: [
+        'playback/scrubbing',
+      ],
+    },
+    {
+      type: 'category',
       label: 'Motion & Detection',
       link: { type: 'doc', id: 'motion/index' },
       items: [

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,70 @@ revisit.
 
 ---
 
+## 2026-07-07, Scrub preview: pre-generated JPEG proxy (API-side); keyframe index rejected
+
+**Problem.** Timeline scrubbing does not yet feel like a leading commercial VMS:
+buttery, instant scrub (including synchronized multi-camera) and frame-accurate
+seek. The open question was whether that requires (a) a low-res preview proxy,
+(b) a finer-than-per-segment seek index, or (c) a custom video container. A
+grounded audit (`services/api/src/filmstrip.rs`, `services/recorder/src/recording.rs`,
+`motion.rs`, the segment schema, and all four clients) answered it.
+
+**Findings that shaped the decision:**
+
+- The preview-proxy plumbing already exists as an explicit "Phase 1":
+  `filmstrip.rs` serves `/filmstrip/{cam}` + `/frame` from on-demand single-frame
+  ffmpeg extraction cached under `{export_dir}/.thumbs`. `db::list_thumbnail_times`
+  is a stub returning empty; there is no background pre-generation. iOS (single-cam
+  plus a multi-camera synchronized wall), Android (single-cam), and the desktop
+  export-preview already consume these frames. The UX is built; the server starves it.
+- Two live defects make the existing cache nearly useless: thumbnail filenames are
+  exact millisecond timestamps but clients request arbitrary cursor times, so the
+  hit rate is near zero and every scrub re-spawns ffmpeg; and extraction has no
+  concurrency cap (unlike `/play`'s `play_semaphore`) and `.thumbs` is never evicted.
+- Segments are standard fMP4, ~4 s each (`SEGMENT_SECONDS`, clamped 2-6), written
+  `-movflags +frag_keyframe+empty_moov+default_base_moof` (fragment boundaries are
+  keyframe boundaries). Only the policy-selected stream is recorded (default `main`);
+  the sub stream is NOT recorded for playback.
+
+**Options considered:**
+
+| # | Option | Verdict |
+|---|--------|---------|
+| 1 | **Pre-generate the JPEG preview proxy, API-side background worker** reusing `extract_thumbnail`, deriving slot times from `segments` coverage (no migration), grid-aligned cache keys, hour subdirs | **CHOSEN.** Zero recorder changes, zero write-path risk (API mount is read-only), covers all cameras and both recording modes, and three client UIs already render it. |
+| 2 | Recorder piggyback on the motion decoder's in-RAM frames | Deferred. The motion frames are grayscale (`format=gray`); color needs a filtergraph split; coverage holes (Frigate-source cameras bypass the frame pipeline); couples a cosmetic feature to the always-must-work recorder. Revisit only if option 1's API-side CPU is measured too high. |
+| 3 | Dedicated long-running ffmpeg-per-camera off go2rtc | Rejected. Duplicates the sub-stream decode the motion task already pays, the exact cost the power-optimization work fought. |
+| 4 | **Finer-grained seek index** (per-keyframe / byte offsets) | **REJECTED.** At 4 s segments over LAN with native fMP4 fragment parsing in every player, nothing inside a ~2 MB segment is worth indexing server-side. Frame accuracy is a decode problem an index cannot solve (an index cannot create keyframes); all three players already expose exact-seek / frame-step. Would matter only if segments were 5-15 minutes. |
+| 5 | Custom video container | Out of scope. A container buys storage packing / inline metadata / evidence integrity, not scrub smoothness, and would cost fMP4 interop + per-client demuxers + write-path risk. |
+| 6 | Dual-stream recording (record sub continuously for cheap multi-cam scrub) | Out of scope here; separate write-path decision, tracked as ROADMAP dual-stream (#7) and option 5 of the 2026-07-03 motion-recording entry. Do not bundle. |
+
+**Chosen approach.** Finish the preview proxy as an API-side, read-side feature.
+Phase 0 (grid-snap cache keys + extraction semaphore + `.thumbs` eviction) fixes
+the two live defects and stands alone. Phase 1 adds the background pre-generation
+worker and a real `list_thumbnail_times` derived from `segments` (no new table, no
+migration). Phase 2 adds the desktop timeline preview UI (the one client lacking
+it). Phasing in `docs/ROADMAP.md` initiative 8.
+
+**Trades knowingly accepted:**
+
+- Preview granularity equals the generation interval (recommended 10 s), so during
+  a drag the preview steps at ~10 s; sub-second precision still comes from the real
+  video on release (desktop already live-seeks in-segment). This matches commercial
+  VMS behavior.
+- Thumbnails are extra small files (~16-39 GB and 2.6-6.5 M files for 10 cams / 30 d
+  at recommended settings, under 1% of video bytes; file count is the real cost,
+  mitigated by hour subdirs; sprite atlases deferred until file count actually hurts).
+- The Phase 1 thumbnail-retention task is a NEW deletion path; it is path-guarded to
+  `.thumbs`, extension-filtered to `.jpg`, and gets a test, per golden rule 2.
+
+**Revisit triggers:**
+
+- API-side extraction CPU measured unacceptably high on real deployments, reopen
+  option 2 (recorder motion-decoder piggyback).
+- Segment length raised beyond ~15 s, or WAN/remote scrubbing becomes a first-class
+  target, reopen option 4 (finer index) and sprite atlases.
+- `.thumbs` file count demonstrably hurts backup/inode performance, build sprite atlases.
+
 ## 2026-07-06, Docs site: Docusaurus, self-hosted behind cloudflared (docs.crumbvms.com)
 
 **Context.** Crumb needs a public, versioned, searchable documentation site in

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -553,6 +553,54 @@ footage.
   advanced option layered onto Motion mode ("also record sub-stream
   continuously").
 
+### 8. Instant timeline scrub (pre-generated preview proxy)
+
+Make timeline scrubbing feel instant, on every client and across multiple cameras at once, by finishing the already-scaffolded low-res thumbnail preview proxy so the server pre-generates frames instead of decoding one on demand per scrub tick. Decision and rejected alternatives (notably a finer seek index and a custom container) are recorded in `docs/DECISIONS.md` (2026-07-07).
+
+#### Where we are today
+
+The preview-proxy plumbing exists as an explicit "Phase 1" but is server-starved. `services/api/src/filmstrip.rs` serves `/filmstrip/{cam}` (list) + `/frame` (JPEG) from on-demand single-frame ffmpeg extraction cached at `{export_dir}/.thumbs/{cam}/{ts_ms}.jpg`; `crumb_common::db::list_thumbnail_times` is a stub returning empty, and there is no background pre-generation. The client UIs already consume it: iOS single-cam (`PlaybackView`) plus a multi-camera synchronized wall (`PlaybackWallView`), Android single-cam (`PlaybackScreen`), and the desktop export-preview scrubber. Two live defects cripple the cache: filenames are exact-millisecond but clients request arbitrary cursor times (near-zero hit rate, an ffmpeg re-spawn per scrub), and extraction has no concurrency cap (contrast `/play`'s `play_semaphore`) with `.thumbs` never evicted.
+
+Segments are standard fMP4 ~4 s each; the per-segment seek index is sufficient (a finer keyframe index was evaluated and rejected, see the decision entry). The desktop is the only client whose main playback timeline live-seeks the real mpv panes instead of showing thumbnails, so it stalls when a drag crosses segment boundaries (an mpv `loadfile` per 4 s).
+
+#### Where we are going
+
+The server pre-generates the preview frames so a scrub is a static-file fetch (~5-20 ms LAN) instead of a 150-500 ms ffmpeg spawn, N cameras at once, on hardware the operator already owns. iOS and Android get the win with zero client changes; desktop gains a timeline preview it lacks today. All work is API-side / read-side, off the recorder write path (golden rule 2 unaffected), and preserves standard fMP4 (no interop loss).
+
+#### Plan
+
+Phase 0, cache hygiene, API only, standalone (S)
+
+- [ ] Grid-snap the frame timestamp in `serve_frame` and emit grid-aligned slots in `list_filmstrip` (floor to `SEGMENT_SECONDS`) so repeat and multi-cam-wall scrubs hit warm cache (S)
+- [ ] Global extraction semaphore mirroring `playback.rs`'s `play_semaphore` to cap concurrent ffmpeg spawns (S)
+- [ ] Size/age-capped `.thumbs` eviction task, path-guarded to `.thumbs`, `.jpg` only, tested (S)
+
+Phase 1, pre-generation, API + `db.rs` stub, no migration (M)
+
+- [ ] Background per-camera worker reusing `extract_thumbnail`, interval-driven, semaphore-bounded; hour subdirs `.thumbs/{cam}/{YYYYMMDDHH}/` (M)
+- [ ] Implement `list_thumbnail_times` as grid slots intersected with recorded `segments` coverage (kills 404 slots in gaps; no new table) (S)
+- [ ] Thumbnail retention tied to policy retention, a NEW delete path, path-guarded + tested (S)
+- [ ] Config knobs (`THUMB_INTERVAL_SECS`, enable flag) → `.env.example` / `docs/AI-INSTALL.md` (golden rule 5) (S)
+- [ ] Optional `THUMB_CACHE_DIR` to place the scrub cache on fast/separate storage (e.g. an NVMe partition) while footage stays on bulk HDD, matching the random-read-hot thumbnail workload to the right medium. Low-risk: thumbnails are regenerable and the on-demand path self-heals a wiped cache, so the thumb drive can be cheap and non-redundant (a failure only makes scrubbing temporarily slower, never loses footage) (S)
+
+Phase 2, desktop preview UI, `apps/desktop/src/app.js` only (M)
+
+- [ ] Timeline hover/drag thumbnail strip (webview territory, no pane z-order issue) (M)
+- [ ] Optional full drag swap-grid using the existing native-pane hide/show: JPEG grid while dragging, mpv resolves full-res on release (M)
+
+Phase 3, client polish, optional (S)
+
+- [ ] Android playback-wall scrub tiles (iOS parity); client-side grid-snap of requested timestamps; prefetch around the playhead (S)
+
+Phase 4, efficiency, only if measured need (M)
+
+- [ ] Recorder motion-decoder color-split piggyback to remove the per-interval spawn (needs its own DECISIONS entry + motion tests), and/or sprite atlases if `.thumbs` file count hurts (M)
+
+#### Decisions for the maintainer
+
+- Generation interval (preview granularity vs. CPU/storage): 10 s recommended; 4 s equals per-segment, richer but ~6.5 M files over 30 d at 10 cameras.
+- Whether pre-generation backfills history at low priority, or relies on the on-demand fallback to self-heal history as users scrub it.
+
 ### Cross-cutting
 
 Two pairs of initiatives share infrastructure. Building the shared piece once, deliberately, avoids two divergent half-implementations.

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -167,7 +167,10 @@ pub struct ApiConfig {
     /// ffmpeg extractions (the filmstrip scrubber). Each cache miss spawns one
     /// single-frame ffmpeg; a fast multi-camera scrub would otherwise spawn a
     /// storm. A shared semaphore caps them, mirroring `playback_max_concurrency`
-    /// and `clip_gen_max_concurrency`. Default: `4`.
+    /// and `clip_gen_max_concurrency`. Default scales with the host: about half
+    /// the CPU cores, clamped to `[2, 12]`, so a small box keeps CPU headroom for
+    /// the recorder while a big box isn't throttled to a fixed handful. Override
+    /// to taste.
     pub thumb_extract_max_concurrency: usize,
 
     /// `THUMB_CACHE_MAX_BYTES` -- soft byte budget for the filmstrip thumbnail
@@ -319,8 +322,11 @@ impl ApiConfig {
             export_max_concurrent: parse_env("EXPORT_MAX_CONCURRENT", 2usize)?.max(1),
             clip_gen_max_concurrency: parse_env("CLIP_GEN_MAX_CONCURRENCY", 4usize)?.max(1),
             clip_cache_max_bytes: parse_env("CLIP_CACHE_MAX_BYTES", 10_737_418_240_u64)?,
-            thumb_extract_max_concurrency: parse_env("THUMB_EXTRACT_MAX_CONCURRENCY", 4usize)?
-                .max(1),
+            thumb_extract_max_concurrency: parse_env(
+                "THUMB_EXTRACT_MAX_CONCURRENCY",
+                default_thumb_concurrency(),
+            )?
+            .max(1),
             thumb_cache_max_bytes: parse_env("THUMB_CACHE_MAX_BYTES", 21_474_836_480_u64)?,
             thumb_cache_ttl_seconds: parse_env("THUMB_CACHE_TTL_SECONDS", 2_592_000_u64)?,
             thumb_pregen_enabled: parse_env("THUMB_PREGEN_ENABLED", false)?,
@@ -360,6 +366,14 @@ fn optional_env_opt(key: &str) -> Option<String> {
         Ok(v) if !v.trim().is_empty() => Some(v),
         _ => None,
     }
+}
+
+/// Default concurrency for on-demand thumbnail extraction, scaled to the host:
+/// about half the CPU cores, clamped to `[2, 12]`. A small box keeps CPU
+/// headroom for the recorder; a big box isn't throttled to a fixed handful.
+fn default_thumb_concurrency() -> usize {
+    let cores = std::thread::available_parallelism().map_or(4, std::num::NonZeroUsize::get);
+    (cores / 2).clamp(2, 12)
 }
 
 fn parse_env<T>(key: &str, default: T) -> Result<T>

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -200,6 +200,13 @@ pub struct ApiConfig {
     /// extraction (width is part of the cache key). Default: `160`.
     pub thumb_pregen_width: u32,
 
+    /// `THUMB_CACHE_DIR` -- optional override for where the thumbnail cache
+    /// (`.thumbs`) lives. Empty (default) means "under `EXPORT_DIR`". Point it at
+    /// a fast/separate volume (e.g. an `NVMe` mount) so scrub-cache reads don't
+    /// compete with footage on a spinning disk. Safe because thumbnails are
+    /// regenerable: a wiped or dead cache self-heals via on-demand extraction.
+    pub thumb_cache_dir: String,
+
     // -- detection (Frigate) -----------------------------------------------
     /// `FRIGATE_API_BASE` -- base URL of Frigate's HTTP API, used by the
     /// snapshot proxy handler to fetch detection JPEGs.
@@ -249,6 +256,17 @@ pub struct ApiConfig {
 }
 
 impl ApiConfig {
+    /// Base directory the thumbnail `.thumbs` cache lives under: `THUMB_CACHE_DIR`
+    /// when set (e.g. a separate `NVMe` mount), otherwise `EXPORT_DIR`.
+    #[must_use]
+    pub fn thumb_cache_base(&self) -> &str {
+        if self.thumb_cache_dir.is_empty() {
+            &self.export_dir
+        } else {
+            &self.thumb_cache_dir
+        }
+    }
+
     /// Read configuration from the process environment.
     ///
     /// # Errors
@@ -309,6 +327,7 @@ impl ApiConfig {
             thumb_pregen_lookback_hours: parse_env("THUMB_PREGEN_LOOKBACK_HOURS", 2_i64)?.max(0),
             thumb_pregen_scan_secs: parse_env("THUMB_PREGEN_SCAN_SECS", 60_u64)?.max(5),
             thumb_pregen_width: parse_env("THUMB_PREGEN_WIDTH", 160_u32)?,
+            thumb_cache_dir: optional_env("THUMB_CACHE_DIR", ""),
             frigate_api_base: optional_env("FRIGATE_API_BASE", ""),
             alert_webhook_url: optional_env_opt("ALERT_WEBHOOK_URL"),
             seed_admin_username: optional_env("SEED_ADMIN_USERNAME", "admin"),

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -163,6 +163,23 @@ pub struct ApiConfig {
     /// the cache unbounded within a day. Default: `10 GiB`.
     pub clip_cache_max_bytes: u64,
 
+    /// `THUMB_EXTRACT_MAX_CONCURRENCY` -- max concurrent on-demand thumbnail
+    /// ffmpeg extractions (the filmstrip scrubber). Each cache miss spawns one
+    /// single-frame ffmpeg; a fast multi-camera scrub would otherwise spawn a
+    /// storm. A shared semaphore caps them, mirroring `playback_max_concurrency`
+    /// and `clip_gen_max_concurrency`. Default: `4`.
+    pub thumb_extract_max_concurrency: usize,
+
+    /// `THUMB_CACHE_MAX_BYTES` -- soft byte budget for the filmstrip thumbnail
+    /// cache (`{export_dir}/.thumbs`). A periodic sweeper evicts oldest-by-mtime
+    /// past this budget (and past `THUMB_CACHE_TTL_SECONDS` by age), so scrubbing
+    /// can't grow the cache unbounded. Default: `20 GiB`.
+    pub thumb_cache_max_bytes: u64,
+
+    /// `THUMB_CACHE_TTL_SECONDS` -- age past which a cached thumbnail is evicted
+    /// by the sweeper regardless of the byte budget. Default: `30 days`.
+    pub thumb_cache_ttl_seconds: u64,
+
     // -- detection (Frigate) -----------------------------------------------
     /// `FRIGATE_API_BASE` -- base URL of Frigate's HTTP API, used by the
     /// snapshot proxy handler to fetch detection JPEGs.
@@ -264,6 +281,10 @@ impl ApiConfig {
             export_max_concurrent: parse_env("EXPORT_MAX_CONCURRENT", 2usize)?.max(1),
             clip_gen_max_concurrency: parse_env("CLIP_GEN_MAX_CONCURRENCY", 4usize)?.max(1),
             clip_cache_max_bytes: parse_env("CLIP_CACHE_MAX_BYTES", 10_737_418_240_u64)?,
+            thumb_extract_max_concurrency: parse_env("THUMB_EXTRACT_MAX_CONCURRENCY", 4usize)?
+                .max(1),
+            thumb_cache_max_bytes: parse_env("THUMB_CACHE_MAX_BYTES", 21_474_836_480_u64)?,
+            thumb_cache_ttl_seconds: parse_env("THUMB_CACHE_TTL_SECONDS", 2_592_000_u64)?,
             frigate_api_base: optional_env("FRIGATE_API_BASE", ""),
             alert_webhook_url: optional_env_opt("ALERT_WEBHOOK_URL"),
             seed_admin_username: optional_env("SEED_ADMIN_USERNAME", "admin"),

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -180,6 +180,26 @@ pub struct ApiConfig {
     /// by the sweeper regardless of the byte budget. Default: `30 days`.
     pub thumb_cache_ttl_seconds: u64,
 
+    /// `THUMB_PREGEN_ENABLED` -- run the background thumbnail pre-generation
+    /// worker. Off by default: scrubbing is already fast on revisit (the grid-snap
+    /// cache) with zero background cost; pre-generation additionally makes COLD
+    /// first-touch fast, at the price of continuous decode CPU + cache storage.
+    /// Default: `false`.
+    pub thumb_pregen_enabled: bool,
+
+    /// `THUMB_PREGEN_LOOKBACK_HOURS` -- on start, and for a newly-seen camera, the
+    /// worker backfills thumbnails this far back before rolling forward. Default: `2`.
+    pub thumb_pregen_lookback_hours: i64,
+
+    /// `THUMB_PREGEN_SCAN_SECS` -- how often the worker wakes to generate
+    /// thumbnails for newly-recorded footage. Default: `60`.
+    pub thumb_pregen_scan_secs: u64,
+
+    /// `THUMB_PREGEN_WIDTH` -- width the worker pre-generates at. Clients requesting
+    /// this width hit the pre-generated cache; other widths fall back to on-demand
+    /// extraction (width is part of the cache key). Default: `160`.
+    pub thumb_pregen_width: u32,
+
     // -- detection (Frigate) -----------------------------------------------
     /// `FRIGATE_API_BASE` -- base URL of Frigate's HTTP API, used by the
     /// snapshot proxy handler to fetch detection JPEGs.
@@ -285,6 +305,10 @@ impl ApiConfig {
                 .max(1),
             thumb_cache_max_bytes: parse_env("THUMB_CACHE_MAX_BYTES", 21_474_836_480_u64)?,
             thumb_cache_ttl_seconds: parse_env("THUMB_CACHE_TTL_SECONDS", 2_592_000_u64)?,
+            thumb_pregen_enabled: parse_env("THUMB_PREGEN_ENABLED", false)?,
+            thumb_pregen_lookback_hours: parse_env("THUMB_PREGEN_LOOKBACK_HOURS", 2_i64)?.max(0),
+            thumb_pregen_scan_secs: parse_env("THUMB_PREGEN_SCAN_SECS", 60_u64)?.max(5),
+            thumb_pregen_width: parse_env("THUMB_PREGEN_WIDTH", 160_u32)?,
             frigate_api_base: optional_env("FRIGATE_API_BASE", ""),
             alert_webhook_url: optional_env_opt("ALERT_WEBHOOK_URL"),
             seed_admin_username: optional_env("SEED_ADMIN_USERNAME", "admin"),

--- a/services/api/src/filmstrip.rs
+++ b/services/api/src/filmstrip.rs
@@ -187,7 +187,18 @@ async fn serve_frame(
     // Filename = milliseconds since epoch, zero-padded to 13 digits.
     // This is deterministic and contains no user-controlled data beyond the
     // parsed timestamp.
-    let ts_ms = q.ts.timestamp_millis();
+    // Snap the requested timestamp to a fixed global grid BEFORE deriving the
+    // cache key. Clients scrub to arbitrary cursor times; without snapping, two
+    // scrubs milliseconds apart produce different filenames and the cache is
+    // never reused, forcing a fresh ffmpeg decode on every scrub tick (and a
+    // multi-camera wall multiplies that per camera). Flooring to the thumbnail
+    // interval on a wall-clock-epoch grid (NOT the query window) means the same
+    // instant always maps to the same file across requests, so a scrub settles
+    // onto cache hits. `snapped_ts` is used for BOTH the filename and the
+    // extraction offset so the file's content matches its name.
+    let grid_ms = DEFAULT_THUMB_INTERVAL_SECS * 1000;
+    let ts_ms = q.ts.timestamp_millis().div_euclid(grid_ms) * grid_ms;
+    let snapped_ts = Utc.timestamp_millis_opt(ts_ms).single().unwrap_or(q.ts);
     // Cache thumbnails under the WRITABLE export volume — the live/archive storage
     // roots are mounted read-only in the API container, so `.thumbs` can't live there.
     let thumbs_root = std::path::PathBuf::from(&state.config().export_dir)
@@ -201,7 +212,15 @@ async fn serve_frame(
     // scrubber + clip-start thumbnails actually work (and gives a past-frame still,
     // which the live `frame.jpg` proxy cannot). Subsequent requests hit the cache.
     if tokio::fs::metadata(&frame_path).await.is_err() {
-        extract_thumbnail(&state, camera_id, q.ts, q.width, &thumbs_root, &frame_path).await?;
+        extract_thumbnail(
+            &state,
+            camera_id,
+            snapped_ts,
+            q.width,
+            &thumbs_root,
+            &frame_path,
+        )
+        .await?;
     }
 
     // Path traversal guard: the resolved path must start with the thumbs root.
@@ -318,6 +337,16 @@ async fn extract_thumbnail(
         .await
         .map_err(|e| ApiError::Internal(anyhow::anyhow!("create thumbs dir: {e}")))?;
 
+    // Cap concurrent extractions so a fast multi-camera scrub (each miss is one
+    // single-frame ffmpeg) can't spawn a storm, mirroring the `/play` and
+    // clip-gen semaphores. The permit is held only for the decode below and
+    // released on drop when this function returns.
+    let _permit = state
+        .thumb_semaphore()
+        .acquire_owned()
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("thumb semaphore closed: {e}")))?;
+
     let args: Vec<String> = vec![
         "-y".to_owned(),
         "-ss".to_owned(),
@@ -363,11 +392,15 @@ async fn extract_thumbnail(
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
-/// Generate evenly-spaced timestamp slots across `[start, end)` with
-/// `interval_secs` spacing.
+/// Generate timestamp slots across `[start, end)` anchored to a fixed global
+/// grid of `interval_secs`.
 ///
-/// Always includes a slot at exactly `start`.  The last slot is the largest
-/// multiple of `interval_secs` from `start` that is strictly less than `end`.
+/// Slots are floored to the interval on the wall-clock epoch, NOT anchored to
+/// the arbitrary query `start`. Identical slot timestamps across different scrub
+/// windows are what let the pre-extracted / cached frames be reused instead of
+/// re-extracted per window (the list side of the same snapping `serve_frame`
+/// applies to a single frame). The first slot is `start` floored to the grid;
+/// the last is the largest grid multiple strictly less than `end`.
 fn generate_synthetic_timestamps(
     start: DateTime<Utc>,
     end: DateTime<Utc>,
@@ -376,16 +409,19 @@ fn generate_synthetic_timestamps(
     if interval_secs <= 0 {
         return vec![];
     }
-    let total_ms = (end - start).num_milliseconds();
-    if total_ms <= 0 {
+    let step_ms = interval_secs * 1_000;
+    // Floor `start` to the global grid so slot timestamps are stable across
+    // query windows (cache reuse). `div_euclid` floors correctly even for a
+    // pre-epoch input.
+    let start_ms = start.timestamp_millis().div_euclid(step_ms) * step_ms;
+    let end_ms = end.timestamp_millis();
+    if end_ms <= start_ms {
         return vec![];
     }
-    let step_ms = interval_secs * 1_000;
-    // total_ms and step_ms are both positive here; quotient fits usize on all
+    // start_ms < end_ms and step_ms > 0 here; the quotient fits usize on all
     // targets we care about (Linux x86_64 with 48-bit virtual address space).
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    let count = (total_ms / step_ms) as usize + 1;
-    let start_ms = start.timestamp_millis();
+    let count = ((end_ms - start_ms) / step_ms) as usize + 1;
 
     (0..count)
         .filter_map(|i| {

--- a/services/api/src/filmstrip.rs
+++ b/services/api/src/filmstrip.rs
@@ -203,7 +203,7 @@ async fn serve_frame(
     let snapped_ts = Utc.timestamp_millis_opt(ts_ms).single().unwrap_or(q.ts);
     let w = q.width.clamp(THUMB_MIN_WIDTH, THUMB_MAX_WIDTH);
     let (thumbs_root, frame_path) =
-        thumb_frame_path(&state.config().export_dir, camera_id, ts_ms, w);
+        thumb_frame_path(state.config().thumb_cache_base(), camera_id, ts_ms, w);
     ensure_thumbnail(&state, camera_id, snapped_ts, w).await?;
 
     // Path traversal guard: the resolved path must start with the thumbs root.
@@ -296,7 +296,7 @@ pub(crate) async fn ensure_thumbnail(
 ) -> Result<PathBuf, ApiError> {
     let w = width.clamp(THUMB_MIN_WIDTH, THUMB_MAX_WIDTH);
     let (thumbs_root, frame_path) = thumb_frame_path(
-        &state.config().export_dir,
+        state.config().thumb_cache_base(),
         camera_id,
         snapped_ts.timestamp_millis(),
         w,

--- a/services/api/src/filmstrip.rs
+++ b/services/api/src/filmstrip.rs
@@ -71,7 +71,7 @@ use crate::{
 
 /// Spacing between synthetic thumbnail entries when no pre-extracted frames
 /// exist.  4 s matches the default `SEGMENT_SECONDS` in the recorder.
-const DEFAULT_THUMB_INTERVAL_SECS: i64 = 4;
+pub(crate) const DEFAULT_THUMB_INTERVAL_SECS: i64 = 4;
 
 /// Bounds on the requested thumbnail width. The width is part of the cache key,
 /// so clamping here keeps the number of distinct cached resolutions finite.
@@ -191,51 +191,20 @@ async fn serve_frame(
     // Camera access check.
     user.assert_camera_access(camera_id)?;
 
-    // Derive the file path from the timestamp.
-    //
-    // Filename = milliseconds since epoch, zero-padded to 13 digits.
-    // This is deterministic and contains no user-controlled data beyond the
-    // parsed timestamp.
-    // Snap the requested timestamp to a fixed global grid BEFORE deriving the
-    // cache key. Clients scrub to arbitrary cursor times; without snapping, two
-    // scrubs milliseconds apart produce different filenames and the cache is
-    // never reused, forcing a fresh ffmpeg decode on every scrub tick (and a
-    // multi-camera wall multiplies that per camera). Flooring to the thumbnail
-    // interval on a wall-clock-epoch grid (NOT the query window) means the same
-    // instant always maps to the same file across requests, so a scrub settles
-    // onto cache hits. `snapped_ts` is used for BOTH the filename and the
-    // extraction offset so the file's content matches its name.
+    // Snap the requested timestamp to a fixed global grid so arbitrary scrub
+    // cursor times settle onto shared cache keys (a mid-scrub jitter no longer
+    // produces a fresh filename + decode per tick), key the cache on the clamped
+    // width, then ensure the frame exists, extracting on demand (singleflight +
+    // atomic write) if the background pre-generation worker hasn't produced it.
+    // The `.thumbs` cache lives under the WRITABLE export volume (the live/archive
+    // roots are read-only in the api container). See `thumb_frame_path`.
     let grid_ms = DEFAULT_THUMB_INTERVAL_SECS * 1000;
     let ts_ms = q.ts.timestamp_millis().div_euclid(grid_ms) * grid_ms;
     let snapped_ts = Utc.timestamp_millis_opt(ts_ms).single().unwrap_or(q.ts);
-    // Clamp the requested width to the same range `extract_thumbnail` uses, and
-    // key the cache on it. Different clients ask for different widths (Android
-    // wall 320, iOS single-cam 160); without width in the key the FIRST requester
-    // fixes the stored resolution for everyone. All requests that clamp to the
-    // same width share a file; others get their own.
     let w = q.width.clamp(THUMB_MIN_WIDTH, THUMB_MAX_WIDTH);
-    // Cache thumbnails under the WRITABLE export volume — the live/archive storage
-    // roots are mounted read-only in the API container, so `.thumbs` can't live there.
-    let thumbs_root = std::path::PathBuf::from(&state.config().export_dir)
-        .join(THUMBS_SUBDIR)
-        .join(camera_id.to_string());
-    let frame_path = thumbs_root.join(format!("{ts_ms:013}_w{w}.jpg"));
-
-    // On-demand extraction: there is no background thumbnail task, so if this
-    // frame isn't cached yet, pull a single frame from the recorded segment that
-    // covers `ts` and write it to the cache path. This is what makes the filmstrip
-    // scrubber + clip-start thumbnails actually work (and gives a past-frame still,
-    // which the live `frame.jpg` proxy cannot). Subsequent requests hit the cache.
-    if tokio::fs::metadata(&frame_path).await.is_err() {
-        // Singleflight: serialize concurrent misses on this key so only one
-        // request extracts (the rest wait and hit the freshly-published file).
-        let lock = state.thumb_inflight_lock(&frame_path);
-        let _flight = lock.lock().await;
-        // Re-check under the lock: a prior holder may have just published it.
-        if tokio::fs::metadata(&frame_path).await.is_err() {
-            extract_thumbnail(&state, camera_id, snapped_ts, w, &thumbs_root, &frame_path).await?;
-        }
-    }
+    let (thumbs_root, frame_path) =
+        thumb_frame_path(&state.config().export_dir, camera_id, ts_ms, w);
+    ensure_thumbnail(&state, camera_id, snapped_ts, w).await?;
 
     // Path traversal guard: the resolved path must start with the thumbs root.
     // We canonicalize the root first (it must exist for the guard to be
@@ -295,6 +264,54 @@ async fn serve_frame(
         .map_err(|e| ApiError::Internal(anyhow::anyhow!("build frame response: {e}")))?;
 
     Ok(response)
+}
+
+// ─── shared cache-path + ensure helpers ───────────────────────────────────────
+
+/// On-disk cache path for a thumbnail:
+/// `{export_dir}/.thumbs/{camera}/{ts_ms}_w{width}.jpg`. Returns
+/// `(thumbs_root_dir, frame_file)`. Shared by the request handler and the
+/// background pre-generation worker so both agree on the exact layout.
+pub(crate) fn thumb_frame_path(
+    export_dir: &str,
+    camera_id: Uuid,
+    ts_ms: i64,
+    width: u32,
+) -> (PathBuf, PathBuf) {
+    let root = PathBuf::from(export_dir)
+        .join(THUMBS_SUBDIR)
+        .join(camera_id.to_string());
+    let frame = root.join(format!("{ts_ms:013}_w{width}.jpg"));
+    (root, frame)
+}
+
+/// Ensure a thumbnail exists for the (already grid-snapped) `snapped_ts` at
+/// `width`, extracting it once under the singleflight lock if absent. Reused by
+/// the request path and the Phase 1 background worker. Returns the cache path.
+pub(crate) async fn ensure_thumbnail(
+    state: &AppState,
+    camera_id: Uuid,
+    snapped_ts: DateTime<Utc>,
+    width: u32,
+) -> Result<PathBuf, ApiError> {
+    let w = width.clamp(THUMB_MIN_WIDTH, THUMB_MAX_WIDTH);
+    let (thumbs_root, frame_path) = thumb_frame_path(
+        &state.config().export_dir,
+        camera_id,
+        snapped_ts.timestamp_millis(),
+        w,
+    );
+    if tokio::fs::metadata(&frame_path).await.is_ok() {
+        return Ok(frame_path);
+    }
+    // Singleflight: serialize concurrent misses on this key so only one caller
+    // extracts (background worker vs on-demand request, or two scrubbers).
+    let lock = state.thumb_inflight_lock(&frame_path);
+    let _flight = lock.lock().await;
+    if tokio::fs::metadata(&frame_path).await.is_err() {
+        extract_thumbnail(state, camera_id, snapped_ts, w, &thumbs_root, &frame_path).await?;
+    }
+    Ok(frame_path)
 }
 
 // ─── on-demand thumbnail extraction ───────────────────────────────────────────

--- a/services/api/src/filmstrip.rs
+++ b/services/api/src/filmstrip.rs
@@ -73,6 +73,15 @@ use crate::{
 /// exist.  4 s matches the default `SEGMENT_SECONDS` in the recorder.
 const DEFAULT_THUMB_INTERVAL_SECS: i64 = 4;
 
+/// Bounds on the requested thumbnail width. The width is part of the cache key,
+/// so clamping here keeps the number of distinct cached resolutions finite.
+const THUMB_MIN_WIDTH: u32 = 48;
+const THUMB_MAX_WIDTH: u32 = 640;
+
+/// Monotonic counter for unique temp-file suffixes during atomic thumbnail
+/// writes (ffmpeg renders to `<final>.tmpN`, then we rename into place).
+static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// Subdirectory within `live_storage_path` where thumbnails are stored.
 const THUMBS_SUBDIR: &str = ".thumbs";
 
@@ -199,12 +208,18 @@ async fn serve_frame(
     let grid_ms = DEFAULT_THUMB_INTERVAL_SECS * 1000;
     let ts_ms = q.ts.timestamp_millis().div_euclid(grid_ms) * grid_ms;
     let snapped_ts = Utc.timestamp_millis_opt(ts_ms).single().unwrap_or(q.ts);
+    // Clamp the requested width to the same range `extract_thumbnail` uses, and
+    // key the cache on it. Different clients ask for different widths (Android
+    // wall 320, iOS single-cam 160); without width in the key the FIRST requester
+    // fixes the stored resolution for everyone. All requests that clamp to the
+    // same width share a file; others get their own.
+    let w = q.width.clamp(THUMB_MIN_WIDTH, THUMB_MAX_WIDTH);
     // Cache thumbnails under the WRITABLE export volume — the live/archive storage
     // roots are mounted read-only in the API container, so `.thumbs` can't live there.
     let thumbs_root = std::path::PathBuf::from(&state.config().export_dir)
         .join(THUMBS_SUBDIR)
         .join(camera_id.to_string());
-    let frame_path = thumbs_root.join(format!("{ts_ms:013}.jpg"));
+    let frame_path = thumbs_root.join(format!("{ts_ms:013}_w{w}.jpg"));
 
     // On-demand extraction: there is no background thumbnail task, so if this
     // frame isn't cached yet, pull a single frame from the recorded segment that
@@ -212,15 +227,14 @@ async fn serve_frame(
     // scrubber + clip-start thumbnails actually work (and gives a past-frame still,
     // which the live `frame.jpg` proxy cannot). Subsequent requests hit the cache.
     if tokio::fs::metadata(&frame_path).await.is_err() {
-        extract_thumbnail(
-            &state,
-            camera_id,
-            snapped_ts,
-            q.width,
-            &thumbs_root,
-            &frame_path,
-        )
-        .await?;
+        // Singleflight: serialize concurrent misses on this key so only one
+        // request extracts (the rest wait and hit the freshly-published file).
+        let lock = state.thumb_inflight_lock(&frame_path);
+        let _flight = lock.lock().await;
+        // Re-check under the lock: a prior holder may have just published it.
+        if tokio::fs::metadata(&frame_path).await.is_err() {
+            extract_thumbnail(&state, camera_id, snapped_ts, w, &thumbs_root, &frame_path).await?;
+        }
     }
 
     // Path traversal guard: the resolved path must start with the thumbs root.
@@ -331,11 +345,21 @@ async fn extract_thumbnail(
     // In-segment offset (clamped non-negative).
     #[allow(clippy::cast_precision_loss)]
     let offset_secs: f64 = (ts - seg.start_ts).num_milliseconds().max(0) as f64 / 1000.0;
-    let w = width.clamp(48, 640);
+    let w = width.clamp(THUMB_MIN_WIDTH, THUMB_MAX_WIDTH);
 
     tokio::fs::create_dir_all(thumbs_root)
         .await
         .map_err(|e| ApiError::Internal(anyhow::anyhow!("create thumbs dir: {e}")))?;
+
+    // Atomic write: ffmpeg renders to a unique temp file, then we rename it into
+    // place. A rename on the same filesystem is atomic, so a concurrent reader
+    // (or the Phase 1 background writer racing an on-demand request) can never
+    // observe a half-written JPEG. The `.tmp*` suffix keeps the `.jpg`-only
+    // sweeper from touching an in-flight temp.
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut tmp_os = frame_path.as_os_str().to_owned();
+    tmp_os.push(format!(".tmp{seq}"));
+    let tmp_path = PathBuf::from(tmp_os);
 
     // Cap concurrent extractions so a fast multi-camera scrub (each miss is one
     // single-frame ffmpeg) can't spawn a storm, mirroring the `/play` and
@@ -360,7 +384,7 @@ async fn extract_thumbnail(
         format!("scale={w}:-2"),
         "-q:v".to_owned(),
         "4".to_owned(),
-        frame_path.to_string_lossy().into_owned(),
+        tmp_path.to_string_lossy().into_owned(),
     ];
 
     let child = Command::new(FFMPEG_BIN)
@@ -380,12 +404,21 @@ async fn extract_thumbnail(
     .map_err(|_| ApiError::Internal(anyhow::anyhow!("thumbnail extraction timed out")))?
     .map_err(|e| ApiError::Internal(anyhow::anyhow!("ffmpeg wait: {e}")))?;
 
-    if !status.status.success() || tokio::fs::metadata(frame_path).await.is_err() {
+    if !status.status.success() || tokio::fs::metadata(&tmp_path).await.is_err() {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
         return Err(ApiError::NotFound(format!(
             "could not extract a thumbnail at {} for camera {camera_id}",
             ts.to_rfc3339()
         )));
     }
+
+    // Publish atomically: rename the completed temp into the final cache path.
+    tokio::fs::rename(&tmp_path, frame_path)
+        .await
+        .map_err(|e| {
+            let _ = std::fs::remove_file(&tmp_path);
+            ApiError::Internal(anyhow::anyhow!("finalize thumbnail: {e}"))
+        })?;
 
     Ok(())
 }

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -792,11 +792,12 @@ async fn export_ttl_sweeper(state: AppState, ttl_seconds: u64) {
         .await;
 
         // Thumbnail cache: filmstrip scrub frames cached under
-        // {export_dir}/.thumbs/<camera>/; evict by age then byte budget so a
-        // long scrubbing history can't grow it unbounded. Only .jpg files
-        // inside .thumbs are ever removed (guarded in the sweeper).
+        // {thumb_cache_base}/.thumbs/<camera>/ (EXPORT_DIR, or THUMB_CACHE_DIR if
+        // set); evict by age then byte budget so a long scrubbing history can't
+        // grow it unbounded. Only .jpg files inside .thumbs are ever removed
+        // (guarded in the sweeper).
         sweep_thumbs_cache(
-            &state.config().export_dir,
+            state.config().thumb_cache_base(),
             chrono::Duration::seconds(
                 i64::try_from(state.config().thumb_cache_ttl_seconds).unwrap_or(2_592_000),
             ),

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -100,6 +100,7 @@ mod state;
 mod stats;
 mod status;
 mod stream_test;
+mod thumb_pregen;
 mod timeline;
 mod views;
 
@@ -594,6 +595,11 @@ async fn main() -> anyhow::Result<()> {
             db_backup::run_db_backup_job(backup_pool, backup_db_url).await;
         });
     }
+
+    // Phase 1 thumbnail pre-generation (opt-in via THUMB_PREGEN_ENABLED). The
+    // worker logs + returns immediately when disabled, so spawning it here is
+    // always safe.
+    tokio::spawn(thumb_pregen::run(state.clone()));
 
     // ── 7. bind and serve ─────────────────────────────────────────────────────
     // `into_make_service_with_connect_info` exposes the peer SocketAddr to the

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -784,6 +784,19 @@ async fn export_ttl_sweeper(state: AppState, ttl_seconds: u64) {
             state.config().clip_cache_max_bytes,
         )
         .await;
+
+        // Thumbnail cache: filmstrip scrub frames cached under
+        // {export_dir}/.thumbs/<camera>/; evict by age then byte budget so a
+        // long scrubbing history can't grow it unbounded. Only .jpg files
+        // inside .thumbs are ever removed (guarded in the sweeper).
+        sweep_thumbs_cache(
+            &state.config().export_dir,
+            chrono::Duration::seconds(
+                i64::try_from(state.config().thumb_cache_ttl_seconds).unwrap_or(2_592_000),
+            ),
+            state.config().thumb_cache_max_bytes,
+        )
+        .await;
     }
 }
 
@@ -831,5 +844,109 @@ async fn sweep_clips_cache(export_dir: &str, ttl: chrono::Duration, max_bytes: u
                 total = total.saturating_sub(size);
             }
         }
+    }
+}
+
+/// Evict cached filmstrip thumbnails under `{export_dir}/.thumbs` (walked
+/// recursively: `<camera>/…/<ts>.jpg`, including Phase-1 hour subdirs). First
+/// anything older than `ttl` by mtime, then, if survivors still exceed
+/// `max_bytes`, the oldest until back under budget.
+///
+/// GUARDED: only `.jpg` files inside the canonical `.thumbs` root are ever
+/// removed, so it can never touch a segment, export, or clip even if an odd
+/// entry appears under the tree.
+async fn sweep_thumbs_cache(export_dir: &str, ttl: chrono::Duration, max_bytes: u64) {
+    let root_canon =
+        match tokio::fs::canonicalize(std::path::Path::new(export_dir).join(".thumbs")).await {
+            Ok(p) => p,
+            Err(_) => return, // no thumbs cache yet
+        };
+    let now = std::time::SystemTime::now();
+    let max_age =
+        std::time::Duration::from_secs(u64::try_from(ttl.num_seconds()).unwrap_or(2_592_000));
+
+    // Pass 1: recursive walk + age eviction; collect survivors for pass 2.
+    let mut survivors: Vec<(std::path::PathBuf, std::time::SystemTime, u64)> = Vec::new();
+    let mut total: u64 = 0;
+    let mut stack: Vec<std::path::PathBuf> = vec![root_canon.clone()];
+    while let Some(dir) = stack.pop() {
+        let mut rd = match tokio::fs::read_dir(&dir).await {
+            Ok(rd) => rd,
+            Err(_) => continue,
+        };
+        while let Ok(Some(entry)) = rd.next_entry().await {
+            let path = entry.path();
+            let Ok(meta) = entry.metadata().await else {
+                continue;
+            };
+            if meta.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            // GUARD: only .jpg files, and only within the canonical .thumbs
+            // root. Anything else is left untouched.
+            if !meta.is_file()
+                || path.extension().and_then(|e| e.to_str()) != Some("jpg")
+                || !path.starts_with(&root_canon)
+            {
+                continue;
+            }
+            let mtime = meta.modified().unwrap_or(now);
+            if now.duration_since(mtime).ok().is_some_and(|a| a > max_age) {
+                let _ = tokio::fs::remove_file(&path).await;
+                continue;
+            }
+            total += meta.len();
+            survivors.push((path, mtime, meta.len()));
+        }
+    }
+
+    // Pass 2: byte-budget LRU eviction (oldest mtime first).
+    if total > max_bytes {
+        survivors.sort_by_key(|(_, mtime, _)| *mtime);
+        for (path, _, size) in survivors {
+            if total <= max_bytes {
+                break;
+            }
+            if tokio::fs::remove_file(&path).await.is_ok() {
+                total = total.saturating_sub(size);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod thumb_sweep_tests {
+    use super::sweep_thumbs_cache;
+
+    /// The sweeper removes `.jpg` thumbnails but NEVER a non-jpg file under
+    /// `.thumbs`, and honours the byte budget. Uses `max_bytes = 0` so the
+    /// byte-eviction pass runs on all surviving jpgs without needing to age
+    /// their mtimes, and a generous ttl so the age pass keeps everything for
+    /// pass 2 to act on.
+    #[tokio::test]
+    async fn sweeps_only_jpgs_within_thumbs() {
+        // Manual unique temp dir (the api test-suite avoids the tempfile crate;
+        // see tests/support). Keyed by pid so parallel test binaries don't clash.
+        let base = std::env::temp_dir().join(format!("crumb-thumbsweep-{}", std::process::id()));
+        let _ = tokio::fs::remove_dir_all(&base).await;
+        let cam_dir = base.join(".thumbs").join("cam-a");
+        tokio::fs::create_dir_all(&cam_dir).await.unwrap();
+
+        let jpg1 = cam_dir.join("0000000001000.jpg");
+        let jpg2 = cam_dir.join("0000000002000.jpg");
+        let keep = cam_dir.join("do-not-touch.mp4"); // a non-jpg the guard must skip
+        tokio::fs::write(&jpg1, b"xxxx").await.unwrap();
+        tokio::fs::write(&jpg2, b"yyyy").await.unwrap();
+        tokio::fs::write(&keep, b"segment-ish").await.unwrap();
+
+        // ttl huge (nothing age-evicted), byte budget 0 (all jpgs LRU-evicted).
+        sweep_thumbs_cache(base.to_str().unwrap(), chrono::Duration::seconds(86_400), 0).await;
+
+        assert!(!jpg1.exists(), "jpg1 should be byte-budget evicted");
+        assert!(!jpg2.exists(), "jpg2 should be byte-budget evicted");
+        assert!(keep.exists(), "non-jpg file must never be removed");
+
+        let _ = tokio::fs::remove_dir_all(&base).await;
     }
 }

--- a/services/api/src/state.rs
+++ b/services/api/src/state.rs
@@ -67,6 +67,12 @@ struct Inner {
     /// `config.clip_gen_max_concurrency`.
     clip_gen_semaphore: Arc<Semaphore>,
 
+    /// Bounds concurrent on-demand thumbnail ffmpeg extractions (the filmstrip
+    /// scrubber). A fast multi-camera scrub can miss the cache on many frames at
+    /// once; without a cap each miss spawns a single-frame ffmpeg, a spawn storm.
+    /// Permit count = `config.thumb_extract_max_concurrency`.
+    thumb_semaphore: Arc<Semaphore>,
+
     /// In-memory cache of permission [`Role`]s keyed by id. The `AuthUser`
     /// extractor resolves a token's `role_id` to its effective capabilities +
     /// cameras through this, so per-request auth costs no DB round-trip after the
@@ -130,6 +136,7 @@ impl AppState {
         let decoding_key = DecodingKey::from_secret(config.jwt_secret.as_bytes());
         let play_semaphore = Arc::new(Semaphore::new(config.playback_max_concurrency));
         let clip_gen_semaphore = Arc::new(Semaphore::new(config.clip_gen_max_concurrency));
+        let thumb_semaphore = Arc::new(Semaphore::new(config.thumb_extract_max_concurrency));
 
         // Health-alert maintenance window (issue #46). Off by default; an
         // optional `MAINTENANCE_UNTIL` env (unix seconds) lets a deployment
@@ -149,6 +156,7 @@ impl AppState {
             export_cancels: DashMap::new(),
             play_semaphore,
             clip_gen_semaphore,
+            thumb_semaphore,
             roles_cache: DashMap::new(),
             revoked_jtis: DashMap::new(),
             revoked_jtis_loaded_at: AtomicI64::new(0),
@@ -266,6 +274,14 @@ impl AppState {
     #[inline]
     pub fn clip_gen_semaphore(&self) -> Arc<Semaphore> {
         Arc::clone(&self.0.clip_gen_semaphore)
+    }
+
+    /// Clone the thumbnail-extraction concurrency semaphore handle (cheap `Arc`
+    /// clone). Used by the filmstrip handler to cap concurrent single-frame
+    /// ffmpeg extractions during a scrub.
+    #[inline]
+    pub fn thumb_semaphore(&self) -> Arc<Semaphore> {
+        Arc::clone(&self.0.thumb_semaphore)
     }
 
     // ── health-alert maintenance window (issue #46) ───────────────────────────

--- a/services/api/src/state.rs
+++ b/services/api/src/state.rs
@@ -73,6 +73,12 @@ struct Inner {
     /// Permit count = `config.thumb_extract_max_concurrency`.
     thumb_semaphore: Arc<Semaphore>,
 
+    /// Per-key in-flight locks for thumbnail extraction (singleflight). Keyed by
+    /// the final cache path; a request serializes on its key so two concurrent
+    /// misses on the same slot (e.g. the Phase 1 background writer racing an
+    /// on-demand request) extract once instead of both spawning ffmpeg.
+    thumb_inflight: DashMap<std::path::PathBuf, Arc<tokio::sync::Mutex<()>>>,
+
     /// In-memory cache of permission [`Role`]s keyed by id. The `AuthUser`
     /// extractor resolves a token's `role_id` to its effective capabilities +
     /// cameras through this, so per-request auth costs no DB round-trip after the
@@ -157,6 +163,7 @@ impl AppState {
             play_semaphore,
             clip_gen_semaphore,
             thumb_semaphore,
+            thumb_inflight: DashMap::new(),
             roles_cache: DashMap::new(),
             revoked_jtis: DashMap::new(),
             revoked_jtis_loaded_at: AtomicI64::new(0),
@@ -282,6 +289,25 @@ impl AppState {
     #[inline]
     pub fn thumb_semaphore(&self) -> Arc<Semaphore> {
         Arc::clone(&self.0.thumb_semaphore)
+    }
+
+    /// Get (or create) the singleflight lock for a thumbnail cache key. Callers
+    /// lock it around the "check file, else extract" sequence so concurrent
+    /// misses on the same key extract exactly once.
+    ///
+    /// The map holds only transient per-key locks; if it grows large (many
+    /// distinct on-demand thumbnails), it is cleared wholesale. Dropping an entry
+    /// mid-flight at worst permits one redundant extraction (atomic writes keep
+    /// that correct), never corruption.
+    pub fn thumb_inflight_lock(&self, path: &std::path::Path) -> Arc<tokio::sync::Mutex<()>> {
+        if self.0.thumb_inflight.len() > 8192 {
+            self.0.thumb_inflight.clear();
+        }
+        self.0
+            .thumb_inflight
+            .entry(path.to_path_buf())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
     }
 
     // ── health-alert maintenance window (issue #46) ───────────────────────────

--- a/services/api/src/thumb_pregen.rs
+++ b/services/api/src/thumb_pregen.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Background thumbnail pre-generation worker (Phase 1).
+//!
+//! Off by default (`THUMB_PREGEN_ENABLED`). When on, it rolls forward over each
+//! enabled camera's recently-recorded footage, extracting a thumbnail per grid
+//! slot so timeline scrubbing is fast on the FIRST touch, not just on revisit.
+//!
+//! It shares the grid interval, the cache path, the singleflight lock, and the
+//! extraction semaphore with the on-demand request path
+//! ([`crate::filmstrip::ensure_thumbnail`]), so the worker and live requests
+//! never double-extract or fight over resources.
+//!
+//! Cost note: the FIRST pass backfills `THUMB_PREGEN_LOOKBACK_HOURS` of history
+//! sequentially (gentle, one extraction in flight at a time); steady state only
+//! generates the handful of new slots recorded since the previous scan.
+
+use std::collections::HashMap;
+
+use chrono::{Duration, TimeZone, Utc};
+use uuid::Uuid;
+
+use crumb_common::db;
+
+use crate::{filmstrip, state::AppState};
+
+/// Run the pre-generation loop. Returns immediately (after logging) when the
+/// feature is disabled, so it is always safe to spawn.
+pub async fn run(state: AppState) {
+    let (enabled, width, lookback_hours, scan_secs) = {
+        let cfg = state.config();
+        (
+            cfg.thumb_pregen_enabled,
+            cfg.thumb_pregen_width,
+            cfg.thumb_pregen_lookback_hours,
+            cfg.thumb_pregen_scan_secs,
+        )
+    };
+    if !enabled {
+        tracing::info!("thumb pre-generation: disabled (THUMB_PREGEN_ENABLED unset)");
+        return;
+    }
+
+    let grid_ms = filmstrip::DEFAULT_THUMB_INTERVAL_SECS * 1000;
+    let lookback_ms = Duration::hours(lookback_hours).num_milliseconds();
+    let scan = std::time::Duration::from_secs(scan_secs);
+    tracing::info!(
+        grid_secs = filmstrip::DEFAULT_THUMB_INTERVAL_SECS,
+        width,
+        lookback_hours,
+        scan_secs,
+        "thumb pre-generation: started"
+    );
+
+    // Per-camera high-water mark: the newest instant we've generated up to.
+    let mut watermark: HashMap<Uuid, i64> = HashMap::new();
+
+    loop {
+        let now_ms = Utc::now().timestamp_millis();
+        let cameras = match db::list_enabled_cameras(state.pool()).await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(error = %e, "thumb pre-gen: listing cameras failed");
+                tokio::time::sleep(scan).await;
+                continue;
+            }
+        };
+
+        for cam in &cameras {
+            let from_ms = watermark
+                .get(&cam.id)
+                .copied()
+                .unwrap_or(now_ms - lookback_ms);
+            // Floor the start to the grid; step forward one slot at a time.
+            let mut slot = from_ms.div_euclid(grid_ms) * grid_ms;
+            let mut steps: u64 = 0;
+            while slot < now_ms {
+                if let Some(ts) = Utc.timestamp_millis_opt(slot).single() {
+                    // No-op if already cached; a gap (NotFound) is fine — the
+                    // on-demand path self-heals if the user ever scrubs there.
+                    let _ = filmstrip::ensure_thumbnail(&state, cam.id, ts, width).await;
+                }
+                slot += grid_ms;
+                steps += 1;
+                // Yield periodically so a large initial backfill can't monopolize
+                // the runtime between the semaphore-bounded extractions.
+                if steps.is_multiple_of(64) {
+                    tokio::task::yield_now().await;
+                }
+            }
+            watermark.insert(cam.id, now_ms);
+        }
+
+        tokio::time::sleep(scan).await;
+    }
+}


### PR DESCRIPTION
## What this does

Makes dragging the playback timeline feel instant. As the scrubber moves it shows small preview frames instead of decoding full video, then reuses them so dragging back over a spot you have already looked at is instant. Scrubbing a whole wall of cameras at the same moment works the same way.

Two phases:

- **Phase 0 (cache hygiene):** preview frames snap to a fixed time grid so revisiting a position reuses the cached frame instead of re-decoding. An extraction semaphore plus a singleflight lock stop duplicate ffmpeg spawns, and frames are written atomically (temp then rename). Measured on real 9-camera footage: revisit-scrub p95 dropped from 236 ms to 1.1 ms, and ffmpeg spawns on a revisit went from 150 to 0.
- **Phase 1 (background pre-generation):** an opt-in worker builds previews for recent footage ahead of time so even the first drag is instant. Off by default.

Also adds `THUMB_CACHE_DIR` so the disposable preview cache can live on an SSD/NVMe mount while footage stays on spinning disks, and auto-scales extraction concurrency to roughly half the host CPU cores.

## Config (all optional, safe defaults)

New `THUMB_*` keys are documented in the environment reference. Pre-generation stays off unless `THUMB_PREGEN_ENABLED=true`.

## Client / API impact

None. Clients already call the existing filmstrip endpoints; this only changes how the server answers them. Fully backward compatible.

## Docs

- New user page: Timeline scrubbing and previews (docs site)
- Environment reference updated with the `THUMB_*` keys
- `docs/DECISIONS.md` entry (pre-generated JPEG proxy chosen over a keyframe index or a custom container) and a `docs/ROADMAP.md` initiative

## Verification

Gate green on the CI-runner host: `cargo fmt` clean, `cargo clippy --all-targets -D warnings` clean, `cargo test --workspace` = 192 passed. The only change since gating was a one-line docs wording fix (no code change).
