### PR TITLE
docs: operator-facing pages for Clips, Export, Users & access

### DIFF
--- a/docs-site/docs/admin-console/users-and-access.md
+++ b/docs-site/docs/admin-console/users-and-access.md
@@ -1,0 +1,58 @@
+---
+title: Users & access
+sidebar_label: Users & access
+slug: /admin-console/users-and-access
+---
+
+# Users & access
+
+Not everyone who logs into Crumb should see everything. A house-sitter might need
+the front and back cameras for a week; a family member might get live view but
+not the ability to export footage; only you might touch settings. Crumb's Users &
+Security section (in the [admin console](/admin-console/)) lets you draw those
+lines.
+
+There are two pieces: **what a person can do** (their role) and **which cameras
+they can see** (their access).
+
+## What a person can do: roles
+
+A role is a named bundle of permissions you can hand to one person or many. You
+create a role once (for example "Family" or "Guard"), decide what it's allowed to
+do, then assign it to users. When you change the role later, everyone with it
+updates at once.
+
+The permissions a role can grant include:
+
+- **Playback**: review recorded footage, not just the live view.
+- **Clips**: open the [Clips](/playback/clips) feed of detections and motion.
+- **Export**: build and download [export](/playback/export) archives.
+- **PTZ**: pan, tilt, and zoom cameras that support it.
+- **Manage views**: create and edit saved camera layouts.
+- **Bookmarks**: whether a person sees only their own
+  [bookmarks](/recording/bookmarks), everyone's, or none.
+
+Leave a permission off and that person simply doesn't see that capability. Someone
+with live view but no Export, for instance, can watch cameras but can't pull
+footage off the system.
+
+## Which cameras they can see: access
+
+Separately from what they can do, each user can be limited to specific cameras. A
+viewer scoped to the two entrance cameras sees only those two, everywhere in every
+client: live, timeline, clips, and export all respect the same boundary. They have
+no way to know the other cameras exist.
+
+Administrators are the exception: an admin sees every camera and every setting.
+Keep the number of admins small, and give everyone else a scoped role with just
+the cameras they need.
+
+## Adding a user
+
+In the admin console's Users & Security section you add a user with a username and
+password, pick their role, and (for non-admins) choose which cameras they can see.
+They can sign in from any [client](/clients/) with those credentials and will be
+held to exactly that boundary.
+
+Because access is enforced by the server, not the app, a scoped user stays scoped
+no matter which client they use or how they connect.

--- a/docs-site/docs/playback/clips.md
+++ b/docs-site/docs/playback/clips.md
@@ -1,0 +1,39 @@
+---
+title: Clips
+sidebar_label: Clips
+slug: /playback/clips
+---
+
+# Clips
+
+The Clips tab is a feed of short, interesting moments from your cameras, so you
+can review what happened without scrubbing through hours of timeline. Each entry
+is a thumbnail you can click to watch the moment it captured.
+
+## Where clips come from
+
+Crumb pulls clips from two places, automatically, and shows them in one list:
+
+- **Motion**: whenever a camera saw movement, Crumb turns those stretches of its
+  own recorded footage into clips. This works on any camera Crumb records, with
+  no extra setup.
+- **Detections**: if you've connected [Frigate](/integrations/frigate), its
+  object detections (a person, a car, a package) show up as clips too, labelled
+  with what was detected.
+
+You don't choose a source per clip; they're merged into a single feed, newest
+first, so "show me what happened" is one place to look.
+
+## Reviewing a clip
+
+Click a clip to play it. From there you can jump straight to that moment on the
+full [timeline](/playback/scrubbing) if you want the surrounding context, or move
+to the next clip to keep scanning. A clip you want to keep can be
+[bookmarked](/recording/bookmarks) so it's protected from automatic cleanup, or
+[exported](/playback/export) to save or share.
+
+## Filtering the feed
+
+The feed can be narrowed to a camera, a time range, or (for Frigate detections) a
+label, so a question like "did anyone come to the front door this afternoon"
+turns into a short, scannable list instead of a full evening of footage.

--- a/docs-site/docs/playback/export.md
+++ b/docs-site/docs/playback/export.md
@@ -1,0 +1,42 @@
+---
+title: Exporting footage
+sidebar_label: Export
+slug: /playback/export
+---
+
+# Exporting footage
+
+When you need to hand footage to someone (a neighbor, an insurer, the police),
+Crumb lets you pull the relevant moments out and save them as ordinary video
+files, without giving anyone access to your system.
+
+## Building an export list
+
+Rather than exporting one clip at a time, Crumb works from a list. As you review
+[clips](/playback/clips) or scrub the [timeline](/playback/scrubbing), you add the
+moments you care about to an export list, from one camera or several, across a
+whole afternoon if you need to. When the list is complete you export it in one
+action and Crumb packages everything together into a single archive you can
+download.
+
+This mirrors how a professional operator assembles an evidence package: gather
+the relevant moments first, review the list, then export once.
+
+## What you get
+
+The export is a downloadable archive of standard video files, playable in any
+normal video player, no Crumb software required on the other end. Because the
+files are plain video, the person you hand them to never needs an account, a
+login, or any access to your cameras or recordings.
+
+## Where exports live and how long they last
+
+Exports are written to their own storage area (`EXPORT_DIR`), separate from your
+recorded footage, so building an export never touches or competes with recording.
+Completed exports are cleaned up automatically after a while
+(`EXPORT_TTL_SECONDS`, 24 hours by default) so they don't accumulate. Download
+the archive when it's ready; if it expires before you get to it, just export the
+list again.
+
+See the [environment reference](/configuration/environment-reference) for those
+two settings. Most installs never need to change them.

--- a/docs-site/sidebars.js
+++ b/docs-site/sidebars.js
@@ -59,6 +59,8 @@ const sidebars = {
       link: { type: 'doc', id: 'playback/scrubbing' },
       items: [
         'playback/scrubbing',
+        'playback/clips',
+        'playback/export',
       ],
     },
     {
@@ -92,6 +94,7 @@ const sidebars = {
       link: { type: 'doc', id: 'admin-console/index' },
       items: [
         'admin-console/index',
+        'admin-console/users-and-access',
       ],
     },
     {


### PR DESCRIPTION
Three core operator features (Clips, Export, Users & access) had shipped with only developer-facing docs (config-struct comments, DECISIONS entries). These add plain-language pages on the docs site so the people running Crumb can actually find them:

- **Clips**: the feed of interesting moments (motion, plus Frigate detections if connected)
- **Export**: building an export list and downloading footage as one archive
- **Users & access**: roles (capabilities) and per-camera access grants; admin vs scoped users

Wired into the Playback and Admin Console sidebar categories. Builds clean under `onBrokenLinks: throw`.
