### PR TITLE
feat(api): update-available check endpoint + opt-in toggle (refs #7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,13 @@ ALERT_WEBHOOK_URL=
 # CAMERA_OFFLINE_BOOT_GRACE_SECS=180      # grace after a restart before camera-offline alerts
 # MAINTENANCE_UNTIL=                       # unix-seconds; suppress all health alerts until then
 
+# --- Update-available check (optional, issue #7; OFF by default) ---
+# When enabled, the api periodically asks github.com for the latest CrumbVMS
+# release tag (version number only, nothing sent) so clients can show an
+# "update available" notice. The admin console toggle (Server settings) wins
+# over this env once set. false = zero github.com requests, ever.
+UPDATE_CHECK_ENABLED=false
+
 # --- Seed (admin bootstrap) ---
 # Easiest: leave blank and create the admin at /admin on first run. Headless: set
 # SEED_ADMIN_PASSWORD (api argon2-hashes it) or SEED_ADMIN_PASSWORD_HASH (a PHC

--- a/db/migrations/0045_update_check.sql
+++ b/db/migrations/0045_update_check.sql
@@ -1,0 +1,14 @@
+-- Operator opt-in toggle for the update-available check (issue #7). NULL means
+-- "the operator has never touched this" -> services/api/src/config.rs falls
+-- back to the UPDATE_CHECK_ENABLED env var (default false, D3: OFF BY
+-- DEFAULT, so a fresh install makes zero GitHub requests until the operator
+-- explicitly opts in via the admin console or the env).
+--
+-- Nullable + no DEFAULT (unlike bookmarks_enabled's NOT NULL DEFAULT true,
+-- migration 0029) is deliberate: it distinguishes "never set" from an explicit
+-- false, matching the house server_settings precedence rule (admin-set DB
+-- value wins over env; an unset/NULL DB value falls back to env).
+--
+-- Additive + nullable, so it is safe on an already-running install.
+ALTER TABLE server_settings
+    ADD COLUMN IF NOT EXISTS update_check_enabled boolean;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,6 +144,7 @@ services:
       FRIGATE_MIN_SCORE: ${FRIGATE_MIN_SCORE:-0.3}
       FRIGATE_CATCHUP_HOURS: ${FRIGATE_CATCHUP_HOURS:-24}
       ALERT_WEBHOOK_URL: ${ALERT_WEBHOOK_URL:-}         # Discord/Slack webhook on recorder-heartbeat stall; empty = silent
+      UPDATE_CHECK_ENABLED: ${UPDATE_CHECK_ENABLED:-false}   # opt-in (issue #7); false = zero github.com requests
       RUST_LOG: ${RUST_LOG:-info}
       LOG_FORMAT: ${LOG_FORMAT:-json}
       # Built-in nightly pg_dump of the segments index (the mp4→camera/time map). docs/BACKUP.md

--- a/docs-site/docs/configuration/environment-reference.md
+++ b/docs-site/docs/configuration/environment-reference.md
@@ -133,6 +133,12 @@ See [Backups](/configuration/backups) for the full picture.
 | `CAMERA_OFFLINE_BOOT_GRACE_SECS` | `180` | holds camera-offline alerts for this long after a recorder restart |
 | `MAINTENANCE_UNTIL` | empty | unix-seconds timestamp to pre-arm a maintenance window at boot |
 
+## Update-available check (issue #7)
+
+| Key | Default | Notes |
+|---|---|---|
+| `UPDATE_CHECK_ENABLED` | `false` | opt-in; when `true`, the api periodically asks github.com for the latest CrumbVMS release tag (version number only, nothing sent) so clients can show an "update available" notice. `false` means zero github.com requests, ever. The admin console's "Enable update checks" toggle (Server settings) overrides this once set — DB wins over env. |
+
 ## Seed (admin bootstrap)
 
 | Key | Default | Notes |

--- a/docs/AI-INSTALL.md
+++ b/docs/AI-INSTALL.md
@@ -547,6 +547,21 @@ For that, add a small **external uptime check** hitting
 healthchecks.io, or a one-line cron that curls `/health` and alerts on failure.
 Without it, an API outage is silent until someone notices a client won't connect.
 
+**Update notifications (optional, off by default; issue #7).** CrumbVMS can
+tell the operator when a newer release exists, via `GET /updates/latest` and a
+toggle in the admin **Server** settings ("Enable update checks"). This is the
+**one opt-in exception** to the LAN-only/no-egress posture in Step 0: when
+enabled, the api periodically (at most a few times an hour, cached 6h) makes a
+plain HTTPS `GET` to `api.github.com` for the latest `badbread/crumbvms`
+release tag, a version number, nothing else. No telemetry, no client
+identifiers, no counts are sent, and there's no download/auto-install, it is
+strictly a "you're behind, here's the release notes link" notice. **Default is
+OFF** (`UPDATE_CHECK_ENABLED=false`): a fresh install makes zero requests to
+github.com until the operator explicitly flips the switch. Enable it via the
+admin console, or set `UPDATE_CHECK_ENABLED=true` in `.env` before first boot.
+An "enabled" answer includes a manual **"Check now"** button that forces an
+immediate re-check (rate-limited server-side to protect GitHub's API).
+
 ---
 
 ## 10. Remote access (ONLY if the user asks)

--- a/docs/COMPONENT-MAP.md
+++ b/docs/COMPONENT-MAP.md
@@ -36,7 +36,7 @@ All paths below are repo-relative and verified to exist as of 2026-07-06.
 | Component | Path(s) | Owns | Built / deployed by |
 |---|---|---|---|
 | Shared crate | `services/common/src/` (`config.rs`, `db.rs`, `types.rs`, `detection.rs`, `logging.rs`, `redact.rs`, `icons.rs`) | Shared types, DB layer, **the `MIGRATIONS` array** (in `db.rs`, search `static MIGRATIONS`), env config, secret redaction | Compiled into both service images |
-| API service | `services/api/src/` (`main.rs` router at the `json_routes` / `media_routes` split; `config_routes.rs`, `dto.rs`, `auth.rs`, `auth_mw.rs`, `roles.rs`, `cameras.rs`, `timeline.rs`, `playback.rs`, `export.rs`, `export_store.rs`, `filmstrip.rs`, `clips.rs`, `events.rs`, `detection_ingester.rs`, `detection/`, `bookmarks.rs`, `views.rs`, `ptz.rs`, `notifications.rs`, `channel_notify.rs`, `status.rs`, `stats.rs`, `stream_test.rs`, `discover.rs`, `go2rtc.rs`, `alerts.rs`, `db_backup.rs`, `metrics.rs`, `rate_limit.rs`) | HTTP API, auth/RBAC, go2rtc reconcile loop, admin console serving, DB backup task | `services/api/Dockerfile`; image `<prefix>/api:<version>` via CI `images` job |
+| API service | `services/api/src/` (`main.rs` router at the `json_routes` / `media_routes` split; `config_routes.rs`, `dto.rs`, `auth.rs`, `auth_mw.rs`, `roles.rs`, `cameras.rs`, `timeline.rs`, `playback.rs`, `export.rs`, `export_store.rs`, `filmstrip.rs`, `clips.rs`, `events.rs`, `detection_ingester.rs`, `detection/`, `bookmarks.rs`, `views.rs`, `ptz.rs`, `notifications.rs`, `channel_notify.rs`, `status.rs`, `stats.rs`, `stream_test.rs`, `discover.rs`, `go2rtc.rs`, `alerts.rs`, `db_backup.rs`, `metrics.rs`, `rate_limit.rs`, `updates.rs`) | HTTP API, auth/RBAC, go2rtc reconcile loop, admin console serving, DB backup task | `services/api/Dockerfile`; image `<prefix>/api:<version>` via CI `images` job |
 | Recorder service | `services/recorder/src/` (`recording.rs`, `motion.rs`, `archive.rs`, `reconcile.rs`, `go2rtc_embed.rs`, `frigate_motion.rs`, `decode_probe.rs`, `resource_stats.rs`) | Recording, motion detection, retention/eviction, segment index, embedded go2rtc supervision. The always-must-work component (golden rule 2) | `services/recorder/Dockerfile`; image `<prefix>/recorder:<version>` |
 | DB schema | `db/migrations/0001..NNNN_*.sql` + the `MIGRATIONS` array in `services/common/src/db.rs` | Schema history. A migration file not listed in the array **silently never runs** (golden rule 4) | Applied on boot by whichever service starts first |
 
@@ -262,6 +262,7 @@ is not. The web admin console doubles as the desktop's management surface
 | Views (saved layouts) | views handling | views + server-backed `/views` | server-backed views | `Platform/`/`Features` |
 | Settings | server settings + users/RBAC | settings + embedded `/admin` | `settings/` | `Settings/` |
 | Notifications | rules + history CRUD | toasts | poll + local notifications | `Settings/` |
+| Update notice (issue #7) | Server settings toggle + status/"Check now" (the console's own update IS the server update) | Phase 2, not yet shipped (`docs/UPDATE-SYSTEM-PLAN.md` §7 C2) | Phase 2, not yet shipped (§7 C3) | Phase 2, not yet shipped, iOS lowest priority per D5 (§7 C4) |
 
 Parity walk for a new feature:
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,85 @@ revisit.
 
 ---
 
+## 2026-07-09, Update-available check: api-mediated, notify-only, opt-in / OFF BY DEFAULT
+
+**Problem.** Issue #7 asks for a non-intrusive "update available → release
+notes" signal across every client (web console, Windows/Linux/macOS desktop,
+Android, iOS), so an install doesn't silently drift for months without the
+operator noticing a new release exists. `docs/UPDATE-SYSTEM-PLAN.md` is the
+full design; this entry records the decisions ratified for Phase 1 (server).
+
+**Chosen.**
+
+- **Notify-only (D1).** Version comparison and a release-notes link only. No
+  download, no install, no update channels, and the recorder is never touched
+  by any part of this feature — footage/metadata are structurally uninvolved.
+- **Api-mediated, not per-client direct polling (D2).** Only `services/api`
+  (`services/api/src/updates.rs`) talks to `GitHub`; every client (including
+  the web console) consumes its own server's `GET /updates/latest`. One
+  implementation, one cache, one operator off-switch that actually turns the
+  whole thing off site-wide, instead of five client codebases each with their
+  own `GitHub` HTTP code and their own switch.
+- **Opt-in, OFF BY DEFAULT (D3).** `UPDATE_CHECK_ENABLED` defaults to `false`;
+  the admin-editable `server_settings.update_check_enabled` (migration
+  `0045_update_check.sql`, nullable — DB wins, `NULL` falls back to env) can
+  turn it on. A fresh install makes **zero** requests to `github.com` until
+  the operator explicitly opts in via the admin console or the env var. This
+  is the plan doc's non-default alternative, deliberately chosen over its
+  "recommended enabled" option to keep Crumb's no-phone-home posture intact
+  out of the box — the checker is a value-add an operator turns on, not a
+  default behavior a privacy-conscious install has to notice and turn off.
+- **Stable releases only, via `releases/latest` (D6).** That `GitHub` endpoint
+  already excludes drafts and pre-releases, so channel selection needs no
+  extra code for Phase 1.
+- **Manual "Check now" (§2.5), added mid-implementation.** `?refresh=1` forces
+  an immediate re-check bypassing the 6h cache TTL, gated to a separate 60s
+  minimum interval between actual forced `GitHub` hits so a burst of manual
+  clicks can't stampede the 60/h/IP unauthenticated rate limit. The disabled
+  state still wins unconditionally: `refresh=1` while disabled makes zero
+  requests, there is no "one-off check while disabled" escape hatch.
+- **No Tauri built-in updater (D4).** Its value is install/relaunch machinery,
+  which #7 explicitly excludes; using it only for version detection would
+  still require its manifest format and a signing keypair at build time for a
+  job a 20-line fetch + hand-rolled `SemVer` compare does against one endpoint.
+
+**Rejected.**
+
+- *Per-client direct `GitHub` polling as the default.* More resilient to a
+  disabled/old server, but five implementations, five off-switches to keep in
+  sync, and every client device (including wall displays) hitting `GitHub`
+  independently instead of one cached point per site. Not ruled out forever —
+  see revisit triggers.
+- *On-by-default (the plan doc's original recommendation).* Would surface the
+  feature to exactly the operators it's meant to help without them hunting for
+  a toggle, but costs a fresh install non-zero external egress before the
+  operator has made any choice at all — a worse trade against the project's
+  "operator's hardware is the whole world, no phone-home" direction than the
+  minor discoverability cost of an opt-in switch.
+- *A server-hosted artifact/manifest system as the #7 vehicle.* Explicitly
+  deferred to the `docs/UPDATE-SYSTEM-PLAN.md` §6 future extension (real
+  install automation, if ever demanded) — out of scope for a notify-only
+  nicety.
+- *Tauri's built-in updater for detection only.* See D4 above.
+
+**Trade-offs accepted.** A client talking to an older server that lacks the
+route gets a 404 and shows nothing — the accepted cost of server-mediation.
+Version-level granularity misses an Android intra-version re-ship
+(`workflow_dispatch` bumping `VERSION_CODE` without a new tag). An unparsable
+own version (a local `-dev` build) shows no banner rather than guessing.
+
+**Revisit triggers.** Real operator demand for in-app download/install
+surfaces (→ design the §6 future extension properly, with signing and scoped
+tokens). `GitHub`'s REST API terms or rate limits change in a way that makes
+server-side caching insufficient. A legitimate need emerges for a client to
+check `GitHub` directly (e.g. a client that is never paired with a Crumb
+server) — revisit D2. Enough operators report never noticing the admin
+console toggle exists that the opt-in default becomes counterproductive —
+revisit D3 (the plan doc's original recommendation is preserved above as the
+alternative to fall back to).
+
+---
+
 ## 2026-07-09, Pin the Rust toolchain (CI + `rust-toolchain.toml`) instead of tracking `stable`
 
 **Problem.** CI installed Rust via `dtolnay/rust-toolchain@stable` (unpinned)

--- a/docs/UPDATE-SYSTEM-PLAN.md
+++ b/docs/UPDATE-SYSTEM-PLAN.md
@@ -384,8 +384,8 @@ reference `refs #7`; the PR that completes the last in-scope client carries
 - **S4 Install surface + docs floor.** `.env.example`, `setup-env.sh`
   comment, `docker-compose.yml` api env (+ variant sweep), `docs/AI-INSTALL.md`
   (key + the one-egress disclosure per D3), docs-site environment-reference
-  row. Acceptance: `docker compose config` clean on a real Docker host
-  (dev1/mrUbuntu); smoke workflow green; AI-INSTALL "For maintainers" items
+  row. Acceptance: `docker compose config` clean on a real Docker host (the
+  build/prod host); smoke workflow green; AI-INSTALL "For maintainers" items
   re-verified. Sonnet, small.
 - **S5 Decision log + component map.** The `docs/DECISIONS.md` entry and
   `docs/COMPONENT-MAP.md` "Update notice" parity row per §5 row M, in the

--- a/docs/UPDATE-SYSTEM-PLAN.md
+++ b/docs/UPDATE-SYSTEM-PLAN.md
@@ -1,0 +1,439 @@
+# Update-available checker: design and task breakdown (issue #7)
+
+Status: **DESIGN, not implemented.** This is the skeleton for
+[issue #7, "Update-available checker across all clients"](https://github.com/badbread/crumbvms/issues/7),
+written to be implemented task-by-task by separate agent sessions. Read
+`AGENTS.md` first; every task below is bound by the golden rules (secure by
+default, CI gate, migration registration, install-guide honesty,
+DECISIONS/COMPONENT-MAP obligations).
+
+## 0. Scope, straight from issue #7
+
+The deliverable is an **"update available" signal**, nothing more:
+
+- Each client compares its own build version to the latest CrumbVMS release
+  and shows a **non-intrusive "update available → release notes" notice**.
+- Clients in scope: Windows desktop (Tauri), Linux desktop (Tauri), macOS,
+  Android (sideloaded APK), iOS (SwiftUI, **lowest priority**, the App
+  Store/TestFlight handles it once distributed), and the web console
+  (`/admin`, served by the api, whose "update" is the server image itself).
+- Source of truth: **GitHub Releases** for `badbread/crumbvms` (the repo
+  already publishes tagged releases via the `*-release` workflows).
+- Constraints, verbatim from the issue's recorded maintainer direction:
+  - "Must be optional and operator-disableable, no mandatory phone-home. The
+    check contacts GitHub (where the software came from), sends no
+    telemetry, and can be turned off."
+  - "Version check only; footage and metadata are never involved."
+  - "No auto-download / auto-install without explicit user action, and never
+    auto-update the recorder."
+- Explicitly **out of scope** for #7: auto-download, auto-install, artifact
+  hosting/serving, artifact signing, update channels, and any self-update
+  mechanics (Sparkle, PackageInstaller sessions, the Tauri updater's install
+  feature). A fuller update system is sketched as a clearly-labeled future
+  extension in §6 and is NOT part of this work.
+- Priority: "post-alpha nicety, not blocking." The design and the task
+  sizing below are deliberately proportionate to that.
+
+Clarification on direction: contacting GitHub for a **version number** is
+ratified as acceptable here (it is where the software came from, it carries
+no telemetry, and it can be switched off). This checker must never be
+extended to send anything, telemetry stays nonexistent, and footage/metadata
+are structurally uninvolved (the code never touches media paths, media
+tokens, or the recorder).
+
+## 1. Architecture
+
+```
+                       (only while the operator leaves the check enabled)
+                    ┌──────────────────────────────────────────────────┐
+                    │  GitHub Releases API (badbread/crumbvms)         │
+                    │  GET /repos/.../releases/latest  → tag + notes   │
+                    └──────────────────────▲───────────────────────────┘
+                                           │ one plain HTTPS GET,
+                                           │ api-initiated, cached (TTL),
+                                           │ nothing sent, version-only
+                              ┌────────────┴───────────────┐
+                              │  Crumb api (services/api)  │
+                              │  updates.rs                │
+                              │   • GET /updates/latest    │
+                              │   • in-memory cache        │
+                              │   • server_settings toggle │
+                              └────────────┬───────────────┘
+                     LAN, existing :8080/:8443, bearer-JWT authed
+          ┌───────────┬───────────┬────────┴──┬───────────┬───────────┐
+          ▼           ▼           ▼           ▼           ▼           ▼
+      Web admin   Win desktop  Linux desktop  Android    macOS       iOS
+      (server-    (banner →    (banner →     (banner →  (banner →  (banner;
+       update      release      release       release    release    lowest
+       notice)     notes)       notes)        notes)     notes)     priority)
+```
+
+Recommended topology (decision point D2): the api owns the single
+GitHub-facing check behind `GET /updates/latest`, and every client consumes
+that from the server it is already paired and authenticated with. Rationale
+(convenience and single-source-of-truth, per the issue's suggestion, not an
+anti-phone-home mandate, the maintainer has ratified direct GitHub contact
+as acceptable):
+
+- The version-source logic, caching, and semver parsing live in ONE place
+  instead of five client codebases.
+- The operator's disable switch is ONE switch that actually turns the whole
+  thing off for every client on the site, instead of a per-client setting
+  audit.
+- One cached egress point per site (a handful of GitHub hits per day)
+  instead of every wall display and phone polling GitHub independently.
+- Clients keep the property that they only ever talk to their own server.
+
+A client talking to an older server that lacks the endpoint gets a 404 and
+shows nothing (feature detection, component-map §3 parity item 3). That is
+the accepted trade-off of server-mediation: a client can only learn about
+updates while its server is new enough and has the check enabled.
+
+Restated invariants: **no new ports, no new binds, no telemetry, never
+auto-update the recorder, nothing here touches footage or the recorder
+service at all.**
+
+## 2. The framework
+
+### 2.1 Server endpoint
+
+New module `services/api/src/updates.rs`, one route wired into `main.rs` on
+the **json** side (`json_routes`: gzip + 30s timeout + rate limit, the right
+side for a small JSON response):
+
+`GET /updates/latest`, authenticated, **any** authenticated user (viewers
+run wall displays and phones too; this is deliberately not admin-only).
+Response DTO (canonical serde shape in `services/api/src/dto.rs`,
+component-map row A):
+
+```json
+{
+  "enabled": true,
+  "latest_version": "0.0.2",
+  "notes_url": "https://github.com/badbread/crumbvms/releases/tag/v0.0.2",
+  "published_at": "2026-07-20T00:00:00Z",
+  "server_version": "0.0.1",
+  "server_update_available": true,
+  "checked_at": "2026-07-21T18:00:00Z"
+}
+```
+
+- `enabled:false` ⇒ all other fields null; clients show nothing. (Returning
+  200 with `enabled:false`, rather than 404, distinguishes "operator turned
+  it off" from "old server".)
+- `latest_version` is the newest release **tag without the `v` prefix** from
+  `GET https://api.github.com/repos/badbread/crumbvms/releases/latest`.
+  That GitHub endpoint already excludes pre-releases and drafts, so the
+  signal is stable-releases-only by construction (D6).
+- `server_version` / `server_update_available`: the api compares its own
+  build version (the existing `/version` machinery, `CARGO_PKG_VERSION`)
+  so the web console's notice needs zero logic. Client apps compare their
+  OWN build version against `latest_version` locally.
+- Fetch behavior: lazy fetch on demand with an in-memory cache
+  (TTL 6 hours, stale-while-error: keep serving the last good value and
+  never surface a GitHub outage to clients as an error, just an older
+  `checked_at`). No background task needed, no persistence needed, cache
+  dies with the process and that is fine. Honor GitHub rate-limit responses
+  by backing off to the next TTL window (unauthenticated limit is 60/h/IP;
+  a 6h TTL uses ~4/day).
+- The request sends **nothing**: no query params, no client versions, no
+  counts, no identifiers beyond the connection itself. Keep it that way,
+  this is the line between "version check" and telemetry.
+- Endpoint documented in the `config_routes.rs` doc-comment API tables (the
+  reference until OpenAPI exists).
+
+### 2.2 Version-compare semantics
+
+- Versions are the release tags without `v` (`VERSION` file / tauri.conf /
+  `version.properties` `VERSION_NAME` / the iOS project version all follow
+  this already). Compare as SemVer 2.0.0 precedence; treat an unparsable
+  version (dev builds like `0.0.1-dev`) as "never show the banner" rather
+  than erroring.
+- One tiny hand-rolled compare with unit tests per codebase that needs it
+  (Rust once in `updates.rs`; a few lines each in JS/Kotlin/Swift). No new
+  dependency for this (golden rule 6).
+- Notice condition: `latest_version > own_version`, strictly. Equal or
+  newer-local (dev tree) shows nothing.
+- Android note: the `workflow_dispatch` re-ship path can bump `VERSION_CODE`
+  without a new tag; that intra-version re-ship is invisible to this
+  checker. Accepted, #7 is a version-level nicety, not a patch-level
+  distribution system.
+
+### 2.3 Operator control (the off switch)
+
+House config precedence applies: admin-set DB `server_settings` values win
+over env; empty DB value falls back to env.
+
+- **Migration `0045_update_check.sql`**: add
+  `update_check_enabled BOOLEAN` (nullable; NULL = fall back to env) to
+  `server_settings`. `0044_beta_terms_acceptance.sql` is the current highest,
+  so **0045 is the next free number**. **MUST be registered in the
+  `MIGRATIONS` array in `services/common/src/db.rs`** (append after the 0044
+  entry, ~line 7574); an unregistered migration silently never runs (golden
+  rule 4). Nothing footage-adjacent; standard migration test pass suffices.
+- **Env fallback key `UPDATE_CHECK_ENABLED`** (default per D3, recommended
+  `true`), added to: `services/api/src/config.rs`, `.env.example`,
+  `docker-compose.yml` api environment block, a `scripts/setup-env.sh`
+  comment (no secret, nothing to generate), `docs/AI-INSTALL.md`, and
+  `docs-site/docs/configuration/environment-reference.md` (component-map
+  row B).
+- **Admin console toggle** in the server-settings area of
+  `services/api/src/admin.html`, with plain-language copy: "When enabled,
+  this server periodically asks github.com for the latest CrumbVMS version
+  number so clients can tell you when an update exists. Nothing is sent, and
+  turning this off disables the check for every client." Console code writes
+  only this field (house rule).
+- Disabled means disabled: the api makes **zero** GitHub requests and the
+  endpoint returns `enabled:false`. There is no other egress anywhere in
+  this feature.
+
+### 2.4 What this design deliberately does NOT need
+
+Called out so implementers don't cargo-cult the heavier machinery:
+
+- **No media tokens.** There is no artifact download; the endpoint is a
+  small JSON route behind the normal bearer JWT. (The scoped `?token=`
+  pattern is for media; it is not engaged here.)
+- **No new volume, no artifact storage, no signing keys, no new secrets.**
+- **No client-side GitHub HTTP code** (under the recommended D2 default).
+- **No background task** in the api (lazy fetch + TTL cache).
+- **No recorder changes of any kind.**
+
+### 2.5 Manual check ("Check now")
+
+A "Check now" affordance lets the operator force an immediate check instead of
+waiting out the 6h TTL. It is a convenience on the SAME endpoint, not a new
+egress path:
+
+- **Server:** `GET /updates/latest?refresh=1` bypasses the TTL cache and
+  performs one fresh GitHub fetch, then updates the cache. To protect GitHub's
+  unauthenticated rate limit (60/h/IP) and stop many authenticated clients from
+  stampeding it, the server enforces a **minimum interval between actual forced
+  fetches** (60s); a `refresh=1` inside that window serves the cached value
+  (with its existing `checked_at`) instead of hitting GitHub. Without `refresh`,
+  behavior is exactly as §2.1 (serve cache within TTL).
+- **Disabled still means zero egress.** When `update_check_enabled` resolves to
+  off, `refresh=1` is ignored: the endpoint returns `enabled:false` and makes
+  ZERO GitHub requests. The manual check is only live while the check is
+  enabled. There is deliberately NO "one-off check while disabled" mode; it
+  would muddy the zero-egress-when-disabled invariant for a nicety.
+- **UI:** a "Check now" button in the admin console's update area and in each
+  client's Settings/About update area, shown only when the check is enabled. It
+  calls `refresh=1`, then refreshes the displayed status ("Checked just now,
+  you're up to date" / "vX.Y.Z available → release notes"). Non-destructive, no
+  new permission.
+
+## 3. Per-client mechanism
+
+All clients: check once shortly after login/launch and re-check at most
+every 24h while running, against their own server's `GET /updates/latest`.
+404 or `enabled:false` ⇒ show nothing. The notice is non-intrusive: a
+dismissible row/badge in the Settings/About area (dismiss remembers the
+dismissed version and stays quiet until a newer one appears), linking to
+`notes_url` in the platform browser. No download buttons, no install flows.
+
+| Client | Own version from | Notice surface | Notes |
+|---|---|---|---|
+| Web console (`admin.html`) | n/a, uses `server_update_available` | banner in the settings/system area: "Server v0.0.2 is available → release notes", plus the literal upgrade commands (`CRUMB_VERSION` pin + `docker compose pull`, per docs/IMAGES.md) | The console ships inside the api image, so its update IS the server update. Notify-only, the operator runs the upgrade; the server never updates itself. |
+| Windows desktop (Tauri) | `tauri.conf.json` version via the Tauri API (`getVersion()`) | settings/about badge + dismissible banner in `apps/desktop/src/app.js` | Windows and Linux are one codebase and one task; a JS `fetch` via the existing authed helper, no Rust changes needed. |
+| Linux desktop (Tauri) | same | same | Same code path. Release-notes link points at the GitHub release; Linux users build from source per docs/CLIENTS.md. |
+| Android | `BuildConfig.VERSION_NAME` | Settings/About row + dismissible banner (Compose) | Plain repository call through the existing Retrofit stack. No `REQUEST_INSTALL_PACKAGES`, no download. |
+| macOS | `CFBundleShortVersionString` | Settings row + banner | Shared `UpdateChecker` in `apps/ios/Crumb/Networking/`. |
+| iOS | same | same shared code | **Lowest priority** (issue #7): once TestFlight/App Store distribution exists, the platform's own update flow supersedes this notice. Ships only because it is the same shared Swift code as macOS; may be feature-flagged off if distribution lands first. |
+
+On the Tauri built-in updater (evaluated per the issue): **not used for #7.**
+Its value is the install/relaunch machinery, exactly what #7 excludes; using
+it only for detection would still demand its endpoint manifest format and
+its signing keypair at build time, for a job a 20-line `fetch` + semver
+compare does against `/updates/latest`. Reconsider it in the §6 future
+extension, where install is actually in scope. (Decision point D4.)
+
+## 4. Decision points for the maintainer
+
+Each needs Jason's confirmation before the corresponding task starts.
+
+- **D1, scope.** Confirm #7's notify-only scope is the deliverable and the
+  full download/install system stays future work (§6). *Recommended: yes,
+  as the issue states.*
+- **D2, who talks to GitHub.** (a) Clients consume the api's
+  `GET /updates/latest`, only the api contacts GitHub (*recommended*:
+  single implementation, single cache, single off-switch that truly turns
+  it off site-wide; the issue itself suggests this helper), vs (b) each
+  client queries GitHub Releases directly (maintainer-ratified as
+  acceptable; more resilient when the server is old or the check is
+  disabled server-side, but five implementations, five switches, and every
+  client device makes its own external calls). A hybrid (b-with-fallback)
+  is not recommended: two code paths for a nicety.
+- **D3, default state of the check.** *Recommended: enabled by default*,
+  with the off-switch prominent in the admin console, the env fallback
+  key, and disclosure in `docs/AI-INSTALL.md` (which otherwise promises
+  LAN-only behavior, the runbook must mention this one opt-out egress
+  explicitly). Rationale: the issue's whole "why" is that installs silently
+  drift; a default-off check helps nobody who doesn't already watch GitHub.
+  Alternative: default-off for a strictly zero-egress default posture, at
+  the cost of the feature being invisible to exactly the operators it's
+  for.
+- **D4, Tauri built-in updater.** *Recommended: no for #7* (see §3).
+- **D5, iOS inclusion.** *Recommended: include*, it is the same shared
+  Swift checker as macOS at near-zero marginal cost, flagged lowest
+  priority and droppable if TestFlight distribution lands first.
+- **D6, release channels.** *Recommended: stable-only for #7* (the
+  `releases/latest` GitHub endpoint gives this for free; pre-releases are
+  invisible). Beta-channel awareness belongs to the §6 future extension if
+  ever.
+
+## 5. Propagation checklist (docs/COMPONENT-MAP.md walk)
+
+Matching matrix rows, executed across the tasks in §7 (each task names its
+slice):
+
+- **Row A (new endpoint/DTO):** `updates.rs` + `main.rs` wiring (json side),
+  `dto.rs` shape, auth via the standard authed extractor (any user),
+  client mirrors (`admin.html` `api()` helper; desktop `app.js`; Android
+  `CrumbApi.kt`/`CrumbRepository.kt`/`Models.kt`; iOS `Networking/` +
+  `Models/`), tests, `config_routes.rs` doc-comment API table row.
+- **Row B (new config key):** `UPDATE_CHECK_ENABLED` in `config.rs`,
+  `.env.example`, `setup-env.sh` comment, `docker-compose.yml` api env
+  block, `admin.html` server-settings toggle (DB precedence),
+  `docs/AI-INSTALL.md`, docs-site environment reference.
+- **Row C (migration):** `0045_update_check.sql` + `MIGRATIONS` registration
+  in `services/common/src/db.rs`, workspace tests against a throwaway
+  Postgres.
+- **Row H (admin console):** `admin.html` toggle + server-update banner;
+  `node --check` the extracted script; verify in a browser AND in the
+  desktop's embedded `/admin` WebView.
+- **Row I (install surface, golden rule 5):** because a config key and env
+  default are added: `.env.example`, `setup-env.sh`, `docker-compose.yml`
+  (sweep the variants that enumerate api env), `docs/AI-INSTALL.md` in the
+  SAME change (including the D3 egress disclosure), README run path only if
+  it enumerates env keys, smoke workflow stays green, `docker compose
+  config` validated on a real Docker host. No new ports, volumes, services,
+  or secrets, so no setup-secrets/TLS/backup impact.
+- **Row L (user-visible capability):** `docs/CLIENTS.md` gains a short
+  "knowing when to update" note per client; a docs-site operator page
+  (or section) covering the notice, the off switch, and exactly what is and
+  isn't sent; marketing update post when it ships (house copy rules).
+- **Row M, REQUIRED:** a **`docs/DECISIONS.md` entry** lands with the Phase
+  1 server change, matching the file's format: chosen (api-mediated
+  GitHub version check, notify-only, operator-disableable), rejected
+  (per-client direct GitHub polling as default; Tauri updater for
+  detection; a server-hosted artifact/manifest system as the #7 vehicle,
+  deferred to the future extension), trade-offs (old-server clients see
+  nothing; version-level granularity misses Android re-ships), revisit
+  triggers (auto-update demand materializes → §6; GitHub API terms/rate
+  limits change; clients gain a legitimate need for direct checks).
+  **`docs/COMPONENT-MAP.md` §3 parity table gains an "Update notice" row**
+  in the same change (map maintenance rule).
+
+## 6. Future extension (explicitly NOT #7)
+
+Recorded so the notify-only scope is a decision, not an accident. A fuller
+update system, IF ever demanded, would add: server-hosted release artifacts
+(manual upload and/or opt-in GitHub mirroring into an api-RW volume),
+sha256 + detached-signature (minisign/ed25519) verification before any
+install, scoped short-lived `?token=` media-claims for artifact downloads
+(never the bearer JWT), Android PackageInstaller handoff, a signed+notarized
+macOS story (Sparkle or self-replace), Windows installer handoff (after
+bundling `libmpv-2.dll` as a Tauri resource so an installer-driven update
+cannot strand the exe without it), and update channels. Every piece of it
+stays operator-approved, install is never automatic without explicit user
+action, and the recorder is never auto-updated. None of this is designed
+here; it gets its own issue, DECISIONS entry, and plan if a revisit trigger
+fires (real operator demand for in-app install, or signed client builds
+becoming the norm).
+
+## 7. Phased task breakdown
+
+Ground rules for every task: DCO sign-off; stage explicit paths only
+(shared tree, never `git add <dir>`); match surrounding style. Rust
+acceptance floor: `cargo fmt --all -- --check` +
+`cargo clippy --all-targets -- -D warnings` + `cargo test --workspace`
+(throwaway Postgres per AGENTS.md). Client tasks must compile and pass
+their CI job. Default model **Sonnet**; nothing in this scope needs Opus
+(no crypto, no install execution, no footage-adjacent code). Server PRs
+reference `refs #7`; the PR that completes the last in-scope client carries
+**`Closes #7`**.
+
+### Phase 1, server (everything depends on S2)
+
+- **S1 Migration + config key.** `db/migrations/0045_update_check.sql`
+  (nullable `update_check_enabled` on `server_settings`), **register in
+  `MIGRATIONS` in `services/common/src/db.rs`**, db get/update plumbing,
+  `UPDATE_CHECK_ENABLED` in `config.rs`, precedence (DB wins, NULL falls
+  back to env). Acceptance: Rust gate; migration applies on a fresh
+  throwaway Postgres; precedence unit test. Sonnet, small.
+- **S2 `GET /updates/latest`.** `services/api/src/updates.rs`: GitHub
+  `releases/latest` fetch (existing HTTP client stack), 6h in-memory TTL
+  cache with stale-while-error, semver compare + unit tests (including
+  unparsable-version ⇒ no signal), the DTO in `dto.rs`, route wired on the
+  json side of `main.rs` (any authenticated user), `enabled:false`
+  short-circuit making zero external requests, `config_routes.rs` doc-table
+  row. Acceptance: Rust gate; unit tests for compare/cache/disabled-path
+  (GitHub mocked, tests must not hit the network); manual check on a dev
+  stack that disabling the setting stops all egress (observe logs).
+  Sonnet, medium.
+- **S3 Admin console.** In `services/api/src/admin.html`: the settings
+  toggle (writes only its own field) with the §2.3 plain-language copy, and
+  the server-update banner ("Server vX.Y.Z available → release notes" +
+  upgrade commands) driven by `/updates/latest`. House conventions
+  (`esc()`, `api()`, every `on*=` handler defined, semantic color vars).
+  Acceptance: `node --check` on the extracted script block; rebuilt api
+  serves it; banner verified in a browser AND in the desktop's embedded
+  `/admin` WebView (fake a newer release by stubbing the fetch or pointing
+  at a test double, do not tag a release to test). Sonnet, medium.
+- **S4 Install surface + docs floor.** `.env.example`, `setup-env.sh`
+  comment, `docker-compose.yml` api env (+ variant sweep), `docs/AI-INSTALL.md`
+  (key + the one-egress disclosure per D3), docs-site environment-reference
+  row. Acceptance: `docker compose config` clean on a real Docker host
+  (dev1/mrUbuntu); smoke workflow green; AI-INSTALL "For maintainers" items
+  re-verified. Sonnet, small.
+- **S5 Decision log + component map.** The `docs/DECISIONS.md` entry and
+  `docs/COMPONENT-MAP.md` "Update notice" parity row per §5 row M, in the
+  same change series as S1–S4. Acceptance: entries match the files'
+  existing formats. Sonnet or Haiku, small.
+
+### Phase 2, clients (mutually independent, parallel after S2)
+
+- **C1 Web console client notice.** Already covered by S3 (the console's
+  update IS the server update); listed to make the parity walk explicit.
+  No separate task.
+- **C2 Desktop (Windows + Linux, one task).** In `apps/desktop/src/app.js`:
+  post-login fetch of `/updates/latest` via the existing authed helper,
+  compare against `getVersion()`, dismissible settings/about banner
+  (remember dismissed version), 24h re-check, 404/`enabled:false` ⇒
+  nothing. No Rust changes expected. Acceptance: CI `desktop-lint` +
+  `desktop-linux` green; banner verified on the workstation after a REBUILD
+  (Tauri bakes `../src` into the exe, a stale exe proves nothing) against a
+  dev server stubbed to report a newer version. Sonnet, medium.
+- **C3 Android.** Retrofit method in `CrumbApi.kt`, repository +
+  `Models.kt` mirror, compare against `BuildConfig.VERSION_NAME`,
+  dismissible Settings/About banner (Compose), daily re-check, notes link
+  opens the browser. Acceptance: Gradle build + existing checks green
+  (build on dev hosts per house setup); banner verified on-device
+  (wireless ADB) against a stubbed-newer dev server. Sonnet, medium.
+- **C4 macOS + iOS (shared).** `UpdateChecker` in
+  `apps/ios/Crumb/Networking/` + `Models/` mirror, Settings row + banner in
+  both targets, compare against `CFBundleShortVersionString`, iOS flagged
+  lowest-priority per D5. Acceptance: both targets build on the macmini
+  (`scripts/release/ios.sh` path); banner verified on macOS against a
+  stubbed-newer dev server. Sonnet, medium.
+
+### Phase 3, docs + announcement
+
+- **P1 User docs.** `docs/CLIENTS.md` "knowing when to update" notes,
+  docs-site operator section (what the notice is, the off switch, "nothing
+  is sent"), README line if warranted. Acceptance: docs-site CI build green
+  (`onBrokenLinks: 'throw'`); plain user-facing language, house copy rules
+  (no em-dashes). Sonnet or Haiku, small.
+- **P2 Marketing update post** when the first clients ship it
+  (`site/updates/posts/` + `node scripts/build.mjs`, commit sources AND
+  generated output; capability-first humble tone). Haiku or Sonnet, small.
+
+### Dependency spine
+
+```
+S1 → S2 → { S3(+C1), C2, C3, C4 }   (all parallel after S2)
+S4 parallel with S2/S3 (needs S1's key name)
+S5 lands with Phase 1
+P1/P2 last; the final client PR carries "Closes #7"
+```

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -204,6 +204,13 @@ DB_BACKUP_HOST_PATH=./backups
 # ALERT_WEBHOOK_URL=https://discord.com/api/webhooks/xxxxx/yyyyy
 ALERT_WEBHOOK_URL=
 
+# --- Update-available check (optional, issue #7; OFF by default) ---
+# When enabled, the api periodically asks github.com for the latest CrumbVMS
+# release tag (version number only -- nothing sent) so clients can show an
+# "update available" notice. The admin console toggle (Server settings) wins
+# over this env once set. false = zero github.com requests, ever.
+UPDATE_CHECK_ENABLED=false
+
 # --- Seed (admin bootstrap user) ---
 # Easiest: leave SEED_ADMIN_PASSWORD blank and create the admin in the browser at
 # /admin on first run. For a HEADLESS install, the API hashes SEED_ADMIN_PASSWORD

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -5767,9 +5767,20 @@ async function renderServerSettings() {
       </label>
       <div id="srv-bk-msg" style="font-size:12px;color:var(--dim);margin-top:4px"></div>
     </div>
+    <div class="policy-section">
+      <div class="policy-section-title">Update checks</div>
+      <div class="card-hint" style="margin-bottom:10px">When enabled, this server periodically asks github.com for the latest CrumbVMS version number so clients can tell you when an update exists. Nothing is sent, and turning this off disables the check for every client. Off by default on a fresh install.</div>
+      <label class="chk" id="srv-upd-wrap" style="cursor:default;opacity:.7">
+        <input type="checkbox" id="srv-upd-enabled" onchange="saveUpdateCheckEnabled(this.checked)" />
+        <span>Enable update checks</span>
+      </label>
+      <div id="srv-upd-msg" style="font-size:12px;color:var(--dim);margin-top:4px"></div>
+      <div id="srv-upd-status" style="font-size:13px;margin-top:8px"></div>
+    </div>
     <div class="card-hint" style="margin-top:4px">Saving applies immediately. Changing the public address may require toggling a camera (or a recorder restart) to take effect on in-flight recordings.</div>
     <div id="srv-msg" class="form-msg"></div>`;
   loadBookmarksEnabled();
+  loadUpdateCheck();
 }
 function onHwaccelChange() {
   const sel = $('srv-hwaccel'); const wrap = $('srv-vaapi-device-wrap');
@@ -5925,6 +5936,75 @@ async function saveBookmarksEnabled(enabled) {
     /* Revert the checkbox to the last-known server state on failure. */
     loadBookmarksEnabled();
   }
+}
+
+/* ── Update-available check (issue #7): opt-in toggle + status/banner ──
+   OFF by default (D3) — this server makes zero github.com requests until the
+   operator flips the switch below. Console writes ONLY this field. */
+async function loadUpdateCheck() {
+  const chk  = $('srv-upd-enabled');
+  const wrap = $('srv-upd-wrap');
+  const msg  = $('srv-upd-msg');
+  if (!chk) return;
+  try {
+    const data = await api('/config/update-check-enabled');
+    chk.checked = !!data.enabled;
+    if (wrap) wrap.style.opacity = '1';
+    if (msg)  msg.textContent = '';
+  } catch (e) {
+    if (msg) msg.textContent = 'Could not load: ' + (e.message || e);
+  }
+  renderUpdateStatus(false);
+}
+async function saveUpdateCheckEnabled(enabled) {
+  const msg = $('srv-upd-msg');
+  try {
+    await api('/config/update-check-enabled', { method: 'PUT', body: JSON.stringify({ enabled: !!enabled }) });
+    if (msg) {
+      msg.style.color = 'var(--ok)';
+      msg.textContent = enabled ? 'Update checks enabled.' : 'Update checks disabled — no more requests to github.com.';
+      setTimeout(() => { if (msg) msg.textContent = ''; }, 3000);
+    }
+    renderUpdateStatus(false);
+  } catch (e) {
+    if (msg) { msg.style.color = 'var(--danger)'; msg.textContent = 'Save failed: ' + (e.message || e); }
+    /* Revert the checkbox to the last-known server state on failure. */
+    loadUpdateCheck();
+  }
+}
+/* Renders the status line + "Check now" button. `force` = true bypasses the
+   server's 6h cache (subject to its own 60s "Check now" backoff). Empty when
+   the check is disabled — there is nothing to show, and no request is made. */
+async function renderUpdateStatus(force) {
+  const el = $('srv-upd-status');
+  if (!el) return;
+  const chk = $('srv-upd-enabled');
+  if (!chk || !chk.checked) { el.innerHTML = ''; return; }
+  el.innerHTML = '<span style="color:var(--dim)">Checking…</span>';
+  let data;
+  try {
+    data = await api('/updates/latest' + (force ? '?refresh=1' : ''));
+  } catch (e) {
+    el.innerHTML = `<span class="form-msg err">Couldn't check: ${esc(String(e.message || e))}</span>`;
+    return;
+  }
+  if (!data.enabled) { el.innerHTML = ''; return; }
+  const checkedTxt = data.checked_at ? new Date(data.checked_at).toLocaleString() : null;
+  let statusHtml;
+  if (data.server_update_available) {
+    statusHtml = `<span style="color:var(--warn)">Server v${esc(data.latest_version)} is available</span> — ` +
+      `<a href="${esc(data.notes_url)}" target="_blank" rel="noopener">release notes</a>. ` +
+      `Upgrade: pin <code>CRUMB_VERSION</code>, then <code>docker compose pull &amp;&amp; docker compose up -d</code> (docs/IMAGES.md).`;
+  } else if (data.latest_version) {
+    statusHtml = `<span style="color:var(--ok)">Up to date</span> (v${esc(data.server_version || '?')})` +
+      (checkedTxt ? `, checked ${esc(checkedTxt)}` : '');
+  } else {
+    statusHtml = `<span style="color:var(--dim)">Checked — no data yet (github.com unreachable)</span>`;
+  }
+  el.innerHTML = `<div>${statusHtml}</div><button class="ghost" style="margin-top:6px" onclick="checkForUpdatesNow()">Check now</button>`;
+}
+function checkForUpdatesNow() {
+  renderUpdateStatus(true);
 }
 
 /* ── Camera tab 3: Storage & group ──

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -241,6 +241,21 @@ pub struct ApiConfig {
     /// recovery. Empty/unset disables alerting (no-op watchdog).
     pub alert_webhook_url: Option<String>,
 
+    // -- update-available check (issue #7) -----------------------------------
+    /// `UPDATE_CHECK_ENABLED` -- env fallback for the update-available check
+    /// (`GET /updates/latest`, `services/api/src/updates.rs`). Only consulted
+    /// when the admin-editable `server_settings.update_check_enabled` DB value
+    /// is `NULL` (the operator has never touched the toggle) -- the standard
+    /// house precedence, DB wins, empty/NULL falls back to env.
+    ///
+    /// Default: `false` (D3, opt-in / OFF BY DEFAULT). A fresh install makes
+    /// zero requests to github.com until the operator explicitly enables the
+    /// check via the admin console or this env var -- deliberately the
+    /// opposite of the plan doc's "recommended enabled" default, ratified by
+    /// the maintainer to keep a fresh install at zero external egress
+    /// (Crumb's no-phone-home posture; see `docs/DECISIONS.md`).
+    pub update_check_enabled: bool,
+
     // -- admin bootstrap ----------------------------------------------------
     /// `SEED_ADMIN_USERNAME` -- bootstrap admin username, created at startup if
     /// no admin exists yet.  Default: `admin`.
@@ -343,6 +358,7 @@ impl ApiConfig {
             thumb_cache_dir: optional_env("THUMB_CACHE_DIR", ""),
             frigate_api_base: optional_env("FRIGATE_API_BASE", ""),
             alert_webhook_url: optional_env_opt("ALERT_WEBHOOK_URL"),
+            update_check_enabled: parse_env("UPDATE_CHECK_ENABLED", false)?,
             seed_admin_username: optional_env("SEED_ADMIN_USERNAME", "admin"),
             // Secret: supports SEED_ADMIN_PASSWORD_FILE (Docker secret) too.
             seed_admin_password: crumb_common::config::secret_env("SEED_ADMIN_PASSWORD")

--- a/services/api/src/config_routes.rs
+++ b/services/api/src/config_routes.rs
@@ -40,6 +40,15 @@
 //! | `PUT`    | `/config/users/{id}` | Update user (re-hash password if given)  |
 //! | `DELETE` | `/config/users/{id}` | Delete user (refuse last admin)          |
 //!
+//! ## Update-available check (issue #7)
+//! | Method | Path                          | Description                                    |
+//! |--------|-------------------------------|-------------------------------------------------|
+//! | `GET`  | `/config/update-check-enabled` | Resolved effective state (DB, else env default) |
+//! | `PUT`  | `/config/update-check-enabled` | Operator opt-in/out; writes only this field    |
+//!
+//! The public, any-user endpoint clients actually poll is `GET /updates/latest`
+//! (`services/api/src/updates.rs`), not under `/config`.
+//!
 //! # Design notes
 //!
 //! * Every handler requires [`crate::auth_mw::AdminUser`] — viewers never reach
@@ -204,6 +213,13 @@ pub fn routes() -> Router<AppState> {
         .route(
             "/bookmarks-enabled",
             get(get_bookmarks_enabled).put(set_bookmarks_enabled),
+        )
+        // Update-available check opt-in (issue #7, D3: off by default). The
+        // effective GET /updates/latest (any user) lives in updates.rs; this
+        // pair is the admin-only settings toggle.
+        .route(
+            "/update-check-enabled",
+            get(get_update_check_enabled_route).put(set_update_check_enabled_route),
         )
         .route("/setup-complete", put(set_setup_complete_route))
         .route("/beta-terms", put(set_beta_terms_route))
@@ -415,6 +431,45 @@ async fn set_bookmarks_enabled(
     Json(body): Json<BookmarksEnabledRequest>,
 ) -> Result<StatusCode, ApiError> {
     db::set_bookmarks_enabled(state.pool(), body.enabled)
+        .await
+        .map_err(ApiError::Internal)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ─── update-available check opt-in (issue #7, D3: off by default) ──────────────
+
+#[derive(serde::Serialize)]
+struct UpdateCheckEnabledDto {
+    enabled: bool,
+}
+
+#[derive(serde::Deserialize)]
+struct UpdateCheckEnabledRequest {
+    enabled: bool,
+}
+
+/// `GET /config/update-check-enabled` — the RESOLVED effective state (an
+/// explicit DB choice, else the `UPDATE_CHECK_ENABLED` env default, itself
+/// `false` per D3). Mirrors the precedence `crate::updates::resolve_enabled`
+/// applies to `GET /updates/latest` itself, so the admin toggle always shows
+/// what the check is actually doing right now, not just the raw DB row.
+async fn get_update_check_enabled_route(
+    _admin: AdminUser,
+    State(state): State<AppState>,
+) -> Result<Json<UpdateCheckEnabledDto>, ApiError> {
+    let enabled = crate::updates::resolve_enabled(state.pool(), state.config()).await?;
+    Ok(Json(UpdateCheckEnabledDto { enabled }))
+}
+
+/// `PUT /config/update-check-enabled` — explicit operator opt-in/out. Writes
+/// ONLY this field (house rule); once set, the DB value wins over the env
+/// default for good (the standard `server_settings` precedence).
+async fn set_update_check_enabled_route(
+    _admin: AdminUser,
+    State(state): State<AppState>,
+    Json(body): Json<UpdateCheckEnabledRequest>,
+) -> Result<StatusCode, ApiError> {
+    db::set_update_check_enabled(state.pool(), body.enabled)
         .await
         .map_err(ApiError::Internal)?;
     Ok(StatusCode::NO_CONTENT)

--- a/services/api/src/dto.rs
+++ b/services/api/src/dto.rs
@@ -1413,3 +1413,51 @@ pub struct FilmstripResponse {
     pub camera_id: Uuid,
     pub frames: Vec<FilmstripFrame>,
 }
+
+// ─── update-available check (issue #7) ─────────────────────────────────────────
+
+/// Query parameters for `GET /updates/latest`.
+#[derive(Debug, Deserialize)]
+pub struct UpdatesLatestQuery {
+    /// `"1"` forces an immediate re-check ("Check now",
+    /// `docs/UPDATE-SYSTEM-PLAN.md` §2.5), subject to a 60s minimum interval
+    /// between actual forced `GitHub` fetches (a repeat click inside that
+    /// window serves the cached value, `checked_at` unchanged). Anything else,
+    /// including an absent param, is the normal cached path (§2.1).
+    #[serde(default)]
+    pub refresh: Option<String>,
+}
+
+/// `GET /updates/latest` response — see `docs/UPDATE-SYSTEM-PLAN.md` §2.1/§2.5.
+///
+/// `enabled:false` ⇒ every other field is `null` (this, not a 404, is how a
+/// disabled check is told apart from an old server that lacks the route at
+/// all) and `?refresh=1` is silently ignored — disabled means zero `GitHub`
+/// requests, with no exception for a manual "Check now" click.
+///
+/// While enabled, `latest_version` / `notes_url` / `published_at` /
+/// `checked_at` are only `None` in the narrow case where the api has never
+/// completed a `GitHub` fetch yet (no cached value, e.g. right after boot with
+/// `GitHub` unreachable); once a fetch succeeds they stay populated afterwards
+/// even through later outages (stale-while-error — `checked_at` just stops
+/// advancing).
+#[derive(Debug, Serialize)]
+pub struct UpdateCheckResponse {
+    pub enabled: bool,
+    /// Newest stable release tag from `GitHub`, without the leading `v`.
+    pub latest_version: Option<String>,
+    /// `GitHub` release page URL (release notes).
+    pub notes_url: Option<String>,
+    pub published_at: Option<DateTime<Utc>>,
+    /// This server's own build version (the `VERSION` file), so the web
+    /// console's notice needs zero client-side comparison logic.
+    pub server_version: Option<String>,
+    /// `latest_version > server_version`, strict `SemVer` 2.0.0 precedence.
+    /// `None` when either version fails to parse (e.g. a local `-dev` build) —
+    /// "no signal", never a false "you're up to date".
+    pub server_update_available: Option<bool>,
+    /// When the returned release data was last actually refreshed from
+    /// `GitHub` (not merely requested) — an older timestamp during an outage
+    /// is the intentional stale-while-error signal.
+    pub checked_at: Option<DateTime<Utc>>,
+}

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -39,6 +39,7 @@
 //! /filmstrip/*              → filmstrip.rs
 //! /status                   → status.rs
 //! /stats/*                  → stats.rs           (admin only)
+//! /updates/latest           → updates.rs (update-available check, issue #7)
 //! /cameras/:id/ptz          → ptz.rs
 //! /cameras/:id/frame.jpg    → cameras.rs
 //! /health                   → inline (no auth — DB+heartbeat probe, 503 if degraded)
@@ -102,6 +103,7 @@ mod status;
 mod stream_test;
 mod thumb_pregen;
 mod timeline;
+mod updates;
 mod views;
 
 use std::time::Duration;
@@ -454,6 +456,8 @@ async fn main() -> anyhow::Result<()> {
         .merge(clips::json_routes())
         // Notification devices, rules, snooze, presence, and log.
         .merge(notifications::routes())
+        // Update-available check (issue #7): GET /updates/latest, any user.
+        .merge(updates::routes())
         // Layers applied outermost-first: rate-limit (reject early) → timeout →
         // gzip (compress handler output, innermost).
         .layer(CompressionLayer::new())

--- a/services/api/src/updates.rs
+++ b/services/api/src/updates.rs
@@ -1,0 +1,577 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Update-available check (issue #7, Phase 1 — server).
+//!
+//! # Endpoints
+//!
+//! | Method | Path              | Auth               | Description |
+//! |--------|-------------------|---------------------|-------------|
+//! | `GET`  | `/updates/latest` | Bearer (any user)   | Latest `GitHub` release vs. this server's own version |
+//!
+//! See `docs/UPDATE-SYSTEM-PLAN.md` for the full design. Restated invariants
+//! this module must never violate:
+//!
+//! * **Notify-only.** No download, no install, the recorder is never touched.
+//! * **Opt-in, off by default (D3).** [`crate::config::ApiConfig::update_check_enabled`]
+//!   defaults to `false`; the admin-editable `server_settings.update_check_enabled`
+//!   DB value (see `crumb_common::db::get_update_check_enabled`) wins when set.
+//!   When the resolved state is disabled, this module makes **zero** requests
+//!   to `GitHub` — not even for an explicit `?refresh=1` "Check now" click.
+//! * **Sends nothing.** The one outbound request is a plain, unauthenticated
+//!   `GET` to `GitHub`'s public `releases/latest` endpoint: no query params, no
+//!   client identifiers, no counts. That is the line between a version check
+//!   and telemetry.
+//! * **Cache lives in memory only**, TTL 6h, stale-while-error (a `GitHub`
+//!   outage never surfaces as an error to clients, just an older `checked_at`).
+//!   Dies with the process on restart; that's fine, no persistence is needed.
+//! * **"Check now" (§2.5)** — `?refresh=1` forces an immediate re-check,
+//!   bypassing the 6h TTL, but is itself rate-limited to one actual `GitHub`
+//!   hit per 60s so a burst of manual clicks (or several authenticated clients
+//!   each polling "Check now") can't stampede `GitHub`'s unauthenticated
+//!   60/h/IP limit.
+
+use std::future::Future;
+use std::sync::OnceLock;
+
+use anyhow::Context as _;
+use axum::{
+    extract::{Query, State},
+    routing::get,
+    Json, Router,
+};
+use chrono::{DateTime, Utc};
+use deadpool_postgres::Pool;
+use tokio::sync::Mutex;
+
+use crate::{
+    auth_mw::AuthUser,
+    config::ApiConfig,
+    dto::{UpdateCheckResponse, UpdatesLatestQuery},
+    error::ApiError,
+    state::AppState,
+};
+
+/// This server's own build version. Read independently of `crate::VERSION`
+/// (`main.rs`'s copy, used by `GET /version`) rather than referencing it
+/// directly: `services/api/tests/support/mod.rs` re-includes this file's
+/// source under a DIFFERENT crate root (a test binary, not `main.rs`) via
+/// `#[path]`, where `crate::VERSION` would not resolve.
+const VERSION: &str = include_str!("../../../VERSION");
+
+/// Mount the update-check route.
+pub fn routes() -> Router<AppState> {
+    Router::new().route("/updates/latest", get(get_latest_update))
+}
+
+/// `GET /updates/latest` — any authenticated user (viewers run wall displays
+/// and phones too; this is deliberately not admin-only).
+async fn get_latest_update(
+    _user: AuthUser,
+    State(state): State<AppState>,
+    Query(q): Query<UpdatesLatestQuery>,
+) -> Result<Json<UpdateCheckResponse>, ApiError> {
+    let enabled = resolve_enabled(state.pool(), state.config()).await?;
+    let force = q.refresh.as_deref() == Some("1");
+    let server_version = VERSION.trim();
+    let response = build_response(enabled, force, server_version, get_release_info).await;
+    Ok(Json(response))
+}
+
+/// Effective enabled state for the update-available check (house precedence
+/// rule: an explicit admin-set `server_settings` value wins; `NULL` — the
+/// operator has never touched the toggle — falls back to the
+/// `UPDATE_CHECK_ENABLED` env default, which is itself `false` per D3).
+///
+/// # Errors
+///
+/// Returns [`ApiError::Internal`] if the settings query fails.
+pub(crate) async fn resolve_enabled(pool: &Pool, cfg: &ApiConfig) -> Result<bool, ApiError> {
+    let db_value = crumb_common::db::get_update_check_enabled(pool)
+        .await
+        .map_err(ApiError::Internal)?;
+    Ok(db_value.unwrap_or(cfg.update_check_enabled))
+}
+
+// ─── response assembly (pure; unit-tested without a DB or network call) ────────
+
+impl UpdateCheckResponse {
+    /// `enabled:false` — every other field null, per §2.1.
+    fn disabled() -> Self {
+        Self {
+            enabled: false,
+            latest_version: None,
+            notes_url: None,
+            published_at: None,
+            server_version: None,
+            server_update_available: None,
+            checked_at: None,
+        }
+    }
+}
+
+/// Build the response body from the resolved `enabled` state, this server's
+/// own version, and a (test-injectable) cache lookup.
+///
+/// Split out from the handler so the hard invariant — disabled means zero
+/// fetch attempts, even with `force` ("Check now") — is unit-testable without
+/// a DB or network call: `get_release` is never invoked at all when `!enabled`.
+async fn build_response<F, Fut>(
+    enabled: bool,
+    force: bool,
+    server_version: &str,
+    get_release: F,
+) -> UpdateCheckResponse
+where
+    F: FnOnce(bool) -> Fut,
+    Fut: Future<Output = Option<CachedRelease>>,
+{
+    if !enabled {
+        return UpdateCheckResponse::disabled();
+    }
+
+    let cached = get_release(force).await;
+    let server_update_available = cached
+        .as_ref()
+        .and_then(|c| is_update_available(server_version, &c.latest_version));
+
+    UpdateCheckResponse {
+        enabled: true,
+        latest_version: cached.as_ref().map(|c| c.latest_version.clone()),
+        notes_url: cached.as_ref().map(|c| c.notes_url.clone()),
+        published_at: cached.as_ref().map(|c| c.published_at),
+        server_version: Some(server_version.to_owned()),
+        server_update_available,
+        checked_at: cached.as_ref().map(|c| c.checked_at),
+    }
+}
+
+// ─── SemVer compare (§2.2) ──────────────────────────────────────────────────────
+
+/// Parse a plain `MAJOR.MINOR.PATCH` version (exactly three dot-separated
+/// non-negative integers). `None` for anything else — a pre-release/build
+/// suffix like `"-dev"`, a missing part, or non-numeric text — per
+/// `docs/UPDATE-SYSTEM-PLAN.md` §2.2: an unparsable version is "no signal",
+/// deliberately not an error.
+fn parse_semver(s: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = s.trim().split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None; // extra segments (e.g. "1.2.3.4") — not a plain triple.
+    }
+    Some((major, minor, patch))
+}
+
+/// Whether `latest` is a strictly newer release than `current` (`SemVer`
+/// 2.0.0 precedence, tuple-lexicographic since neither side carries a
+/// pre-release/build suffix once parsed). `None` — not `Some(false)` — when
+/// either fails to parse, so an unparsable local dev build never claims to be
+/// "up to date".
+fn is_update_available(current: &str, latest: &str) -> Option<bool> {
+    let cur = parse_semver(current)?;
+    let lat = parse_semver(latest)?;
+    Some(lat > cur)
+}
+
+// ─── GitHub fetch (the one outbound request) ───────────────────────────────────
+
+const GITHUB_RELEASES_URL: &str = "https://api.github.com/repos/badbread/crumbvms/releases/latest";
+
+/// Short-timeout client for the one-off `GitHub` releases/latest GET. Built
+/// fresh per call (mirrors `go2rtc::client()`) — this endpoint fires at most a
+/// handful of times a day even under heavy "Check now" use, so there is no
+/// hot-path reason to cache the client the way the live MSE proxy does.
+fn http_client() -> anyhow::Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .context("build GitHub releases HTTP client")
+}
+
+/// The subset of `GitHub`'s release JSON this module needs.
+#[derive(Debug, serde::Deserialize)]
+struct GithubReleaseJson {
+    tag_name: String,
+    html_url: String,
+    published_at: DateTime<Utc>,
+}
+
+/// A cached, already-parsed release — the notes URL, its stripped version
+/// tag, and when this cache entry was last refreshed from `GitHub`.
+#[derive(Debug, Clone)]
+struct CachedRelease {
+    latest_version: String,
+    notes_url: String,
+    published_at: DateTime<Utc>,
+    checked_at: DateTime<Utc>,
+}
+
+/// Parse a `GitHub` `releases/latest` JSON body into a [`CachedRelease`].
+/// Split out from [`fetch_latest_release`] so the parsing / `v`-prefix
+/// stripping logic is unit-testable with a literal JSON string — no network
+/// call involved.
+fn release_from_github_json(
+    body: &str,
+    checked_at: DateTime<Utc>,
+) -> anyhow::Result<CachedRelease> {
+    let parsed: GithubReleaseJson =
+        serde_json::from_str(body).context("parse GitHub releases/latest JSON")?;
+    Ok(CachedRelease {
+        latest_version: parsed.tag_name.trim_start_matches('v').to_owned(),
+        notes_url: parsed.html_url,
+        published_at: parsed.published_at,
+        checked_at,
+    })
+}
+
+/// One-shot `GET` of `GitHub`'s `releases/latest` for `badbread/crumbvms`.
+/// That endpoint already excludes drafts and pre-releases, so the result is
+/// stable-releases-only by construction (D6). Sends nothing beyond the
+/// request itself — no query params, no client identifiers, no counts.
+async fn fetch_latest_release() -> anyhow::Result<CachedRelease> {
+    let client = http_client()?;
+    let resp = client
+        .get(GITHUB_RELEASES_URL)
+        // GitHub's REST API rejects requests with no User-Agent.
+        .header(reqwest::header::USER_AGENT, "crumbvms-update-check")
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .send()
+        .await
+        .context("GET GitHub releases/latest")?;
+    if !resp.status().is_success() {
+        anyhow::bail!("GitHub releases/latest -> HTTP {}", resp.status());
+    }
+    let body = resp
+        .text()
+        .await
+        .context("read GitHub releases/latest body")?;
+    release_from_github_json(&body, Utc::now())
+}
+
+// ─── in-memory cache: 6h TTL, stale-while-error, 60s "Check now" backoff ───────
+
+/// How long a successful fetch is considered fresh before the organic (non
+/// "Check now") path will try again.
+const CACHE_TTL_SECS: i64 = 6 * 60 * 60;
+
+/// Minimum spacing between actual `GitHub` hits triggered by `?refresh=1`
+/// ("Check now"), independent of the organic TTL — protects the 60/h/IP
+/// unauthenticated rate limit from a burst of manual clicks.
+const FORCE_MIN_INTERVAL_SECS: i64 = 60;
+
+#[derive(Default)]
+struct CacheSlot {
+    /// Last successfully parsed release, if any fetch has ever succeeded.
+    data: Option<CachedRelease>,
+    /// Last fetch ATTEMPT (success or failure) made by the organic TTL path.
+    last_attempt_at: Option<DateTime<Utc>>,
+    /// Last fetch ATTEMPT (success or failure) made by a forced ("Check now")
+    /// call. Tracked separately from `last_attempt_at` so the 60s manual
+    /// backoff and the 6h organic backoff don't fight over one clock.
+    last_forced_attempt_at: Option<DateTime<Utc>>,
+}
+
+/// Decide whether to fetch, then update `slot` in place. Pure with respect to
+/// `GitHub` itself — `fetch` is injected, so the TTL / stale-while-error /
+/// "Check now" backoff logic is unit-tested with a fake closure and no
+/// network call at all (`docs/UPDATE-SYSTEM-PLAN.md` §2.1/§2.5).
+async fn refresh_if_needed<F, Fut>(slot: &mut CacheSlot, now: DateTime<Utc>, force: bool, fetch: F)
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = anyhow::Result<CachedRelease>>,
+{
+    let stale = slot
+        .data
+        .as_ref()
+        .is_none_or(|d| (now - d.checked_at).num_seconds() >= CACHE_TTL_SECS);
+    let organic_blocked = slot
+        .last_attempt_at
+        .is_some_and(|t| (now - t).num_seconds() < CACHE_TTL_SECS);
+    let forced_blocked = slot
+        .last_forced_attempt_at
+        .is_some_and(|t| (now - t).num_seconds() < FORCE_MIN_INTERVAL_SECS);
+
+    let should_fetch = if force {
+        !forced_blocked
+    } else {
+        stale && !organic_blocked
+    };
+    if !should_fetch {
+        return;
+    }
+
+    // Every real attempt (forced or organic) counts against the ORGANIC clock
+    // — an organic re-check shouldn't fire again moments later regardless of
+    // which path triggered the fetch that just happened. The FORCE clock is
+    // narrower on purpose: it must only track actual "Check now" clicks, so a
+    // click shortly after an organic (TTL-driven) fetch still gets its one
+    // immediate manual check rather than being told "just checked".
+    slot.last_attempt_at = Some(now);
+    if force {
+        slot.last_forced_attempt_at = Some(now);
+    }
+
+    match fetch().await {
+        Ok(fresh) => slot.data = Some(fresh),
+        Err(e) => {
+            // Stale-while-error: keep serving the last good value (if any)
+            // unchanged — never surface a GitHub outage to clients as an
+            // error, just an older `checked_at`.
+            tracing::warn!(
+                error = %e,
+                force,
+                "update check: GitHub releases fetch failed; serving stale/none cached value"
+            );
+        }
+    }
+}
+
+fn cache() -> &'static Mutex<CacheSlot> {
+    static CACHE: OnceLock<Mutex<CacheSlot>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(CacheSlot::default()))
+}
+
+/// Look up the cached release info, refreshing from `GitHub` first if the TTL
+/// (or, when `force`, the 60s "Check now" backoff) allows it. Never called at
+/// all when the check is disabled — see [`build_response`].
+async fn get_release_info(force: bool) -> Option<CachedRelease> {
+    let mut guard = cache().lock().await;
+    refresh_if_needed(&mut guard, Utc::now(), force, fetch_latest_release).await;
+    guard.data.clone()
+}
+
+// ─── tests ──────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn dt(secs_from_epoch: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(secs_from_epoch, 0).single().unwrap()
+    }
+
+    fn sample(checked_at: DateTime<Utc>) -> CachedRelease {
+        CachedRelease {
+            latest_version: "0.0.2".to_owned(),
+            notes_url: "https://github.com/badbread/crumbvms/releases/tag/v0.0.2".to_owned(),
+            published_at: checked_at,
+            checked_at,
+        }
+    }
+
+    // ── SemVer compare ──────────────────────────────────────────────────────
+
+    #[test]
+    fn parses_plain_versions() {
+        assert_eq!(parse_semver("0.0.1"), Some((0, 0, 1)));
+        assert_eq!(parse_semver("1.2.3"), Some((1, 2, 3)));
+        assert_eq!(parse_semver(" 1.2.3 "), Some((1, 2, 3)));
+    }
+
+    #[test]
+    fn rejects_prerelease_suffix_and_garbage() {
+        // Unparsable ⇒ "no signal" (§2.2), the exact case a local dev build hits.
+        assert_eq!(parse_semver("0.0.1-dev"), None);
+        assert_eq!(parse_semver("v0.0.1"), None);
+        assert_eq!(parse_semver("0.0"), None);
+        assert_eq!(parse_semver("0.0.1.2"), None);
+        assert_eq!(parse_semver(""), None);
+        assert_eq!(parse_semver("not-a-version"), None);
+    }
+
+    #[test]
+    fn detects_newer_release() {
+        assert_eq!(is_update_available("0.0.1", "0.0.2"), Some(true));
+        assert_eq!(is_update_available("0.0.2", "0.0.2"), Some(false));
+        assert_eq!(is_update_available("0.1.0", "0.0.9"), Some(false));
+        assert_eq!(is_update_available("0.9.9", "1.0.0"), Some(true));
+    }
+
+    #[test]
+    fn unparsable_version_is_no_signal_not_false() {
+        assert_eq!(is_update_available("0.0.1-dev", "0.0.2"), None);
+        assert_eq!(is_update_available("0.0.1", "not-a-version"), None);
+    }
+
+    // ── GitHub JSON parsing ─────────────────────────────────────────────────
+
+    #[test]
+    fn parses_github_release_json_and_strips_v_prefix() {
+        let body = r#"{
+            "tag_name": "v0.0.2",
+            "html_url": "https://github.com/badbread/crumbvms/releases/tag/v0.0.2",
+            "published_at": "2026-07-20T00:00:00Z"
+        }"#;
+        let checked = dt(1_000);
+        let parsed = release_from_github_json(body, checked).expect("valid JSON parses");
+        assert_eq!(parsed.latest_version, "0.0.2");
+        assert_eq!(
+            parsed.notes_url,
+            "https://github.com/badbread/crumbvms/releases/tag/v0.0.2"
+        );
+        assert_eq!(parsed.checked_at, checked);
+    }
+
+    #[test]
+    fn rejects_malformed_github_json() {
+        assert!(release_from_github_json("not json", Utc::now()).is_err());
+        assert!(release_from_github_json("{}", Utc::now()).is_err());
+    }
+
+    // ── cache: TTL, stale-while-error, "Check now" backoff (no network) ────
+
+    #[tokio::test]
+    async fn fetches_when_cache_is_empty() {
+        let mut slot = CacheSlot::default();
+        let now = dt(10_000);
+        let calls = std::cell::Cell::new(0);
+        refresh_if_needed(&mut slot, now, false, || {
+            calls.set(calls.get() + 1);
+            async move { Ok(sample(now)) }
+        })
+        .await;
+        assert_eq!(calls.get(), 1);
+        assert_eq!(slot.data.expect("populated").checked_at, now);
+    }
+
+    #[tokio::test]
+    async fn does_not_refetch_within_the_ttl() {
+        let now0 = dt(10_000);
+        let mut slot = CacheSlot::default();
+        refresh_if_needed(&mut slot, now0, false, || async move { Ok(sample(now0)) }).await;
+
+        let now1 = now0 + chrono::Duration::minutes(30); // well within 6h
+        let calls = std::cell::Cell::new(0);
+        refresh_if_needed(&mut slot, now1, false, || {
+            calls.set(calls.get() + 1);
+            async move { Ok(sample(now1)) }
+        })
+        .await;
+        assert_eq!(
+            calls.get(),
+            0,
+            "organic path must not re-fetch inside the TTL window"
+        );
+    }
+
+    #[tokio::test]
+    async fn refetches_once_the_ttl_elapses() {
+        let now0 = dt(10_000);
+        let mut slot = CacheSlot::default();
+        refresh_if_needed(&mut slot, now0, false, || async move { Ok(sample(now0)) }).await;
+
+        let now1 = now0 + chrono::Duration::seconds(CACHE_TTL_SECS + 1);
+        let calls = std::cell::Cell::new(0);
+        refresh_if_needed(&mut slot, now1, false, || {
+            calls.set(calls.get() + 1);
+            async move { Ok(sample(now1)) }
+        })
+        .await;
+        assert_eq!(calls.get(), 1);
+        assert_eq!(slot.data.unwrap().checked_at, now1);
+    }
+
+    #[tokio::test]
+    async fn stale_while_error_keeps_the_old_value_and_old_checked_at() {
+        let now0 = dt(10_000);
+        let mut slot = CacheSlot::default();
+        refresh_if_needed(&mut slot, now0, false, || async move { Ok(sample(now0)) }).await;
+
+        let now1 = now0 + chrono::Duration::seconds(CACHE_TTL_SECS + 1);
+        refresh_if_needed(&mut slot, now1, false, || async move {
+            Err(anyhow::anyhow!("github is down"))
+        })
+        .await;
+
+        let data = slot.data.expect("stale value retained on a failed fetch");
+        assert_eq!(
+            data.checked_at, now0,
+            "checked_at must not advance on a failed fetch — that's the client-visible signal"
+        );
+    }
+
+    #[tokio::test]
+    async fn force_bypasses_the_ttl_but_respects_its_own_60s_backoff() {
+        let now0 = dt(10_000);
+        let mut slot = CacheSlot::default();
+        refresh_if_needed(&mut slot, now0, false, || async move { Ok(sample(now0)) }).await;
+
+        // Data is fresh (5s old); force=1 ("Check now") must still hit GitHub once.
+        let now1 = now0 + chrono::Duration::seconds(5);
+        let calls = std::cell::Cell::new(0);
+        refresh_if_needed(&mut slot, now1, true, || {
+            calls.set(calls.get() + 1);
+            async move { Ok(sample(now1)) }
+        })
+        .await;
+        assert_eq!(
+            calls.get(),
+            1,
+            "Check now must bypass the TTL freshness check"
+        );
+
+        // A second forced click 10s later (< 60s) must NOT hit GitHub again.
+        let now2 = now1 + chrono::Duration::seconds(10);
+        refresh_if_needed(&mut slot, now2, true, || {
+            calls.set(calls.get() + 1);
+            async move { Ok(sample(now2)) }
+        })
+        .await;
+        assert_eq!(
+            calls.get(),
+            1,
+            "a second Check now inside 60s must serve the cache, not hit GitHub again"
+        );
+    }
+
+    // ── disabled ⇒ zero fetch attempts, even with force=1 ───────────────────
+
+    #[tokio::test]
+    async fn disabled_never_calls_get_release_even_with_force() {
+        let calls = std::cell::Cell::new(0);
+        let resp = build_response(false, true, "0.0.1", |_force: bool| {
+            calls.set(calls.get() + 1);
+            async { None::<CachedRelease> }
+        })
+        .await;
+
+        assert_eq!(
+            calls.get(),
+            0,
+            "disabled must short-circuit before the cache/fetch layer is touched at all"
+        );
+        assert!(!resp.enabled);
+        assert!(resp.latest_version.is_none());
+        assert!(resp.server_version.is_none());
+        assert!(resp.server_update_available.is_none());
+        assert!(resp.checked_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn enabled_with_no_cached_release_yet_reports_no_signal() {
+        // First request ever, GitHub unreachable so far: enabled but no data.
+        let resp = build_response(true, false, "0.0.1", |_force: bool| async {
+            None::<CachedRelease>
+        })
+        .await;
+        assert!(resp.enabled);
+        assert!(resp.latest_version.is_none());
+        assert!(resp.server_update_available.is_none());
+        assert_eq!(resp.server_version.as_deref(), Some("0.0.1"));
+    }
+
+    #[tokio::test]
+    async fn enabled_with_cached_release_reports_update_available() {
+        let checked = dt(50_000);
+        let resp = build_response(true, false, "0.0.1", move |_force: bool| async move {
+            Some(sample(checked))
+        })
+        .await;
+        assert!(resp.enabled);
+        assert_eq!(resp.latest_version.as_deref(), Some("0.0.2"));
+        assert_eq!(resp.server_update_available, Some(true));
+        assert_eq!(resp.checked_at, Some(checked));
+    }
+}

--- a/services/api/tests/support/mod.rs
+++ b/services/api/tests/support/mod.rs
@@ -102,6 +102,8 @@ pub mod stats;
 pub mod status;
 #[path = "../../src/timeline.rs"]
 pub mod timeline;
+#[path = "../../src/updates.rs"]
+pub mod updates;
 #[path = "../../src/views.rs"]
 pub mod views;
 

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -6199,6 +6199,39 @@ pub async fn set_bookmarks_enabled(pool: &Pool, enabled: bool) -> Result<()> {
     Ok(())
 }
 
+/// Operator opt-in toggle for the update-available check (issue #7,
+/// migration 0045). `None` means the operator has never touched this setting
+/// — the caller (`services/api/src/updates.rs::resolve_enabled`) falls back to
+/// the `UPDATE_CHECK_ENABLED` env default (off by default, D3). Unlike
+/// [`get_bookmarks_enabled`], this is deliberately nullable rather than
+/// defaulting in Rust: NULL must be distinguishable from an explicit `false`.
+pub async fn get_update_check_enabled(pool: &Pool) -> Result<Option<bool>> {
+    let client = get_conn(pool).await?;
+    let row = client
+        .query_opt(
+            "SELECT update_check_enabled FROM server_settings LIMIT 1",
+            &[],
+        )
+        .await
+        .context("get_update_check_enabled")?;
+    Ok(row
+        .and_then(|r| r.try_get::<_, Option<bool>>("update_check_enabled").ok())
+        .flatten())
+}
+
+/// Set the operator's explicit update-check opt-in/out (issue #7).
+pub async fn set_update_check_enabled(pool: &Pool, enabled: bool) -> Result<()> {
+    let client = get_conn(pool).await?;
+    client
+        .execute(
+            "UPDATE server_settings SET update_check_enabled = $1",
+            &[&enabled],
+        )
+        .await
+        .context("set_update_check_enabled")?;
+    Ok(())
+}
+
 /// Set the deployment-wide default clip source (`"crumb"` | `"frigate"`).
 pub async fn set_default_clip_source(pool: &Pool, source: &str) -> Result<()> {
     let client = get_conn(pool).await?;
@@ -7573,6 +7606,10 @@ async fn run_migrations_locked(pool: &Pool) -> Result<()> {
         (
             "0044_beta_terms_acceptance.sql",
             include_str!("../../../db/migrations/0044_beta_terms_acceptance.sql"),
+        ),
+        (
+            "0045_update_check.sql",
+            include_str!("../../../db/migrations/0045_update_check.sql"),
         ),
     ];
 


### PR DESCRIPTION
## Summary

Phase 1 (server) of the update-available checker (issue #7). Design doc:
`docs/UPDATE-SYSTEM-PLAN.md` (included in this PR).

- **S1** — migration `0045_update_check.sql` (nullable
  `server_settings.update_check_enabled`; registered in the `MIGRATIONS` array
  in `services/common/src/db.rs`), `db::get_update_check_enabled` /
  `set_update_check_enabled`, `UPDATE_CHECK_ENABLED` env in
  `services/api/src/config.rs` (default `false`, D3).
- **S2** — `services/api/src/updates.rs`: `GET /updates/latest` (any
  authenticated user), a `GitHub` `releases/latest` fetch behind a 6h
  in-memory TTL cache with stale-while-error, a hand-rolled `SemVer` compare
  (unparsable version ⇒ no signal, unit-tested), and `?refresh=1` "Check now"
  (§2.5, added mid-implementation per the maintainer) gated to a separate 60s
  minimum interval between actual forced fetches. Disabled ⇒ zero `GitHub`
  requests, including with `refresh=1` (unit-tested explicitly). Route wired
  on the json side of `main.rs`. `config_routes.rs` doc-table row added.
- **S3** — `services/api/src/admin.html`: a Server-settings "Enable update
  checks" toggle (writes only its own field) + a status area with a "Check
  now" button, following house conventions (`esc()`, `api()`, semantic color
  vars). Verified `node --check` on the extracted script.
- **S4** — install surface: `.env.example`, `scripts/setup-env.sh` comment,
  `docker-compose.yml` api env, `docs/AI-INSTALL.md` (opt-in egress
  disclosure in the monitoring section), docs-site environment-reference row.
- **S5** — `docs/DECISIONS.md` entry (api-mediated, notify-only, opt-in/off
  by default — chosen vs. the plan doc's original "recommended enabled") and
  a `docs/COMPONENT-MAP.md` "Update notice" parity row.

Client consumption (desktop/Android/iOS/macOS) is Phase 2, not part of this
PR — see `docs/UPDATE-SYSTEM-PLAN.md` §7.

## Locked response contract (`GET /updates/latest`)

```json
{
  "enabled": true,
  "latest_version": "0.0.2",
  "notes_url": "https://github.com/badbread/crumbvms/releases/tag/v0.0.2",
  "published_at": "2026-07-20T00:00:00Z",
  "server_version": "0.0.1",
  "server_update_available": true,
  "checked_at": "2026-07-21T18:00:00Z"
}
```

`enabled:false` ⇒ every other field `null`. All fields besides `enabled` are
nullable even when `enabled:true` (the narrow case: no successful `GitHub`
fetch yet). `?refresh=1` forces an immediate re-check subject to the 60s
backoff described above; it is silently ignored while disabled.

## Test plan

- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo clippy -p crumb-api -p crumb-common --all-targets -- -D warnings`
      (clean; also spot-checked `crumb-recorder` since `db.rs` changed)
- [x] `cargo test -p crumb-api --bin crumb-api updates::` — 14 unit tests
      green (semver parsing, `GitHub` JSON parsing, TTL/backoff/stale-while
      -error cache logic, and the disabled+force=1 zero-fetch invariant),
      all with `GitHub` mocked via an injected fetch closure, no network call
- [ ] `cargo test --workspace` against a throwaway Postgres — could not run
      locally (no Docker on this workstation); CI must confirm
- [ ] `docker compose config` on a real Docker host — could not run locally;
      CI/maintainer must confirm
- [ ] Manual verify: disabling the toggle stops all `GitHub` egress (observe
      logs) on a live dev stack

## Notes for the maintainer

- The manual "Check now" (§2.5) requirement arrived mid-implementation and is
  folded in: `?refresh=1`, 60s minimum interval between actual forced
  fetches, hard-disabled-means-disabled invariant (unit-tested).
- `services/api/tests/support/mod.rs` needed a new `#[path]` re-include for
  `updates.rs` (the RBAC integration-test harness recompiles `src/` modules
  under its own crate root) — `updates.rs` reads its own local `VERSION`
  const rather than `crate::VERSION` for this reason.