### PR TITLE
docs: every-launch re-check + always-present About update field (refs #7)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,40 @@ revisit.
 
 ---
 
+## 2026-07-09, Update check: re-check every launch + always-present About field (stale-state fix)
+
+**Problem.** The first client cut of #7 checked once per client and throttled
+even the launch check to 24h, and it hid the update field and "Check now"
+whenever the last response said the feature was disabled. On-device testing
+surfaced a trap: a client that first checked while the operator had the server
+switch OFF cached "disabled" and then had no way to discover it was later turned
+ON — no auto re-check for 24h, and no reachable "Check now" (it was gated behind
+the stale enabled state). The only recovery was wiping app data.
+
+**Chosen.** Across all clients (desktop, Android, iOS/macOS):
+
+- The launch/login check runs on **every cold launch**, ungated by the 24h
+  timer (guarded per-process against re-spam). The 24h throttle now governs
+  only periodic re-checks while the app stays open.
+- The Settings/About screen carries an **always-present update field whenever
+  the server reports the check enabled**, and **opening it triggers a fresh
+  check**, with **"Check now" always reachable there**. The field hides only on
+  `enabled:false`/404.
+
+**Rejected.**
+
+- *Check-once + 24h-throttled launch check* (the original): simplest, but
+  strands a client that checked during a disabled window for a full day with no
+  manual recovery.
+- *A background/periodic poller* to notice enable-flips sooner: heavier than a
+  notify-only nicety warrants; app launch and the About screen are natural,
+  cheap re-check triggers that cover it.
+
+**Revisit triggers.** Every-launch checks become a measurable server/GitHub
+load concern (they shouldn't: the api caches ≤6h and the client→server hop is
+LAN-local); or a client gains a real background presence where a periodic
+poller becomes worthwhile.
+
 ## 2026-07-09, Update-available check: api-mediated, notify-only, opt-in / OFF BY DEFAULT
 
 **Problem.** Issue #7 asks for a non-intrusive "update available → release

--- a/docs/UPDATE-SYSTEM-PLAN.md
+++ b/docs/UPDATE-SYSTEM-PLAN.md
@@ -225,12 +225,19 @@ egress path:
 
 ## 3. Per-client mechanism
 
-All clients: check once shortly after login/launch and re-check at most
-every 24h while running, against their own server's `GET /updates/latest`.
-404 or `enabled:false` ⇒ show nothing. The notice is non-intrusive: a
-dismissible row/badge in the Settings/About area (dismiss remembers the
-dismissed version and stays quiet until a newer one appears), linking to
-`notes_url` in the platform browser. No download buttons, no install flows.
+All clients check their own server's `GET /updates/latest` on **every cold
+launch/login** (ungated, so a client that first checked during a disabled
+window recovers on the next launch), and again whenever the **Settings/About
+screen opens**; a 24h throttle governs only periodic re-checks while the app
+stays open. 404 or `enabled:false` ⇒ show nothing. Two surfaces: (1) a
+non-intrusive **dismissible banner** for update-available (dismiss remembers
+the version and stays quiet until a newer one appears), and (2) an
+**always-present update field in the Settings/About area whenever the server
+reports the check enabled** (states: "checking" / "up to date" / "update
+available → release notes"), with **"Check now" always reachable there** — the
+escape hatch so a server-side disabled→enabled flip is always discoverable
+without wiping app data. Links open `notes_url` in the platform browser. No
+download buttons, no install flows.
 
 | Client | Own version from | Notice surface | Notes |
 |---|---|---|---|


### PR DESCRIPTION
Follow-up docs for the client staleness fix (#32/#33/#34). Updates UPDATE-SYSTEM-PLAN §3 and adds a DECISIONS entry: clients re-check on every cold launch and on opening Settings/About (always shows the update field when the server has the check enabled, Check now always reachable). Refs #7.