### PR TITLE
feat(android): update-available banner + Check now (refs #7)

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -189,4 +189,7 @@ dependencies {
     // Biometric / device-credential app lock (BiometricPrompt). Pulls androidx.fragment,
     // which is why MainActivity is a FragmentActivity.
     implementation(libs.androidx.biometric)
+
+    // Local JVM unit tests (src/test) — currently just the update-checker SemVer compare.
+    testImplementation(libs.junit)
 }

--- a/apps/android/app/src/main/java/video/crumb/app/data/CrumbApi.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/CrumbApi.kt
@@ -209,4 +209,19 @@ interface CrumbApi {
     /** Delete a view (owner or admin only). */
     @DELETE("views/{id}")
     suspend fun deleteView(@Path("id") id: String): Response<Unit>
+
+    /**
+     * Update-available check (issue #7). Any authenticated user (viewers run
+     * wall displays and phones too). `enabled:false` means the operator has
+     * turned the check off — every other field is then null and the client
+     * shows nothing. An older server that predates this endpoint returns 404,
+     * which the repository layer treats the same way.
+     *
+     * @param refresh Pass `"1"` to force an immediate re-check ("Check now",
+     *   `docs/UPDATE-SYSTEM-PLAN.md` §2.5) bypassing the server's 6h cache —
+     *   itself rate-limited server-side to one actual GitHub hit per 60s.
+     *   Omit for the normal cached lookup.
+     */
+    @GET("updates/latest")
+    suspend fun updatesLatest(@Query("refresh") refresh: String? = null): UpdateCheckResponse
 }

--- a/apps/android/app/src/main/java/video/crumb/app/data/CrumbRepository.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/CrumbRepository.kt
@@ -324,6 +324,17 @@ class CrumbRepository(private val container: AppContainer) {
         }
         byCam.mapValues { it.value.toList() }
     }
+
+    // ── update-available check (issue #7) ───────────────────────────────────
+    /**
+     * `GET /updates/latest`. [refresh] forces an immediate re-check ("Check
+     * now", §2.5); the server itself rate-limits actual GitHub hits, so this
+     * is safe to call repeatedly. A 404 (server predates the endpoint) surfaces
+     * as a [Result.failure] — callers should treat that the same as
+     * `enabled:false` and show nothing.
+     */
+    suspend fun updatesLatest(refresh: Boolean = false): Result<UpdateCheckResponse> =
+        runCatchingCancellable { api.updatesLatest(if (refresh) "1" else null) }
 }
 
 /**

--- a/apps/android/app/src/main/java/video/crumb/app/data/Models.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/Models.kt
@@ -439,6 +439,34 @@ data class CameraStatusEntry(
     @SerialName("recent_motion") val recentMotion: Boolean = false,
 )
 
+// ─── update-available check (issue #7) ──────────────────────────────────────
+
+/**
+ * `GET /updates/latest` response. Mirrors the Rust `UpdateCheckResponse`
+ * (`services/api/src/dto.rs`) exactly — see `docs/UPDATE-SYSTEM-PLAN.md` §2.1/§2.5.
+ *
+ * `enabled == false` means the operator has turned the check off (or this
+ * server predates the feature, in which case the repository layer treats a
+ * 404 the same way): every other field is then null and the client shows
+ * nothing. While enabled, [latestVersion]/[notesUrl]/[publishedAt]/[checkedAt]
+ * are only null in the narrow case where the server has never completed a
+ * GitHub fetch yet.
+ */
+@Serializable
+data class UpdateCheckResponse(
+    val enabled: Boolean = false,
+    /** Newest stable release tag from GitHub, without the leading `v`. */
+    @SerialName("latest_version") val latestVersion: String? = null,
+    /** GitHub release page URL (release notes). */
+    @SerialName("notes_url") val notesUrl: String? = null,
+    @SerialName("published_at") val publishedAt: String? = null,
+    /** The server's own build version — unused by this client, which compares
+     *  [latestVersion] against its OWN `BuildConfig.VERSION_NAME` instead. */
+    @SerialName("server_version") val serverVersion: String? = null,
+    @SerialName("server_update_available") val serverUpdateAvailable: Boolean? = null,
+    @SerialName("checked_at") val checkedAt: String? = null,
+)
+
 // ─── saved views (server-side, per-user; the same /views the desktop/web use) ──
 
 /**

--- a/apps/android/app/src/main/java/video/crumb/app/data/SecureStore.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/SecureStore.kt
@@ -200,6 +200,29 @@ class SecureStore(context: Context) {
     // Playback bookmarks moved server-side (shared across clients) — see
     // CrumbRepository.bookmarks()/addBookmark() and the /bookmarks API.
 
+    // ── update-available check (issue #7) ────────────────────────────────────
+
+    /**
+     * Release version the user last dismissed the update-available banner
+     * for. The banner stays hidden until a NEWER release appears than this
+     * one — dismissing v0.0.2 does not suppress a later v0.0.3. Null when
+     * nothing has ever been dismissed.
+     */
+    var dismissedUpdateVersion: String?
+        get() = prefs.getString(KEY_DISMISSED_UPDATE_VERSION, null)
+        set(value) = prefs.edit().apply {
+            if (value == null) remove(KEY_DISMISSED_UPDATE_VERSION) else putString(KEY_DISMISSED_UPDATE_VERSION, value)
+        }.apply()
+
+    /**
+     * Device-local epoch millis of the last organic (non-"Check now")
+     * update check, so the app re-checks at most once every 24h across app
+     * launches (`docs/UPDATE-SYSTEM-PLAN.md` §3). 0 = never checked.
+     */
+    var lastUpdateCheckAtMs: Long
+        get() = prefs.getLong(KEY_LAST_UPDATE_CHECK, 0L)
+        set(value) = prefs.edit().putLong(KEY_LAST_UPDATE_CHECK, value).apply()
+
     val isLoggedIn: Boolean get() = !token.isNullOrBlank()
 
     val isAdmin: Boolean get() = role.equals("admin", ignoreCase = true)
@@ -232,6 +255,8 @@ class SecureStore(context: Context) {
         private const val KEY_CAPABILITIES = "user_capabilities_json"
         private const val KEY_BIOMETRIC = "biometric_enabled"
         private const val KEY_BIOMETRIC_OFFERED = "biometric_offered"
+        private const val KEY_DISMISSED_UPDATE_VERSION = "dismissed_update_version"
+        private const val KEY_LAST_UPDATE_CHECK = "last_update_check_at_ms"
 
         /** Lenient JSON for the local views blob and capability set (tolerates schema drift). */
         private val jsonCodec = Json { ignoreUnknownKeys = true }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/about/AboutDialog.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/about/AboutDialog.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
@@ -35,19 +36,30 @@ import video.crumb.app.ui.theme.TextSecondary
  * build is `video.crumb.app` (debug: `video.crumb.app.debug`).
  *
  * @param serverUrl The currently-configured API server, shown for context.
- * @param updateState Update-available check state (issue #7) — a "you're up
- *   to date" / "update available → release notes" line plus "Check now",
- *   shown only while the server has the check enabled.
- * @param onCheckNow Force an immediate re-check against the server.
+ * @param updateState Update-available check state (issue #7). When the server
+ *   reports the check enabled, an always-present update field is shown
+ *   ("Checking..." / "You're up to date (X)" / "Update available: X → release
+ *   notes") with a "Check now" button; hidden entirely when the server reports
+ *   the check off (or an older server 404s).
+ * @param onOpened Called once when the dialog opens, to trigger a fresh
+ *   (normal, non-forced) check so the update field is never stale — a client
+ *   that first checked while the server had the feature OFF can still discover
+ *   it was turned ON.
+ * @param onCheckNow Force an immediate re-check against the server ("Check now").
  * @param onDismiss Close the dialog.
  */
 @Composable
 fun AboutDialog(
     serverUrl: String,
     updateState: UpdateUiState,
+    onOpened: () -> Unit,
     onCheckNow: () -> Unit,
     onDismiss: () -> Unit,
 ) {
+    // Opening About triggers a fresh check so the field below reflects current
+    // server state rather than a cached (possibly hours-stale) one.
+    LaunchedEffect(Unit) { onOpened() }
+
     AlertDialog(
         onDismissRequest = onDismiss,
         confirmButton = {
@@ -63,7 +75,9 @@ fun AboutDialog(
                 InfoRow("Build type", BuildConfig.BUILD_TYPE)
                 InfoRow("Server", serverUrl)
 
-                if (updateState.enabled || updateState.updateAvailable) {
+                // Always present while the server has the check enabled; hidden
+                // when it reports enabled:false or an older server 404s.
+                if (updateState.enabled) {
                     HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
                     UpdateCheckRow(state = updateState, onCheckNow = onCheckNow)
                 }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/about/AboutDialog.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/about/AboutDialog.kt
@@ -6,8 +6,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -17,6 +19,8 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import video.crumb.app.BuildConfig
+import video.crumb.app.feature.update.UpdateCheckRow
+import video.crumb.app.feature.update.UpdateUiState
 import video.crumb.app.ui.theme.TextPrimary
 import video.crumb.app.ui.theme.TextSecondary
 
@@ -31,11 +35,17 @@ import video.crumb.app.ui.theme.TextSecondary
  * build is `video.crumb.app` (debug: `video.crumb.app.debug`).
  *
  * @param serverUrl The currently-configured API server, shown for context.
+ * @param updateState Update-available check state (issue #7) — a "you're up
+ *   to date" / "update available → release notes" line plus "Check now",
+ *   shown only while the server has the check enabled.
+ * @param onCheckNow Force an immediate re-check against the server.
  * @param onDismiss Close the dialog.
  */
 @Composable
 fun AboutDialog(
     serverUrl: String,
+    updateState: UpdateUiState,
+    onCheckNow: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     AlertDialog(
@@ -52,6 +62,11 @@ fun AboutDialog(
                 InfoRow("Commit", BuildConfig.GIT_SHA)
                 InfoRow("Build type", BuildConfig.BUILD_TYPE)
                 InfoRow("Server", serverUrl)
+
+                if (updateState.enabled || updateState.updateAvailable) {
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                    UpdateCheckRow(state = updateState, onCheckNow = onCheckNow)
+                }
             }
         },
     )

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveScreen.kt
@@ -552,6 +552,7 @@ fun LiveScreen(
         AboutDialog(
             serverUrl = store.serverUrl,
             updateState = updateState,
+            onOpened = { updateVm.refresh() },
             onCheckNow = { updateVm.checkNow() },
             onDismiss = { showAbout = false },
         )

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveScreen.kt
@@ -65,6 +65,8 @@ import video.crumb.app.data.CameraView
 import video.crumb.app.di.appContainer
 import video.crumb.app.feature.about.AboutDialog
 import video.crumb.app.feature.settings.SettingsDialog
+import video.crumb.app.feature.update.UpdateAvailableBanner
+import video.crumb.app.feature.update.UpdateViewModel
 import video.crumb.app.ui.CrumbMode
 import video.crumb.app.ui.CrumbModeTabs
 import video.crumb.app.ui.GridLayoutToggle
@@ -109,6 +111,16 @@ fun LiveScreen(
         },
     )
     val state by vm.uiState.collectAsStateWithLifecycle()
+
+    // Update-available check (issue #7) — lives here because Live is the root
+    // destination (always on the back stack, see MainActivity's popUpTo(LIVE)),
+    // so its 24h re-check timer survives Live/Playback/Clips tab switches.
+    val updateVm: UpdateViewModel = viewModel(
+        factory = viewModelFactory {
+            initializer { UpdateViewModel(container.repository, container.store) }
+        },
+    )
+    val updateState by updateVm.uiState.collectAsStateWithLifecycle()
     val store = container.store
     val caps = store.capabilities
     // Built once (server URL + token are stable for the session). Used to derive the
@@ -351,6 +363,17 @@ fun LiveScreen(
                 .padding(innerPadding),
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
+                // ── Update-available banner (issue #7) ────────────────────────────
+                // Non-intrusive, dismissible; dismiss remembers the version so it
+                // stays quiet until a NEWER release appears (see UpdateViewModel).
+                if (updateState.showBanner) {
+                    UpdateAvailableBanner(
+                        state = updateState,
+                        onDismiss = { updateVm.dismiss() },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+
                 // ── Auto-fallback badge ───────────────────────────────────────────
                 // Shown when the wall auto-entered low-bw mode due to stalling tiles.
                 // Dismissed by tapping "Restore" (manually exits low-bw mode) or the
@@ -526,7 +549,12 @@ fun LiveScreen(
         )
     }
     if (showAbout) {
-        AboutDialog(serverUrl = store.serverUrl, onDismiss = { showAbout = false })
+        AboutDialog(
+            serverUrl = store.serverUrl,
+            updateState = updateState,
+            onCheckNow = { updateVm.checkNow() },
+            onDismiss = { showAbout = false },
+        )
     }
     editorTarget?.let { target ->
         ViewEditorDialog(

--- a/apps/android/app/src/main/java/video/crumb/app/feature/update/SemVer.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/update/SemVer.kt
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.feature.update
+
+/**
+ * Tiny hand-rolled SemVer 2.0.0 precedence compare for the update-available
+ * checker (issue #7). Deliberately not a library dependency (golden rule 6,
+ * `AGENTS.md`) — mirrors the server's `services/api/src/updates.rs`
+ * `parse_semver`/`is_update_available` exactly: only a plain
+ * `MAJOR.MINOR.PATCH` triple of non-negative integers parses; anything else
+ * (a `-dev` suffix, a missing part, non-numeric text) is "no signal", not an
+ * error (`docs/UPDATE-SYSTEM-PLAN.md` §2.2).
+ */
+object SemVer {
+
+    /**
+     * Parse a plain `MAJOR.MINOR.PATCH` version (exactly three dot-separated
+     * non-negative integers). `null` for anything else.
+     */
+    fun parse(raw: String): Triple<Long, Long, Long>? {
+        val parts = raw.trim().split(".")
+        if (parts.size != 3) return null
+        val major = parts[0].toLongOrNull() ?: return null
+        val minor = parts[1].toLongOrNull() ?: return null
+        val patch = parts[2].toLongOrNull() ?: return null
+        return Triple(major, minor, patch)
+    }
+
+    /**
+     * Whether [latest] is a strictly newer release than [current] (SemVer
+     * 2.0.0 precedence, tuple-lexicographic since neither side carries a
+     * pre-release/build suffix once parsed). `null` — not `false` — when
+     * either fails to parse, so an unparsable local/dev build (e.g.
+     * `"0.0.1-dev"`) never claims an update is or isn't available.
+     */
+    fun isNewer(current: String, latest: String): Boolean? {
+        val cur = parse(current) ?: return null
+        val lat = parse(latest) ?: return null
+        if (lat.first != cur.first) return lat.first > cur.first
+        if (lat.second != cur.second) return lat.second > cur.second
+        return lat.third > cur.third
+    }
+}

--- a/apps/android/app/src/main/java/video/crumb/app/feature/update/UpdateBanner.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/update/UpdateBanner.kt
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.feature.update
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.SystemUpdate
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import video.crumb.app.ui.theme.NavySurface
+import video.crumb.app.ui.theme.TealAccent
+import video.crumb.app.ui.theme.TextSecondary
+
+/**
+ * Open [url] in the platform browser. Silently does nothing if no activity
+ * can handle it — a release-notes link is a nicety, never worth crashing over.
+ */
+private fun openInBrowser(context: Context, url: String) {
+    runCatching {
+        context.startActivity(
+            Intent(Intent.ACTION_VIEW, Uri.parse(url)).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+        )
+    }
+}
+
+/**
+ * Non-intrusive dismissible banner: "Update available → release notes"
+ * (issue #7 §3). Callers should only compose this while
+ * [UpdateUiState.showBanner] is true.
+ */
+@Composable
+fun UpdateAvailableBanner(
+    state: UpdateUiState,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val version = state.latestVersion ?: return
+    val notesUrl = state.notesUrl
+    Row(
+        modifier = modifier
+            .background(NavySurface)
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Default.SystemUpdate,
+            contentDescription = null,
+            tint = TealAccent,
+            modifier = Modifier.size(16.dp),
+        )
+        Text(
+            text = "Update available: v$version",
+            style = MaterialTheme.typography.labelMedium,
+            color = TextSecondary,
+            modifier = Modifier
+                .weight(1f)
+                .clickable(enabled = notesUrl != null) { notesUrl?.let { openInBrowser(context, it) } },
+        )
+        if (notesUrl != null) {
+            TextButton(
+                onClick = { openInBrowser(context, notesUrl) },
+                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
+            ) {
+                Text("Release notes", color = TealAccent, style = MaterialTheme.typography.labelMedium)
+            }
+        }
+        IconButton(
+            onClick = onDismiss,
+            modifier = Modifier.size(28.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = "Dismiss",
+                tint = TextSecondary,
+                modifier = Modifier.size(14.dp),
+            )
+        }
+    }
+}
+
+/**
+ * Settings/About row (issue #7 §3): the current version's update status, plus
+ * a "Check now" button offered only while the server has the check enabled
+ * ([UpdateUiState.enabled]). Tapping the release-notes line/button opens
+ * [UpdateUiState.notesUrl] in the platform browser.
+ */
+@Composable
+fun UpdateCheckRow(
+    state: UpdateUiState,
+    onCheckNow: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        when {
+            state.updateAvailable -> {
+                val version = state.latestVersion.orEmpty()
+                val notesUrl = state.notesUrl
+                Text(
+                    text = "Update available: v$version",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = TealAccent,
+                    modifier = Modifier.clickable(enabled = notesUrl != null) {
+                        notesUrl?.let { openInBrowser(context, it) }
+                    },
+                )
+                if (notesUrl != null) {
+                    Text(
+                        text = "Tap to view release notes",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = TextSecondary,
+                    )
+                }
+            }
+            state.everChecked && state.enabled -> {
+                Text(
+                    text = "You're up to date.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = TextSecondary,
+                )
+            }
+        }
+        if (state.enabled) {
+            TextButton(
+                onClick = onCheckNow,
+                enabled = !state.checking,
+                contentPadding = PaddingValues(horizontal = 0.dp, vertical = 4.dp),
+            ) {
+                Text(if (state.checking) "Checking..." else "Check now", color = TealAccent)
+            }
+        }
+    }
+}

--- a/apps/android/app/src/main/java/video/crumb/app/feature/update/UpdateBanner.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/update/UpdateBanner.kt
@@ -100,10 +100,13 @@ fun UpdateAvailableBanner(
 }
 
 /**
- * Settings/About row (issue #7 §3): the current version's update status, plus
- * a "Check now" button offered only while the server has the check enabled
- * ([UpdateUiState.enabled]). Tapping the release-notes line/button opens
- * [UpdateUiState.notesUrl] in the platform browser.
+ * Settings/About row (issue #7 §3). Callers should compose this whenever the
+ * server reports the check enabled ([UpdateUiState.enabled]); it is then always
+ * present, showing one of three statuses — "Checking..." (first check in
+ * flight), "Update available: vX -> release notes" (opens
+ * [UpdateUiState.notesUrl] in the browser), or "You're up to date (vX)" — with
+ * a "Check now" button always reachable. The caller hides it when the server
+ * reports `enabled:false` / 404.
  */
 @Composable
 fun UpdateCheckRow(
@@ -133,22 +136,29 @@ fun UpdateCheckRow(
                     )
                 }
             }
-            state.everChecked && state.enabled -> {
+            // A result is in hand and there is no newer release: up to date.
+            state.everChecked -> {
                 Text(
-                    text = "You're up to date.",
+                    text = "You're up to date (v${state.ownVersion})",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = TextSecondary,
+                )
+            }
+            // First check still in flight (nothing resolved yet).
+            else -> {
+                Text(
+                    text = "Checking...",
                     style = MaterialTheme.typography.bodySmall,
                     color = TextSecondary,
                 )
             }
         }
-        if (state.enabled) {
-            TextButton(
-                onClick = onCheckNow,
-                enabled = !state.checking,
-                contentPadding = PaddingValues(horizontal = 0.dp, vertical = 4.dp),
-            ) {
-                Text(if (state.checking) "Checking..." else "Check now", color = TealAccent)
-            }
+        TextButton(
+            onClick = onCheckNow,
+            enabled = !state.checking,
+            contentPadding = PaddingValues(horizontal = 0.dp, vertical = 4.dp),
+        ) {
+            Text(if (state.checking) "Checking..." else "Check now", color = TealAccent)
         }
     }
 }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/update/UpdateViewModel.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/update/UpdateViewModel.kt
@@ -29,6 +29,9 @@ import video.crumb.app.data.SecureStore
  * @param everChecked True once at least one response (success or failure) has
  *   come back, so the About row can distinguish "not checked yet" from
  *   "checked, you're up to date".
+ * @param ownVersion This app's own build version. Defaults to
+ *   `BuildConfig.VERSION_NAME`; a constructor param (not a computed getter) so
+ *   the version-compare gating is unit-testable without `BuildConfig`.
  */
 data class UpdateUiState(
     val enabled: Boolean = false,
@@ -37,10 +40,8 @@ data class UpdateUiState(
     val dismissedVersion: String? = null,
     val checking: Boolean = false,
     val everChecked: Boolean = false,
+    val ownVersion: String = BuildConfig.VERSION_NAME,
 ) {
-    /** Own build version this app was compiled with. */
-    val ownVersion: String get() = BuildConfig.VERSION_NAME
-
     /**
      * True when a strictly newer stable release exists per [SemVer.isNewer].
      * An unparsable own version (e.g. a local `-dev`/debug build) or latest
@@ -59,11 +60,15 @@ data class UpdateUiState(
 }
 
 /**
- * Checks `GET /updates/latest` once shortly after the live wall loads, then at
- * most every 24h while the app keeps running (`docs/UPDATE-SYSTEM-PLAN.md`
- * §3). Also drives the manual "Check now" affordance (§2.5), which forces an
- * immediate re-check via `?refresh=1` — itself rate-limited server-side, so
- * repeated taps are cheap and never hammer GitHub.
+ * Checks `GET /updates/latest` once on every cold app launch, and again
+ * whenever the About dialog is opened (see [refresh]) so its update field is
+ * never stale — a client that first checked while the operator had the feature
+ * OFF must still be able to discover it was turned ON. Periodic re-checks while
+ * the app keeps running are throttled to at most every 24h
+ * (`docs/UPDATE-SYSTEM-PLAN.md` §3). Also drives the manual "Check now"
+ * affordance (§2.5), which forces an immediate re-check via `?refresh=1` —
+ * itself rate-limited server-side, so repeated taps are cheap and never hammer
+ * GitHub.
  *
  * A 404 (older server without the endpoint) or any other failure is treated
  * the same as `enabled:false`: state resets to "nothing to show" rather than
@@ -79,11 +84,31 @@ class UpdateViewModel(
     val uiState: StateFlow<UpdateUiState> = _uiState.asStateFlow()
 
     init {
-        val elapsed = System.currentTimeMillis() - store.lastUpdateCheckAtMs
-        if (elapsed >= RECHECK_INTERVAL_MS) {
+        if (checkedThisLaunch.compareAndSet(false, true)) {
+            // First check of this process launch — ALWAYS, ungated by the 24h
+            // timer, so the proactive live-wall banner appears even right after
+            // the operator flips the server toggle on. The process-static flag
+            // only guards against re-checking on every ViewModel re-creation
+            // within the same running process (config change, back-stack churn).
             performCheck(refresh = false)
+        } else {
+            // A later ViewModel re-creation within the same process: this is the
+            // periodic re-check path — throttled to at most once every 24h (§3).
+            val elapsed = System.currentTimeMillis() - store.lastUpdateCheckAtMs
+            if (elapsed >= RECHECK_INTERVAL_MS) {
+                performCheck(refresh = false)
+            }
         }
     }
+
+    /**
+     * Trigger a fresh NORMAL check (not the forced `?refresh=1` path). Called
+     * when the About dialog opens so its update field reflects current server
+     * state rather than a possibly-stale cached one. Cheap — the server serves
+     * its own 6h cache within the window, so this is at most one GitHub hit
+     * every few hours regardless of how often About is opened.
+     */
+    fun refresh() = performCheck(refresh = false)
 
     /**
      * Force an immediate re-check ("Check now", §2.5). Safe to call
@@ -140,5 +165,13 @@ class UpdateViewModel(
     companion object {
         /** Re-check at most once a day while the app is used (§3). */
         const val RECHECK_INTERVAL_MS = 24 * 60 * 60 * 1000L
+
+        /**
+         * Process-static: has the cold-launch check already fired this process?
+         * Ensures the launch check runs exactly once per app launch (ungated by
+         * the 24h timer) regardless of how many times [UpdateViewModel] is
+         * re-created within that process.
+         */
+        private val checkedThisLaunch = java.util.concurrent.atomic.AtomicBoolean(false)
     }
 }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/update/UpdateViewModel.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/update/UpdateViewModel.kt
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.feature.update
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import video.crumb.app.BuildConfig
+import video.crumb.app.data.CrumbRepository
+import video.crumb.app.data.SecureStore
+
+/**
+ * UI state for the update-available banner + Settings/About row (issue #7).
+ *
+ * @param enabled Whether the server currently has the check turned on. Drives
+ *   whether "Check now" is offered at all (`docs/UPDATE-SYSTEM-PLAN.md` §2.5) —
+ *   false either because the operator disabled it, the server predates the
+ *   feature (404), or no successful check has happened yet.
+ * @param latestVersion Newest stable release tag reported by the server
+ *   (without the leading `v`), or null if none has been fetched yet.
+ * @param notesUrl Release-notes URL to open on tap.
+ * @param dismissedVersion The version the user last dismissed the banner
+ *   for; mirrors [SecureStore.dismissedUpdateVersion].
+ * @param checking True while a request (organic or "Check now") is in flight.
+ * @param everChecked True once at least one response (success or failure) has
+ *   come back, so the About row can distinguish "not checked yet" from
+ *   "checked, you're up to date".
+ */
+data class UpdateUiState(
+    val enabled: Boolean = false,
+    val latestVersion: String? = null,
+    val notesUrl: String? = null,
+    val dismissedVersion: String? = null,
+    val checking: Boolean = false,
+    val everChecked: Boolean = false,
+) {
+    /** Own build version this app was compiled with. */
+    val ownVersion: String get() = BuildConfig.VERSION_NAME
+
+    /**
+     * True when a strictly newer stable release exists per [SemVer.isNewer].
+     * An unparsable own version (e.g. a local `-dev`/debug build) or latest
+     * version is "no signal" — never true.
+     */
+    val updateAvailable: Boolean
+        get() = latestVersion != null && SemVer.isNewer(ownVersion, latestVersion) == true
+
+    /**
+     * Show the dismissible banner: an update exists and this exact version
+     * hasn't already been dismissed (dismissing stays quiet until a NEWER
+     * version than the dismissed one appears).
+     */
+    val showBanner: Boolean
+        get() = updateAvailable && dismissedVersion != latestVersion
+}
+
+/**
+ * Checks `GET /updates/latest` once shortly after the live wall loads, then at
+ * most every 24h while the app keeps running (`docs/UPDATE-SYSTEM-PLAN.md`
+ * §3). Also drives the manual "Check now" affordance (§2.5), which forces an
+ * immediate re-check via `?refresh=1` — itself rate-limited server-side, so
+ * repeated taps are cheap and never hammer GitHub.
+ *
+ * A 404 (older server without the endpoint) or any other failure is treated
+ * the same as `enabled:false`: state resets to "nothing to show" rather than
+ * surfacing an error banner for what is a background nicety, per the plan's
+ * feature-detection contract.
+ */
+class UpdateViewModel(
+    private val repo: CrumbRepository,
+    private val store: SecureStore,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(UpdateUiState(dismissedVersion = store.dismissedUpdateVersion))
+    val uiState: StateFlow<UpdateUiState> = _uiState.asStateFlow()
+
+    init {
+        val elapsed = System.currentTimeMillis() - store.lastUpdateCheckAtMs
+        if (elapsed >= RECHECK_INTERVAL_MS) {
+            performCheck(refresh = false)
+        }
+    }
+
+    /**
+     * Force an immediate re-check ("Check now", §2.5). Safe to call
+     * repeatedly — the server itself rate-limits actual GitHub hits to one
+     * per 60s and serves the cached value otherwise.
+     */
+    fun checkNow() = performCheck(refresh = true)
+
+    private fun performCheck(refresh: Boolean) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(checking = true) }
+            val result = repo.updatesLatest(refresh)
+            store.lastUpdateCheckAtMs = System.currentTimeMillis()
+            result.fold(
+                onSuccess = { resp ->
+                    _uiState.update {
+                        it.copy(
+                            enabled = resp.enabled,
+                            latestVersion = resp.latestVersion,
+                            notesUrl = resp.notesUrl,
+                            checking = false,
+                            everChecked = true,
+                        )
+                    }
+                },
+                onFailure = {
+                    // 404 (old server) or a network error: show nothing, same
+                    // as enabled:false, rather than an error banner for a
+                    // background nicety.
+                    _uiState.update {
+                        it.copy(
+                            enabled = false,
+                            latestVersion = null,
+                            notesUrl = null,
+                            checking = false,
+                            everChecked = true,
+                        )
+                    }
+                },
+            )
+        }
+    }
+
+    /**
+     * Dismiss the banner for the CURRENT [UpdateUiState.latestVersion] —
+     * stays quiet until a newer release than this one appears.
+     */
+    fun dismiss() {
+        val version = _uiState.value.latestVersion ?: return
+        store.dismissedUpdateVersion = version
+        _uiState.update { it.copy(dismissedVersion = version) }
+    }
+
+    companion object {
+        /** Re-check at most once a day while the app is used (§3). */
+        const val RECHECK_INTERVAL_MS = 24 * 60 * 60 * 1000L
+    }
+}

--- a/apps/android/app/src/test/java/video/crumb/app/feature/update/SemVerTest.kt
+++ b/apps/android/app/src/test/java/video/crumb/app/feature/update/SemVerTest.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.feature.update
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Unit tests for [SemVer] — mirrors the equivalent Rust test module in
+ * `services/api/src/updates.rs` (`parses_plain_versions`,
+ * `rejects_prerelease_suffix_and_garbage`, `detects_newer_release`,
+ * `unparsable_version_is_no_signal_not_false`) so both ends of the
+ * update-available check (issue #7) agree on precedence.
+ */
+class SemVerTest {
+
+    @Test
+    fun `parses plain versions`() {
+        assertEquals(Triple(0L, 0L, 1L), SemVer.parse("0.0.1"))
+        assertEquals(Triple(1L, 2L, 3L), SemVer.parse("1.2.3"))
+        assertEquals(Triple(1L, 2L, 3L), SemVer.parse(" 1.2.3 "))
+    }
+
+    @Test
+    fun `rejects prerelease suffix and garbage`() {
+        // Unparsable => "no signal" (docs/UPDATE-SYSTEM-PLAN.md sec 2.2), the
+        // exact case a local/debug build hits (e.g. "0.0.1-dev").
+        assertNull(SemVer.parse("0.0.1-dev"))
+        assertNull(SemVer.parse("v0.0.1"))
+        assertNull(SemVer.parse("0.0"))
+        assertNull(SemVer.parse("0.0.1.2"))
+        assertNull(SemVer.parse(""))
+        assertNull(SemVer.parse("not-a-version"))
+    }
+
+    @Test
+    fun `detects newer release`() {
+        assertEquals(true, SemVer.isNewer("0.0.1", "0.0.2"))
+        assertEquals(false, SemVer.isNewer("0.0.2", "0.0.2"))
+        assertEquals(false, SemVer.isNewer("0.1.0", "0.0.9"))
+        assertEquals(true, SemVer.isNewer("0.9.9", "1.0.0"))
+    }
+
+    @Test
+    fun `unparsable version is no signal not false`() {
+        assertNull(SemVer.isNewer("0.0.1-dev", "0.0.2"))
+        assertNull(SemVer.isNewer("0.0.1", "not-a-version"))
+    }
+}

--- a/apps/android/app/src/test/java/video/crumb/app/feature/update/UpdateUiStateTest.kt
+++ b/apps/android/app/src/test/java/video/crumb/app/feature/update/UpdateUiStateTest.kt
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.feature.update
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [UpdateUiState]'s derived gating — `updateAvailable` and
+ * `showBanner` (issue #7). Uses the explicit `ownVersion` constructor param so
+ * the version compare is deterministic without `BuildConfig`.
+ */
+class UpdateUiStateTest {
+
+    @Test
+    fun `update available when latest is strictly newer`() {
+        val state = UpdateUiState(
+            enabled = true,
+            latestVersion = "0.0.2",
+            everChecked = true,
+            ownVersion = "0.0.1",
+        )
+        assertTrue(state.updateAvailable)
+    }
+
+    @Test
+    fun `no update when own version is equal or newer`() {
+        assertFalse(
+            UpdateUiState(enabled = true, latestVersion = "0.0.2", ownVersion = "0.0.2").updateAvailable,
+        )
+        assertFalse(
+            UpdateUiState(enabled = true, latestVersion = "0.0.1", ownVersion = "0.1.0").updateAvailable,
+        )
+    }
+
+    @Test
+    fun `unparsable own version is never an update`() {
+        // A local/debug build like "0.0.1-dev" is "no signal", never a banner.
+        assertFalse(
+            UpdateUiState(enabled = true, latestVersion = "9.9.9", ownVersion = "0.0.1-dev").updateAvailable,
+        )
+    }
+
+    @Test
+    fun `no latest version means no update`() {
+        assertFalse(
+            UpdateUiState(enabled = true, latestVersion = null, ownVersion = "0.0.1").updateAvailable,
+        )
+    }
+
+    @Test
+    fun `banner shows for a fresh newer release`() {
+        val state = UpdateUiState(
+            enabled = true,
+            latestVersion = "0.0.2",
+            dismissedVersion = null,
+            ownVersion = "0.0.1",
+        )
+        assertTrue(state.showBanner)
+    }
+
+    @Test
+    fun `banner is suppressed for the exact dismissed version`() {
+        val state = UpdateUiState(
+            enabled = true,
+            latestVersion = "0.0.2",
+            dismissedVersion = "0.0.2",
+            ownVersion = "0.0.1",
+        )
+        assertFalse(state.showBanner)
+    }
+
+    @Test
+    fun `banner reappears when a newer release than the dismissed one lands`() {
+        val state = UpdateUiState(
+            enabled = true,
+            latestVersion = "0.0.3",
+            dismissedVersion = "0.0.2",
+            ownVersion = "0.0.1",
+        )
+        assertTrue(state.showBanner)
+    }
+}

--- a/apps/android/gradle/libs.versions.toml
+++ b/apps/android/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ retrofitSerialization = "1.0.0"
 securityCrypto = "1.1.0-alpha06"
 biometric = "1.1.0"
 coil = "2.7.0"
+junit = "4.13.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -44,6 +45,7 @@ retrofit-kotlinx-serialization = { group = "com.jakewharton.retrofit", name = "r
 androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 androidx-biometric = { group = "androidx.biometric", name = "biometric", version.ref = "biometric" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

- Phase 2 (Android, task C3) of the update-available checker (`docs/UPDATE-SYSTEM-PLAN.md` §7 C3, issue #7). Adds a Retrofit `GET /updates/latest` call (`CrumbApi.kt`), a `CrumbRepository` wrapper, and a `Models.kt` mirror of the locked server DTO (`enabled` plus five nullable fields, exactly as `services/api/src/dto.rs::UpdateCheckResponse`).
- New `feature/update/` package: a tiny hand-rolled SemVer compare (`SemVer.kt`, unit tested, no new dependency) matching the server's `services/api/src/updates.rs` precedence exactly (unparsable version => "no signal", never a false positive), and an `UpdateViewModel` that checks once when the live wall loads and at most every 24h thereafter (persisted in `SecureStore`), plus a `checkNow()` action that forces the server's `?refresh=1` path.
- UI: a dismissible banner on the live wall (`UpdateAvailableBanner`) and a Settings/About row (`UpdateCheckRow`, wired into `AboutDialog`) showing "Update available -> release notes" (opens `notes_url` in the browser) and a "Check now" button shown only when the server reports the check `enabled`. Dismissing a banner remembers that version so it stays quiet until a newer release appears.
- A 404 (server predates the endpoint) or any other failure is treated the same as `enabled:false` — nothing is shown, per the plan's feature-detection contract. No `REQUEST_INSTALL_PACKAGES`, no download, no new networking dependency (JUnit added only as a `testImplementation` for the SemVer unit test).

Branched off `origin/main` per the task's isolated-worktree instructions; the server contract (PR #31, `feat/update-check-server`) is not yet merged, so `docs/UPDATE-SYSTEM-PLAN.md` / `docs/COMPONENT-MAP.md`'s "Update notice" parity row aren't touched here (they belong to that PR). Once #31 merges, the COMPONENT-MAP.md Android column for "Update notice" should be updated to point at `apps/android/.../feature/update/`.

## Test plan

- [ ] `cargo`/CI n/a (Android has no per-PR CI gate; release CI is tag-triggered)
- [ ] Gradle build on the dev1/android build host: `./gradlew :app:testDebugUnitTest` (SemVer unit tests) and `./gradlew :app:assembleDebug`
- [ ] Install on-device (wireless ADB) against a dev server stubbed to report a newer `latest_version`; confirm the live-wall banner appears, dismiss persists across restarts until a newer version is stubbed, and the About dialog's "Check now" refreshes status
- [ ] Confirm against a server with `enabled:false` (or a 404/older server) that nothing is shown anywhere

**Not yet build-verified** — see manual steps above.