### PR TITLE
docs: fairly credit Frigate in the comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,12 +178,12 @@ should include please open an issue.
 | License | AGPL-3.0 | MIT | Open core | Commercial ($) | GPL |
 | Primary focus | Operator/timeline layer + recording | Object-detection NVR | Integration hub + NVR | All-in-one NVR | Classic NVR |
 | Object detection | **BYO Frigate** (composes) | ✅ built-in | ✅ plugins | ✅ (DeepStack / CodeProject) | Basic / add-ons |
-| Scrubbable timeline | ✅ frame-level, H.265 native | Basic web viewer | Basic | ✅ | Basic |
+| Scrubbable timeline | ✅ frame-level, native (libmpv) | ✅ web-based | ✅ web-based | ✅ native | Basic |
 | Native desktop client | ✅ Tauri/libmpv | ❌ (web) | ❌ (web) | ✅ Windows | ❌ (web) |
-| Mobile app | ✅ Android (iOS built) | via HA / 3rd-party | ✅ | ✅ | 3rd-party |
-| Multi-cam saveable wall | ✅ | limited | limited | ✅ | limited |
+| Mobile app | ✅ Android (iOS in progress) | via HA / 3rd-party | ✅ | ✅ | 3rd-party |
+| Multi-cam saveable wall | ✅ | ✅ camera groups | limited | ✅ | limited |
 | Batch export | ✅ list → MP4 / AES-256 zip | manual | limited | ✅ | limited |
-| RBAC / per-camera roles | ✅ | limited | limited | ✅ | ✅ |
+| RBAC / per-camera roles | ✅ | ✅ roles + per-camera | limited | ✅ | ✅ |
 | Cloud / account required | **Never** | Never | Optional | Never | Never |
 | Runs on | Linux + Docker | Linux + Docker | cross-platform | Windows | Linux |
 


### PR DESCRIPTION
A tester on r/frigate_nvr flagged that the README comparison undersold Frigate. They were right. This corrects the scrubbing row (native-vs-web, not good-vs-basic), the RBAC row (Frigate has role-based auth with per-camera access as of 0.15/0.16), the multi-cam wall row (Frigate has camera groups), and fixes the mobile row to 'iOS in progress'. Scrypted cells left untouched (unverified).