### PR TITLE
ci(android): manual APK re-ship + bump versionCode

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -28,6 +28,19 @@ name: android-release
 on:
   push:
     tags: ["v*"]
+  # Manual re-ship: rebuild + re-sign the APK from the selected branch and REPLACE
+  # the asset on an EXISTING release, without cutting a new version tag (and
+  # without firing the macOS/Windows release builds, which only trigger on v*).
+  # Use this when you've fixed something Android-only and just want a fresh signed
+  # APK on the same release. Bump apps/android/version.properties VERSION_CODE
+  # first (Android refuses an update with an equal/lower code), then run this from
+  # the branch that has the fix (default: the default branch).
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing release tag to attach the rebuilt APK to (e.g. v0.0.1)"
+        required: true
+        type: string
 
 permissions:
   contents: write   # to create/update the GitHub Release and upload the APK
@@ -125,7 +138,12 @@ jobs:
       - name: Upload signed APK + checksum to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          # Tag push -> the pushed tag; manual re-ship -> the release_tag input
+          # (the existing release whose APK we're replacing).
+          tag_name: ${{ github.event.inputs.release_tag || github.ref_name }}
           files: |
             apps/android/${{ steps.apk.outputs.path }}
             apps/android/${{ steps.sum.outputs.path }}
-          generate_release_notes: true
+          # Only (re)generate notes when creating the release on a tag push; a
+          # manual re-ship must not clobber an existing release's notes.
+          generate_release_notes: ${{ github.event_name == 'push' }}

--- a/apps/android/version.properties
+++ b/apps/android/version.properties
@@ -12,5 +12,5 @@
 # These are read by app/build.gradle.kts; if this file is missing or a key is
 # absent, sane debug-friendly defaults are used instead (versionCode=1,
 # versionName="0.0.1-dev") so local builds never hard-fail.
-VERSION_CODE=1
+VERSION_CODE=2
 VERSION_NAME=0.0.1

--- a/docs/COMPONENT-MAP.md
+++ b/docs/COMPONENT-MAP.md
@@ -66,7 +66,7 @@ All paths below are repo-relative and verified to exist as of 2026-07-06.
 |---|---|---|
 | CI gate | `.github/workflows/ci.yml` (jobs: `rust` fmt/clippy/test, `desktop-lint`, `desktop-linux`, `images` recorder+api) | Golden rule 3: fmt, clippy `-D warnings`, workspace tests green before push/PR |
 | Fresh-install smoke | `.github/workflows/smoke.yml` + `docker-compose.smoke.yml` | Boots the stack from scratch; install-surface changes must keep it green |
-| Android release | `.github/workflows/android-release.yml` | `v*` tag, signed APK + sha256 on the GitHub Release. Keystore is a CI secret |
+| Android release | `.github/workflows/android-release.yml` | `v*` tag, signed APK + sha256 on the GitHub Release. Keystore is a CI secret. Also `workflow_dispatch` (input: `release_tag`) to re-ship an Android-only fix onto an existing release without a new tag — bump `apps/android/version.properties` `VERSION_CODE` first |
 | CLA bot | `.github/workflows/cla.yml`, `CLA.md`, `CCLA.md`, `DCO` | |
 | Release orchestration | `scripts/release/` (`release.sh`, `lib.sh`, `backend.sh`, `android.sh`, `ios.sh`, `desktop-windows.sh`, `desktop-linux.sh`, `README.md`), `VERSION`, `docs/RELEASE.md` | Multi-host build fan-out over SSH; versioned-image deploy/rollback contract |
 | GitHub presence | `README.md`, `.github/ISSUE_TEMPLATE/`, `.github/pull_request_template.md`, `.github/FUNDING.yml`, `.github/media/` (README GIFs/screenshots), `LICENSE`, `NOTICE`, `SECURITY.md`, `CONTRIBUTING.md` | README screenshots/GIFs live in `.github/media/` and go stale when the UI changes |


### PR DESCRIPTION
## Why
The signed-APK workflow only ran on a `v*` tag, and any `v*` tag also fires the macOS and Windows release builds. There was no way to re-ship an **Android-only** fix (e.g. #13, the wall-scrub-tiles fix already merged to `main` but not yet in the published `v0.0.1` APK) as a fresh signed APK without either cutting a new version or rebuilding every desktop client.

## What
- **`android-release.yml`** — add a `workflow_dispatch` trigger with a `release_tag` input. It rebuilds + re-signs the APK from the selected branch and replaces the asset on that existing release (Android-only, no new tag, macOS/Windows untouched). The upload step targets `release_tag` on manual runs and the pushed tag on tag runs, and only regenerates release notes on a tag push so a re-ship can't clobber an existing release's notes.
- **`version.properties`** — bump `VERSION_CODE` 1 → 2 so the refreshed APK installs over the copy testers already have (Android refuses an equal/lower code). `VERSION_NAME` stays `0.0.1` — versionName is cosmetic; versionCode is the upgrade key.
- **`COMPONENT-MAP.md`** — document the manual re-ship path.

## How to use it after merge
1. Ensure the Android fix is on `main` (it is — #13).
2. Actions → **android-release** → **Run workflow**, from `main`, `release_tag = v0.0.1`.
3. It rebuilds, re-signs, and replaces `app-release.apk` (+ sha256) on the `v0.0.1` release. Testers get a clean in-place update thanks to the versionCode bump.

No desktop/backend behavior changes; other release workflows untouched.