### PR TITLE
fix(desktop): gapless playback across segment boundaries

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -619,7 +619,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crumb-desktop"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "base64 0.22.1",
  "futures",

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -392,6 +392,8 @@ fn configure_mpv(child_hwnd: isize, url: &str) -> Result<Mpv, String> {
     mpv.set_option("demuxer-max-back-bytes", "1MiB")?;
     mpv.set_option("rtsp-transport", "tcp")?;
     mpv.set_option("keep-open", "yes")?;
+    mpv.set_option("prefetch-playlist", "yes")?;
+    mpv.set_option("gapless-audio", "yes")?;
     // Stream resilience: give up on a dead RTSP feed after ~10 s of no data and
     // let FFmpeg attempt reconnects, so a transient drop recovers instead of
     // freezing on the last frame. A hard stall is also caught by the frontend
@@ -557,6 +559,12 @@ fn sync_panes(app: AppHandle, panes: Vec<PaneSpec>) -> Result<Vec<PaneZoom>, Str
                     }
                     if pane.url != spec.url {
                         pane.mpv.loadfile(&spec.url)?;
+                        // A replacing loadfile is a jump / camera-switch, never a
+                        // gapless boundary advance (those skip sync_panes). Drop any
+                        // segment the playback prefetch appended for the OLD position
+                        // so mpv can't auto-advance to it after this file ends. No-op
+                        // for live panes (single-entry playlists).
+                        let _ = pane.mpv.playlist_clear();
                         pane.url = spec.url.clone();
                         if spec.preserve_zoom {
                             // Same camera, next playback segment — keep the
@@ -1164,6 +1172,36 @@ fn seek_pane(
     } else {
         pane.mpv.set_property("time-pos", &format!("{seconds:.3}"))
     }
+}
+
+/// Append a URL to a pane's mpv playlist (gapless segment prefetch). mpv's
+/// `prefetch-playlist` demuxes the appended file while the current one is still
+/// playing, so the decoder is already warm when the boundary arrives.
+#[tauri::command]
+fn append_pane_next(app: AppHandle, id: String, url: String) -> Result<(), String> {
+    let state = app.state::<AppState>();
+    let map = state.panes.lock().unwrap_or_else(|p| p.into_inner());
+    let pane = map.get(&id).ok_or("no such pane")?;
+    pane.mpv.loadfile_append(&url)
+}
+
+/// Advance a pane to the next playlist entry (the segment appended by
+/// [`append_pane_next`]). `weak` means "do nothing if there is no next entry"
+/// rather than erroring. Also updates the stored URL so a subsequent
+/// `sync_panes` doesn't see a stale mismatch and re-loadfile.
+#[tauri::command]
+fn advance_pane(app: AppHandle, id: String, url: String) -> Result<(), String> {
+    let state = app.state::<AppState>();
+    let mut map = state.panes.lock().unwrap_or_else(|p| p.into_inner());
+    let pane = map.get_mut(&id).ok_or("no such pane")?;
+    pane.mpv.command(&["playlist-next", "weak"])?;
+    // Drop the now-played entry so the playlist never grows past {current, next}
+    // over a long linear playback (each boundary appends one). `playlist-clear`
+    // keeps the current file, so this can't perturb what's on screen; the next
+    // prefetch re-appends. Best-effort — a hiccup here only leaves a stale entry.
+    let _ = pane.mpv.playlist_clear();
+    pane.url = url;
+    Ok(())
 }
 
 /// Set playback speed for a single pane.
@@ -1942,6 +1980,8 @@ pub fn run() {
             set_pane_paused,
             set_pane_muted,
             seek_pane,
+            append_pane_next,
+            advance_pane,
             set_pane_speed,
             frame_step_pane,
             snapshot_pane,

--- a/apps/desktop/src-tauri/src/mpv.rs
+++ b/apps/desktop/src-tauri/src/mpv.rs
@@ -195,6 +195,14 @@ impl Mpv {
         self.command(&["loadfile", url])
     }
 
+    pub fn loadfile_append(&self, url: &str) -> Result<(), String> {
+        self.command(&["loadfile", url, "append"])
+    }
+
+    pub fn playlist_clear(&self) -> Result<(), String> {
+        self.command(&["playlist-clear"])
+    }
+
     /// Create an OpenGL render context for this player (Linux render-API path).
     ///
     /// `get_proc_address` resolves GL symbols against the *current* GL context

--- a/apps/desktop/src/app.js
+++ b/apps/desktop/src/app.js
@@ -6966,6 +6966,7 @@ async function pbPrefetchNextSegment(slot) {
         segEndMs:   seg.endMs,
         segDurationMs: seg.duration_ms ?? (seg.endMs - seg.startMs),
       });
+      void invoke('append_pane_next', { id: 'slot' + slot, url: seg.absoluteUrl }).catch(() => {});
     }
   } catch { /* ignore — the boundary resolve will fall back to a live fetch */ }
   finally { pbState._prefetching.delete(slot); }
@@ -7259,7 +7260,7 @@ async function pbResolveAllPanesInner(tMs, forceReload = false) {
     const pre = pbState.slotNextSeg.get(i);
     if (!forceReload && pre && tMs >= pre.segStartMs && tMs < pre.segEndMs) {
       pbState.slotNextSeg.delete(i); // consume it
-      segFetches.push(Promise.resolve({ slot: i, seg: pre }));
+      segFetches.push(Promise.resolve({ slot: i, seg: pre, gapless: true }));
       continue;
     }
 
@@ -7282,8 +7283,10 @@ async function pbResolveAllPanesInner(tMs, forceReload = false) {
 
   const results = await Promise.all(segFetches);
 
-  // Determine which panes need a new URL pushed via sync_panes
+  // Determine which panes need a new URL pushed via sync_panes (gapless
+  // boundary advances are handled by mpv's playlist, not a loadfile).
   const needsSync = results.some(r => {
+    if (r.gapless) return false;
     const existing = pbState.slotSegments.get(r.slot);
     if (!r.seg && !existing) return false;
     if (!r.seg || !existing) return true;
@@ -7292,6 +7295,16 @@ async function pbResolveAllPanesInner(tMs, forceReload = false) {
 
   // Update state
   results.forEach(r => pbState.slotSegments.set(r.slot, r.seg ?? null));
+
+  // Advance gapless panes: mpv's playlist already has the next entry appended
+  // (prefetch-playlist demuxed it), so playlist-next transitions with the
+  // decoder already warm — no re-init stutter.
+  const advanceOps = results.filter(r => r.gapless).map(r =>
+    invoke('advance_pane', { id: `slot${r.slot}`, url: r.seg.segmentUrl }).catch(e => {
+      console.warn(`advance_pane slot${r.slot} failed:`, e);
+    })
+  );
+  if (advanceOps.length) await Promise.all(advanceOps);
 
   // Update tile "no footage" styling
   const grid = els.pbTileGrid;
@@ -7321,6 +7334,7 @@ async function pbResolveAllPanesInner(tMs, forceReload = false) {
     results.forEach(r => {
       if (!r.seg) return;
       if (!forceReload && r.cached) return;
+      if (r.gapless) return;
       const offsetSec = Math.max(0, (tMs - r.seg.segStartMs) / 1000);
       seekOps.push(
         invoke('seek_pane', { id: `slot${r.slot}`, seconds: offsetSec }).catch(e => {


### PR DESCRIPTION
Fixes #8

## Problem
Desktop recorded-playback played footage one 4s segment at a time. At each boundary the frontend re-resolved the next `/segments/{id}.mp4` and issued a fresh mpv `loadfile`, tearing down and re-initializing mpv's demux/decode pipeline for the new standalone fMP4 — a visible ~4s (`SEGMENT_SECONDS`) hitch. Not a decode/perf problem.

## Fix (client-only, no recorder changes)
Use mpv's gapless playlist so the decoder is already warm at the boundary.

- **`mpv.rs`** — add `loadfile_append()` (playlist append) + `playlist_clear()`.
- **`lib.rs`** — set `prefetch-playlist=yes` + `gapless-audio=yes` at pane init so mpv pre-demuxes the appended next segment while the current one plays. New commands `append_pane_next` / `advance_pane` (advance updates the stored URL so a later `sync_panes` doesn't see a stale mismatch and re-loadfile).
- **`app.js`** — `pbPrefetchNextSegment` appends the next segment to the pane's mpv playlist as it prefetches. At the boundary a consumed prefetch is marked `gapless` and transitions via `playlist-next` (decoder warm), skipping the `sync_panes` loadfile + the offset-0 seek. Jumps/scrubs (`forceReload`) keep the existing `loadfile`-replace path.

### Playlist hygiene
So the append can't strand a stale segment:
- `advance_pane` clears the now-played entry after `playlist-next` → linear playback never grows the playlist past `{current, next}`.
- the `sync_panes` replacing-loadfile path (jump / camera-switch) clears the playlist too, so a jump fired in the ~1s window after the next segment was prefetch-appended can't auto-advance into that stale entry when the jumped-to file ends. Both keep the current file (no on-screen effect); no-op for live panes.

## Why no recorder change
The recorder's `-reset_timestamps` + standalone-fMP4 flags are load-bearing for clock-aligned, independently-seekable segments (golden rule 2). This works *with* the independent-segment shape, not against it.

## Verification
- On-screen (Windows): stutter gone at 4s boundaries during continuous playback; scrub + jump still land on the correct segment; digital zoom/pan preserved across boundaries; no black/wedged panes under scrub + jump + boundary crossing.
- Desktop `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` green.