### PR TITLE
fix(macos): export-window preview + format polish

### DIFF
--- a/apps/ios/Crumb/Features/Export/ExportView.swift
+++ b/apps/ios/Crumb/Features/Export/ExportView.swift
@@ -140,6 +140,10 @@ struct ExportView: View {
                 }
             }
             .aspectRatio(16.0 / 9.0, contentMode: .fit)
+            // Cap the height so a wide window doesn't blow the preview up to fill
+            // the whole column and push the camera + time-range controls below the
+            // fold. Centered; stays 16:9.
+            .frame(maxWidth: .infinity, maxHeight: 300)
             .clipShape(RoundedRectangle(cornerRadius: 10))
             // Scoped media token (P0-SESSIONS): the preview URL is now minted
             // async, so it's refreshed reactively rather than computed inline
@@ -175,6 +179,10 @@ struct ExportView: View {
             SectionHeader("Format")
             SurfaceCard {
                 VStack(alignment: .leading, spacing: 8) {
+                    // Menu-style picker with an explicit control chrome (filled +
+                    // bordered + chevron) so it reads as a real dropdown. The plain
+                    // picker rendered like a static "MP4 · H.264" caption, so the
+                    // other four formats went unnoticed.
                     Picker("", selection: Binding(
                         get: { vm.state.format },
                         set: { vm.setFormat($0) }
@@ -184,7 +192,16 @@ struct ExportView: View {
                         }
                     }
                     .labelsHidden()
-                    .tint(CrumbColors.tealAccent)
+                    .pickerStyle(.menu)
+                    .tint(CrumbColors.textPrimary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(CrumbColors.surfaceVariant, in: RoundedRectangle(cornerRadius: 8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .strokeBorder(CrumbColors.divider, lineWidth: 1)
+                    )
                     .disabled(vm.state.polling)
 
                     Text(vm.state.format.detail)

--- a/apps/ios/Crumb/Features/Export/ExportViewModel.swift
+++ b/apps/ios/Crumb/Features/Export/ExportViewModel.swift
@@ -125,7 +125,9 @@ final class ExportViewModel: ObservableObject {
         let iso = ISO8601DateFormatter().string(from: state.start)
         previewTask = Task { [weak self] in
             guard let self else { return }
-            let url = await container.mediaUrls().historicalFrameUrl(cameraId: camId, tsISO: iso)
+            // Request the server's max thumbnail width (640): the preview renders
+            // large, so the default ~160px still would look blurry blown up.
+            let url = await container.mediaUrls().historicalFrameUrl(cameraId: camId, tsISO: iso, width: 640)
             guard !Task.isCancelled else { return }
             previewURL = url
         }

--- a/apps/ios/Crumb/Networking/MediaUrls.swift
+++ b/apps/ios/Crumb/Networking/MediaUrls.swift
@@ -78,10 +78,18 @@ struct MediaUrls {
     }
 
     /// Historical still extracted on-demand from recorded footage at `ts`
-    /// (RFC-3339). Used for the playback wall's scrub-to-moment tile previews.
-    func historicalFrameUrl(cameraId: String, tsISO: String) async -> URL? {
+    /// (RFC-3339). Used for the playback wall's scrub-to-moment tile previews and
+    /// the export preview.
+    ///
+    /// `width` (px) is optional: when nil the server picks its default thumbnail
+    /// width (small, cache-shared with the scrub pre-gen — keep it nil for the
+    /// fast wall-scrub path). Callers that render the still LARGE (the export
+    /// preview) pass an explicit width up to the server cap (640) so it isn't a
+    /// tiny thumbnail blown up blurry.
+    func historicalFrameUrl(cameraId: String, tsISO: String, width: Int? = nil) async -> URL? {
         let encoded = tsISO.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? tsISO
-        return await scopedURL(cameraId: cameraId, "/filmstrip/\(cameraId)/frame?ts=\(encoded)")
+        let widthQuery = width.map { "&width=\($0)" } ?? ""
+        return await scopedURL(cameraId: cameraId, "/filmstrip/\(cameraId)/frame?ts=\(encoded)\(widthQuery)")
     }
 
     /// Thumbnail still for a clip. Requires token auth; scoped to `cameraId`.


### PR DESCRIPTION
Three fixes to the macOS/iOS SwiftUI export view (`apps/ios/Crumb/Features/Export/`), verified on a `Crumb-mac` build.

## Fixes
- **Blurry preview** — the export preview requested no thumbnail width, so `/filmstrip/{cam}/frame` served its ~160px default (`default_thumb_width`) blown up huge. `MediaUrls.historicalFrameUrl` gains an optional `width:`; the export preview now passes **640** (the server's `THUMB_MAX_WIDTH`). Other callers (the playback wall's fast-scrub path) are unchanged — `nil` width keeps them on the shared pre-gen cache.
- **Preview dominated the layout** — on a wide window the 16:9 preview grew to fill the whole left column, pushing the camera list + time range below the fold. Capped at 300pt tall, centered.
- **"Only one format"** — the picker already offers all five (MP4/MKV × H264/H265/copy) but rendered like a static caption. Restyled as a bordered `.menu` picker with a chevron so the formats are discoverable.

## Verification
- `xcodebuild -scheme Crumb-mac` → **BUILD SUCCEEDED**.
- On-screen: the preview is crisp (was blurry), the layout no longer buries controls, and the format reads as a dropdown.

## Not in this PR
Broader Windows-parity work is tracked in a separate issue: batch-list export model, default-camera seeding when exporting from a fullscreen playback tile, scrubber export-region resize, and the playback wall-tile blur.