### PR TITLE
fix(api): force -f mjpeg for thumbnail extraction (fixes 100% scrub 404)

### DIFF
--- a/services/api/src/filmstrip.rs
+++ b/services/api/src/filmstrip.rs
@@ -401,6 +401,13 @@ async fn extract_thumbnail(
         format!("scale={w}:-2"),
         "-q:v".to_owned(),
         "4".to_owned(),
+        // Force the muxer explicitly. The atomic-write temp path ends in
+        // `.tmp{seq}` (not `.jpg`), so ffmpeg cannot infer the output format from
+        // the extension and fails to open the output — every extraction 404s. A
+        // single-frame mjpeg IS a JPEG, so the served bytes and the `.jpg` cache
+        // file are unchanged.
+        "-f".to_owned(),
+        "mjpeg".to_owned(),
         tmp_path.to_string_lossy().into_owned(),
     ];
 


### PR DESCRIPTION
Fixes #14.

## The bug
Scrub-preview thumbnail extraction has been **100% failing** since PR #2. `extract_thumbnail` renders ffmpeg output to the atomic-write temp path `…_w{w}.jpg.tmp{seq}`, but the ffmpeg args carry **no `-f`**, so ffmpeg infers the muxer from the extension. `.tmp{seq}` is unknown:
```
Unable to choose an output format for '…/x.jpg.tmp99'; use a standard extension or specify the format manually.
```
Extraction never produces output → `serve_frame` returns `404 "could not extract a thumbnail"` → the multi-camera wall / timeline scrub shows "No footage" everywhere.

## Why it slipped through
Phase 0 (the benchmarked change) wrote straight to the `.jpg` path, so the format inferred fine. Phase 1's atomic temp-write (`.jpg` → `.jpg.tmp{seq}`) broke inference and was never exercised end-to-end against a real extraction.

## The fix
Add explicit `-f mjpeg` to the ffmpeg args. A single-frame mjpeg is a JPEG, so the served bytes and the `.jpg` cache file are byte-identical to intent; only the muxer selection changes.

## Verification
- Reproduced + fixed against the **live prod api**: its exact command fails without `-f` (`NO_OUTPUT`) and produces a valid 5 KB JPEG with `-f mjpeg`.
- Gate green on dev2: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --workspace` all pass.

## Impact / rollout
Affects on-demand extraction **and** the pre-gen worker (both call `extract_thumbnail`). This is the server-side root cause behind #12 (surfaced by #13's client-side visibility fix). Once merged, prod needs an api redeploy (bump `CRUMB_VERSION` → pull) for the scrub to work.
