### PR TITLE
feat(macos): Windows-parity export + playback (closes #22)

### DIFF
--- a/apps/ios/Crumb/App/Theme.swift
+++ b/apps/ios/Crumb/App/Theme.swift
@@ -8,6 +8,10 @@ enum CrumbColors {
     static let surfaceVariant = Color(hex: 0x2C2C2C)
     static let teal = Color(hex: 0x009688)
     static let tealAccent = Color(hex: 0x4DB6AC)
+    /// "On / enabled" switch tint. A bright, unmistakably-positive green — the
+    /// dark `teal` reads too close in luminance to the gray off-track to signal
+    /// "on" at switch scale.
+    static let positive = Color(hex: 0x4CAF50)
     static let recDot = Color(hex: 0xFF1744)
     static let motionDot = Color(hex: 0xFFAB00)
     static let timelineGreen = Color(hex: 0x4CAF50)

--- a/apps/ios/Crumb/Features/Export/ExportView.swift
+++ b/apps/ios/Crumb/Features/Export/ExportView.swift
@@ -290,14 +290,17 @@ struct ExportView: View {
                     // persist the tokened URL (and thus the token) to disk.
                     // `TokenedAsyncImage` (MediaSession.swift) fetches via the
                     // ephemeral `.crumbMedia` session instead — in-memory only.
-                    TokenedAsyncImage(url: url) { img in
+                    //
+                    // keepStaleImage: the URL changes on every scrub/play tick;
+                    // the previous frame must stay up while the next one loads
+                    // (blanking per tick = a black flash per frame).
+                    TokenedAsyncImage(url: url, keepStaleImage: true) { img in
                         img.resizable().scaledToFit()
                     } placeholder: {
                         ProgressView().tint(CrumbColors.tealAccent)
                     } failure: {
                         previewPlaceholder("No footage at this moment")
                     }
-                    .id(url)   // reload when camera/position changes
                 } else {
                     previewPlaceholder("Pick a camera to preview")
                 }

--- a/apps/ios/Crumb/Features/Export/ExportView.swift
+++ b/apps/ios/Crumb/Features/Export/ExportView.swift
@@ -140,6 +140,10 @@ struct ExportView: View {
                 }
             }
             .aspectRatio(16.0 / 9.0, contentMode: .fit)
+            // Cap the height so a wide window doesn't blow the preview up to fill
+            // the whole column and push the camera + time-range controls below the
+            // fold. Centered; stays 16:9.
+            .frame(maxWidth: .infinity, maxHeight: 300)
             .clipShape(RoundedRectangle(cornerRadius: 10))
             // Scoped media token (P0-SESSIONS): the preview URL is now minted
             // async, so it's refreshed reactively rather than computed inline
@@ -175,6 +179,10 @@ struct ExportView: View {
             SectionHeader("Format")
             SurfaceCard {
                 VStack(alignment: .leading, spacing: 8) {
+                    // Menu-style picker with an explicit control chrome (filled +
+                    // bordered + chevron) so it reads as a real dropdown. The plain
+                    // picker rendered like a static "MP4 · H.264" caption, so the
+                    // other four formats went unnoticed.
                     Picker("", selection: Binding(
                         get: { vm.state.format },
                         set: { vm.setFormat($0) }
@@ -184,7 +192,16 @@ struct ExportView: View {
                         }
                     }
                     .labelsHidden()
-                    .tint(CrumbColors.tealAccent)
+                    .pickerStyle(.menu)
+                    .tint(CrumbColors.textPrimary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(CrumbColors.surfaceVariant, in: RoundedRectangle(cornerRadius: 8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .strokeBorder(CrumbColors.divider, lineWidth: 1)
+                    )
                     .disabled(vm.state.polling)
 
                     Text(vm.state.format.detail)

--- a/apps/ios/Crumb/Features/Export/ExportView.swift
+++ b/apps/ios/Crumb/Features/Export/ExportView.swift
@@ -481,7 +481,7 @@ struct ExportView: View {
             Toggle("", isOn: Binding(get: get, set: set))
                 .labelsHidden()
                 .toggleStyle(.switch)
-                .tint(CrumbColors.teal)
+                .tint(CrumbColors.positive)
                 .disabled(vm.state.polling)
         }
         .padding(.horizontal, 16)
@@ -755,7 +755,8 @@ private struct ClipRow: View {
     let onEdit: () -> Void
     let onRemove: () -> Void
 
-    @State private var url: URL?
+    @State private var image: PlatformImage?
+    @State private var failed = false
 
     var body: some View {
         HStack(spacing: 12) {
@@ -766,15 +767,19 @@ private struct ClipRow: View {
 
             ZStack {
                 Color.black
-                if let url {
-                    TokenedAsyncImage(url: url) { img in
-                        img.resizable().scaledToFill()
-                    } placeholder: {
-                        EmptyView()
-                    } failure: {
-                        EmptyView()
-                    }
-                    .id(url)
+                if let image {
+                    Image(platformImage: image).resizable().scaledToFill()
+                } else if failed {
+                    // Distinguish a genuinely-failed extraction from a dark night
+                    // frame — a silent black tile reads as "broken" either way.
+                    Image(systemName: "camera.metering.unknown")
+                        .font(.system(size: 12))
+                        .foregroundColor(CrumbColors.textTertiary)
+                } else {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .scaleEffect(0.5)
+                        .tint(CrumbColors.textTertiary)
                 }
             }
             .frame(width: 64, height: 36)
@@ -818,7 +823,35 @@ private struct ClipRow: View {
         .padding(.vertical, 8)
         .background(CrumbColors.surface)
         .cornerRadius(10)
-        .task(id: clip) { url = await thumbURL() }
+        .task(id: clip) { await loadThumb() }
+    }
+
+    /// Load the clip's start-frame thumbnail, retrying transient failures.
+    /// The clip-start still is an ON-DEMAND server extraction (not a pre-cached
+    /// clip thumbnail), and the frame endpoint drops some requests when several
+    /// rows fetch at once — a single silent fetch left the tile permanently
+    /// black. Mirrors the proven retry loop in `ClipThumbnail` (ClipsView).
+    private func loadThumb() async {
+        failed = false
+        image = nil
+        for attempt in 0..<4 {
+            if Task.isCancelled { return }
+            guard let url = await thumbURL() else {
+                try? await Task.sleep(nanoseconds: UInt64(attempt + 1) * 600_000_000)
+                continue
+            }
+            var req = URLRequest(url: url)
+            req.cachePolicy = .returnCacheDataElseLoad
+            req.timeoutInterval = 12
+            if let (data, resp) = try? await URLSession.crumbMedia.data(for: req),
+               let http = resp as? HTTPURLResponse, (200...299).contains(http.statusCode),
+               let img = PlatformImage(data: data) {
+                image = img
+                return
+            }
+            try? await Task.sleep(nanoseconds: UInt64(attempt + 1) * 600_000_000)
+        }
+        if !Task.isCancelled { failed = true }
     }
 
     /// Wall-clock "MM/dd HH:mm:ss" for a clip edge (desktop `exportFmtClock`).

--- a/apps/ios/Crumb/Features/Export/ExportView.swift
+++ b/apps/ios/Crumb/Features/Export/ExportView.swift
@@ -7,11 +7,14 @@ import AppKit
 
 // MARK: - Sheet entry point
 
-/// Export sheet: operator picks cameras, adjusts the clip window, toggles burn-in,
-/// taps Export, then watches the job progress to completion. On success the iOS
-/// native Share sheet presents the authenticated download URL(s).
+/// Export view, mirroring the desktop client's batch-list flow: the operator
+/// builds a LIST of clips (camera + range each, "+ Add to list"), sets global
+/// output options (format, burn-in, audio, optional AES-256 ZIP password), then
+/// runs the whole batch as one job and watches it to completion. On success each
+/// output file offers a native Share (iOS) / Save (macOS) action.
 ///
-/// Present this as `.sheet(isPresented:)` from a parent view.
+/// Present as `.sheet(isPresented:)` from playback, or embed (the macOS
+/// Exports tab).
 struct ExportView: View {
 
     @StateObject private var vm: ExportViewModel
@@ -20,24 +23,24 @@ struct ExportView: View {
     /// - Parameters:
     ///   - container: App-wide service locator.
     ///   - cameras: Full list of cameras the user may pick from.
-    ///   - cameraIds: Pre-selected camera IDs.
-    ///   - start: Pre-filled clip start.
-    ///   - end: Pre-filled clip end.
-    ///   - onClose: Called when the user taps Cancel / Done.
+    ///   - seedCameraId: Camera to pre-select in the add-clip builder (the
+    ///     camera the user was viewing), nil for no preference.
+    ///   - initialRange: Non-nil (playback "Export selection…" path) opens the
+    ///     builder pre-filled with this range so it's one click to add the
+    ///     first clip. nil (Exports tab) starts in list mode.
+    ///   - onClose: Called when the user taps Close.
     init(
         container: AppContainer,
         cameras: [CameraDto],
-        cameraIds: [String],
-        start: Date,
-        end: Date,
+        seedCameraId: String? = nil,
+        initialRange: (start: Date, end: Date)? = nil,
         onClose: @escaping () -> Void
     ) {
         _vm = StateObject(wrappedValue: ExportViewModel(
             container: container,
             cameras: cameras,
-            cameraIds: cameraIds,
-            start: start,
-            end: end
+            seedCameraId: seedCameraId,
+            initialRange: initialRange
         ))
         self.onClose = onClose
     }
@@ -94,12 +97,14 @@ struct ExportView: View {
 
     // MARK: - Columns
 
-    /// Left builder column: what to export.
+    /// Left builder column: what to export — the clip list, or the add/edit-clip
+    /// builder while it's open (desktop list mode ⇄ builder mode).
+    @ViewBuilder
     private var leftColumn: some View {
-        VStack(alignment: .leading, spacing: 18) {
-            previewSection
-            cameraSection
-            timeRangeSection
+        if vm.state.builder != nil {
+            builderSection
+        } else {
+            listSection
         }
     }
 
@@ -108,16 +113,174 @@ struct ExportView: View {
         VStack(alignment: .leading, spacing: 18) {
             formatSection
             optionsSection
+            summarySection
             exportButton
             jobSection
         }
     }
 
-    // MARK: - Section: Preview
+    // MARK: - Section: Export list
 
-    private var previewSection: some View {
+    private var listSection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            SectionHeader("Preview")
+            HStack {
+                SectionHeader(vm.clipCount > 0 ? "Export list (\(vm.clipCount))" : "Export list")
+                Spacer()
+                Button {
+                    vm.openBuilder()
+                } label: {
+                    Label("Add clip", systemImage: "plus")
+                        .font(.subheadline.weight(.medium))
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(CrumbColors.tealAccent)
+                .disabled(vm.state.polling)
+            }
+
+            if let err = vm.state.cameraError {
+                Text(err)
+                    .font(.caption)
+                    .foregroundColor(CrumbColors.error)
+            }
+
+            if vm.state.clips.isEmpty {
+                SurfaceCard {
+                    VStack(spacing: 6) {
+                        Text("No clips yet.")
+                            .font(.subheadline)
+                            .foregroundColor(CrumbColors.textSecondary)
+                        Text("Add a camera + time range to build your export.")
+                            .font(.caption)
+                            .foregroundColor(CrumbColors.textTertiary)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 28)
+                }
+            } else {
+                ForEach(Array(vm.state.clips.enumerated()), id: \.element.id) { index, clip in
+                    ClipRow(
+                        index: index + 1,
+                        clip: clip,
+                        cameraName: cameraName(for: clip.cameraId),
+                        thumbURL: { [weak vm] in
+                            await vm?.mediaUrls().historicalFrameUrl(
+                                cameraId: clip.cameraId,
+                                tsISO: iso8601String(clip.start),
+                                width: 160
+                            )
+                        },
+                        onEdit: { vm.openBuilder(editing: clip) },
+                        onRemove: { vm.removeClip(clip.id) }
+                    )
+                    .disabled(vm.state.polling)
+                }
+            }
+        }
+        .padding(.bottom, 16)
+    }
+
+    // MARK: - Section: Add/edit-clip builder
+
+    @ViewBuilder
+    private var builderSection: some View {
+        if let b = vm.state.builder {
+            VStack(alignment: .leading, spacing: 12) {
+                SectionHeader(b.editId != nil ? "Edit clip" : "Add clip")
+
+                // Camera
+                SurfaceCard {
+                    HStack {
+                        Text("Camera")
+                            .font(.body)
+                            .foregroundColor(CrumbColors.textPrimary)
+                        Spacer()
+                        Picker("", selection: Binding(
+                            get: { b.cameraId ?? "" },
+                            set: { vm.setBuilderCamera($0) }
+                        )) {
+                            ForEach(vm.state.cameras) { cam in
+                                Text(cam.name).tag(cam.id)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.menu)
+                        .tint(CrumbColors.textPrimary)
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                }
+
+                // Range
+                SurfaceCard {
+                    DatePicker(
+                        "Start",
+                        selection: Binding(get: { b.start }, set: { vm.setBuilderStart($0) }),
+                        displayedComponents: [.date, .hourAndMinute]
+                    )
+                    .foregroundColor(CrumbColors.textPrimary)
+                    .tint(CrumbColors.tealAccent)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                }
+                SurfaceCard {
+                    DatePicker(
+                        "End",
+                        selection: Binding(get: { b.end }, set: { vm.setBuilderEnd($0) }),
+                        displayedComponents: [.date, .hourAndMinute]
+                    )
+                    .foregroundColor(CrumbColors.textPrimary)
+                    .tint(CrumbColors.tealAccent)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                }
+
+                Text("Duration: \(formatDuration(b.end.timeIntervalSince(b.start)))")
+                    .font(.caption)
+                    .foregroundColor(CrumbColors.textSecondary)
+
+                previewSection(b)
+
+                if let err = b.error {
+                    Text(err)
+                        .font(.subheadline)
+                        .foregroundColor(CrumbColors.error)
+                }
+
+                HStack(spacing: 10) {
+                    Button {
+                        vm.cancelBuilder()
+                    } label: {
+                        Text("Cancel")
+                            .font(.subheadline.weight(.medium))
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                            .background(CrumbColors.surfaceVariant, in: RoundedRectangle(cornerRadius: 10))
+                            .foregroundColor(CrumbColors.textPrimary)
+                    }
+                    .buttonStyle(.plain)
+
+                    Button {
+                        vm.commitBuilder()
+                    } label: {
+                        Text(b.editId != nil ? "Save changes" : "+ Add to list")
+                            .font(.subheadline.weight(.semibold))
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                            .background(CrumbColors.teal, in: RoundedRectangle(cornerRadius: 10))
+                            .foregroundColor(.white)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.bottom, 16)
+        }
+    }
+
+    /// Frame-accurate review before adding: a still at the scrubber position,
+    /// a play toggle (auto-advance, extraction-capped) and a scrub slider —
+    /// the desktop builder's preview scrubber.
+    private func previewSection(_ b: ExportBuilder) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
             ZStack {
                 Color.black
                 if let url = vm.previewURL {
@@ -132,30 +295,51 @@ struct ExportView: View {
                     } placeholder: {
                         ProgressView().tint(CrumbColors.tealAccent)
                     } failure: {
-                        previewPlaceholder("Preview unavailable")
+                        previewPlaceholder("No footage at this moment")
                     }
-                    .id(url)   // reload when camera/start changes
+                    .id(url)   // reload when camera/position changes
                 } else {
-                    previewPlaceholder("Select a camera to preview")
+                    previewPlaceholder("Pick a camera to preview")
                 }
             }
             .aspectRatio(16.0 / 9.0, contentMode: .fit)
             // Cap the height so a wide window doesn't blow the preview up to fill
-            // the whole column and push the camera + time-range controls below the
-            // fold. Centered; stays 16:9.
+            // the whole column and push the range controls below the fold.
             .frame(maxWidth: .infinity, maxHeight: 300)
             .clipShape(RoundedRectangle(cornerRadius: 10))
-            // Scoped media token (P0-SESSIONS): the preview URL is now minted
-            // async, so it's refreshed reactively rather than computed inline
-            // in `body`. Keyed on the inputs that change which still to show.
-            .task(id: PreviewKey(cameraIds: vm.state.selectedCameraIds, start: vm.state.start)) {
+            // Scoped media token (P0-SESSIONS): the preview URL is minted async,
+            // so it's refreshed reactively rather than computed inline in `body`.
+            // Keyed on every input that changes which still to show.
+            .task(id: PreviewKey(cameraId: b.cameraId, start: b.start, end: b.end, fraction: b.scrubFraction)) {
                 vm.refreshPreview()
             }
-            Text("Still frame at the clip start.")
-                .font(.caption)
-                .foregroundColor(CrumbColors.textSecondary)
+
+            HStack(spacing: 10) {
+                Button {
+                    vm.togglePlay()
+                } label: {
+                    Image(systemName: b.playing ? "pause.fill" : "play.fill")
+                        .font(.system(size: 13))
+                        .foregroundColor(.white)
+                        .frame(width: 28, height: 28)
+                        .background(CrumbColors.teal)
+                        .clipShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(b.playing ? "Pause preview" : "Play preview")
+
+                Slider(value: Binding(
+                    get: { b.scrubFraction },
+                    set: { vm.setScrubFraction($0) }
+                ), in: 0...1)
+                .tint(CrumbColors.tealAccent)
+
+                Text(scrubReadout(b))
+                    .font(.caption.monospacedDigit())
+                    .foregroundColor(CrumbColors.textSecondary)
+                    .frame(minWidth: 96, alignment: .trailing)
+            }
         }
-        .padding(.bottom, 2)
     }
 
     private func previewPlaceholder(_ text: String) -> some View {
@@ -165,11 +349,19 @@ struct ExportView: View {
         }
     }
 
-    /// `.task(id:)` identity for `vm.refreshPreview()` — the preview still
-    /// depends on the selected camera set and the clip start date.
+    /// "+M:SS / 7m 19s" — offset into the clip at the scrubber, over the total.
+    private func scrubReadout(_ b: ExportBuilder) -> String {
+        let span = max(0, b.end.timeIntervalSince(b.start))
+        let off = Int((span * b.scrubFraction).rounded())
+        return String(format: "+%d:%02d / %@", off / 60, off % 60, formatDuration(span))
+    }
+
+    /// `.task(id:)` identity for `vm.refreshPreview()`.
     private struct PreviewKey: Equatable {
-        let cameraIds: Set<String>
+        let cameraId: String?
         let start: Date
+        let end: Date
+        let fraction: Double
     }
 
     // MARK: - Section: Format
@@ -208,100 +400,18 @@ struct ExportView: View {
                         .font(.caption)
                         .foregroundColor(CrumbColors.textSecondary)
                         .fixedSize(horizontal: false, vertical: true)
+
+                    if vm.state.format.videoCodec == "h265" {
+                        Text("H.265 (HEVC) re-encodes the video — noticeably slower to export.")
+                            .font(.caption)
+                            .foregroundColor(CrumbColors.textTertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
                 .padding(.horizontal, 16)
                 .padding(.vertical, 12)
             }
         }
-    }
-
-    // MARK: - Section: Camera Selection
-
-    private var cameraSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            SectionHeader("Cameras")
-
-            let s = vm.state
-            if s.cameras.isEmpty {
-                Text("No cameras available.")
-                    .font(.subheadline)
-                    .foregroundColor(CrumbColors.textSecondary)
-                    .padding(.vertical, 8)
-            } else {
-                if let err = s.cameraError {
-                    Text(err)
-                        .font(.caption)
-                        .foregroundColor(CrumbColors.error)
-                        .padding(.bottom, 4)
-                }
-                SurfaceCard {
-                    ForEach(Array(s.cameras.enumerated()), id: \.element.id) { index, camera in
-                        CameraCheckRow(
-                            camera: camera,
-                            isSelected: s.selectedCameraIds.contains(camera.id),
-                            onToggle: { vm.toggleCamera(camera.id) }
-                        )
-                        if index < s.cameras.count - 1 {
-                            Divider()
-                                .background(CrumbColors.divider)
-                                .padding(.horizontal, 12)
-                        }
-                    }
-                }
-            }
-        }
-        .padding(.bottom, 16)
-    }
-
-    // MARK: - Section: Time Range
-
-    private var timeRangeSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            SectionHeader("Clip Window")
-
-            let s = vm.state
-            let disabled = s.polling
-
-            // Start picker
-            SurfaceCard {
-                DatePicker(
-                    "Start",
-                    selection: Binding(
-                        get: { s.start },
-                        set: { vm.setStart($0) }
-                    ),
-                    displayedComponents: [.date, .hourAndMinute]
-                )
-                .disabled(disabled)
-                .foregroundColor(CrumbColors.textPrimary)
-                .tint(CrumbColors.tealAccent)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 10)
-            }
-
-            // End picker
-            SurfaceCard {
-                DatePicker(
-                    "End",
-                    selection: Binding(
-                        get: { s.end },
-                        set: { vm.setEnd($0) }
-                    ),
-                    displayedComponents: [.date, .hourAndMinute]
-                )
-                .disabled(disabled)
-                .foregroundColor(CrumbColors.textPrimary)
-                .tint(CrumbColors.tealAccent)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 10)
-            }
-
-            // Duration hint
-            Text("Duration: \(formatDuration(s.end.timeIntervalSince(s.start)))")
-                .font(.caption)
-                .foregroundColor(CrumbColors.textSecondary)
-        }
-        .padding(.bottom, 16)
     }
 
     // MARK: - Section: Options
@@ -325,10 +435,31 @@ struct ExportView: View {
                         get: { vm.state.includeAudio },
                         set: { vm.setIncludeAudio($0) }
                     )
+                    Divider().background(CrumbColors.divider).padding(.horizontal, 16)
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Encryption password")
+                            .font(.body)
+                            .foregroundColor(CrumbColors.textPrimary)
+                        SecureField("Optional", text: Binding(
+                            get: { vm.state.password },
+                            set: { vm.setPassword($0) }
+                        ))
+                        .textFieldStyle(.plain)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 7)
+                        .background(CrumbColors.surfaceVariant, in: RoundedRectangle(cornerRadius: 8))
+                        .disabled(vm.state.polling)
+                        Text("When set, the outputs are bundled into an AES-256 encrypted ZIP.")
+                            .font(.caption)
+                            .foregroundColor(CrumbColors.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
                 }
             }
         }
-        .padding(.bottom, 16)
+        .padding(.bottom, 4)
     }
 
     private func optionToggle(_ title: String, _ description: String,
@@ -354,6 +485,42 @@ struct ExportView: View {
         .padding(.vertical, 12)
     }
 
+    // MARK: - Section: Batch summary
+
+    /// Live batch summary — clip count, distinct cameras, total duration, rough
+    /// size estimate. Mirrors the desktop Output panel's "Batch" block.
+    private var summarySection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            SectionHeader("Batch")
+            SurfaceCard {
+                VStack(spacing: 0) {
+                    summaryRow("Clips", vm.clipCount > 0 ? "\(vm.clipCount)" : "—")
+                    Divider().background(CrumbColors.divider).padding(.horizontal, 16)
+                    summaryRow("Cameras", vm.clipCount > 0 ? "\(vm.distinctCameraCount)" : "—")
+                    Divider().background(CrumbColors.divider).padding(.horizontal, 16)
+                    summaryRow("Duration", vm.clipCount > 0 ? formatDuration(vm.totalDuration) : "—")
+                    Divider().background(CrumbColors.divider).padding(.horizontal, 16)
+                    summaryRow("Est. size", vm.clipCount > 0 ? "~" + formatFileSize(vm.estimatedSizeBytes) : "—")
+                }
+            }
+        }
+        .padding(.bottom, 4)
+    }
+
+    private func summaryRow(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label)
+                .font(.subheadline)
+                .foregroundColor(CrumbColors.textSecondary)
+            Spacer()
+            Text(value)
+                .font(.subheadline.weight(.medium).monospacedDigit())
+                .foregroundColor(CrumbColors.textPrimary)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 9)
+    }
+
     // MARK: - Export button
 
     private var exportButton: some View {
@@ -366,7 +533,7 @@ struct ExportView: View {
                         .scaleEffect(0.85)
                         .padding(.trailing, 4)
                 }
-                Text(vm.state.polling ? "Exporting…" : "Create Export")
+                Text(exportButtonLabel)
                     .fontWeight(.semibold)
             }
             .frame(maxWidth: .infinity)
@@ -377,6 +544,12 @@ struct ExportView: View {
         }
         .disabled(!vm.canExport)
         .padding(.bottom, 16)
+    }
+
+    private var exportButtonLabel: String {
+        if vm.state.polling { return "Exporting…" }
+        let n = vm.clipCount
+        return n > 0 ? "Export \(n) clip\(n == 1 ? "" : "s")" : "Export"
     }
 
     // MARK: - Section: Job Status
@@ -427,7 +600,9 @@ struct ExportView: View {
                             .foregroundColor(CrumbColors.error)
                     }
 
-                    ForEach(job.outputFiles, id: \.cameraId) { file in
+                    // Keyed on downloadUrl: a batch job's files aren't guaranteed
+                    // unique per camera (the whole-job archive uses a nil camera).
+                    ForEach(job.outputFiles, id: \.downloadUrl) { file in
                         OutputFileRow(
                             title: cameraName(for: file.cameraId),
                             outputFile: file,
@@ -502,7 +677,7 @@ struct ExportView: View {
 
     /// Friendly name for an output file's camera id (or the archive sentinel).
     private func cameraName(for cameraId: String) -> String {
-        if cameraId == "00000000-0000-0000-0000-000000000000" { return "Archive (all cameras)" }
+        if cameraId == "00000000-0000-0000-0000-000000000000" { return "Archive (all clips)" }
         return vm.state.cameras.first(where: { $0.id == cameraId })?.name ?? cameraId
     }
 
@@ -566,34 +741,88 @@ private struct SurfaceCard<Content: View>: View {
     }
 }
 
-private struct CameraCheckRow: View {
-    let camera: CameraDto
-    let isSelected: Bool
-    let onToggle: () -> Void
+/// One clip card in the export list: index, start-frame thumbnail, camera,
+/// range, duration, edit/remove. The thumbnail URL is minted per-row (a
+/// short-lived per-camera scoped media token, never the full login JWT).
+private struct ClipRow: View {
+    let index: Int
+    let clip: ExportClip
+    let cameraName: String
+    let thumbURL: () async -> URL?
+    let onEdit: () -> Void
+    let onRemove: () -> Void
+
+    @State private var url: URL?
 
     var body: some View {
-        Button(action: onToggle) {
-            HStack(spacing: 12) {
-                Image(systemName: isSelected ? "checkmark.square.fill" : "square")
-                    .foregroundColor(isSelected ? CrumbColors.tealAccent : CrumbColors.textSecondary)
-                    .font(.system(size: 20))
+        HStack(spacing: 12) {
+            Text("\(index)")
+                .font(.caption.weight(.semibold).monospacedDigit())
+                .foregroundColor(CrumbColors.textTertiary)
+                .frame(width: 18)
 
-                Text(camera.name)
-                    .font(.body)
-                    .foregroundColor(CrumbColors.textPrimary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                if !camera.enabled {
-                    Text("disabled")
-                        .font(.caption2)
-                        .foregroundColor(CrumbColors.textTertiary)
+            ZStack {
+                Color.black
+                if let url {
+                    TokenedAsyncImage(url: url) { img in
+                        img.resizable().scaledToFill()
+                    } placeholder: {
+                        EmptyView()
+                    } failure: {
+                        EmptyView()
+                    }
+                    .id(url)
                 }
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .contentShape(Rectangle())
+            .frame(width: 64, height: 36)
+            .clipShape(RoundedRectangle(cornerRadius: 5))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(cameraName)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundColor(CrumbColors.textPrimary)
+                    .lineLimit(1)
+                Text("\(clipClock(clip.start)) → \(clipClock(clip.end))")
+                    .font(.caption.monospacedDigit())
+                    .foregroundColor(CrumbColors.textSecondary)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Text(formatDuration(clip.duration))
+                .font(.caption.monospacedDigit())
+                .foregroundColor(CrumbColors.textSecondary)
+
+            Button(action: onEdit) {
+                Image(systemName: "pencil")
+                    .font(.system(size: 13))
+                    .foregroundColor(CrumbColors.textSecondary)
+                    .frame(width: 26, height: 26)
+            }
+            .buttonStyle(.plain)
+            .help("Edit clip")
+
+            Button(action: onRemove) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(CrumbColors.textSecondary)
+                    .frame(width: 26, height: 26)
+            }
+            .buttonStyle(.plain)
+            .help("Remove clip")
         }
-        .buttonStyle(.plain)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(CrumbColors.surface)
+        .cornerRadius(10)
+        .task(id: clip) { url = await thumbURL() }
+    }
+
+    /// Wall-clock "MM/dd HH:mm:ss" for a clip edge (desktop `exportFmtClock`).
+    private func clipClock(_ d: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "MM/dd HH:mm:ss"
+        return f.string(from: d)
     }
 }
 

--- a/apps/ios/Crumb/Features/Export/ExportViewModel.swift
+++ b/apps/ios/Crumb/Features/Export/ExportViewModel.swift
@@ -2,15 +2,45 @@
 
 import Foundation
 
+// MARK: - Model
+
+/// One clip in the export list (the desktop client's `exportState.list` item):
+/// a camera + a time range. Output settings are global to the batch.
+struct ExportClip: Identifiable, Equatable {
+    let id: Int
+    var cameraId: String
+    var start: Date
+    var end: Date
+
+    var duration: TimeInterval { end.timeIntervalSince(start) }
+}
+
+/// The add/edit-clip builder (the desktop client's `exportState.builder`).
+/// Non-nil = builder mode; nil = list mode.
+struct ExportBuilder: Equatable {
+    /// Id of the clip being edited, nil for a new clip.
+    var editId: Int? = nil
+    var cameraId: String? = nil
+    var start: Date
+    var end: Date
+    /// Validation error shown inside the builder.
+    var error: String? = nil
+    /// Preview-scrubber position as a 0…1 fraction of the clip range.
+    var scrubFraction: Double = 0
+    /// True while the preview auto-advances (the builder's play toggle).
+    var playing: Bool = false
+}
+
 // MARK: - UI State
 
-/// Snapshot of everything the Export sheet needs to render.
+/// Snapshot of everything the Export view needs to render.
 ///
 /// - `cameraError`: optional banner shown above the camera list (e.g. 403 partial access).
 /// - `cameras`: full list passed in by the caller at init; the VM never fetches cameras.
-/// - `selectedCameraIds`: set of camera IDs the user has toggled on.
-/// - `start` / `end`: current DatePicker values (clamped so start < end).
-/// - `burnTimestamp`: overlay date/time on the exported video.
+/// - `clips`: the export list — the batch exports the whole list.
+/// - `builder`: non-nil while the add/edit-clip builder is open.
+/// - `burnTimestamp` / `format` / `includeAudio` / `password`: global output settings.
+///   A non-empty password → AES-256-encrypted ZIP archive server-side.
 /// - `job`: most-recent ExportJob polled from the server (nil until first response).
 /// - `jobError`: human-readable error from a failed job or a polling network blip.
 /// - `polling`: true while we are actively polling exportStatus.
@@ -22,12 +52,12 @@ import Foundation
 struct ExportUiState {
     var cameraError: String? = nil
     var cameras: [CameraDto] = []
-    var selectedCameraIds: Set<String> = []
-    var start: Date = Date(timeIntervalSinceNow: -600)
-    var end: Date = Date()
+    var clips: [ExportClip] = []
+    var builder: ExportBuilder? = nil
     var burnTimestamp: Bool = true
     var format: ExportFormat = .mp4H264
     var includeAudio: Bool = false
+    var password: String = ""
     var job: ExportJob? = nil
     var jobError: String? = nil
     var polling: Bool = false
@@ -42,110 +72,271 @@ struct ExportUiState {
 final class ExportViewModel: ObservableObject {
 
     @Published var state: ExportUiState
-    /// Still-frame preview at the clip start for the first selected (or first
-    /// available) camera. Resolved async (scoped media token) — refreshed by
+    /// Builder preview: still frame at the scrubber position for the builder's
+    /// camera. Resolved async (scoped media token) — refreshed by
     /// `refreshPreview()`, which the view calls from a `.task(id:)` keyed on
-    /// whatever inputs affect it (selected cameras, start date).
+    /// whatever inputs affect it (builder camera, range, scrub position).
     @Published private(set) var previewURL: URL?
 
     private let container: AppContainer
     private var pollTask: Task<Void, Never>?
     private var previewTask: Task<Void, Never>?
+    private var playTask: Task<Void, Never>?
     /// Id of the in-flight export job, used to cancel it server-side.
     private var currentJobId: String?
+    /// Monotonic id source for list items.
+    private var seq = 0
+    /// Builder camera pre-selection when the caller had a camera focused
+    /// (fullscreen playback / selected wall tile) — mirrors the desktop's
+    /// `exportPopulateCameraSelect(selectedId)`.
+    private let seedCameraId: String?
 
     /// - Parameters:
     ///   - container: App-wide service locator (API, MediaUrls).
     ///   - cameras: Full list of cameras the user may pick from.
-    ///   - cameraIds: Pre-selected IDs (e.g. the camera the user was viewing).
-    ///   - start: Pre-filled clip start time.
-    ///   - end: Pre-filled clip end time.
+    ///   - seedCameraId: Camera to pre-select in the add-clip builder (e.g. the
+    ///     camera the user was viewing). nil → first camera.
+    ///   - initialRange: When set (the playback "Export selection…" path), the
+    ///     builder opens pre-filled with `seedCameraId` + this range, so it's
+    ///     one click to add it as the first clip — the desktop `exportEnter`
+    ///     behavior. nil (the Exports tab) → start in list mode.
     init(
         container: AppContainer,
         cameras: [CameraDto],
-        cameraIds: [String],
-        start: Date,
-        end: Date
+        seedCameraId: String? = nil,
+        initialRange: (start: Date, end: Date)? = nil
     ) {
         self.container = container
-        self.state = ExportUiState(
-            cameras: cameras,
-            selectedCameraIds: Set(cameraIds),
-            start: start,
-            end: end
-        )
+        self.seedCameraId = seedCameraId
+        var st = ExportUiState(cameras: cameras)
+        if let range = initialRange {
+            st.builder = ExportBuilder(
+                cameraId: seedCameraId ?? cameras.first?.id,
+                start: min(range.start, range.end.addingTimeInterval(-1)),
+                end: range.end
+            )
+        }
+        self.state = st
     }
 
-    // MARK: - Camera selection
+    /// Media-URL builder, exposed for the clip-list thumbnails (each row mints
+    /// its own short-lived scoped token, same as the desktop list).
+    func mediaUrls() -> MediaUrls { container.mediaUrls() }
 
-    func toggleCamera(_ id: String) {
-        if state.selectedCameraIds.contains(id) {
-            state.selectedCameraIds.remove(id)
+    // MARK: - Clip list
+
+    func openBuilder(editing clip: ExportClip? = nil) {
+        stopPlay()
+        if let clip {
+            state.builder = ExportBuilder(
+                editId: clip.id, cameraId: clip.cameraId,
+                start: clip.start, end: clip.end
+            )
         } else {
-            state.selectedCameraIds.insert(id)
+            state.builder = ExportBuilder(
+                cameraId: seedCameraId ?? state.clips.last?.cameraId ?? state.cameras.first?.id,
+                start: Date(timeIntervalSinceNow: -60),
+                end: Date()
+            )
         }
     }
 
-    // MARK: - Date/time
+    func cancelBuilder() {
+        stopPlay()
+        state.builder = nil
+    }
 
-    func setStart(_ date: Date) {
+    /// Validate + commit the builder's clip into the list (add new or save an edit).
+    func commitBuilder() {
+        guard var b = state.builder else { return }
+        guard let cam = b.cameraId, state.cameras.contains(where: { $0.id == cam }) else {
+            b.error = "Pick a camera for this clip."
+            state.builder = b
+            return
+        }
+        guard b.end > b.start else {
+            b.error = "End must be after start."
+            state.builder = b
+            return
+        }
+        if let editId = b.editId, let idx = state.clips.firstIndex(where: { $0.id == editId }) {
+            state.clips[idx].cameraId = cam
+            state.clips[idx].start = b.start
+            state.clips[idx].end = b.end
+        } else {
+            seq += 1
+            state.clips.append(ExportClip(id: seq, cameraId: cam, start: b.start, end: b.end))
+        }
+        // Output-setting/list changes after a completed export revert the job
+        // panel so the button reads "Export N clips" again (desktop behavior).
+        clearFinishedJob()
+        stopPlay()
+        state.builder = nil
+    }
+
+    func removeClip(_ id: Int) {
+        state.clips.removeAll { $0.id == id }
+        clearFinishedJob()
+    }
+
+    // MARK: - Builder fields
+
+    func setBuilderCamera(_ id: String) {
+        state.builder?.cameraId = id
+        state.builder?.error = nil
+    }
+
+    func setBuilderStart(_ date: Date) {
+        guard var b = state.builder else { return }
         // Clamp: start must be at least 1 second before end.
-        state.start = min(date, state.end.addingTimeInterval(-1))
+        b.start = min(date, b.end.addingTimeInterval(-1))
+        b.error = nil
+        state.builder = b
     }
 
-    func setEnd(_ date: Date) {
+    func setBuilderEnd(_ date: Date) {
+        guard var b = state.builder else { return }
         // Clamp: end must be at least 1 second after start.
-        state.end = max(date, state.start.addingTimeInterval(1))
+        b.end = max(date, b.start.addingTimeInterval(1))
+        b.error = nil
+        state.builder = b
     }
 
-    func setBurnTimestamp(_ value: Bool) {
-        state.burnTimestamp = value
+    // MARK: - Builder preview scrubber
+
+    func setScrubFraction(_ f: Double) {
+        stopPlay()
+        state.builder?.scrubFraction = min(max(f, 0), 1)
     }
 
-    func setFormat(_ value: ExportFormat) {
-        state.format = value
+    /// The wall-clock moment the scrubber points at, or nil in list mode.
+    var scrubDate: Date? {
+        guard let b = state.builder else { return nil }
+        return b.start.addingTimeInterval(b.scrubFraction * b.end.timeIntervalSince(b.start))
     }
 
-    func setIncludeAudio(_ value: Bool) {
-        state.includeAudio = value
+    /// Toggle the preview auto-advance: steps the scrubber so a full play is
+    /// ≤ ~24 frames (each step is one server-side frame extraction — the cap
+    /// keeps a long clip from hammering the extractor; desktop parity).
+    func togglePlay() {
+        guard var b = state.builder else { return }
+        if b.playing { stopPlay(); return }
+        b.playing = true
+        state.builder = b
+        let span = b.end.timeIntervalSince(b.start)
+        guard span > 0 else { stopPlay(); return }
+        let step = max(1.0, span / 24) / span   // fraction per tick
+        playTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 700_000_000)
+                guard let self, var cur = self.state.builder, cur.playing else { return }
+                let next = cur.scrubFraction + step
+                if next >= 1 {
+                    cur.scrubFraction = 1
+                    cur.playing = false
+                    self.state.builder = cur
+                    return
+                }
+                cur.scrubFraction = next
+                self.state.builder = cur
+            }
+        }
     }
 
-    /// Re-resolve `previewURL` (a still frame at the clip start for the first
-    /// selected, or first available, camera) — the export preview thumbnail.
-    /// Call from a `.task(id:)` keyed on the inputs that can change it
-    /// (selected camera set, start date); cancels any still-resolving prior
-    /// request so a rapid camera-toggle or date-drag doesn't race in a stale
-    /// URL after a newer one.
+    private func stopPlay() {
+        playTask?.cancel()
+        playTask = nil
+        state.builder?.playing = false
+    }
+
+    /// Re-resolve `previewURL` — the builder's still frame at the scrubber
+    /// position. Call from a `.task(id:)` keyed on the inputs that can change
+    /// it (builder camera, range, scrub position); a short debounce plus
+    /// cancellation keeps a fast scrub from racing in stale frames or minting
+    /// a token per tick.
     func refreshPreview() {
         previewTask?.cancel()
-        guard let camId = state.selectedCameraIds.sorted().first ?? state.cameras.first?.id else {
+        guard let b = state.builder, let camId = b.cameraId, let at = scrubDate else {
             previewURL = nil
             return
         }
-        let iso = ISO8601DateFormatter().string(from: state.start)
+        let iso = iso8601String(at)
         previewTask = Task { [weak self] in
             guard let self else { return }
-            // Request the server's max thumbnail width (640): the preview renders
-            // large, so the default ~160px still would look blurry blown up.
-            let url = await container.mediaUrls().historicalFrameUrl(cameraId: camId, tsISO: iso, width: 640)
+            // Debounce continuous scrubs (each frame is a server-side extraction).
+            try? await Task.sleep(nanoseconds: 120_000_000)
+            guard !Task.isCancelled else { return }
+            // Builder-preview width matches the desktop scrubber's 480px request
+            // (crisp at panel size without paying for the 640px cap per tick).
+            let url = await container.mediaUrls().historicalFrameUrl(cameraId: camId, tsISO: iso, width: 480)
             guard !Task.isCancelled else { return }
             previewURL = url
         }
     }
 
+    // MARK: - Output settings
+
+    func setBurnTimestamp(_ value: Bool) {
+        state.burnTimestamp = value
+        clearFinishedJob()
+    }
+
+    func setFormat(_ value: ExportFormat) {
+        state.format = value
+        clearFinishedJob()
+    }
+
+    func setIncludeAudio(_ value: Bool) {
+        state.includeAudio = value
+        clearFinishedJob()
+    }
+
+    func setPassword(_ value: String) {
+        state.password = value
+        clearFinishedJob()
+    }
+
+    /// Any list/output change after a completed run clears the finished-job
+    /// panel so the view reverts to a fresh "Export N clips" state.
+    private func clearFinishedJob() {
+        guard let job = state.job, job.isTerminal else { return }
+        state.job = nil
+        state.jobError = nil
+        currentJobId = nil
+    }
+
+    // MARK: - Batch summary
+
+    var clipCount: Int { state.clips.count }
+
+    var distinctCameraCount: Int { Set(state.clips.map(\.cameraId)).count }
+
+    var totalDuration: TimeInterval { state.clips.reduce(0) { $0 + max(0, $1.duration) } }
+
+    /// Rough size estimate (heuristic ~4 Mbps main stream), scaled by codec:
+    /// H.265 re-encodes to roughly half the bitrate; copy/H.264 keep the source
+    /// rate. Always labelled "~" by the view. Mirrors the desktop `exportEstSize`.
+    var estimatedSizeBytes: Int64 {
+        let factor = state.format.videoCodec == "h265" ? 0.5 : 1.0
+        return Int64(totalDuration * 500_000 * factor) // 4 Mbps ≈ 500 KB/s
+    }
+
     // MARK: - Export job
 
     var canExport: Bool {
-        !state.selectedCameraIds.isEmpty && !state.polling
+        !state.clips.isEmpty && !state.polling
     }
 
     func createExport() {
         guard canExport else { return }
 
-        let fmt = ISO8601DateFormatter()
-        let startIso = fmt.string(from: state.start)
-        let endIso = fmt.string(from: state.end)
-        let cameraIds = Array(state.selectedCameraIds)
+        let items = state.clips.map {
+            BatchExportItem(
+                cameraId: $0.cameraId,
+                start: iso8601String($0.start),
+                end: iso8601String($0.end)
+            )
+        }
 
         // Reset any previous job state.
         state.job = nil
@@ -154,15 +345,14 @@ final class ExportViewModel: ObservableObject {
 
         Task {
             do {
-                let response = try await container.api.createExport(
-                    CreateExportRequest(
-                        cameraIds: cameraIds,
-                        start: startIso,
-                        end: endIso,
+                let response = try await container.api.createBatchExport(
+                    CreateBatchExportRequest(
+                        items: items,
                         burnTimestamp: state.burnTimestamp,
+                        includeAudio: state.includeAudio,
                         videoCodec: state.format.videoCodec,
                         container: state.format.container,
-                        includeAudio: state.includeAudio
+                        password: state.password.isEmpty ? nil : state.password
                     )
                 )
                 currentJobId = response.jobId
@@ -307,6 +497,7 @@ final class ExportViewModel: ObservableObject {
 
     func onDisappear() {
         stopPolling()
+        stopPlay()
     }
 
     // MARK: - Constants

--- a/apps/ios/Crumb/Features/Export/ExportViewModel.swift
+++ b/apps/ios/Crumb/Features/Export/ExportViewModel.swift
@@ -125,7 +125,9 @@ final class ExportViewModel: ObservableObject {
         let iso = ISO8601DateFormatter().string(from: state.start)
         previewTask = Task { [weak self] in
             guard let self else { return }
-            let url = await container.mediaUrls().historicalFrameUrl(cameraId: camId, tsISO: iso)
+            // Request the server's max thumbnail width (640): the preview renders
+            // large, so the default ~160px still would look blurry blown up.
+            let url = await container.mediaUrls().historicalFrameUrl(cameraId: camId, tsISO: iso, width: 640)
             guard !Task.isCancelled else { return }
             previewURL = url
         }

--- a/apps/ios/Crumb/Features/Live/LiveWallView.swift
+++ b/apps/ios/Crumb/Features/Live/LiveWallView.swift
@@ -372,12 +372,12 @@ struct LiveWallView: View {
                 }
             }
         case .exports:
+            // List mode; the selected/fullscreen wall camera (if any) seeds the
+            // add-clip builder's camera picker, matching the desktop client.
             ExportView(
                 container: container,
                 cameras: visibleCameras.isEmpty ? vm.cameras : visibleCameras,
-                cameraIds: [],
-                start: Date().addingTimeInterval(-3600),
-                end: Date(),
+                seedCameraId: selectedCameraId,
                 onClose: { mode = .live }
             )
         case .clips:

--- a/apps/ios/Crumb/Features/Playback/CenteredTimelineView.swift
+++ b/apps/ios/Crumb/Features/Playback/CenteredTimelineView.swift
@@ -126,7 +126,8 @@ struct CenteredTimelineView: View {
                     onZoom: { delta in zoom(by: delta) },
                     playheadMs: playheadMs,
                     spanMs: spanMs,
-                    hasExportSelection: exportSelStartMs != nil && exportSelEndMs != nil,
+                    exportSelStartMs: exportSelStartMs,
+                    exportSelEndMs: exportSelEndMs,
                     onSetExportStart: onSetExportStart,
                     onSetExportEnd: onSetExportEnd,
                     onExportSelection: onExportSelection,
@@ -363,7 +364,8 @@ struct CenteredTimelineView: View {
 import AppKit
 
 /// Transparent AppKit overlay that drives the timeline with a mouse: drag pans,
-/// scroll-wheel zooms. Lives on macOS only; iOS uses SwiftUI drag/pinch gestures.
+/// scroll-wheel zooms, dragging an export handle resizes the export region.
+/// Lives on macOS only; iOS uses SwiftUI drag/pinch gestures.
 private struct TimelineMouseView: NSViewRepresentable {
     let onPanStart: () -> Void
     let onPan: (CGFloat) -> Void
@@ -371,7 +373,8 @@ private struct TimelineMouseView: NSViewRepresentable {
     let onZoom: (CGFloat) -> Void
     let playheadMs: Int64
     let spanMs: Int64
-    let hasExportSelection: Bool
+    let exportSelStartMs: Int64?
+    let exportSelEndMs: Int64?
     let onSetExportStart: ((Int64) -> Void)?
     let onSetExportEnd: ((Int64) -> Void)?
     let onExportSelection: (() -> Void)?
@@ -382,7 +385,8 @@ private struct TimelineMouseView: NSViewRepresentable {
 
     private func configure(_ v: MouseNSView) -> MouseNSView {
         v.onPanStart = onPanStart; v.onPan = onPan; v.onPanEnd = onPanEnd; v.onZoom = onZoom
-        v.playheadMs = playheadMs; v.spanMs = spanMs; v.hasExportSelection = hasExportSelection
+        v.playheadMs = playheadMs; v.spanMs = spanMs
+        v.exportSelStartMs = exportSelStartMs; v.exportSelEndMs = exportSelEndMs
         v.onSetExportStart = onSetExportStart; v.onSetExportEnd = onSetExportEnd
         v.onExportSelection = onExportSelection; v.onClearExportSelection = onClearExportSelection
         return v
@@ -395,30 +399,106 @@ private struct TimelineMouseView: NSViewRepresentable {
         var onZoom: (CGFloat) -> Void = { _ in }
         var playheadMs: Int64 = 0
         var spanMs: Int64 = 0
-        var hasExportSelection = false
+        var exportSelStartMs: Int64?
+        var exportSelEndMs: Int64?
         var onSetExportStart: ((Int64) -> Void)?
         var onSetExportEnd: ((Int64) -> Void)?
         var onExportSelection: (() -> Void)?
         var onClearExportSelection: (() -> Void)?
 
+        private var hasExportSelection: Bool { exportSelStartMs != nil && exportSelEndMs != nil }
+
         private var startX: CGFloat = 0
         private var menuTimeMs: Int64 = 0
+        /// Which export edge a left-drag is resizing: the callback for the edge
+        /// grabbed at mouseDown (start or end), captured so the same edge keeps
+        /// following the mouse even if the handles cross mid-drag. nil = pan.
+        private var resizeEdge: ((Int64) -> Void)?
+
+        /// Pixels of grab slack around an export handle (the drawn handle is 3px).
+        private static let handleTolerance: CGFloat = 6
 
         override func scrollWheel(with event: NSEvent) {
             let d = event.hasPreciseScrollingDeltas ? event.scrollingDeltaY : event.deltaY
             if d != 0 { onZoom(d) }
         }
+
+        /// Time at an x offset for the CURRENT view window (only valid while not
+        /// panning — the window follows the playhead, which a pan itself moves).
+        private func timeAt(x: CGFloat) -> Int64 {
+            let w = bounds.width
+            guard w > 0 else { return playheadMs }
+            let frac = max(0, min(1, x / w))
+            return (playheadMs - spanMs / 2) + Int64(Double(frac) * Double(spanMs))
+        }
+
+        /// The export-edge setter whose handle sits within grab range of `x`,
+        /// or nil when none does. Nearest wins when the two handles overlap.
+        private func exportEdge(near x: CGFloat) -> ((Int64) -> Void)? {
+            guard let s = exportSelStartMs, let e = exportSelEndMs,
+                  onSetExportStart != nil, onSetExportEnd != nil,
+                  bounds.width > 0, spanMs > 0 else { return nil }
+            let visStart = playheadMs - spanMs / 2
+            func xOf(_ ts: Int64) -> CGFloat {
+                CGFloat(Double(ts - visStart) / Double(spanMs)) * bounds.width
+            }
+            let dS = abs(xOf(s) - x), dE = abs(xOf(e) - x)
+            if min(dS, dE) > Self.handleTolerance { return nil }
+            return dS <= dE ? onSetExportStart : onSetExportEnd
+        }
+
         override func mouseDown(with event: NSEvent) {
-            startX = convert(event.locationInWindow, from: nil).x
+            let x = convert(event.locationInWindow, from: nil).x
+            // Grabbing an export handle resizes the region instead of panning.
+            if let edge = exportEdge(near: x) {
+                resizeEdge = edge
+                edge(clampToNow(timeAt(x: x)))
+                return
+            }
+            startX = x
             onPanStart()
         }
         override func mouseDragged(with event: NSEvent) {
-            onPan(convert(event.locationInWindow, from: nil).x - startX)
+            let x = convert(event.locationInWindow, from: nil).x
+            if let edge = resizeEdge {
+                edge(clampToNow(timeAt(x: x)))
+                return
+            }
+            onPan(x - startX)
         }
         override func mouseUp(with event: NSEvent) {
-            onPanEnd(convert(event.locationInWindow, from: nil).x - startX)
+            let x = convert(event.locationInWindow, from: nil).x
+            if let edge = resizeEdge {
+                edge(clampToNow(timeAt(x: x)))
+                resizeEdge = nil
+                return
+            }
+            onPanEnd(x - startX)
         }
         override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+        private func clampToNow(_ ms: Int64) -> Int64 {
+            min(max(ms, 0), Int64(Date().timeIntervalSince1970 * 1000))
+        }
+
+        // Resize cursor while hovering an export handle, so it reads as draggable.
+        override func updateTrackingAreas() {
+            super.updateTrackingAreas()
+            for ta in trackingAreas { removeTrackingArea(ta) }
+            addTrackingArea(NSTrackingArea(
+                rect: .zero,
+                options: [.mouseMoved, .activeInKeyWindow, .inVisibleRect],
+                owner: self, userInfo: nil
+            ))
+        }
+        override func mouseMoved(with event: NSEvent) {
+            let x = convert(event.locationInWindow, from: nil).x
+            if resizeEdge != nil || exportEdge(near: x) != nil {
+                NSCursor.resizeLeftRight.set()
+            } else {
+                NSCursor.arrow.set()
+            }
+        }
 
         // Right-click → "mark for export" menu, with the bracket edge placed at the
         // clicked time (matching the desktop client).

--- a/apps/ios/Crumb/Features/Playback/PlaybackView.swift
+++ b/apps/ios/Crumb/Features/Playback/PlaybackView.swift
@@ -188,7 +188,9 @@ struct PlaybackView: View {
                 // no custom-URLSession init, and always uses `URLSession.shared`
                 // (disk-cached) — use `TokenedAsyncImage` (MediaSession.swift),
                 // which fetches via the ephemeral `.crumbMedia` session instead.
-                TokenedAsyncImage(url: f) { img in img.resizable().scaledToFit() } placeholder: { EmptyView() }
+                // keepStaleImage: the scrub URL changes per tick; keep the prior
+                // frame up while the next loads instead of blinking to black.
+                TokenedAsyncImage(url: f, keepStaleImage: true) { img in img.resizable().scaledToFit() } placeholder: { EmptyView() }
             }
             if vm.loading && vm.currentSegment == nil {
                 ProgressView().tint(CrumbColors.teal)

--- a/apps/ios/Crumb/Features/Playback/PlaybackView.swift
+++ b/apps/ios/Crumb/Features/Playback/PlaybackView.swift
@@ -18,6 +18,8 @@ struct PlaybackView: View {
     let onBack: () -> Void
 
     @State private var bookmarks: [Int64] = []
+    /// Full bookmark records (macOS "Bookmarks" menu shows description + time).
+    @State private var bookmarkList: [BookmarkDto] = []
     @State private var showAddBookmark = false
     @State private var showJump = false
     @State private var showExport = false
@@ -109,16 +111,18 @@ struct PlaybackView: View {
             }
         }
         .sheet(isPresented: $showExport) {
+            // Seed the batch builder with the viewed camera + the bracketed
+            // selection (or the trailing hour) — one click to add it as the
+            // first clip, mirroring the desktop "Export selection…" flow.
             let range = exportRange()
             ExportView(
                 container: vm.container,
                 cameras: cameras,
-                cameraIds: [vm.cameraId],
-                start: range.start,
-                end: range.end,
+                seedCameraId: vm.cameraId,
+                initialRange: (start: range.start, end: range.end),
                 onClose: { showExport = false }
             )
-            .macModalSize(width: 480, height: 600)
+            .macModalSize(width: 560, height: 700)
         }
         .statusBarHiddenCompat(false)
     }
@@ -387,21 +391,30 @@ struct PlaybackView: View {
                     .disabled(bookmarks.isEmpty)
                 iconChip("chevron.forward.to.line", "Next bookmark") { jumpBookmark(forward: true) }
                     .disabled(bookmarks.isEmpty)
+                // "Bookmarks" list — labeled like the desktop client's
+                // "Bookmarks" button (was a bare ≡ icon that read as a mystery
+                // date list). Each item jumps playback to that bookmark.
                 Menu {
-                    if bookmarks.isEmpty {
-                        Text("No bookmarks")
+                    if bookmarkList.isEmpty {
+                        Text("No saved bookmarks")
                     } else {
-                        ForEach(bookmarks, id: \.self) { bm in
-                            Button(formatTime(Date(timeIntervalSince1970: Double(bm) / 1000), style: .clockLong)) {
-                                vm.jumpToTime(bm)
+                        ForEach(bookmarkList) { bm in
+                            Button(bookmarkMenuTitle(bm)) {
+                                if let d = parseISO8601(bm.ts) {
+                                    vm.jumpToTime(Int64(d.timeIntervalSince1970 * 1000))
+                                }
                             }
                         }
                     }
                 } label: {
-                    Image(systemName: "list.bullet").font(.system(size: 15))
-                        .foregroundColor(CrumbColors.textSecondary).frame(width: 32, height: 30)
+                    HStack(spacing: 4) {
+                        Image(systemName: "bookmark").font(.system(size: 12))
+                        Text("Bookmarks").font(.callout)
+                    }
+                    .foregroundColor(CrumbColors.textSecondary)
+                    .frame(height: 30)
                 }
-                .menuStyle(.borderlessButton).fixedSize().help("Bookmarks")
+                .menuStyle(.borderlessButton).fixedSize().help("View saved bookmarks")
 
                 if vm.container.isAdmin || vm.container.capabilities.export {
                     macDivider
@@ -540,8 +553,16 @@ struct PlaybackView: View {
 
     private func loadBookmarks() async {
         if let list = try? await vm.container.api.bookmarks(cameraId: vm.cameraId) {
+            bookmarkList = list.sorted { $0.ts < $1.ts }
             bookmarks = list.compactMap { parseISO8601($0.ts).map { Int64($0.timeIntervalSince1970 * 1000) } }.sorted()
         }
+    }
+
+    /// "Front door — Mon Jun 3, 14:05:30" (or just the time when undescribed).
+    private func bookmarkMenuTitle(_ bm: BookmarkDto) -> String {
+        let time = parseISO8601(bm.ts).map { formatTime($0, style: .clockLong) } ?? bm.ts
+        if let desc = bm.description, !desc.isEmpty { return "\(desc) — \(time)" }
+        return time
     }
 
     /// [both] H1 fix: snapshot the PLAYHEAD frame, not the live camera frame.

--- a/apps/ios/Crumb/Features/Playback/PlaybackViewModel.swift
+++ b/apps/ios/Crumb/Features/Playback/PlaybackViewModel.swift
@@ -333,7 +333,10 @@ final class PlaybackViewModel: ObservableObject {
                 cameraId: cameraId,
                 start: iso(max(centerMs - halfMs, 0)),
                 end: iso(centerMs + halfMs),
-                width: 160
+                // Crisp scrub still (matches the wall + server pre-gen width); the
+                // list only mints frame URLs, so a bigger width costs nothing until
+                // the one nearest frame is actually fetched for the scrub overlay.
+                width: MediaUrls.scrubThumbWidth
             ).frames {
                 guard !Task.isCancelled else { return }
                 filmstrip = frames

--- a/apps/ios/Crumb/Features/Playback/PlaybackWallView.swift
+++ b/apps/ios/Crumb/Features/Playback/PlaybackWallView.swift
@@ -230,7 +230,9 @@ private struct PlaybackTile: View {
         scrubTask = Task { @MainActor in
             try? await Task.sleep(nanoseconds: 250_000_000) // debounce continuous scrub
             guard !Task.isCancelled else { return }
-            guard let url = await mediaUrls.historicalFrameUrl(cameraId: camera.id, tsISO: tsISO) else { return }
+            guard let url = await mediaUrls.historicalFrameUrl(
+                cameraId: camera.id, tsISO: tsISO, width: MediaUrls.scrubThumbWidth
+            ) else { return }
             guard !Task.isCancelled else { return }
             var req = URLRequest(url: url)
             req.cachePolicy = .reloadIgnoringLocalCacheData

--- a/apps/ios/Crumb/Models/Models.swift
+++ b/apps/ios/Crumb/Models/Models.swift
@@ -335,6 +335,44 @@ struct CreateExportRequest: Encodable {
     }
 }
 
+/// One clip of a `POST /export/batch` list: a camera + a time range. Ranges and
+/// cameras may differ per item; output settings are global to the batch.
+struct BatchExportItem: Encodable {
+    let cameraId: String
+    let start: String
+    let end: String
+
+    enum CodingKeys: String, CodingKey {
+        case cameraId = "camera_id"
+        case start, end
+    }
+}
+
+/// `POST /export/batch` request body — the commercial-VMS-style export list the
+/// desktop client sends. The server bundles the outputs into one archive
+/// (`crumb_export.zip`, AES-256 when `password` is set) whenever more than one
+/// file is produced or a password is given.
+struct CreateBatchExportRequest: Encodable {
+    let items: [BatchExportItem]
+    let burnTimestamp: Bool
+    let includeAudio: Bool
+    /// `"h264"`, `"h265"`, or `"copy"` (stream-copy, no re-encode).
+    let videoCodec: String
+    /// `"mp4"` or `"mkv"`.
+    let container: String
+    /// Non-empty → AES-256-encrypted ZIP archive.
+    let password: String?
+
+    enum CodingKeys: String, CodingKey {
+        case items
+        case burnTimestamp = "burn_timestamp"
+        case includeAudio = "include_audio"
+        case videoCodec = "video_codec"
+        case container
+        case password
+    }
+}
+
 /// User-facing export format = a container + a video codec, matching the desktop
 /// client's options and the backend's accepted (`video_codec`, `container`) pairs.
 enum ExportFormat: String, CaseIterable, Identifiable {

--- a/apps/ios/Crumb/Networking/CrumbAPI.swift
+++ b/apps/ios/Crumb/Networking/CrumbAPI.swift
@@ -127,6 +127,12 @@ final class CrumbAPI {
         try await post("export", body: body)
     }
 
+    /// Batch export: a list of {camera, range} clips bundled into one job
+    /// (single archive server-side when >1 output or a password is set).
+    func createBatchExport(_ body: CreateBatchExportRequest) async throws -> CreateExportResponse {
+        try await post("export/batch", body: body)
+    }
+
     func exportStatus(jobId: String) async throws -> ExportJob {
         try await get("export/\(jobId)")
     }

--- a/apps/ios/Crumb/Networking/MediaSession.swift
+++ b/apps/ios/Crumb/Networking/MediaSession.swift
@@ -26,6 +26,12 @@ extension URLSession {
 /// three.
 struct TokenedAsyncImage<Content: View, Placeholder: View, Failure: View>: View {
     let url: URL?
+    /// When true, a URL change keeps showing the CURRENT image until the new
+    /// fetch resolves, instead of dropping to the placeholder. For scrub-style
+    /// consumers (the export builder's preview) whose URL changes every tick —
+    /// blanking between frames reads as a black flash per frame. A failed fetch
+    /// still clears to the failure view ("no footage here" must stay honest).
+    var keepStaleImage: Bool = false
     @ViewBuilder let content: (Image) -> Content
     @ViewBuilder let placeholder: () -> Placeholder
     @ViewBuilder let failure: () -> Failure
@@ -35,11 +41,13 @@ struct TokenedAsyncImage<Content: View, Placeholder: View, Failure: View>: View 
 
     init(
         url: URL?,
+        keepStaleImage: Bool = false,
         @ViewBuilder content: @escaping (Image) -> Content,
         @ViewBuilder placeholder: @escaping () -> Placeholder,
         @ViewBuilder failure: @escaping () -> Failure
     ) {
         self.url = url
+        self.keepStaleImage = keepStaleImage
         self.content = content
         self.placeholder = placeholder
         self.failure = failure
@@ -56,14 +64,14 @@ struct TokenedAsyncImage<Content: View, Placeholder: View, Failure: View>: View 
             }
         }
         .task(id: url) {
-            image = nil
+            if !keepStaleImage { image = nil }
             failed = false
             await fetch()
         }
     }
 
     private func fetch() async {
-        guard let url else { failed = true; return }
+        guard let url else { image = nil; failed = true; return }
         var req = URLRequest(url: url)
         req.cachePolicy = .reloadIgnoringLocalCacheData
         req.timeoutInterval = 12
@@ -71,10 +79,11 @@ struct TokenedAsyncImage<Content: View, Placeholder: View, Failure: View>: View 
               let http = resp as? HTTPURLResponse, (200...299).contains(http.statusCode),
               let img = PlatformImage(data: data)
         else {
-            failed = true
+            if !Task.isCancelled { image = nil; failed = true }
             return
         }
         image = img
+        failed = false
     }
 }
 
@@ -82,9 +91,11 @@ extension TokenedAsyncImage where Failure == Placeholder {
     /// 2-parameter convenience: failure state renders the same as the placeholder.
     init(
         url: URL?,
+        keepStaleImage: Bool = false,
         @ViewBuilder content: @escaping (Image) -> Content,
         @ViewBuilder placeholder: @escaping () -> Placeholder
     ) {
-        self.init(url: url, content: content, placeholder: placeholder, failure: placeholder)
+        self.init(url: url, keepStaleImage: keepStaleImage,
+                  content: content, placeholder: placeholder, failure: placeholder)
     }
 }

--- a/apps/ios/Crumb/Networking/MediaSession.swift
+++ b/apps/ios/Crumb/Networking/MediaSession.swift
@@ -79,6 +79,8 @@ struct TokenedAsyncImage<Content: View, Placeholder: View, Failure: View>: View 
               let http = resp as? HTTPURLResponse, (200...299).contains(http.statusCode),
               let img = PlatformImage(data: data)
         else {
+            // A superseded (cancelled) fetch must NOT flip the view to failed —
+            // a newer URL's task is already resolving. Only a real failure clears.
             if !Task.isCancelled { image = nil; failed = true }
             return
         }

--- a/apps/ios/Crumb/Networking/MediaUrls.swift
+++ b/apps/ios/Crumb/Networking/MediaUrls.swift
@@ -78,10 +78,18 @@ struct MediaUrls {
     }
 
     /// Historical still extracted on-demand from recorded footage at `ts`
-    /// (RFC-3339). Used for the playback wall's scrub-to-moment tile previews.
-    func historicalFrameUrl(cameraId: String, tsISO: String) async -> URL? {
+    /// (RFC-3339). Used for the playback wall's scrub-to-moment tile previews and
+    /// the export preview.
+    ///
+    /// `width` (px) is optional: when nil the server picks its default thumbnail
+    /// width (small, cache-shared with the scrub pre-gen — keep it nil for the
+    /// fast wall-scrub path). Callers that render the still LARGE (the export
+    /// preview) pass an explicit width up to the server cap (640) so it isn't a
+    /// tiny thumbnail blown up blurry.
+    func historicalFrameUrl(cameraId: String, tsISO: String, width: Int? = nil) async -> URL? {
         let encoded = tsISO.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? tsISO
-        return await scopedURL(cameraId: cameraId, "/filmstrip/\(cameraId)/frame?ts=\(encoded)")
+        let widthQuery = width.map { "&width=\($0)" } ?? ""
+        return await scopedURL(cameraId: cameraId, "/filmstrip/\(cameraId)/frame?ts=\(encoded)\(widthQuery)")
     }
 
     /// Thumbnail still for a clip. Requires token auth; scoped to `cameraId`.

--- a/apps/ios/Crumb/Networking/MediaUrls.swift
+++ b/apps/ios/Crumb/Networking/MediaUrls.swift
@@ -3,6 +3,18 @@
 import Foundation
 
 struct MediaUrls {
+    /// Width requested for playback scrub stills (the multi-camera playback wall
+    /// and the single-camera scrub preview). A crisp value so those stills don't
+    /// look blurry blown up on a large display — the ~160px default did.
+    ///
+    /// IMPORTANT: keep this equal to the server's `THUMB_PREGEN_WIDTH`
+    /// (services/api/src/config.rs). The pre-generated thumbnail cache is keyed
+    /// on width, so a request at a different width MISSES the pre-gen cache and
+    /// falls back to per-tick on-demand extraction (slow on a multi-cam wall).
+    /// When pre-generation is disabled (the default) the frame is still cached
+    /// lazily at this width, grid-snapped — so revisits stay fast either way.
+    static let scrubThumbWidth = 480
+
     let serverUrl: String
     let token: String?
     /// Per-camera scoped media-token cache (P0-SESSIONS), owned by

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,54 @@ revisit.
 
 ---
 
+## 2026-07-08, macOS/iOS export: adopt the desktop batch-list model (single-shot export retired)
+
+**Problem.** The SwiftUI (macOS/iOS) export flow had drifted from the
+Windows/Linux desktop client: it exported a single time window across N
+selected cameras (`POST /export`), while the desktop builds a **list** of
+clips (each its own camera + range), with a batch summary, an optional
+AES-256 ZIP password, and one job for the whole list (`POST /export/batch`).
+Issue #22 tracks the parity gap; the maintainer's direction (2026-07-08) is
+"mimic the Windows client as closely as possible".
+
+**Chosen.** Port the desktop batch-list model to the SwiftUI client
+(`ExportViewModel` holds `[ExportClip]` + an add/edit-clip builder with a
+frame-preview scrubber; `ExportView` renders list ⇄ builder on the left and
+the global output panel — format, burn-in, audio, password, batch summary,
+"Export N clips" — on the right). Submission goes through the existing
+server `POST /export/batch`; job polling/cancel is unchanged. Entry points
+seed the builder the way the desktop does: playback passes the viewed camera
+plus the bracketed timeline selection (builder opens pre-filled, one click to
+add); the Exports tab starts in list mode with the selected wall camera
+pre-picked.
+
+**Rejected.**
+
+- *Keeping the single-shot model* (or shipping both flows side by side):
+  re-litigating the ratified "desktop is the reference UX" direction, and two
+  export UIs is worse than one.
+- *A Windows-identical persisted destination-folder picker on macOS/iOS.*
+  Platform-inappropriate: sandboxed macOS/iOS apps get durable folder access
+  only via security-scoped bookmarks, and iOS has no folder workflow at all.
+  Outputs keep the platform-native ends: NSSavePanel per output file (macOS)
+  and the share sheet fed a locally-downloaded file (iOS) — preserving the
+  C1/C2 token-leak fixes. Revisit if operators ask for one-click batch saves.
+
+**Deferred, stated explicitly (component-map §3 parity walk):**
+
+- **Android** still has the single-shot export flow; porting the batch model
+  there is follow-up work under issue #22's umbrella, not silently dropped.
+- **Wall-tile thumbnail crispness** (issue #22 item 5) is server-side
+  (pre-generation width in `filmstrip.rs`) and intentionally not bundled into
+  this client-only change.
+- Issue #22 item 6 (format-set parity) was verified a **no-op**: both clients
+  already offer exactly MP4/MKV × {H.264 (MP4 only), H.265, copy}.
+
+**Revisit triggers:** the desktop export flow changes shape (this port
+follows it); operators request persisted batch-save destinations on macOS.
+
+---
+
 ## 2026-07-07, Scrub preview: pre-generated JPEG proxy (API-side); keyframe index rejected
 
 **Problem.** Timeline scrubbing does not yet feel like a leading commercial VMS:

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -45,9 +45,18 @@ pre-picked.
 
 - **Android** still has the single-shot export flow; porting the batch model
   there is follow-up work under issue #22's umbrella, not silently dropped.
-- **Wall-tile thumbnail crispness** (issue #22 item 5) is server-side
-  (pre-generation width in `filmstrip.rs`) and intentionally not bundled into
-  this client-only change.
+- **Wall-tile thumbnail crispness** (issue #22 item 5) — since addressed:
+  the playback wall + single-camera scrub previews requested ~160px stills
+  that blurred blown up to tile size on a large display. The scrub-still width
+  is now a shared constant (iOS `MediaUrls.scrubThumbWidth` = 480) kept equal
+  to the server's `THUMB_PREGEN_WIDTH` default (raised 160 → 480) so the two
+  agree and requests hit the pre-generated cache when it is enabled (and are
+  cached lazily at that width, grid-snapped, when it is not — the default).
+  480 sits at the top of the maintainer's suggested 320–480 range: notably
+  crisper without paying the full 640 cap on per-tick on-demand extraction for
+  a multi-camera wall. Trade-off: when an operator enables pre-generation the
+  cache is ~3–4× the bytes of the old 160px cache; lowering `THUMB_PREGEN_WIDTH`
+  is safe and just drops those clients back to on-demand at their width.
 - Issue #22 item 6 (format-set parity) was verified a **no-op**: both clients
   already offer exactly MP4/MKV × {H.264 (MP4 only), H.265, copy}.
 

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -200,7 +200,14 @@ pub struct ApiConfig {
 
     /// `THUMB_PREGEN_WIDTH` -- width the worker pre-generates at. Clients requesting
     /// this width hit the pre-generated cache; other widths fall back to on-demand
-    /// extraction (width is part of the cache key). Default: `160`.
+    /// extraction (width is part of the cache key). Default: `480`.
+    ///
+    /// Kept equal to the playback clients' scrub-still width (iOS
+    /// `MediaUrls.scrubThumbWidth`) so the multi-camera playback wall and the
+    /// single-camera scrub preview hit the pre-generated cache. Raised from the
+    /// original 160 because that looked blurry blown up to wall-tile size on a
+    /// large display. Lowering it (to shrink pre-gen storage) is safe but means
+    /// those clients fall back to on-demand extraction at their requested width.
     pub thumb_pregen_width: u32,
 
     /// `THUMB_CACHE_DIR` -- optional override for where the thumbnail cache
@@ -332,7 +339,7 @@ impl ApiConfig {
             thumb_pregen_enabled: parse_env("THUMB_PREGEN_ENABLED", false)?,
             thumb_pregen_lookback_hours: parse_env("THUMB_PREGEN_LOOKBACK_HOURS", 2_i64)?.max(0),
             thumb_pregen_scan_secs: parse_env("THUMB_PREGEN_SCAN_SECS", 60_u64)?.max(5),
-            thumb_pregen_width: parse_env("THUMB_PREGEN_WIDTH", 160_u32)?,
+            thumb_pregen_width: parse_env("THUMB_PREGEN_WIDTH", 480_u32)?,
             thumb_cache_dir: optional_env("THUMB_CACHE_DIR", ""),
             frigate_api_base: optional_env("FRIGATE_API_BASE", ""),
             alert_webhook_url: optional_env_opt("ALERT_WEBHOOK_URL"),


### PR DESCRIPTION
Brings the macOS/iOS SwiftUI client to parity with the Windows/Linux desktop client for export and the playback scrubber, per #22. Consolidates and supersedes #21 (the export-window polish is the first commit here).

## What's in it
- **Batch-list export** — ports the desktop client's flow: build a list of clips (camera + range each, "Add clip"), global output settings (format, burn-in, audio, optional AES-256 ZIP password), run the whole batch as one job. Replaces the old single-clip export.
- **Default-camera seeding** — exporting from a fullscreen playback tile now pre-selects that camera (was opening with nothing selected).
- **Scrubber export-region resize** — draggable handles on the timeline export selection.
- **Wall-tile blur** — playback scrub stills request a crisper width backed by a server pre-gen width (`THUMB_PREGEN_WIDTH` in `services/api/src/config.rs`), kept in sync with the client (`MediaUrls.scrubThumbWidth`) so the fast-scrub cache still hits.
- **Export-window polish** (folded from #21): crisp preview (640px vs the ~160px default), preview height cap so it stops burying controls, and a discoverable bordered format picker.
- Misc: positive toggle color, robust clip-list thumbnails, no black flash between preview frames.
- `docs/DECISIONS.md` entry for the batch-list model (golden rule 7).

## Gate
Only `config.rs` (+9/-2) touches the cargo workspace; `cargo fmt --check` is clean locally. clippy / build / test run here in CI (the Swift changes aren't in the Rust workspace).

Closes #22.