### PR TITLE
fix(desktop): show date on playback timeline when scrubbed off today

### DIFF
--- a/apps/desktop/src/app.js
+++ b/apps/desktop/src/app.js
@@ -8111,7 +8111,21 @@ function pbUpdateTimeDisplay() {
   const hh = String(d.getHours()).padStart(2, '0');
   const mm = String(d.getMinutes()).padStart(2, '0');
   const ss = String(d.getSeconds()).padStart(2, '0');
-  els.pbTimeDisplay.textContent = `${hh}:${mm}:${ss}`;
+  if (!pbIsToday(pbState.playheadMs)) {
+    const mon = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    els.pbTimeDisplay.textContent = `${mon}/${day} ${hh}:${mm}:${ss}`;
+  } else {
+    els.pbTimeDisplay.textContent = `${hh}:${mm}:${ss}`;
+  }
+}
+
+function pbIsToday(epochMs) {
+  const d = new Date(epochMs);
+  const now = new Date();
+  return d.getFullYear() === now.getFullYear() &&
+         d.getMonth() === now.getMonth() &&
+         d.getDate() === now.getDate();
 }
 
 // ── Keyboard shortcuts (playback) ─────────────────────────────────────────────
@@ -8854,15 +8868,24 @@ function pbPickGridInterval(winDurMs) {
   return 6 * HRS;                                   // 6 h
 }
 
-/** Format a label appropriate to the grid interval. */
+/** Format a label appropriate to the grid interval.
+ *  Prefixes a short date (MM/DD) when the gridline falls on a day other than
+ *  today, so scrubbing into the past never loses day context. */
 function pbFmtGridLabel(epochMs, intervalMs) {
   const d  = new Date(epochMs);
   const hh = String(d.getHours()).padStart(2, '0');
   const mm = String(d.getMinutes()).padStart(2, '0');
   const ss = String(d.getSeconds()).padStart(2, '0');
-  if (intervalMs >= 3600_000) return `${hh}:00`;
-  if (intervalMs >= 60_000)   return `${hh}:${mm}`;
-  return `${hh}:${mm}:${ss}`;
+  let time;
+  if (intervalMs >= 3600_000) time = `${hh}:00`;
+  else if (intervalMs >= 60_000) time = `${hh}:${mm}`;
+  else time = `${hh}:${mm}:${ss}`;
+  if (!pbIsToday(epochMs)) {
+    const mon = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${mon}/${day} ${time}`;
+  }
+  return time;
 }
 
 /** Human-readable window duration label for the span badge. */
@@ -8881,6 +8904,11 @@ function pbFmtTime(epochMs) {
   const hh = String(d.getHours()).padStart(2, '0');
   const mm = String(d.getMinutes()).padStart(2, '0');
   const ss = String(d.getSeconds()).padStart(2, '0');
+  if (!pbIsToday(epochMs)) {
+    const mon = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${mon}/${day} ${hh}:${mm}:${ss}`;
+  }
   return `${hh}:${mm}:${ss}`;
 }
 

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1476,7 +1476,7 @@ body.vs-reordering, body.vs-reordering * { cursor: grabbing !important; user-sel
   font-weight: 600;
   color: var(--text);
   letter-spacing: 1px;
-  min-width: 84px;
+  min-width: 130px;
   text-align: center;
 }
 


### PR DESCRIPTION
Fixes #17

## Problem
In desktop playback, the timeline scrubber and time readouts showed only the time of day (`HH:MM:SS`), never the date. Scrub back a day or more and there was **no indication of which day** was on screen — the whole UI read as if it were still today.

## Fix
Add a shared `pbIsToday()` helper and prefix a short `MM/DD` date whenever the value falls on a day other than today, in the three places that render a playback time:

- `pbFmtGridLabel` — timeline gridline labels.
- `pbFmtTime` — bottom edge timestamps + the centered playhead chip.
- `pbUpdateTimeDisplay` — the large transport-bar readout.

Today stays time-only (no change to the common case); only past days get the date prefix, so the label exactly marks where the day changes across a window that spans midnight. The transport-bar readout `min-width` is widened so the `MM/DD` prefix doesn't clip.

## Verification
- On-screen (Windows): scrubbed back to a prior day — grid labels, edge timestamps, playhead chip, and the large readout all show `MM/DD HH:MM(:SS)`; today's view is unchanged.
- `node --check` on the extracted script; no new undefined globals (ESLint `no-undef` clean).