### PR TITLE
fix(android): wall scrub tiles surface no-footage instead of freezing

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackWallScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackWallScreen.kt
@@ -110,12 +110,12 @@ private const val WALL_MAX_SPAN_MS = WALL_WINDOW_HOURS * 3600_000L
  * pinned at the bottom: a scrubbable coverage timeline, a "Latest" reset, and a
  * jump-to-date/time button.
  *
- * The bottom controls drive a single shared **cursor** time. Tapping a camera tile
- * opens that camera in single-camera [PlaybackScreen] seeded at the cursor — or at
- * its latest footage when the wall is at "Latest". (Per-tile frames don't track the
- * scrubbed time because thumbnail extraction isn't wired yet; the frozen entry frame
- * is just a "which camera is which" reference — the time-accurate footage shows once
- * you tap in.)
+ * The bottom controls drive a single shared **cursor** time. Scrubbing the shared
+ * timeline sets a preview time and every tile swaps to its RECORDED frame nearest
+ * that moment (fetched from the filmstrip), so the whole wall tracks the scrub; a
+ * tile shows "No footage" when no recording covers that instant for that camera.
+ * Tapping a tile opens that camera in single-camera [PlaybackScreen] seeded at the
+ * cursor, or at its latest footage when the wall is at "Latest".
  *
  * @param onOpenLive Switches to the Live tab (anchored so it never lands on
  *   another tab that happens to be under Playback on the back stack).
@@ -564,24 +564,36 @@ private fun WallSnapshotTile(
                 width = 320,
             ).onSuccess { frames ->
                 val nearest = frames.minByOrNull { abs(Time.parseToMillis(it.ts) - previewMs) }
-                if (nearest == null) {
-                    noFootage = true
-                    frame = null
-                } else {
-                    val scoped = runCatching { repo.mediaUrls().scopedUrl(camera.id, nearest.url) }.getOrNull()
-                    if (scoped != null) {
-                        val req = ImageRequest.Builder(context)
-                            .data(scoped)
-                            .allowHardware(false)
-                            .build()
-                        val result = context.imageLoader.execute(req)
-                        if (result is SuccessResult) {
-                            (result.drawable as? BitmapDrawable)?.bitmap?.let {
-                                frame = it.asImageBitmap(); noFootage = false
-                            }
-                        }
-                    }
+                val scoped = nearest?.let {
+                    runCatching { repo.mediaUrls().scopedUrl(camera.id, it.url) }.getOrNull()
                 }
+                val bmp = if (scoped == null) {
+                    null
+                } else {
+                    val req = ImageRequest.Builder(context)
+                        .data(scoped)
+                        .allowHardware(false)
+                        .build()
+                    (context.imageLoader.execute(req) as? SuccessResult)
+                        ?.let { it.drawable as? BitmapDrawable }
+                        ?.bitmap
+                }
+                if (bmp != null) {
+                    frame = bmp.asImageBitmap()
+                    noFootage = false
+                } else {
+                    // No thumbnail available at this instant (the frame request
+                    // 404s when no recorded segment covers previewMs), or the
+                    // image fetch failed. Surface it instead of silently holding
+                    // the stale "Latest" frame — that silent-hold was the bug.
+                    frame = null
+                    noFootage = true
+                }
+            }.onFailure {
+                // The filmstrip LIST request itself failed; don't leave the tile
+                // frozen on its old frame with no feedback.
+                frame = null
+                noFootage = true
             }
         }
     }


### PR DESCRIPTION
Fixes #12.

## Root cause
The wall's tiles didn't follow the scrub because a failed per-frame **image** fetch was silently ignored:
- `list_thumbnail_times` is a stub returning empty, so `list_filmstrip` always falls back to synthetic grid slots -> the LIST always succeeds, making the `nearest == null` "No footage" branch dead code.
- The per-frame image failed (it turned out extraction itself was broken server-side, see #14/#15); Coil returned `ErrorResult`, and `WallSnapshotTile` only handled `SuccessResult`, so it kept the stale "Latest" frame with no feedback.

## Fix (client-only, `PlaybackWallScreen.kt`)
- Any non-success (image `ErrorResult`, or null scoped URL) now sets `noFootage = true; frame = null`.
- Added `.onFailure { … }` to the `repo.filmstrip(...)` call.
- Corrected the stale KDoc.

Tiles now react to the scrub: a frame where footage exists at that instant, "No footage" where it doesn't.

## Verification — CONFIRMED on-device ✅
Built + installed to the test phone and scrubbed the wall: tiles now update to real frames (and show "No footage" only for genuine gaps) instead of freezing. This was verified together with the server-side extraction fix (#15, deployed to prod), which was the critical half; #13 makes the client react correctly and surface failures instead of hiding them behind a frozen frame. Also compiled clean out-of-band (`gradlew assembleDebug`), since Android isn't built in PR CI.

## Related
- **#15** (server: force `-f mjpeg`) was the actual cause of the 100% frame failure; both are needed for the wall to work.
- **#9** (coverage-aware `list_thumbnail_times`) will stop the LIST returning synthetic slots for gaps, further reducing false "No footage".
