### PR TITLE
fix(pregen): make list_thumbnail_times coverage-aware (closes #9)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -569,7 +569,7 @@ The server pre-generates the preview frames so a scrub is a static-file fetch (~
 
 #### Plan
 
-> **Status (2026-07-07):** Phase 0 and the core of Phase 1 (background pre-generation, `THUMB_CACHE_DIR`, config knobs) shipped in #2. Coverage-aware `list_thumbnail_times`, policy-tied thumbnail retention, and the admin-console tunables below remain.
+> **Status (2026-07-09):** Phase 0 and the core of Phase 1 (background pre-generation, `THUMB_CACHE_DIR`, config knobs, coverage-aware `list_thumbnail_times`) shipped in #2 and #9. Policy-tied thumbnail retention and the admin-console tunables below remain.
 
 Phase 0, cache hygiene, API only, standalone (S)
 
@@ -580,7 +580,7 @@ Phase 0, cache hygiene, API only, standalone (S)
 Phase 1, pre-generation, API + `db.rs` stub, no migration (M)
 
 - [x] Background per-camera worker reusing `extract_thumbnail`, interval-driven, semaphore-bounded (shipped in #2 as `thumb_pregen.rs`) (M)
-- [ ] Implement `list_thumbnail_times` as grid slots intersected with recorded `segments` coverage (kills 404 slots in gaps; no new table) (S)
+- [x] Implement `list_thumbnail_times` as grid slots intersected with recorded `segments` coverage (kills 404 slots in gaps; no new table) (S)
 - [ ] Thumbnail retention tied to policy retention, a NEW delete path, path-guarded + tested (S)
 - [x] Config knobs (`THUMB_PREGEN_ENABLED` + lookback/scan/width, cache size/age budget) → `.env.example` / environment reference (golden rule 5) (S)
 - [x] Optional `THUMB_CACHE_DIR` to place the scrub cache on fast/separate storage (e.g. an NVMe partition) while footage stays on bulk HDD, matching the random-read-hot thumbnail workload to the right medium. Low-risk: thumbnails are regenerable and the on-demand path self-heals a wiped cache, so the thumb drive can be cheap and non-redundant (a failure only makes scrubbing temporarily slower, never loses footage) (S)

--- a/services/api/src/filmstrip.rs
+++ b/services/api/src/filmstrip.rs
@@ -20,17 +20,20 @@
 //!
 //! The frame timestamp encoded in the filename is the milliseconds-since-epoch
 //! of the frame's wall-clock time.  The API lists frames by scanning the DB
-//! (via `db::list_thumbnail_times`, which is currently stubbed and returns an
-//! empty vec) and builds download URLs pointing at `GET /filmstrip/{id}/frame`.
+//! (via `db::list_thumbnail_times`, which intersects the fixed grid with
+//! recorded `segments` coverage so gap slots are never listed) and builds
+//! download URLs pointing at `GET /filmstrip/{id}/frame`.
 //!
 //! ## On-demand extraction (fallback)
 //!
-//! When `list_thumbnail_times` returns no pre-generated frames (Phase 1 stub),
-//! the list endpoint generates synthetic frame entries spaced every
-//! `DEFAULT_THUMB_INTERVAL_SECS` seconds across the requested range.  Each
-//! synthetic entry points at the same `frame` endpoint which will attempt to
-//! locate the file on disk; if the file is not there (because the background
-//! task has not run yet), the frame endpoint returns 404.
+//! When `list_thumbnail_times` finds NO recorded coverage anywhere in the
+//! requested range (a brand-new camera, or a window entirely before its first
+//! segment), the list endpoint falls back to a synthetic grid spaced every
+//! `DEFAULT_THUMB_INTERVAL_SECS` seconds across the range so the client still
+//! has something to probe as the background task catches up.  Each synthetic
+//! entry points at the same `frame` endpoint which will attempt to locate the
+//! file on disk; if the file is not there (because the background task has
+//! not run yet), the frame endpoint returns 404.
 //!
 //! ## Path traversal guard
 //!
@@ -110,9 +113,12 @@ pub fn routes() -> Router<AppState> {
 /// timestamp and a `GET /filmstrip/{camera_id}/frame?ts=<ts>` URL the client
 /// can fetch for the JPEG.
 ///
-/// When no pre-extracted frames exist in the DB (the current Phase 1 state),
-/// synthetic entries are generated across the range so the client can
-/// conditionally request frames as the background task catches up.
+/// `db::list_thumbnail_times` is coverage-aware: it already excludes grid
+/// slots that fall in a recording gap. The only remaining fallback case is a
+/// range with NO recorded coverage at all (a camera newly added, or a window
+/// entirely before its first segment) — there `db_times` comes back empty and
+/// we synthesise the plain grid so the client still gets slots to probe as
+/// the background task catches up (each will 404 until it does).
 async fn list_filmstrip(
     user: AuthUser,
     State(state): State<AppState>,
@@ -128,11 +134,19 @@ async fn list_filmstrip(
         ));
     }
 
-    // Query pre-extracted thumbnail timestamps from the DB.
-    let db_times = db::list_thumbnail_times(state.pool(), camera_id, q.start, q.end).await?;
+    // Query coverage-filtered thumbnail slot timestamps from the DB.
+    let db_times = db::list_thumbnail_times(
+        state.pool(),
+        camera_id,
+        q.start,
+        q.end,
+        DEFAULT_THUMB_INTERVAL_SECS,
+    )
+    .await?;
 
     let timestamps: Vec<DateTime<Utc>> = if db_times.is_empty() {
-        // Phase 1 fallback: synthesise frame slots across the range.
+        // No recorded coverage anywhere in the range: synthesise the plain
+        // grid (unfiltered) rather than return nothing.
         generate_synthetic_timestamps(q.start, q.end, DEFAULT_THUMB_INTERVAL_SECS)
     } else {
         db_times
@@ -434,49 +448,19 @@ async fn extract_thumbnail(
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
 /// Generate timestamp slots across `[start, end)` anchored to a fixed global
-/// grid of `interval_secs`.
+/// grid of `interval_secs`, unfiltered by recorded coverage.
 ///
-/// Slots are floored to the interval on the wall-clock epoch, NOT anchored to
-/// the arbitrary query `start`. Identical slot timestamps across different scrub
-/// windows are what let the pre-extracted / cached frames be reused instead of
-/// re-extracted per window (the list side of the same snapping `serve_frame`
-/// applies to a single frame). The first slot is `start` floored to the grid;
-/// the last is the largest grid multiple strictly less than `end`.
+/// Thin wrapper over `db::thumbnail_grid_slots` — the SAME grid
+/// `list_thumbnail_times` filters by segment coverage, kept here as the
+/// zero-coverage fallback so a brand-new camera (or a window entirely before
+/// its first segment) still gets slots to probe. See that function's doc
+/// comment for the floor/anchor semantics.
 fn generate_synthetic_timestamps(
     start: DateTime<Utc>,
     end: DateTime<Utc>,
     interval_secs: i64,
 ) -> Vec<DateTime<Utc>> {
-    if interval_secs <= 0 {
-        return vec![];
-    }
-    let step_ms = interval_secs * 1_000;
-    // Floor `start` to the global grid so slot timestamps are stable across
-    // query windows (cache reuse). `div_euclid` floors correctly even for a
-    // pre-epoch input.
-    let start_ms = start.timestamp_millis().div_euclid(step_ms) * step_ms;
-    let end_ms = end.timestamp_millis();
-    if end_ms <= start_ms {
-        return vec![];
-    }
-    // start_ms < end_ms and step_ms > 0 here; the quotient fits usize on all
-    // targets we care about (Linux x86_64 with 48-bit virtual address space).
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    let count = ((end_ms - start_ms) / step_ms) as usize + 1;
-
-    (0..count)
-        .filter_map(|i| {
-            #[allow(clippy::cast_possible_wrap)]
-            let ts_ms = start_ms + (i as i64) * step_ms;
-            // Keep slots strictly before `end`.
-            let ts = Utc.timestamp_millis_opt(ts_ms).single()?;
-            if ts < end {
-                Some(ts)
-            } else {
-                None
-            }
-        })
-        .collect()
+    db::thumbnail_grid_slots(start, end, interval_secs)
 }
 
 // ─── urlencoding helper ───────────────────────────────────────────────────────

--- a/services/api/src/thumb_pregen.rs
+++ b/services/api/src/thumb_pregen.rs
@@ -11,6 +11,11 @@
 //! ([`crate::filmstrip::ensure_thumbnail`]), so the worker and live requests
 //! never double-extract or fight over resources.
 //!
+//! Slot selection is coverage-aware: `db::list_thumbnail_times` intersects the
+//! fixed grid with recorded `segments` coverage, so a recording gap never
+//! produces a slot here in the first place (issue #9) — no wasted ffmpeg spawn
+//! that can only 404.
+//!
 //! Cost note: the FIRST pass backfills `THUMB_PREGEN_LOOKBACK_HOURS` of history
 //! sequentially (gentle, one extraction in flight at a time); steady state only
 //! generates the handful of new slots recorded since the previous scan.
@@ -41,7 +46,6 @@ pub async fn run(state: AppState) {
         return;
     }
 
-    let grid_ms = filmstrip::DEFAULT_THUMB_INTERVAL_SECS * 1000;
     let lookback_ms = Duration::hours(lookback_hours).num_milliseconds();
     let scan = std::time::Duration::from_secs(scan_secs);
     tracing::info!(
@@ -57,6 +61,12 @@ pub async fn run(state: AppState) {
 
     loop {
         let now_ms = Utc::now().timestamp_millis();
+        let Some(until) = Utc.timestamp_millis_opt(now_ms).single() else {
+            // Should be unreachable (Utc::now() is always in range); skip this
+            // tick rather than panic a background worker over a clock oddity.
+            tokio::time::sleep(scan).await;
+            continue;
+        };
         let cameras = match db::list_enabled_cameras(state.pool()).await {
             Ok(c) => c,
             Err(e) => {
@@ -71,16 +81,41 @@ pub async fn run(state: AppState) {
                 .get(&cam.id)
                 .copied()
                 .unwrap_or(now_ms - lookback_ms);
-            // Floor the start to the grid; step forward one slot at a time.
-            let mut slot = from_ms.div_euclid(grid_ms) * grid_ms;
-            let mut steps: u64 = 0;
-            while slot < now_ms {
-                if let Some(ts) = Utc.timestamp_millis_opt(slot).single() {
-                    // No-op if already cached; a gap (NotFound) is fine — the
-                    // on-demand path self-heals if the user ever scrubs there.
-                    let _ = filmstrip::ensure_thumbnail(&state, cam.id, ts, width).await;
+            let Some(since) = Utc.timestamp_millis_opt(from_ms).single() else {
+                continue;
+            };
+            if since >= until {
+                watermark.insert(cam.id, now_ms);
+                continue;
+            }
+
+            // Coverage-aware grid slots: gap slots (no recorded footage) are
+            // already excluded, so every extraction below has real footage to
+            // read.
+            let slots = match db::list_thumbnail_times(
+                state.pool(),
+                cam.id,
+                since,
+                until,
+                filmstrip::DEFAULT_THUMB_INTERVAL_SECS,
+            )
+            .await
+            {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(
+                        camera_id = %cam.id,
+                        error = %e,
+                        "thumb pre-gen: listing thumbnail times failed"
+                    );
+                    continue;
                 }
-                slot += grid_ms;
+            };
+
+            let mut steps: u64 = 0;
+            for ts in slots {
+                // No-op if already cached.
+                let _ = filmstrip::ensure_thumbnail(&state, cam.id, ts, width).await;
                 steps += 1;
                 // Yield periodically so a large initial backfill can't monopolize
                 // the runtime between the semaphore-bounded extractions.

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -22,7 +22,7 @@
 //! * Item 13 — [`upsert_storage`] is idempotent on `name` (`ON CONFLICT`).
 
 use anyhow::{Context, Result};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use deadpool_postgres::{Config as DeadpoolConfig, Hook, HookError, Pool, Runtime};
 use serde::Serialize;
 use tokio_postgres::NoTls;
@@ -3700,18 +3700,109 @@ pub async fn ensure_segments_camera_start_index(pool: &Pool) -> Result<()> {
     Ok(())
 }
 
-/// Stub: return thumbnail timestamps for a camera in a time range.
+/// Build ascending grid-aligned slot timestamps across `[start, end)`.
 ///
-/// Returns an empty vec until the filmstrip background task is implemented and
-/// a thumbnails index (DB table or directory scan) is available.
+/// Slots are floored to `interval_secs` on the wall-clock epoch (NOT anchored
+/// to `start`), so the same interval requested across different query windows
+/// lands on identical timestamps. That stability is what lets pre-generated
+/// and on-demand frames share cache keys instead of each scrub minting a new
+/// filename. The first slot is `start` floored to the grid; the last is the
+/// largest grid multiple strictly less than `end`.
+///
+/// Shared by [`list_thumbnail_times`] (coverage-filtered below) and
+/// `filmstrip::list_filmstrip`'s synthetic fallback (unfiltered — used only
+/// when a requested range has zero recorded coverage at all), so the two
+/// never drift apart into two different grids.
+pub fn thumbnail_grid_slots(
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    interval_secs: i64,
+) -> Vec<DateTime<Utc>> {
+    if interval_secs <= 0 {
+        return vec![];
+    }
+    let step_ms = interval_secs * 1_000;
+    // div_euclid floors correctly even for a pre-epoch input.
+    let start_ms = start.timestamp_millis().div_euclid(step_ms) * step_ms;
+    let end_ms = end.timestamp_millis();
+    if end_ms <= start_ms {
+        return vec![];
+    }
+    // start_ms < end_ms and step_ms > 0 here; the quotient fits usize on all
+    // targets we care about (Linux x86_64 with 48-bit virtual address space).
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let count = ((end_ms - start_ms) / step_ms) as usize + 1;
+
+    (0..count)
+        .filter_map(|i| {
+            #[allow(clippy::cast_possible_wrap)]
+            let ts_ms = start_ms + (i as i64) * step_ms;
+            // Keep slots strictly before `end`.
+            let ts = Utc.timestamp_millis_opt(ts_ms).single()?;
+            if ts < end {
+                Some(ts)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Return pre-generation / scrub-preview grid slot timestamps for a camera in
+/// `[start, end)`, filtered to slots that fall within actual recorded `main`-
+/// stream `segments` coverage.
+///
+/// The grid itself is [`thumbnail_grid_slots`] at `interval_secs` — unchanged
+/// cadence from the Phase 1 synthetic fallback. What's new is the filter: a
+/// slot is only returned when some `main`-stream segment's `[start_ts, end_ts)`
+/// span covers it, the same half-open convention [`resolve_segment`] uses (a
+/// slot exactly at a segment's `start_ts` is covered; one exactly at its
+/// `end_ts` is not, unless the next contiguous segment starts exactly there).
+/// This is what keeps recording-gap slots out of both the client-facing
+/// `/filmstrip` list and the background pre-generation worker, so neither ever
+/// requests a frame ffmpeg has no footage to extract (issue #9).
+///
+/// Callers relying on `interval_secs` for cache-key stability (the on-demand
+/// `serve_frame` grid-snap) must pass the same value used elsewhere for this
+/// camera — [`filmstrip::DEFAULT_THUMB_INTERVAL_SECS`] in production.
+///
+/// Implemented by fetching the (already indexed, `camera_id, start_ts`)
+/// segments overlapping the window once via [`list_segments_for_range`], then
+/// sweeping the grid against them in a single linear pass — segments are
+/// non-overlapping and returned ordered by `start_ts`, so a monotonically
+/// advancing cursor is sufficient (no per-slot query).
+///
+/// # Errors
+///
+/// Returns an error if the underlying segments query fails.
 pub async fn list_thumbnail_times(
-    _pool: &Pool,
-    _camera_id: Uuid,
-    _start: DateTime<Utc>,
-    _end: DateTime<Utc>,
+    pool: &Pool,
+    camera_id: Uuid,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    interval_secs: i64,
 ) -> Result<Vec<DateTime<Utc>>> {
-    // PHASE 1 stub — implement when the thumb generator lands.
-    Ok(vec![])
+    let grid = thumbnail_grid_slots(start, end, interval_secs);
+    if grid.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let segments = list_segments_for_range(pool, camera_id, "main", start, end).await?;
+
+    let mut covered = Vec::with_capacity(grid.len());
+    let mut idx = 0usize;
+    for ts in grid {
+        // Advance past segments that end at-or-before this slot — such a
+        // segment (and anything earlier) can never cover this or any later
+        // slot, since both the grid and the segments are ascending.
+        while idx < segments.len() && segments[idx].end_ts <= ts {
+            idx += 1;
+        }
+        if idx < segments.len() && segments[idx].start_ts <= ts {
+            covered.push(ts);
+        }
+    }
+    Ok(covered)
 }
 
 // ─── users — CRUD ────────────────────────────────────────────────────────────
@@ -9412,6 +9503,203 @@ mod tests {
         assert!(
             valid_index_survives,
             "reap_invalid_indexes must never touch a VALID index"
+        );
+    }
+
+    // ── thumbnail_grid_slots — pure grid math, no DB needed ───────────────────
+
+    /// The grid must floor to the interval on the wall-clock epoch (not anchor
+    /// to `start`) and must exclude a slot landing exactly on `end` (half-open
+    /// range), matching `filmstrip::generate_synthetic_timestamps`'s original
+    /// contract now that both share this implementation.
+    #[test]
+    fn thumbnail_grid_slots_floors_and_excludes_end() {
+        let base = Utc
+            .timestamp_millis_opt(1_700_000_000_000)
+            .single()
+            .unwrap();
+        // start is 2s past a 5s-grid boundary; the first slot must still be
+        // the grid boundary at-or-before start, i.e. `base`, not `start`.
+        let start = base + chrono::Duration::seconds(2);
+        let end = base + chrono::Duration::seconds(15); // exactly a grid multiple
+        let slots = thumbnail_grid_slots(start, end, 5);
+        let expected: Vec<_> = [0, 5, 10]
+            .iter()
+            .map(|s| base + chrono::Duration::seconds(*s))
+            .collect();
+        assert_eq!(
+            slots, expected,
+            "grid floors to the epoch-aligned interval and excludes a slot at exactly `end`"
+        );
+    }
+
+    #[test]
+    fn thumbnail_grid_slots_empty_when_end_not_after_start() {
+        let t = Utc
+            .timestamp_millis_opt(1_700_000_000_000)
+            .single()
+            .unwrap();
+        assert!(thumbnail_grid_slots(t, t, 5).is_empty());
+        assert!(thumbnail_grid_slots(t + chrono::Duration::seconds(5), t, 5).is_empty());
+    }
+
+    // ── list_thumbnail_times — coverage-aware grid, throwaway-DB integration test ──
+    //
+    // Opt-in: skips (passes) unless `TEST_DATABASE_URL` points at a reachable
+    // Postgres, same convention as `reap_invalid_indexes_drops_invalid_index`
+    // above. Unlike that test, this one needs the REAL schema (segments's FKs
+    // to cameras/storages, cameras' FK to recording_policies), so it runs
+    // `run_migrations` against the freshly created schema rather than hand-
+    // rolling a table.
+
+    /// Seed the single global-default `recording_policies` row
+    /// (`is_default = true`) that `clone_default_policy` requires. Mirrors
+    /// `services/api/tests/support/mod.rs`'s `seed_default_policy_if_absent`
+    /// (same columns/defaults as the recorder's `seed.rs`), duplicated here
+    /// rather than shared because that harness is `services/api`-only
+    /// (`#[path]`-included test source, not a reusable library).
+    async fn seed_default_policy_for_test(pool: &Pool) {
+        let client = get_conn(pool)
+            .await
+            .expect("get_conn (seed_default_policy_for_test)");
+        client
+            .execute(
+                r"
+                INSERT INTO recording_policies (
+                    is_default, mode, live_storage_id, live_retention_hours,
+                    archive_enabled, archive_storage_id, archive_schedule, archive_retention_hours,
+                    motion_pre_seconds, motion_post_seconds, motion_sensitivity,
+                    motion_keyframes_only, record_stream
+                )
+                VALUES (
+                    true, 'continuous', NULL, 48,
+                    false, NULL, NULL, NULL,
+                    5, 10, 'dynamic',
+                    false, 'main'
+                )
+                ",
+                &[],
+            )
+            .await
+            .expect("seed default recording_policies row");
+    }
+
+    /// Seed a minimal camera (own policy cloned from the just-seeded default).
+    async fn seed_camera_for_test(pool: &Pool) -> Uuid {
+        let policy_id = clone_default_policy(pool)
+            .await
+            .expect("clone_default_policy");
+        let suffix = Uuid::new_v4().simple().to_string();
+        let params = CreateCameraParams {
+            name: &format!("cam_{suffix}"),
+            go2rtc_name: &format!("go2rtc_{suffix}"),
+            main_url: "rtsp://127.0.0.1:18554/does-not-matter",
+            sub_url: None,
+            source_url: None,
+            source_sub_url: None,
+            enabled: true,
+            policy_id,
+            motion_mask: None,
+            onvif_motion: false,
+            motion_source: "pixel",
+            motion_algorithm: "census",
+            camera_type: None,
+            icon: None,
+            served_by: "crumb",
+            source_camera_name: None,
+            onvif_host: None,
+            onvif_port: None,
+            onvif_user: None,
+            onvif_password: None,
+        };
+        create_camera(pool, &params)
+            .await
+            .expect("create_camera")
+            .id
+    }
+
+    /// Insert a `main`-stream segment row directly (no real file — this test
+    /// only exercises the coverage query, never opens the path).
+    async fn insert_test_segment(
+        pool: &Pool,
+        camera_id: Uuid,
+        storage_id: Uuid,
+        start_ts: DateTime<Utc>,
+        end_ts: DateTime<Utc>,
+    ) {
+        let client = get_conn(pool)
+            .await
+            .expect("get_conn (insert_test_segment)");
+        let duration_ms = (end_ts - start_ts).num_milliseconds();
+        #[allow(clippy::cast_possible_truncation)]
+        let duration_ms = duration_ms as i32;
+        client
+            .execute(
+                r"
+                INSERT INTO segments
+                    (camera_id, storage_id, stage, path, stream, start_ts, end_ts, duration_ms, has_motion, size_bytes)
+                VALUES ($1, $2, 'live', 'seg.mp4', 'main', $3, $4, $5, false, 64)
+                ",
+                &[&camera_id, &storage_id, &start_ts, &end_ts, &duration_ms],
+            )
+            .await
+            .expect("insert test segment");
+    }
+
+    /// A recording gap in the middle of the requested window must never
+    /// surface a slot, and the two segment BOUNDARIES must resolve per the
+    /// half-open `[start_ts, end_ts)` convention `resolve_segment` already
+    /// uses: a slot exactly at a segment's `end_ts` is NOT covered (that
+    /// instant belongs to whatever comes next, if anything), and a slot
+    /// exactly at the following segment's `start_ts` IS covered.
+    ///
+    /// Layout (grid = 5s, `base` an arbitrary 5s-grid-aligned instant):
+    /// ```text
+    /// offset(s):  0    5    10   15   20   25   30
+    /// segment:    [--- seg1 ---)     [--- seg2 ---)
+    /// grid slot:  ✓    ✓    ✗    ✗    ✓    ✓
+    /// ```
+    /// Slot 10 sits exactly on seg1's `end_ts` (excluded); slot 20 sits
+    /// exactly on seg2's `start_ts` (included); slots 10 and 15 are the pure
+    /// mid-gap case (excluded).
+    #[tokio::test]
+    async fn list_thumbnail_times_excludes_gap_slots() {
+        let Some(url) = test_db_url() else {
+            eprintln!("skipping: TEST_DATABASE_URL not set");
+            return;
+        };
+        let fx = setup_schema(&url).await;
+        run_migrations(&fx.pool)
+            .await
+            .expect("run_migrations (test schema)");
+        seed_default_policy_for_test(&fx.pool).await;
+
+        let camera_id = seed_camera_for_test(&fx.pool).await;
+        let storage_id = create_storage(&fx.pool, "test-storage", "/does/not/matter", None, None)
+            .await
+            .expect("create_storage")
+            .id;
+
+        let base = Utc
+            .timestamp_millis_opt(1_700_000_000_000)
+            .single()
+            .unwrap();
+        let sec = |n: i64| base + chrono::Duration::seconds(n);
+
+        // seg1 covers [0, 10); a real recording gap sits in [10, 20); seg2
+        // covers [20, 30).
+        insert_test_segment(&fx.pool, camera_id, storage_id, sec(0), sec(10)).await;
+        insert_test_segment(&fx.pool, camera_id, storage_id, sec(20), sec(30)).await;
+
+        let times = list_thumbnail_times(&fx.pool, camera_id, sec(0), sec(30), 5)
+            .await
+            .expect("list_thumbnail_times");
+
+        let expected = vec![sec(0), sec(5), sec(20), sec(25)];
+        assert_eq!(
+            times, expected,
+            "gap slots (10, 15) must be excluded; the segment-end boundary (10) \
+             must be excluded and the next segment's start boundary (20) included"
         );
     }
 }

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -9411,7 +9411,10 @@ mod tests {
         // technique used by the recorder's throwaway-DB tests), URL-encoded.
         let sep = if base_url.contains('?') { '&' } else { '?' };
         let schema_url = format!("{base_url}{sep}options=-c%20search_path%3D{schema}");
-        let pool = build_pool(&schema_url, 2).expect("build_pool (test schema)");
+        // `run_migrations` holds an advisory-lock connection AND a work
+        // connection (via `run_migrations_locked`) concurrently, so a max_size
+        // of 2 deadlocks itself waiting for a slot. Give the fixture headroom.
+        let pool = build_pool(&schema_url, 8).expect("build_pool (test schema)");
 
         SchemaFixture {
             pool,

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -9550,23 +9550,44 @@ mod tests {
     //
     // Opt-in: skips (passes) unless `TEST_DATABASE_URL` points at a reachable
     // Postgres, same convention as `reap_invalid_indexes_drops_invalid_index`
-    // above. Unlike that test, this one needs the REAL schema (segments's FKs
-    // to cameras/storages, cameras' FK to recording_policies), so it runs
-    // `run_migrations` against the freshly created schema rather than hand-
-    // rolling a table.
+    // above.
+    //
+    // Isolation model — deliberately NOT the `setup_schema` search_path trick the
+    // reap test uses: this test needs the REAL schema (segments's FKs to
+    // cameras/storages, cameras' FK to recording_policies), which means running
+    // the full `run_migrations`, and `run_migrations` does not survive the
+    // per-connection `search_path` isolation (it re-acquires pooled connections
+    // and runs `CREATE INDEX CONCURRENTLY` statements as their own sessions,
+    // where the schema-scoping does not hold; migration 0014 then fails looking
+    // up `storage_migrations`). Instead we mirror the PROVEN model in
+    // `services/api/tests/support/mod.rs`: migrate the shared database in its
+    // real `public` schema (idempotent + advisory-locked, so concurrent test
+    // binaries serialize safely), then isolate this test's DATA by a freshly
+    // generated `camera_id`. `list_thumbnail_times` filters solely by
+    // `camera_id`, so a unique camera is complete isolation from any other
+    // rows in the shared throwaway DB — no private schema, no teardown needed.
 
-    /// Seed the single global-default `recording_policies` row
-    /// (`is_default = true`) that `clone_default_policy` requires. Mirrors
-    /// `services/api/tests/support/mod.rs`'s `seed_default_policy_if_absent`
-    /// (same columns/defaults as the recorder's `seed.rs`), duplicated here
-    /// rather than shared because that harness is `services/api`-only
-    /// (`#[path]`-included test source, not a reusable library).
-    async fn seed_default_policy_for_test(pool: &Pool) {
-        let client = get_conn(pool)
+    /// Build a size-8 pool at the raw (public-schema) URL and run migrations.
+    /// The pool needs headroom because `run_migrations` holds an advisory-lock
+    /// connection AND a work connection concurrently (a max_size of 2 would
+    /// deadlock itself).
+    async fn migrated_public_pool(url: &str) -> Pool {
+        let pool = build_pool(url, 8).expect("build_pool (public)");
+        run_migrations(&pool)
             .await
-            .expect("get_conn (seed_default_policy_for_test)");
-        client
-            .execute(
+            .expect("run_migrations (public schema)");
+        pool
+    }
+
+    /// Insert a non-default `recording_policies` row and return its id. Using a
+    /// non-default policy sidesteps the `one_default_policy` partial-unique
+    /// constraint entirely (this test never needs the global default), and the
+    /// explicit column set mirrors `services/api/tests/support/mod.rs`'s seed so
+    /// it stays valid as the schema grows.
+    async fn insert_nondefault_policy(pool: &Pool) -> Uuid {
+        let client = get_conn(pool).await.expect("get_conn (insert_policy)");
+        let row = client
+            .query_one(
                 r"
                 INSERT INTO recording_policies (
                     is_default, mode, live_storage_id, live_retention_hours,
@@ -9575,23 +9596,23 @@ mod tests {
                     motion_keyframes_only, record_stream
                 )
                 VALUES (
-                    true, 'continuous', NULL, 48,
+                    false, 'continuous', NULL, 48,
                     false, NULL, NULL, NULL,
                     5, 10, 'dynamic',
                     false, 'main'
                 )
+                RETURNING id
                 ",
                 &[],
             )
             .await
-            .expect("seed default recording_policies row");
+            .expect("insert non-default recording_policies row");
+        row.get(0)
     }
 
-    /// Seed a minimal camera (own policy cloned from the just-seeded default).
-    async fn seed_camera_for_test(pool: &Pool) -> Uuid {
-        let policy_id = clone_default_policy(pool)
-            .await
-            .expect("clone_default_policy");
+    /// Seed a camera with a UNIQUE name/go2rtc_name on the given policy and
+    /// return its id — the unique id is this test's isolation boundary.
+    async fn seed_camera_for_test(pool: &Pool, policy_id: Uuid) -> Uuid {
         let suffix = Uuid::new_v4().simple().to_string();
         let params = CreateCameraParams {
             name: &format!("cam_{suffix}"),
@@ -9671,14 +9692,14 @@ mod tests {
             eprintln!("skipping: TEST_DATABASE_URL not set");
             return;
         };
-        let fx = setup_schema(&url).await;
-        run_migrations(&fx.pool)
-            .await
-            .expect("run_migrations (test schema)");
-        seed_default_policy_for_test(&fx.pool).await;
+        let pool = migrated_public_pool(&url).await;
 
-        let camera_id = seed_camera_for_test(&fx.pool).await;
-        let storage_id = create_storage(&fx.pool, "test-storage", "/does/not/matter", None, None)
+        let policy_id = insert_nondefault_policy(&pool).await;
+        let camera_id = seed_camera_for_test(&pool, policy_id).await;
+        // Unique storage name — the shared public DB persists rows across runs
+        // and `storages.name` is UNIQUE.
+        let storage_name = format!("test-storage-{}", Uuid::new_v4().simple());
+        let storage_id = create_storage(&pool, &storage_name, "/does/not/matter", None, None)
             .await
             .expect("create_storage")
             .id;
@@ -9691,10 +9712,10 @@ mod tests {
 
         // seg1 covers [0, 10); a real recording gap sits in [10, 20); seg2
         // covers [20, 30).
-        insert_test_segment(&fx.pool, camera_id, storage_id, sec(0), sec(10)).await;
-        insert_test_segment(&fx.pool, camera_id, storage_id, sec(20), sec(30)).await;
+        insert_test_segment(&pool, camera_id, storage_id, sec(0), sec(10)).await;
+        insert_test_segment(&pool, camera_id, storage_id, sec(20), sec(30)).await;
 
-        let times = list_thumbnail_times(&fx.pool, camera_id, sec(0), sec(30), 5)
+        let times = list_thumbnail_times(&pool, camera_id, sec(0), sec(30), 5)
             .await
             .expect("list_thumbnail_times");
 


### PR DESCRIPTION
## What

Implements `list_thumbnail_times` (previously a Phase 1 stub returning an empty vec) as the fixed scrub-preview grid **intersected with actual recorded `segments` coverage**, so recording-gap slots are never requested.

Closes #9.

## Why

The background pre-generation worker (`thumb_pregen.rs`) requested scrub-preview slots on a fixed time grid. Slots landing in a recording gap have no footage and return 404 (~2-3% of slots on a typical timeline), wasting an ffmpeg spawn per gap slot. Per #9, the fix intersects the grid with `segments` coverage **in `list_thumbnail_times`** — no new table.

## How

- **`db::thumbnail_grid_slots`** (new, shared): the grid math, extracted so the coverage-aware list and filmstrip's zero-coverage synthetic fallback use one identical grid. Cadence, epoch-floor anchoring, and the half-open `[start, end)` window are all unchanged from the previous `generate_synthetic_timestamps` — the two can no longer drift.
- **`db::list_thumbnail_times`**: floors to the grid, fetches the `main`-stream segments overlapping the window once (via the indexed `list_segments_for_range`), then sweeps the ascending grid against the ascending, non-overlapping segments with a single monotonic cursor. A slot is emitted iff some segment satisfies `start_ts <= ts < end_ts`, matching `resolve_segment`'s half-open convention. **Gap slots are never emitted; covered ranges are unchanged.**
- **`thumb_pregen.rs`**: the worker now derives its slots from `list_thumbnail_times` instead of stepping the raw grid, so every extraction it attempts has real footage behind it.
- **`filmstrip.rs` (`list_filmstrip`)**: passes the same `DEFAULT_THUMB_INTERVAL_SECS`; only falls back to the unfiltered synthetic grid when a range has **no** recorded coverage at all (brand-new camera / window before the first segment). Its `generate_synthetic_timestamps` is now a thin wrapper over the shared helper.

Backend-only, read-side, off the recorder write path (golden rule 2 unaffected). No migration, no new endpoint/DTO, no config key, no client change.

## Tests

`services/common/src/db.rs`:
- **Pure-grid unit tests** (no DB): floor/anchor behavior and half-open exclusion of a slot at exactly `end`.
- **Opt-in throwaway-Postgres integration test** (`list_thumbnail_times_excludes_gap_slots`), same convention as the existing `reap_invalid_indexes` DB test — skips unless `TEST_DATABASE_URL` is set; `run_migrations` self-provisions the schema in a uniquely-named schema dropped on teardown. Seeds two `main` segments `[0s,10s)` and `[20s,30s)` with a deliberate gap, then asserts (grid = 5s):
  - mid-gap slots (10s, 15s) are **excluded**,
  - covered slots (0s, 5s, 20s, 25s) are **kept**,
  - the boundary at a segment's `end_ts` (10s) is **excluded** and the next segment's `start_ts` (20s) is **included**.

## Verification

- `cargo fmt --all -- --check` — clean.
- `cargo clippy` — clean for `crumb-common` (the changed core) and `crumb-recorder`. `crumb-api` cannot be compiled on the Windows dev workstation (pre-existing: `db_backup.rs` uses `std::os::unix::fs::symlink`; verified the same error is present on the clean base) — **CI (Linux) must confirm `crumb-api` clippy + the full `cargo test --workspace`, including the new DB-integration test against the CI Postgres.** The DB test needs Postgres, which is unavailable locally (no Docker).