### PR TITLE
feat(desktop): update-available banner + Check now (refs #7)

### DIFF
--- a/apps/desktop/src/app.js
+++ b/apps/desktop/src/app.js
@@ -3693,6 +3693,7 @@ async function activateTab(tabId) {
 function showLogin(errorMsg) {
   setCamerasFullscreen(false); // never strand the OS window in fullscreen at the login screen
   stopRecordingAlertPoll();    // clear the at-risk banner when signed out
+  stopUpdateCheckPoll();       // clear the update notice when signed out (issue #7)
   bootRetryStop();             // H1: don't keep retrying a boot-time camera load once signed out
   reauthClose();               // H6: don't leave the re-auth overlay up under the login screen
   els.loginScreen.classList.remove('hidden');
@@ -3723,6 +3724,9 @@ function showApp() {
 
   // Begin watching for disk-full / under-provisioned recording risk (every tab).
   startRecordingAlertPoll();
+  // Begin the update-available poll (issue #7): checks this server's
+  // /updates/latest, re-checks at most every 24h while the app runs.
+  startUpdateCheckPoll();
 }
 
 // ── Cameras-only fullscreen ("camera wall") ───────────────────────────────────
@@ -6466,6 +6470,16 @@ window.addEventListener('DOMContentLoaded', async () => {
     srvSelectSection('server');
   });
   document.getElementById('srv-hotkeys-reset')?.addEventListener('click', srvHotkeyReset);
+  // Update-available notice (issue #7): "Check now" forces a fresh server-side
+  // check, the release-notes link opens in the OS browser (not the WebView2
+  // in-app pane), Dismiss remembers this version only.
+  document.getElementById('srv-update-check-btn')?.addEventListener('click', () => void onUpdateCheckNow());
+  document.getElementById('srv-update-dismiss-btn')?.addEventListener('click', onUpdateDismiss);
+  document.getElementById('srv-update-link')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    const url = e.currentTarget.dataset.url;
+    if (url) invoke('open_url', { url }).catch(() => setStatus('Could not open the release notes.'));
+  });
   document.getElementById('srv-admin-open')?.addEventListener('click', () => {
     const url = (state.server || '').replace(/\/$/, '') + '/admin';
     if (state.server) invoke('open_url', { url }).catch(() => setStatus('Could not open the console.'));
@@ -11494,6 +11508,149 @@ function startRecordingAlertPoll() {
 function stopRecordingAlertPoll() {
   if (recordingAlertState.timer) { clearInterval(recordingAlertState.timer); recordingAlertState.timer = null; }
   renderRecordingAlert([]);
+}
+
+// ── Update-available checker (issue #7) ───────────────────────────────────────
+// Non-intrusive "vX.Y.Z available -> release notes" notice in Settings → This
+// Computer → About. The signal comes from THIS server's GET /updates/latest
+// (server-mediated per docs/UPDATE-SYSTEM-PLAN.md D2 — the client never talks
+// to GitHub itself); version compare against getVersion() is local. A 404 (old
+// server) or enabled:false (operator turned the check off) shows nothing.
+
+const LS_UPDATE_DISMISSED_KEY = 'crumb_update_dismissed_version';
+const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // re-check at most every 24h
+
+const updateState = {
+  data: null,        // last successful enabled:true /updates/latest body, else null
+  ownVersion: null,  // resolved once via the Tauri app API; null = unknown/dev build
+  timer: null,
+};
+
+/** Parse a bare "MAJOR.MINOR.PATCH" string into [maj,min,patch] ints. Anything
+ *  else (a dev build like "0.0.1-dev", empty, non-numeric) is unparsable —
+ *  callers must treat that as "don't know," never guess a comparison. */
+function updParseVersion(v) {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(String(v || '').trim());
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+/** True only when `latest` is a parsable version strictly greater than `own`.
+ *  Either side failing to parse means never show the banner (own == a dev
+ *  build, or a malformed latest_version) rather than guessing. */
+function updIsNewer(latest, own) {
+  const a = updParseVersion(latest);
+  const b = updParseVersion(own);
+  if (!a || !b) return false;
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] > b[i];
+  }
+  return false;
+}
+
+/** Resolve this build's own version once via the Tauri app API. Cached; an
+ *  unavailable/unparsable version (dev tree) just means the banner never shows. */
+async function updResolveOwnVersion() {
+  try {
+    updateState.ownVersion = await window.__TAURI__.app.getVersion();
+  } catch {
+    updateState.ownVersion = null;
+  }
+  updRender();
+}
+
+function getDismissedUpdateVersion() {
+  try { return localStorage.getItem(LS_UPDATE_DISMISSED_KEY) || ''; } catch { return ''; }
+}
+function setDismissedUpdateVersion(v) {
+  try { localStorage.setItem(LS_UPDATE_DISMISSED_KEY, v || ''); } catch { /* quota */ }
+}
+
+/** Fetch GET /updates/latest (optionally forcing a fresh GitHub check server-side
+ *  via ?refresh=1, see UPDATE-SYSTEM-PLAN.md §2.5 "Check now"). A 404 (server too
+ *  old for the endpoint) or a transient failure just keeps showing the last known
+ *  state; a 200 with enabled:false clears it (operator turned the check off). */
+async function updCheck(refresh) {
+  if (!state.server || !state.token) return;
+  try {
+    const res = await api(`/updates/latest${refresh ? '?refresh=1' : ''}`);
+    if (res.status === 404) { updateState.data = null; updRender(); return; }
+    if (!res.ok) return; // transient — keep the last known state
+    const body = await res.json();
+    updateState.data = body && body.enabled ? body : null;
+  } catch { /* transient — keep the last known state */ }
+  updRender();
+}
+
+/** Begin the post-login poll: check once immediately, then at most every 24h. */
+function startUpdateCheckPoll() {
+  if (updateState.timer) clearInterval(updateState.timer);
+  if (!updateState.ownVersion) void updResolveOwnVersion();
+  void updCheck(false);
+  updateState.timer = setInterval(() => void updCheck(false), UPDATE_CHECK_INTERVAL_MS);
+}
+
+/** Stop the poll + clear the notice (on sign-out). */
+function stopUpdateCheckPoll() {
+  if (updateState.timer) { clearInterval(updateState.timer); updateState.timer = null; }
+  updateState.data = null;
+  updRender();
+}
+
+/** Reflect updateState into the Settings → This Computer → About panel. */
+function updRender() {
+  const verEl = document.getElementById('srv-app-version');
+  if (verEl) verEl.textContent = updateState.ownVersion ? `v${updateState.ownVersion}` : 'unknown (dev build)';
+
+  const checkBtn = document.getElementById('srv-update-check-btn');
+  const banner = document.getElementById('srv-update-banner');
+  const text = document.getElementById('srv-update-text');
+  const link = document.getElementById('srv-update-link');
+  const d = updateState.data;
+
+  // "Check now" only makes sense while the server confirms the check is enabled.
+  if (checkBtn) checkBtn.classList.toggle('hidden', !d);
+
+  const newer = !!(d && d.latest_version && updIsNewer(d.latest_version, updateState.ownVersion));
+  const dismissed = getDismissedUpdateVersion();
+  const show = newer && d.latest_version !== dismissed;
+
+  if (banner) banner.classList.toggle('hidden', !show);
+  if (show) {
+    if (text) text.textContent = `Update available: v${d.latest_version}`;
+    if (link) {
+      link.classList.toggle('hidden', !d.notes_url);
+      link.dataset.url = d.notes_url || '';
+    }
+  }
+}
+
+/** "Check now" click (§2.5): force a fresh check, then report the outcome
+ *  inline next to the button, never a popup. */
+async function onUpdateCheckNow() {
+  const btn = document.getElementById('srv-update-check-btn');
+  const status = document.getElementById('srv-update-status');
+  if (btn) btn.disabled = true;
+  if (status) status.textContent = 'Checking…';
+  await updCheck(true);
+  if (status) {
+    const d = updateState.data;
+    if (d && d.latest_version && updIsNewer(d.latest_version, updateState.ownVersion)) {
+      status.textContent = `Checked just now, v${d.latest_version} is available.`;
+    } else if (d) {
+      status.textContent = "Checked just now, you're up to date.";
+    } else {
+      status.textContent = '';
+    }
+  }
+  if (btn) btn.disabled = false;
+}
+
+/** Dismiss the current notice — remembers this version so it stays quiet until
+ *  a newer release appears (per-version, not permanent). */
+function onUpdateDismiss() {
+  const d = updateState.data;
+  if (d && d.latest_version) setDismissedUpdateVersion(d.latest_version);
+  updRender();
 }
 
 /** A short human forecast string for a policy's LIVE store. */

--- a/apps/desktop/src/app.js
+++ b/apps/desktop/src/app.js
@@ -6475,10 +6475,14 @@ window.addEventListener('DOMContentLoaded', async () => {
   // in-app pane), Dismiss remembers this version only.
   document.getElementById('srv-update-check-btn')?.addEventListener('click', () => void onUpdateCheckNow());
   document.getElementById('srv-update-dismiss-btn')?.addEventListener('click', onUpdateDismiss);
-  document.getElementById('srv-update-link')?.addEventListener('click', (e) => {
-    e.preventDefault();
-    const url = e.currentTarget.dataset.url;
-    if (url) invoke('open_url', { url }).catch(() => setStatus('Could not open the release notes.'));
+  // Both release-notes links (the always-present field + the dismissible banner)
+  // open the notes URL in the OS browser, not the WebView2 in-app pane.
+  document.querySelectorAll('.srv-update-link').forEach((el) => {
+    el.addEventListener('click', (e) => {
+      e.preventDefault();
+      const url = e.currentTarget.dataset.url;
+      if (url) invoke('open_url', { url }).catch(() => setStatus('Could not open the release notes.'));
+    });
   });
   document.getElementById('srv-admin-open')?.addEventListener('click', () => {
     const url = (state.server || '').replace(/\/$/, '') + '/admin';
@@ -10927,7 +10931,7 @@ function srvSelectSection(name) {
     s.classList.toggle('hidden', s.dataset.section !== name));
   // Leaving Motion: halt the inline tuner's polling so it doesn't run unseen.
   if (name !== 'motion') mtStop();
-  if (name === 'client')      srvReflectClientOptions();
+  if (name === 'client')      { srvReflectClientOptions(); updEnterAbout(); }
   else if (name === 'server') { srvState.lastPolicyUsageMs = 0; void srvLoadHealth(); void srvLoadStats(); void pollRecordingAlerts(); }
   else if (name === 'motion') { void srvEnterMotion(); }
   else if (name === 'admin')  { srvEnterAdmin(); }
@@ -11518,12 +11522,18 @@ function stopRecordingAlertPoll() {
 // server) or enabled:false (operator turned the check off) shows nothing.
 
 const LS_UPDATE_DISMISSED_KEY = 'crumb_update_dismissed_version';
-const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // re-check at most every 24h
+const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // periodic re-check while the app stays open
+// Light in-session guard: coalesce checks fired close together (a launch check +
+// an About-panel open, or rapid re-renders) into one actual request. The 24h
+// interval governs periodic re-checks; this only debounces bursts.
+const UPDATE_CHECK_MIN_GAP_MS = 15 * 1000;
 
 const updateState = {
   data: null,        // last successful enabled:true /updates/latest body, else null
   ownVersion: null,  // resolved once via the Tauri app API; null = unknown/dev build
   timer: null,
+  checking: false,   // a request is in flight → the About field shows "Checking…"
+  lastCheckMs: 0,    // wall time of the last fired check (for the burst guard)
 };
 
 /** Parse a bare "MAJOR.MINOR.PATCH" string into [maj,min,patch] ints. Anything
@@ -11567,25 +11577,47 @@ function setDismissedUpdateVersion(v) {
 
 /** Fetch GET /updates/latest (optionally forcing a fresh GitHub check server-side
  *  via ?refresh=1, see UPDATE-SYSTEM-PLAN.md §2.5 "Check now"). A 404 (server too
- *  old for the endpoint) or a transient failure just keeps showing the last known
- *  state; a 200 with enabled:false clears it (operator turned the check off). */
+ *  old for the endpoint) or a 200 with enabled:false clears the state (nothing
+ *  shows); other transient failures keep the last known state. Sets the in-flight
+ *  flag so the About field can show "Checking…" while the request runs. */
 async function updCheck(refresh) {
   if (!state.server || !state.token) return;
+  updateState.checking = true;
+  updateState.lastCheckMs = Date.now();
+  updRender();
   try {
     const res = await api(`/updates/latest${refresh ? '?refresh=1' : ''}`);
-    if (res.status === 404) { updateState.data = null; updRender(); return; }
-    if (!res.ok) return; // transient — keep the last known state
-    const body = await res.json();
-    updateState.data = body && body.enabled ? body : null;
+    if (res.status === 404) {
+      updateState.data = null;                    // server too old for the endpoint
+    } else if (res.ok) {
+      const body = await res.json();
+      updateState.data = body && body.enabled ? body : null; // enabled:false → clear
+    }
+    // Any other non-ok status: keep the last known state (transient).
   } catch { /* transient — keep the last known state */ }
-  updRender();
+  finally {
+    updateState.checking = false;
+    updRender();
+  }
 }
 
-/** Begin the post-login poll: check once immediately, then at most every 24h. */
+/** Fire a normal (non-forced) check unless one ran very recently — coalesces a
+ *  launch check with an immediate About-panel open, and absorbs rapid re-renders,
+ *  without spamming the server. `force` (the manual "Check now") bypasses this. */
+function updMaybeCheck() {
+  if (updateState.checking) return;
+  if (Date.now() - updateState.lastCheckMs < UPDATE_CHECK_MIN_GAP_MS) return;
+  void updCheck(false);
+}
+
+/** Begin the update poll on app launch: resolve own version, run one check now
+ *  (every launch — NOT gated behind the 24h interval), then re-check periodically
+ *  while the app stays open. */
 function startUpdateCheckPoll() {
   if (updateState.timer) clearInterval(updateState.timer);
   if (!updateState.ownVersion) void updResolveOwnVersion();
-  void updCheck(false);
+  updateState.lastCheckMs = 0;                    // ensure the launch check always fires
+  updMaybeCheck();
   updateState.timer = setInterval(() => void updCheck(false), UPDATE_CHECK_INTERVAL_MS);
 }
 
@@ -11593,7 +11625,16 @@ function startUpdateCheckPoll() {
 function stopUpdateCheckPoll() {
   if (updateState.timer) { clearInterval(updateState.timer); updateState.timer = null; }
   updateState.data = null;
+  updateState.checking = false;
   updRender();
+}
+
+/** Opening Settings → This Computer (which holds the About panel) triggers a
+ *  fresh check so the always-present Updates field is never stale. This is how a
+ *  client that first checked while the server had the feature OFF can discover it
+ *  was later turned ON. Coalesced by updMaybeCheck so re-entry doesn't spam. */
+function updEnterAbout() {
+  updMaybeCheck();
 }
 
 /** Reflect updateState into the Settings → This Computer → About panel. */
@@ -11601,21 +11642,53 @@ function updRender() {
   const verEl = document.getElementById('srv-app-version');
   if (verEl) verEl.textContent = updateState.ownVersion ? `v${updateState.ownVersion}` : 'unknown (dev build)';
 
+  const d = updateState.data;
+  const enabled = !!d;                            // server reports the check enabled
+  const newer = !!(d && d.latest_version && updIsNewer(d.latest_version, updateState.ownVersion));
+  const ownKnown = !!updParseVersion(updateState.ownVersion);
+
+  // "Check now" is present only while the check is enabled.
   const checkBtn = document.getElementById('srv-update-check-btn');
+  if (checkBtn) checkBtn.classList.toggle('hidden', !enabled);
+
+  // Always-present Updates status field (only while enabled). States:
+  //   "Checking…" / "Update available: vX" (+link) / "You're up to date (vX)".
+  const fieldRow = document.getElementById('srv-update-field-row');
+  const fieldText = document.getElementById('srv-update-field-text');
+  const fieldLink = document.getElementById('srv-update-field-link');
+  if (fieldRow) fieldRow.classList.toggle('hidden', !enabled);
+  if (enabled && fieldText) {
+    let msg;
+    let linkUrl = '';
+    if (updateState.checking) {
+      msg = 'Checking…';
+    } else if (newer) {
+      msg = `Update available: v${d.latest_version}`;
+      linkUrl = d.notes_url || '';
+    } else if (d.latest_version && ownKnown) {
+      msg = `You're up to date (v${d.latest_version})`;
+    } else if (d.latest_version) {
+      // Own version unparsable (dev build): no up-to-date/behind claim, just report latest.
+      msg = `Latest release: v${d.latest_version}`;
+    } else {
+      // Enabled, but the server has no successful GitHub fetch yet.
+      msg = 'Latest version unknown';
+    }
+    fieldText.textContent = msg;
+    if (fieldLink) {
+      fieldLink.classList.toggle('hidden', !linkUrl);
+      fieldLink.dataset.url = linkUrl;
+    }
+  }
+
+  // Dismissible proactive banner: only while an update is available and this
+  // version hasn't been dismissed. Fed by the every-launch check.
   const banner = document.getElementById('srv-update-banner');
   const text = document.getElementById('srv-update-text');
   const link = document.getElementById('srv-update-link');
-  const d = updateState.data;
-
-  // "Check now" only makes sense while the server confirms the check is enabled.
-  if (checkBtn) checkBtn.classList.toggle('hidden', !d);
-
-  const newer = !!(d && d.latest_version && updIsNewer(d.latest_version, updateState.ownVersion));
-  const dismissed = getDismissedUpdateVersion();
-  const show = newer && d.latest_version !== dismissed;
-
-  if (banner) banner.classList.toggle('hidden', !show);
-  if (show) {
+  const showBanner = newer && d.latest_version !== getDismissedUpdateVersion();
+  if (banner) banner.classList.toggle('hidden', !showBanner);
+  if (showBanner) {
     if (text) text.textContent = `Update available: v${d.latest_version}`;
     if (link) {
       link.classList.toggle('hidden', !d.notes_url);
@@ -11624,29 +11697,18 @@ function updRender() {
   }
 }
 
-/** "Check now" click (§2.5): force a fresh check, then report the outcome
- *  inline next to the button, never a popup. */
+/** "Check now" click (§2.5): force a fresh server-side check. The always-present
+ *  field reflects the outcome ("Checking…" → up-to-date / update-available). */
 async function onUpdateCheckNow() {
   const btn = document.getElementById('srv-update-check-btn');
-  const status = document.getElementById('srv-update-status');
   if (btn) btn.disabled = true;
-  if (status) status.textContent = 'Checking…';
   await updCheck(true);
-  if (status) {
-    const d = updateState.data;
-    if (d && d.latest_version && updIsNewer(d.latest_version, updateState.ownVersion)) {
-      status.textContent = `Checked just now, v${d.latest_version} is available.`;
-    } else if (d) {
-      status.textContent = "Checked just now, you're up to date.";
-    } else {
-      status.textContent = '';
-    }
-  }
   if (btn) btn.disabled = false;
 }
 
-/** Dismiss the current notice — remembers this version so it stays quiet until
- *  a newer release appears (per-version, not permanent). */
+/** Dismiss the current banner — remembers this version so the banner stays quiet
+ *  until a newer release appears (per-version, not permanent). The always-present
+ *  Updates field still shows the available update. */
 function onUpdateDismiss() {
   const d = updateState.data;
   if (d && d.latest_version) setDismissedUpdateVersion(d.latest_version);

--- a/apps/desktop/src/index.html
+++ b/apps/desktop/src/index.html
@@ -437,12 +437,23 @@
                   </div>
                   <div class="srv-panel-body">
                     <div class="srv-kv"><span class="srv-kv-k">Version</span><span class="srv-kv-v" id="srv-app-version">,</span></div>
+                    <!-- Always-present update status field: shown whenever the server reports
+                         the check enabled. Opening this panel triggers a fresh (non-forced)
+                         check so the field is never stale. Hidden when disabled/404. -->
+                    <div class="srv-kv hidden" id="srv-update-field-row">
+                      <span class="srv-kv-k">Updates</span>
+                      <span class="srv-kv-v srv-update-field">
+                        <span id="srv-update-field-text"></span>
+                        <a id="srv-update-field-link" class="srv-update-link hidden" href="#">Release notes</a>
+                      </span>
+                    </div>
+                    <!-- Dismissible proactive banner: only while an update is available and
+                         this version hasn't been dismissed. Fed by the every-launch check. -->
                     <div id="srv-update-banner" class="srv-update-banner hidden">
                       <span id="srv-update-text" class="srv-update-text"></span>
                       <a id="srv-update-link" class="srv-update-link hidden" href="#">Release notes</a>
                       <button id="srv-update-dismiss-btn" type="button" class="pb-btn srv-update-dismiss-btn">Dismiss</button>
                     </div>
-                    <div class="srv-note" id="srv-update-status"></div>
                   </div>
                 </div>
               </div>

--- a/apps/desktop/src/index.html
+++ b/apps/desktop/src/index.html
@@ -426,6 +426,25 @@
                     </div>
                   </div>
                 </div>
+                <!-- Update-available notice (issue #7): the signal comes from THIS
+                     server's GET /updates/latest (server-mediated, never GitHub
+                     directly); version compare against getVersion() is local.
+                     enabled:false or a 404 (old/disabled server) shows nothing. -->
+                <div class="srv-panel">
+                  <div class="srv-panel-header">
+                    <span class="srv-panel-title">About</span>
+                    <button id="srv-update-check-btn" type="button" class="pb-btn hidden">Check now</button>
+                  </div>
+                  <div class="srv-panel-body">
+                    <div class="srv-kv"><span class="srv-kv-k">Version</span><span class="srv-kv-v" id="srv-app-version">,</span></div>
+                    <div id="srv-update-banner" class="srv-update-banner hidden">
+                      <span id="srv-update-text" class="srv-update-text"></span>
+                      <a id="srv-update-link" class="srv-update-link hidden" href="#">Release notes</a>
+                      <button id="srv-update-dismiss-btn" type="button" class="pb-btn srv-update-dismiss-btn">Dismiss</button>
+                    </div>
+                    <div class="srv-note" id="srv-update-status"></div>
+                  </div>
+                </div>
               </div>
 
               <!-- ════════ SERVER ════════ (console link + read-only health + per-camera storage + motion tuning) -->

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2417,6 +2417,22 @@ body.vs-reordering, body.vs-reordering * { cursor: grabbing !important; user-sel
 .srv-kv-v { color: var(--text); font-family: ui-monospace, "Consolas", monospace; text-align: right; word-break: break-word; }
 .srv-note { font-size: 11px; color: var(--text-muted); margin-top: 8px; line-height: 1.4; }
 .srv-note code { background: var(--surface2); padding: 1px 4px; border-radius: 3px; }
+
+/* Update-available notice (Settings → This Computer → About, issue #7). Amber
+   accent (attention, not danger) — non-intrusive, lives only in this panel. */
+.srv-update-banner {
+  display: flex; align-items: center; gap: 10px;
+  margin-top: 10px; padding: 8px 10px; border-radius: 6px;
+  border-left: 3px solid var(--warn, #E8A33D);
+  background: rgba(232, 163, 61, 0.10);
+  font-size: 12px; color: var(--text-dim);
+}
+.srv-update-banner.hidden { display: none; }
+.srv-update-text { flex: 1 1 auto; font-weight: 600; color: var(--text); }
+.srv-update-link { color: var(--accent); text-decoration: none; white-space: nowrap; }
+.srv-update-link:hover { text-decoration: underline; }
+.srv-update-link.hidden { display: none; }
+.srv-update-dismiss-btn { flex: 0 0 auto; padding: 3px 9px; font-size: 11px; }
 .srv-f8-hint {
   font-size: 12px; color: var(--text); line-height: 1.5;
   background: var(--surface2); border: 1px solid var(--border);

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2429,6 +2429,8 @@ body.vs-reordering, body.vs-reordering * { cursor: grabbing !important; user-sel
 }
 .srv-update-banner.hidden { display: none; }
 .srv-update-text { flex: 1 1 auto; font-weight: 600; color: var(--text); }
+/* Always-present status field value (the "Updates" srv-kv row): text + inline link. */
+.srv-update-field { display: inline-flex; align-items: baseline; gap: 8px; justify-content: flex-end; }
 .srv-update-link { color: var(--accent); text-decoration: none; white-space: nowrap; }
 .srv-update-link:hover { text-decoration: underline; }
 .srv-update-link.hidden { display: none; }


### PR DESCRIPTION
## Summary
- Desktop client (Windows + Linux, one Tauri codebase) consumes the server's `GET /updates/latest` (locked contract, no server changes here) and shows a non-intrusive, dismissible "Update available" banner in Settings -> This Computer -> About.
- Own version comes from the Tauri app API (`getVersion()`); comparison is a small hand-rolled `MAJOR.MINOR.PATCH` semver check. An unparsable own version (a dev build) means the banner never shows, per docs/UPDATE-SYSTEM-PLAN.md.
- "Check now" button forces `?refresh=1` and reports the outcome inline ("Checked just now, you're up to date." / "Checked just now, vX.Y.Z is available."); it's only shown when the last response had `enabled:true`.
- A 404 (old server) or `enabled:false` shows nothing (feature detection). Dismiss remembers the dismissed version only, so a newer release re-surfaces the banner.
- Re-checks at most every 24h while the app runs (post-login), stops on sign-out.
- No Rust changes.

## Test plan
- [x] `npx eslint src` in `apps/desktop` — 0 errors (same 20 pre-existing warnings, unrelated to this change).
- [ ] CI `desktop-lint` / `desktop-linux` green (to confirm once CI runs on the PR).
- [x] Full Tauri rebuild + on-workstation visual verify against a dev server stubbed to report a newer version (exe bakes in `../src`; deferred to a workstation follow-up per docs/UPDATE-SYSTEM-PLAN.md task C2 acceptance).