### PR TITLE
docs: Frigate-storage FAQ, Quickstart, install discoverability (+ scrub benchmark highlights)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ should include please open an issue.
 ## What it does
 
 **Investigate**
-- Frame-level scrubbable timeline (H.265 native, no server transcode)
+- Frame-level scrubbable timeline (H.265 native, no server transcode), with pre-generated previews so revisiting a spot is a ~1 ms cached read, not a ~250 ms re-decode
 - Jump to the next/previous motion event; digital zoom into a clip
 - Motion dots **and** Frigate object icons on one timeline bar
 - Bookmarks with protected (never-auto-deleted) retention

--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ client, a batch export list, and roles with per-camera access, with Frigate's ob
 detections drawn right on the timeline over MQTT. Run both: **Frigate detects, Crumb is the
 room you sit in.**
 
+**"Why not just read Frigate's recordings?"** Because a smooth, frame-accurate, multi-camera
+scrubbable timeline is a property of how footage is recorded, not how it's played back. Frigate's
+files play fine, but the things that make scrubbing feel instant (short clock-aligned
+keyframe-guaranteed fMP4 segments, a wall-clock index, a pre-generated preview proxy so a drag
+doesn't re-decode 4K H.265 on every tick) have to be baked in at record time, and can't be
+recovered by reading Frigate's storage after the fact. So Crumb owns recording and composes with
+Frigate at the detection and clip level instead. The full, nerdy version is in the
+[Frigate integration guide](https://docs.crumbvms.com/integrations/frigate#why-crumb-records-its-own-footage-and-doesnt-read-frigates).
+
 **It fits whatever Frigate setup you already have.** Both pull RTSP, so the simplest thing is
 to point each at your cameras and run them side by side, no reconfiguration. If you'd rather
 a camera only get pulled once, connect them, and it works either direction: Crumb can ingest
@@ -94,8 +103,8 @@ exclusion zones and pluggable detectors) for recording triggers and timeline eve
 never does object, face, or plate recognition itself. That's Frigate's job, and Frigate is
 better at it than anything I would bolt on.
 
-No Home Assistant integration yet, either. If that's something you'd want, open an issue and
-tell me what it should actually do; that's how it gets built.
+No Home Assistant integration yet but it is planned. If you have any thoughts on what it
+should include please open an issue.
 
 > [!IMPORTANT]
 > ## Looking for testers

--- a/docs-site/docs/getting-started/install-docker-compose.md
+++ b/docs-site/docs/getting-started/install-docker-compose.md
@@ -6,10 +6,7 @@ slug: /getting-started/install-docker-compose
 
 # Install with Docker Compose
 
-This is the manual install path. If you're setting up with an AI coding
-agent instead, see
-[Install with an AI agent](/getting-started/install-with-ai-agent), which
-follows the same steps with an added Verify check after each one.
+This is the full, step-by-step install path. If you just want the fast path, see the [Quickstart](/getting-started/quickstart). If you're setting up with an AI coding agent instead, see [Install with an AI agent](/getting-started/install-with-ai-agent), which follows the same steps with an added Verify check after each one.
 
 ## 1. Get the repository and generate secrets
 

--- a/docs-site/docs/getting-started/quickstart.md
+++ b/docs-site/docs/getting-started/quickstart.md
@@ -1,0 +1,64 @@
+---
+title: Quickstart
+sidebar_label: Quickstart
+slug: /getting-started/quickstart
+---
+
+# Quickstart
+
+Get Crumb running in a few minutes on a Linux host with Docker. See [Requirements](/getting-started/requirements) for what your host needs, and [Install with Docker Compose](/getting-started/install-docker-compose) for the full explanation of each step.
+
+## 1. Get the repository and generate secrets
+
+```bash
+git clone https://github.com/badbread/crumbvms.git crumb && cd crumb
+./scripts/setup-env.sh
+```
+
+This writes a gitignored `.env` with strong, randomly generated secrets. You'll create your admin account in the browser during first run; no password needed here.
+
+## 2. Point to your storage (optional for trials)
+
+Edit `.env` and set `MEDIA_HOST_PATH` to a disk with real headroom:
+
+```
+MEDIA_HOST_PATH=/mnt/your-disk/crumb-data
+```
+
+The default `./_data` folder works for testing, but cameras fill terabytes over time.
+
+## 3. Bring up the stack
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+If you forked the repo or pinned a version that isn't published, `pull` will report "not found," use the build-from-source override instead:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
+```
+
+## 4. Verify it's running
+
+```bash
+curl -fsS http://localhost:8080/health
+```
+
+Should return `200 OK`. A `503` for the first few seconds is normal while the database finishes migrations.
+
+## 5. Open the browser
+
+`http://<host-lan-ip>:8080/admin`
+
+A wizard walks you through creating your admin account, confirming the server address, choosing storage and retention, and finding cameras on your network.
+
+## Next steps
+
+- [First-run wizard](/getting-started/first-run-wizard) for the full walkthrough
+- [Adding a camera](/cameras/adding-a-camera) to get your first stream
+- [Clients](/clients/) to download the desktop or Android app
+- [Responsible use](/responsible-use) before you rely on Crumb for anything
+
+For the full, step-by-step explanation of each of these commands, see [Install with Docker Compose](/getting-started/install-docker-compose).

--- a/docs-site/docs/integrations/frigate.md
+++ b/docs-site/docs/integrations/frigate.md
@@ -10,6 +10,87 @@ Crumb and Frigate compose at two independent levels. Crumb can be the single
 source of camera video that Frigate consumes, and Crumb can ingest the detection
 events Frigate produces. You can use either, both, or neither.
 
+They do **not** compose at the storage level: Crumb records and archives its own
+footage rather than reading Frigate's recordings. The next section explains why,
+because it's a fair question if you already have Frigate storing everything.
+
+## Why Crumb records its own footage, and doesn't read Frigate's
+
+Short version: the thing Crumb is *for*, a smooth, frame-accurate, multi-camera
+scrubbable timeline, is a property of how footage gets recorded, not how it gets
+played back. Frigate's stored files play fine. What they can't do is hand you
+that timeline after the fact, because the properties that make scrubbing feel
+instant have to be baked in at record time. Crumb composes with Frigate
+everywhere it's cheap to (detections over MQTT, clips, snapshots, live streams).
+Storage is the one seam where reading Frigate's files would quietly cost the
+experience you came for.
+
+Here's the concrete why, for anyone who wants the detail.
+
+**Smooth scrubbing lives in the recorder, not the player.** Frigate writes
+faststart MP4, and libmpv and Media3 will happily seek inside those files, so raw
+seekability isn't the blocker. But "the player can seek this file" and "you can
+drag a scrubber across a dozen cameras and a full day and have every frame land
+instantly" are different problems, and the second one is won or lost at record
+time.
+
+**Segments have to be a known, uniform shape.** Crumb records standard fMP4 in
+short segments (2 to 6 seconds), clock-aligned, written so every fragment
+boundary is also a keyframe boundary (`+frag_keyframe+empty_moov+default_base_moof`).
+The player can then land on any segment boundary without hunting backward for the
+previous keyframe, and it knows exactly where those boundaries are before it
+seeks. Frigate cuts roughly 10-second segments at whatever keyframe your camera
+happens to emit: no forced GOP, no clock alignment, audio stripped by default.
+Seek precision and cross-camera boundary alignment then degrade to your camera's
+settings rather than something Crumb controls.
+
+**Seeking to a wall-clock instant needs a wall-clock index Crumb owns.** To put
+the player on "3:47:12 PM on the driveway camera" you need a per-segment index
+mapping real time to file and offset, at a granularity fine enough to feel
+instant. Crumb keeps that in Postgres, written by the recorder as it records.
+Frigate's index is single-writer SQLite on local disk, with a schema that changes
+across minor releases, pruned hourly plus a 5-minute emergency sweep. Any index
+Crumb mirrored from it would be racing deletion: mid-scrub 404s and mid-export
+file-vanish become structural, not occasional.
+
+**Multi-camera sync falls out of clock-aligned segments.** Drag one scrubber and
+every camera jumps to the same instant only if their segments are cut on the same
+clock. Crumb's are. Segments cut at each camera's own independent keyframe cadence
+don't line up, so a synchronized wall becomes approximate.
+
+**The scrub preview has to be pre-generated, or every drag re-decodes H.265.**
+When you drag across the timeline you want a thumbnail under the cursor the whole
+way. You can't get that by decoding the full-resolution H.265 stream on every
+scrub tick: that's hundreds of full-frame decodes a second, and 4K H.265 is
+exactly what browsers already choke on. So Crumb pre-generates a low-res JPEG
+preview proxy (a small frame roughly every 10 seconds), lands the drag on the
+nearest proxy frame instantly, and only decodes the real frame from the actual
+video when you let go (see [Timeline scrubbing](/playback/scrubbing)). That proxy
+is derived from Crumb's own segment index by a background worker. Reading
+Frigate's files, you'd have to build and decode that proxy yourself from footage
+whose shape and lifetime you don't control, which throws away the whole reason to
+avoid re-decoding.
+
+**Footage you display should be footage you can protect.** Crumb treats losing
+footage as the one unforgivable bug. Frigate's tiered retention deliberately
+turns each camera's history into islands as tiers age out, and its cache overflow
+discards the oldest unprocessed segments by design. It has no "hold this time
+range" primitive, only retain-indefinitely on detected-object events. If Crumb's
+UI showed footage living in Frigate's store, it would be presenting clips it can't
+protect, can't apply per-policy size caps or archive tiers to, and can't even
+reliably detect the loss of.
+
+What Crumb *does* compose with Frigate, and always will: detections drawn on the
+timeline over MQTT, proxied clips and snapshots, and live-stream sharing in
+either direction (the rest of this page). Frigate is a first-rate open-source
+object detector, and Crumb doesn't try to redo that. Frigate detects, Crumb is
+the room you sit in.
+
+If Frigate ever ships a stable recordings API plus a real retention-hold, a
+read-only "browse my existing Frigate archive" view becomes worth revisiting.
+That would be an explicitly second-class overlay, never a peer storage backend,
+for exactly the reasons above.
+
 ## Point Frigate at Crumb's streams (recommended)
 
 Frigate needs the camera video, not just the detection events. Out of the box a
@@ -51,29 +132,56 @@ Now the camera is pulled once, by Crumb, and Frigate fans out from Crumb's
 restream. This is the single-puller topology Crumb is built around, and it keeps
 session-limited cameras from being exhausted by having two systems dial them.
 
-### Moving an existing Frigate setup to Crumb as the hub
+### Moving an existing Frigate setup alongside Crumb
 
-If you already run Frigate with its cameras pulling directly, the migration is
-just repointing those input URLs from the camera address to the Crumb restream
-URLs above, one camera at a time. Nothing else in your Frigate config has to
-change. Crumb becomes the single connection to each camera; Frigate keeps doing
-detection, now sourced from Crumb.
+Two things move separately when you put Crumb next to an existing Frigate
+install: the camera **connection** and the **recording**. Keeping them straight
+is what makes the transition undramatic.
 
-## Object detection (bring your own)
+**The connection (so each camera is pulled once).** You have two ways to avoid
+both systems dialing the camera, and either works:
 
-Crumb does not bundle an object detector and never runs its own object,
-face, or plate detection. If you point Crumb at your own running instance
-of a compatible detector, Crumb stores and displays whatever labels it
-produces, including named people or license plates if you've configured
-the detector for that, since at that point it's your data from your own
-tool.
+- **Crumb's go2rtc as the hub.** Repoint Frigate's input URLs from the camera
+  address to Crumb's restream (the `rtsp://<crumb-host>:18554/...` URLs above),
+  one camera at a time. Crumb pulls the camera; Frigate fans out from Crumb.
+  Nothing else in your Frigate config changes.
+- **Reuse Frigate's go2rtc.** If you'd rather leave Frigate as the puller, point
+  Crumb's camera source at Frigate's existing go2rtc restream instead of at the
+  camera (Frigate publishes RTSP on port `8554`, for example
+  `rtsp://<frigate-host>:8554/<name>`). Crumb then consumes Frigate's stream and
+  never dials the camera itself.
+
+Either direction gives you one connection per camera. Which side is "the hub" is
+just which go2rtc holds the camera session.
+
+**The recording (the part that isn't automatic).** Crumb records its own footage
+into its own storage from the moment you add the camera, and it does not read or
+import Frigate's recordings (see
+[Why Crumb records its own footage](#why-crumb-records-its-own-footage-and-doesnt-read-frigates)
+above). So this is a decision, not a repoint:
+
+- Your existing Frigate recordings stay in Frigate. They don't appear in Crumb's
+  timeline, and adding Crumb does not migrate that history across.
+- Crumb builds its own recording history going forward. Point it at storage
+  you're happy to keep footage on, and set retention there; see
+  [Recording & storage](/recording/).
+- Decide whether Frigate should keep recording too. If you want Crumb to be the
+  recorder, drop the `record` role from Frigate's config so you're not paying
+  disk for two copies of everything. If you want both, leave it: they're then
+  independent archives on independent retention.
+
+Nothing forces the choice on day one. You can let both record for a while,
+confirm Crumb's timeline holds what you expect, and turn Frigate's recording off
+later.
 
 ## How it connects
 
-Detections arrive over MQTT: Crumb subscribes to the same broker your
-detector already publishes events to. If you don't already have an MQTT
-broker, a bundled one is available behind an opt-in Compose profile,
-so it costs nothing to a stock install unless you turn it on:
+Detections arrive over MQTT: Crumb subscribes to the broker Frigate already
+publishes events to and draws whatever labels Frigate emits (person, car,
+package, and named people or plates if you've configured Frigate for that) as
+icons on the timeline, alongside pixel motion. If you don't already have an MQTT
+broker, a bundled one is available behind an opt-in Compose profile, so it costs
+nothing to a stock install unless you turn it on:
 
 ```bash
 docker compose --profile frigate up -d

--- a/docs-site/docs/playback/scrubbing.md
+++ b/docs-site/docs/playback/scrubbing.md
@@ -18,6 +18,10 @@ grabs a preview frame from the recording; after that, that spot is remembered,
 so dragging back and forth over a region you've already looked at is instant.
 Scrubbing a whole wall of cameras at the same moment works the same way.
 
+In practice, revisiting a spot you have already scrubbed redraws in about a
+millisecond (a cached image read) rather than the couple hundred milliseconds it
+takes to decode a fresh frame on a 4K camera.
+
 This smoothness is the reason Crumb records its own footage instead of reading a
 detector's recordings; if you run Frigate, see [why Crumb records its own
 footage](/integrations/frigate#why-crumb-records-its-own-footage-and-doesnt-read-frigates).

--- a/docs-site/docs/playback/scrubbing.md
+++ b/docs-site/docs/playback/scrubbing.md
@@ -18,6 +18,10 @@ grabs a preview frame from the recording; after that, that spot is remembered,
 so dragging back and forth over a region you've already looked at is instant.
 Scrubbing a whole wall of cameras at the same moment works the same way.
 
+This smoothness is the reason Crumb records its own footage instead of reading a
+detector's recordings; if you run Frigate, see [why Crumb records its own
+footage](/integrations/frigate#why-crumb-records-its-own-footage-and-doesnt-read-frigates).
+
 Two optional settings can make it even better on larger systems. Most people
 never need either one.
 

--- a/docs-site/docusaurus.config.js
+++ b/docs-site/docusaurus.config.js
@@ -91,6 +91,11 @@ const config = {
             label: 'Docs',
           },
           {
+            to: '/getting-started/quickstart',
+            label: 'Install',
+            position: 'left',
+          },
+          {
             to: '/responsible-use',
             label: 'Responsible use',
             position: 'left',

--- a/docs-site/sidebars.js
+++ b/docs-site/sidebars.js
@@ -6,8 +6,9 @@ const sidebars = {
     {
       type: 'category',
       label: 'Getting Started',
-      link: { type: 'doc', id: 'getting-started/what-is-crumb' },
+      link: { type: 'doc', id: 'getting-started/quickstart' },
       items: [
+        'getting-started/quickstart',
         'getting-started/what-is-crumb',
         'getting-started/requirements',
         'getting-started/install-docker-compose',

--- a/docs-site/src/pages/index.js
+++ b/docs-site/src/pages/index.js
@@ -46,8 +46,8 @@ function HomepageHeader() {
           </Link>
           <Link
             className={clsx('button button--outline button--lg', styles.secondaryButton)}
-            to="/getting-started/install-docker-compose">
-            Install with Docker Compose
+            to="/getting-started/quickstart">
+            Quickstart
           </Link>
         </div>
       </div>
@@ -92,10 +92,10 @@ export default function Home() {
                 <Link to="/getting-started/what-is-crumb">What is Crumb VMS</Link>.
               </li>
               <li>
-                Ready to install?{' '}
+                Ready to install? Follow the{' '}
+                <Link to="/getting-started/quickstart">Quickstart</Link>, or the detailed{' '}
                 <Link to="/getting-started/install-docker-compose">Install with Docker Compose</Link>{' '}
-                or{' '}
-                <Link to="/getting-started/install-with-ai-agent">install with an AI agent</Link>.
+                guide.
               </li>
               <li>
                 Setting up a client?{' '}


### PR DESCRIPTION
Two related docs additions:

**Frigate-storage FAQ, Quickstart, and install discoverability** (`b9dfebc`)
- A plain-language "why Crumb records its own footage instead of reading Frigate's recordings" explainer in the Frigate integration guide, and a short version in the README.
- A new **Quickstart** page for getting a first instance running.
- Install-guide discoverability tweaks and a couple of landing-page edits.

**Scrub-preview benchmark highlights** (`f9b2f6a`)
- Adds the measured revisit-scrub result (about a 1 ms cached-frame read vs a ~250 ms re-decode) to the README feature list and the scrubbing docs page, so the smoothness claim is backed by a concrete number. Full methodology and the result matrix are in the PR #2 benchmark comment.

Builds clean under `onBrokenLinks: throw`. No em-dashes, no third-party VMS names.
