### PR TITLE
fix(ci): satisfy clippy::question_mark (Rust 1.97) + pin the toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,11 @@ jobs:
           fi
 
       - name: Install Rust toolchain
+        # Pinned to match rust-toolchain.toml so a new `stable` release and its
+        # clippy can't turn CI red with no code change. Bump both together.
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: "1.97.0"
           components: rustfmt, clippy
 
       - name: Cache cargo registry + build
@@ -126,8 +129,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
+        # Pinned to match rust-toolchain.toml so a new `stable` release and its
+        # clippy can't turn CI red with no code change. Bump both together.
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: "1.97.0"
           components: rustfmt, clippy
 
       - name: Install GTK / WebKitGTK build deps

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,41 @@ revisit.
 
 ---
 
+## 2026-07-09, Pin the Rust toolchain (CI + `rust-toolchain.toml`) instead of tracking `stable`
+
+**Problem.** CI installed Rust via `dtolnay/rust-toolchain@stable` (unpinned)
+and runs clippy with `-D warnings`. When Rust 1.97 released, its clippy began
+flagging an untouched `match` in `services/recorder/src/resource_stats.rs` as
+`clippy::question_mark`, turning the gate red on a docs-only merge (#29) with
+zero relevant code change. Green-this-morning / red-this-afternoon with no code
+change is exactly the failure mode a floating toolchain + `-D warnings` invites.
+
+**Chosen.** Pin the toolchain to an explicit version in two coordinated,
+cross-referenced places: `rust-toolchain.toml` at the repo root (governs local
+builds, so `cargo clippy` on dev1 matches CI and "run the gate before pushing"
+actually catches what CI catches) and the `toolchain:` input on the CI
+`dtolnay/rust-toolchain` steps (governs CI). Rust is now bumped deliberately by
+editing both, not surprise-upgraded. First pin: `1.97.0`.
+
+**Rejected.**
+
+- *Keep tracking `stable`.* Zero-maintenance until it isn't: any new stable that
+  adds or tightens a lint can break CI with no code change, and it broke on
+  literally the first run after 1.97 shipped.
+- *Drop `-D warnings`.* Removes the fragility but also removes the guard that
+  keeps the tree clippy-clean; trading a real correctness signal for convenience.
+- *`rust-toolchain.toml` alone, CI left on `@stable`.* Works via rustup's
+  auto-switch, but relies on a subtle interaction (CI installs stable, cargo
+  silently switches to the toml version). Explicit pinning in both spots reads
+  clearly to a future maintainer.
+
+**Revisit triggers.** Bumping the pin becomes frequent toil (wanting the newest
+stable often), or the two pin sites drift apart in practice — then consolidate
+to a single source of truth (e.g. an action that reads `rust-toolchain.toml`,
+accepting the extra CI dependency).
+
+---
+
 ## 2026-07-08, macOS/iOS export: adopt the desktop batch-list model (single-shot export retired)
 
 **Problem.** The SwiftUI (macOS/iOS) export flow had drifted from the

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,9 @@
+# Pin the Rust toolchain so a newly-released `stable` (and its clippy) can't
+# turn CI red with no code change — the gate runs clippy with `-D warnings`.
+# CI (.github/workflows/ci.yml) pins the SAME version via the
+# dtolnay/rust-toolchain `toolchain:` input; bump both together, deliberately.
+# See docs/DECISIONS.md (2026-07-09).
+[toolchain]
+channel = "1.97.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"

--- a/services/recorder/src/resource_stats.rs
+++ b/services/recorder/src/resource_stats.rs
@@ -488,12 +488,10 @@ mod linux {
         // attribute GPU at all (host pids won't match container child pids), so
         // report NULL rather than a misleading 0%.
         let translate = std::path::Path::new(HOST_PROC).is_dir();
+        // `?` early-returns None if we can't establish our own namespace, i.e.
+        // can't safely translate host↔container pids.
         let my_ns = if translate {
-            match my_pid_ns() {
-                Some(ns) => Some(ns),
-                // Can't establish our own namespace ⇒ can't safely translate.
-                None => return None,
-            }
+            Some(my_pid_ns()?)
         } else {
             None
         };

--- a/services/recorder/src/resource_stats.rs
+++ b/services/recorder/src/resource_stats.rs
@@ -490,11 +490,7 @@ mod linux {
         let translate = std::path::Path::new(HOST_PROC).is_dir();
         // `?` early-returns None if we can't establish our own namespace, i.e.
         // can't safely translate host↔container pids.
-        let my_ns = if translate {
-            Some(my_pid_ns()?)
-        } else {
-            None
-        };
+        let my_ns = if translate { Some(my_pid_ns()?) } else { None };
 
         let mut map: HashMap<i32, f64> = HashMap::new();
         for s in samples {


### PR DESCRIPTION
Two commits, one root cause: unpinned Rust toolchain + `-D warnings`.

## 1. The lint fix (unblocks CI now)
Rust 1.97 shipped and CI (`dtolnay/rust-toolchain@stable`) auto-upgraded. Its clippy flags a manual `match` in `services/recorder/src/resource_stats.rs` as `clippy::question_mark`; with `-D warnings` that reds the gate. The README-only merge (#29) was just the first run on the new toolchain. Rewrite as `Some(my_pid_ns()?)` — behavior identical, no change to GPU-attribution logic.

## 2. The durable fix (stops recurrence)
Pin the Rust version so a future stable's clippy can't break CI with no code change, in two coordinated places:
- `rust-toolchain.toml` — governs local builds, so `cargo clippy` on dev1 matches CI.
- the `toolchain:` input on the CI `dtolnay/rust-toolchain` steps — governs CI.

Bump both together, deliberately. Decision + rejected alternatives logged in `docs/DECISIONS.md`.

First pin: 1.97.0 (current stable), so no behavior change vs. what CI already resolved to.