### PR TITLE
feat: expose scrub-preview tunables in the admin console (closes #10)

### DIFF
--- a/db/migrations/0046_scrub_pregen_settings.sql
+++ b/db/migrations/0046_scrub_pregen_settings.sql
@@ -1,0 +1,20 @@
+-- Admin-console overrides for the scrub-preview runtime tunables (issue #10).
+-- NULL means "the operator has never touched this in the console" -> the
+-- consumers fall back to the THUMB_* env defaults (services/api/src/config.rs).
+-- Nullable + no DEFAULT, matching update_check_enabled (migration 0045):
+-- NULL must be distinguishable from an explicit value, per the house
+-- server_settings precedence rule (admin-set DB value wins over env).
+--
+-- THUMB_PREGEN_WIDTH deliberately has NO column here (ratified maintainer
+-- decision D1, issue #10): width is part of the thumbnail cache key, and a
+-- console value that drifted from the clients' fixed scrub-still width would
+-- silently waste all pre-generation CPU + storage. It stays env/compose-only;
+-- the admin console displays it read-only. See docs/DECISIONS.md.
+--
+-- Additive + nullable, so it is safe on an already-running install.
+ALTER TABLE server_settings
+    ADD COLUMN IF NOT EXISTS thumb_pregen_enabled        boolean,
+    ADD COLUMN IF NOT EXISTS thumb_pregen_lookback_hours integer,
+    ADD COLUMN IF NOT EXISTS thumb_pregen_scan_secs      integer,
+    ADD COLUMN IF NOT EXISTS thumb_cache_max_bytes       bigint,
+    ADD COLUMN IF NOT EXISTS thumb_cache_ttl_seconds     bigint;

--- a/docs-site/docs/configuration/environment-reference.md
+++ b/docs-site/docs/configuration/environment-reference.md
@@ -56,16 +56,23 @@ See [Motion & Detection](/motion/) for the mechanism this configures.
 
 See [Timeline scrubbing](/playback/scrubbing) for what these do. All optional; the defaults work.
 
-| Key | Default | Notes |
-|---|---|---|
-| `THUMB_PREGEN_ENABLED` | `false` | build scrub previews in the background so the *first* drag is instant too; costs some ongoing CPU + disk |
-| `THUMB_PREGEN_LOOKBACK_HOURS` | `2` | how far back to build previews when the worker starts |
-| `THUMB_PREGEN_SCAN_SECS` | `60` | how often to build previews for newly-recorded footage |
-| `THUMB_PREGEN_WIDTH` | `160` | preview width in pixels |
-| `THUMB_CACHE_DIR` | (`EXPORT_DIR`) | where the preview cache lives; point at an SSD/NVMe mount to keep scrubbing fast on a spinning-disk system |
-| `THUMB_EXTRACT_MAX_CONCURRENCY` | scales with cores | how many previews Crumb builds at once; default is roughly half the CPU cores |
-| `THUMB_CACHE_MAX_BYTES` | `21474836480` (20 GiB) | preview cache size budget; oldest previews are dropped past this |
-| `THUMB_CACHE_TTL_SECONDS` | `2592000` (30 days) | preview cache age budget |
+Five of these are also editable live from the admin console (**Server settings
+→ Scrub previews**): the env value below is only the *default* until an
+operator sets it in the console, at which point the console value wins (no
+restart needed, takes effect within one scan interval / cache-sweep tick).
+The other two (`THUMB_CACHE_DIR`, `THUMB_PREGEN_WIDTH`) are env/compose-only,
+see the Notes column.
+
+| Key | Default | Console-editable? | Notes |
+|---|---|---|---|
+| `THUMB_PREGEN_ENABLED` | `false` | yes | build scrub previews in the background so the *first* drag is instant too; costs some ongoing CPU + disk |
+| `THUMB_PREGEN_LOOKBACK_HOURS` | `2` | yes | how far back to build previews when the worker starts (console clamps 0-168h) |
+| `THUMB_PREGEN_SCAN_SECS` | `60` | yes | how often to build previews for newly-recorded footage (console clamps 5-3600s) |
+| `THUMB_PREGEN_WIDTH` | `480` | **no, env-only** | preview width in pixels; must equal the playback clients' scrub-still width or pre-generated previews go unused (silently wasted CPU/storage), which is why this one stays a deployment-time setting, not a console toggle |
+| `THUMB_CACHE_DIR` | (`EXPORT_DIR`) | **no, env-only** | where the preview cache lives; point at an SSD/NVMe mount to keep scrubbing fast on a spinning-disk system (a filesystem mount, not a preference) |
+| `THUMB_EXTRACT_MAX_CONCURRENCY` | scales with cores | no | how many previews Crumb builds at once; default is roughly half the CPU cores |
+| `THUMB_CACHE_MAX_BYTES` | `21474836480` (20 GiB) | yes | preview cache size budget; oldest previews are dropped past this (console floors it at 100 MiB) |
+| `THUMB_CACHE_TTL_SECONDS` | `2592000` (30 days) | yes | preview cache age budget (console clamps 1 hour-1 year) |
 
 ## Storage
 

--- a/docs-site/docs/playback/scrubbing.md
+++ b/docs-site/docs/playback/scrubbing.md
@@ -42,7 +42,15 @@ whether or not you scrub much, which is why it's off by default (a small box
 shouldn't do work nobody asked for). Turn it on if you review footage often and
 want it to feel instant everywhere.
 
-In your `.env`:
+The easiest way to turn it on is the admin console: **Server settings → Scrub
+previews**. Flip "Pre-generate scrub previews" and it starts within a few
+seconds, no restart, no container access needed. The same panel lets you adjust
+how far back it backfills, how often it wakes up, and how much cache space and
+time it's allowed, all of it applies live. Turning it back off also takes
+effect within a few seconds, even in the middle of a large backfill.
+
+Prefer the `.env` file instead (for example, to bake the setting into your
+compose file for a scripted deploy)? It works the same way:
 
 ```bash
 THUMB_PREGEN_ENABLED=true
@@ -54,9 +62,11 @@ Then apply it:
 docker compose up -d api
 ```
 
-The fine-tuning knobs (how far back to build, how often, what size) are in the
-[environment reference](/configuration/environment-reference); the defaults are
-sensible.
+Whichever knob you set last wins: once you change a setting from the admin
+console, that value takes over from the `.env` default for good. The
+[environment reference](/configuration/environment-reference) lists every
+knob (the fine-tuning ones and the console-editable ones) with its default and
+whether it's console-editable.
 
 ## Keep it snappy on a busy hard-drive system (put previews on an SSD)
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -42,6 +42,100 @@ load concern (they shouldn't: the api caches ≤6h and the client→server hop i
 LAN-local); or a client gains a real background presence where a periodic
 poller becomes worthwhile.
 
+---
+
+## 2026-07-09, Scrub-preview tunables: per-tick `server_settings` re-query; width stays env-only
+
+**Problem.** Issue #10 asks to move the thumbnail pre-generation worker's and
+cache sweeper's runtime tunables from env-only (`ApiConfig`, read once at
+boot) to the admin console, following the `clip_preroll`/`update_check_enabled`
+`server_settings` precedence (DB wins, `NULL` falls back to env). Unlike those
+two, the consumers here are **background loops**, not per-request handlers, so
+a console change also has to reach an already-running worker without a
+restart. `docs/SCRUB-PREGEN-TUNABLES-PLAN.md` is the full design; this entry
+records the ratified decisions (D1-D5).
+
+**Chosen.**
+
+- **Five nullable `server_settings` columns** (migration `0046`):
+  `thumb_pregen_enabled`, `thumb_pregen_lookback_hours`,
+  `thumb_pregen_scan_secs`, `thumb_cache_max_bytes`, `thumb_cache_ttl_seconds`.
+  Same shape as `update_check_enabled`: DB value wins when set, `NULL` (never
+  touched) falls back to the matching `THUMB_*` env default.
+- **Live-reload = per-tick direct re-query (D2), not a cached-settings
+  struct.** `services/api/src/scrub_settings.rs::resolve(pool, cfg)` does one
+  `query_opt` per cycle; both the pre-gen worker (`thumb_pregen.rs`, one query
+  per `scan_secs`) and the cache sweeper (`main.rs::export_ttl_sweeper`, one
+  query per minute) call it fresh. Roughly 2 tiny queries/minute total against
+  a pool that serves every API request, unmeasurable, and mirrors the existing
+  `updates.rs::resolve_enabled` call-per-use pattern exactly. A resolve
+  failure keeps the last-known-good values and logs a `warn!` rather than
+  aborting either background loop.
+- **Mid-backfill kill switch + watermark clear on disable (D3).** The worker
+  never exits when disabled: it idles (one settings SELECT per `scan_secs`)
+  instead. A console "disable" is honored within seconds even mid-backfill,
+  re-checked between cameras and every 256 extracted slots within one camera.
+  An enabled-to-disabled transition clears the per-camera watermark map, so
+  re-enabling always starts a fresh `pregen_lookback_hours` backfill rather
+  than grinding through the entire disabled gap (the operator asked for pregen
+  *now*, not a surprise multi-day catch-up).
+- **`THUMB_PREGEN_WIDTH` stays env-only (D1).** Width is part of the
+  thumbnail cache key (`.../{ts_ms}_w{width}.jpg`); the playback clients pin
+  their requested width (480, matched to the scrub-still tile size). A console
+  width that drifted from that value would make every pre-generated file sit
+  at a cache key nobody ever requests, 100% of the pregen CPU + storage
+  silently wasted while scrubbing quietly degrades to on-demand extraction,
+  with nothing failing loudly. `GET /config/scrub-preview` still surfaces the
+  effective width, read-only (`source: "env-only"`), so the operator sees the
+  whole picture in one panel.
+- **No "reset to env default" affordance (D4).** Matches `update_check_enabled`
+  shipping without one: plain serde can't distinguish an absent field from an
+  explicit JSON `null` without a double-`Option` PATCH helper, and once a knob
+  is touched in the console the DB value wins for good.
+- **100 MiB `thumb_cache_max_bytes` floor (D5).** A near-zero budget would
+  make the sweeper delete every thumbnail every minute, silently defeating the
+  feature; the clamping setter enforces the floor server-side regardless of
+  what the console sends.
+
+**Rejected.**
+
+- *Shared cached-settings struct with TTL/invalidation* (an `AppState` field
+  refreshed periodically, or invalidated by the PUT handler). No hot-path
+  reader exists to justify the machinery: these are 1-2 reads/minute
+  background loops, and an invalidation seam is a new way to silently go
+  stale (PUT handler forgets to invalidate) that per-tick re-query doesn't
+  have. Revisit if a future hot-path consumer of these settings appears, or a
+  multi-replica API deployment makes per-tick staleness (currently bounded to
+  one tick) visible.
+- *Config-file reload / `SIGHUP`.* No precedent anywhere in Crumb; the DB is
+  already the one settings plane (`server_settings`), and adding a second
+  reload mechanism for one feature would be inconsistent with every other
+  console-editable setting.
+- *Exposing `THUMB_PREGEN_WIDTH` as a sixth column with a warning label*
+  (option B in the plan doc). The cache-key-coherence foot-gun above was
+  judged not worth it for v1; revisit if a client ships a different scrub tile
+  size or an operator has a concrete reason to shrink pregen storage via
+  width rather than the cache-budget/TTL knobs that already exist for that.
+- *Forced cache regeneration on a width change.* Not proposed even under
+  option B: old files can't be safely deleted mid-serve, and a mixed-width
+  cache is already structurally coherent (width is part of the key, so
+  nothing is ever served wrong), just potentially wasteful. Stale-width files
+  age out via the existing TTL sweeper on their own.
+
+**Trade-offs accepted.** Up to one `scan_secs` (60s default) of staleness on
+"enable" (an idle tick just costs one SELECT); up to 256 slots / one camera
+of in-flight work before a "disable" is fully honored during a large backfill.
+Both are explicit, bounded costs of the per-tick model, not silent.
+
+**Revisit triggers.** A hot-path consumer of these settings appears (revisit
+D2, add the cached-settings struct). A client ships a scrub tile size other
+than 480px (revisit D1, expose width with per-client negotiation). Operators
+ask for "reset to env default" (revisit D4, double-`Option` clear support).
+Multi-replica API deployments make per-tick staleness visible in practice
+(revisit D2).
+
+---
+
 ## 2026-07-09, Update-available check: api-mediated, notify-only, opt-in / OFF BY DEFAULT
 
 **Problem.** Issue #7 asks for a non-intrusive "update available → release

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -569,7 +569,7 @@ The server pre-generates the preview frames so a scrub is a static-file fetch (~
 
 #### Plan
 
-> **Status (2026-07-09):** Phase 0 and the core of Phase 1 (background pre-generation, `THUMB_CACHE_DIR`, config knobs, coverage-aware `list_thumbnail_times`) shipped in #2 and #9. Policy-tied thumbnail retention and the admin-console tunables below remain.
+> **Status (2026-07-09):** Phase 0 and the core of Phase 1 (background pre-generation, `THUMB_CACHE_DIR`, config knobs, coverage-aware `list_thumbnail_times`, admin-console tunables) shipped in #2, #9, and #10. Policy-tied thumbnail retention remains.
 
 Phase 0, cache hygiene, API only, standalone (S)
 
@@ -584,7 +584,7 @@ Phase 1, pre-generation, API + `db.rs` stub, no migration (M)
 - [ ] Thumbnail retention tied to policy retention, a NEW delete path, path-guarded + tested (S)
 - [x] Config knobs (`THUMB_PREGEN_ENABLED` + lookback/scan/width, cache size/age budget) → `.env.example` / environment reference (golden rule 5) (S)
 - [x] Optional `THUMB_CACHE_DIR` to place the scrub cache on fast/separate storage (e.g. an NVMe partition) while footage stays on bulk HDD, matching the random-read-hot thumbnail workload to the right medium. Low-risk: thumbnails are regenerable and the on-demand path self-heals a wiped cache, so the thumb drive can be cheap and non-redundant (a failure only makes scrubbing temporarily slower, never loses footage) (S)
-- [ ] Follow-up (post-ship): expose the runtime-safe tunables (the pre-generation on/off toggle, lookback/scan/width, and the cache size/age budget) in the admin console via DB `server_settings`, so an operator can turn pre-generation on/off and adjust the cache budget without editing `.env` and restarting. Requires the pre-gen worker and the cache sweeper to read these live from `server_settings` rather than the startup `ApiConfig` snapshot. `THUMB_CACHE_DIR` stays env/compose-only: it is a filesystem mount (like the storage paths), not a preference (M)
+- [x] Follow-up (post-ship): expose the runtime-safe tunables (the pre-generation on/off toggle, lookback/scan, and the cache size/age budget) in the admin console via DB `server_settings` (migration 0046), so an operator can turn pre-generation on/off and adjust the cache budget without editing `.env` and restarting. The pre-gen worker and the cache sweeper read these live from `server_settings` each cycle rather than the startup `ApiConfig` snapshot (shipped in #10). `THUMB_CACHE_DIR` stays env/compose-only: it is a filesystem mount (like the storage paths), not a preference. `THUMB_PREGEN_WIDTH` also stays env-only (ratified D1): it is part of the thumbnail cache key, and a console value that drifted from the clients' fixed scrub-still width would silently waste all pre-generated output (M)
 
 Phase 2, desktop preview UI, `apps/desktop/src/app.js` only (M)
 

--- a/docs/SCRUB-PREGEN-TUNABLES-PLAN.md
+++ b/docs/SCRUB-PREGEN-TUNABLES-PLAN.md
@@ -1,0 +1,439 @@
+# Scrub-preview runtime tunables in the admin console (issue #10) — design plan
+
+Status: **RATIFIED** — the maintainer confirmed decisions D1–D5 in §9 (all
+recommended options accepted as-is). Implemented on `feat/scrub-pregen-tunables`.
+Architect: Fable session 2026-07-09. Implementers: Sonnet agents per the task
+breakdown in §8. Tracked under `docs/ROADMAP.md` initiative 8, Phase 1
+follow-up item ("expose the runtime-safe tunables … in the admin console").
+
+Issue #10 scope, verbatim anchors:
+
+> Move the runtime tunables to `server_settings` with env fallback (admin
+> value wins), following the existing precedence pattern (cf. `clip_preroll`).
+> Consumers must read **live** from `server_settings`, not the startup
+> `ApiConfig` snapshot: the pre-gen worker (`thumb_pregen.rs`) and the cache
+> sweeper. … **Out of scope:** `THUMB_CACHE_DIR` stays env/compose-only.
+
+The fresh precedent to mirror is the update-check work (#7 / PR #31):
+`update_check_enabled` is a **nullable** `server_settings` column (migration
+`0045_update_check.sql`), resolved by
+`services/api/src/updates.rs::resolve_enabled` as
+`db_value.unwrap_or(cfg.update_check_enabled)` — DB wins, `NULL` (never
+touched) falls back to env. This plan applies exactly that shape to five
+scrub knobs, plus the one thing update-check did not need: background
+consumers that re-read the values **while running**.
+
+---
+
+## 1. Which knobs move, which stay env-only
+
+Current env snapshot (all in `services/api/src/config.rs`, read once at boot
+into the immutable `ApiConfig` held by `AppState`):
+
+| Env key | `ApiConfig` field | Default | Boot clamp |
+|---|---|---|---|
+| `THUMB_PREGEN_ENABLED` | `thumb_pregen_enabled: bool` | `false` | — |
+| `THUMB_PREGEN_LOOKBACK_HOURS` | `thumb_pregen_lookback_hours: i64` | `2` | `.max(0)` |
+| `THUMB_PREGEN_SCAN_SECS` | `thumb_pregen_scan_secs: u64` | `60` | `.max(5)` |
+| `THUMB_PREGEN_WIDTH` | `thumb_pregen_width: u32` | `480` | — (request path clamps 48..=640) |
+| `THUMB_CACHE_MAX_BYTES` | `thumb_cache_max_bytes: u64` | `21_474_836_480` (20 GiB) | — |
+| `THUMB_CACHE_TTL_SECONDS` | `thumb_cache_ttl_seconds: u64` | `2_592_000` (30 d) | — |
+| `THUMB_CACHE_DIR` | `thumb_cache_dir: String` | `""` (= `EXPORT_DIR`) | — |
+
+### Moves to `server_settings` (nullable columns, DB-wins/NULL→env)
+
+| Column (matches env key, lowercased — same convention as `update_check_enabled`) | SQL type | Validation (server-side clamp in the db setter, mirroring `set_clip_pre_roll_seconds`) |
+|---|---|---|
+| `thumb_pregen_enabled` | `boolean` | — |
+| `thumb_pregen_lookback_hours` | `integer` | clamp `0..=168` (a week; larger backfills belong in env where the operator has read the cost note) |
+| `thumb_pregen_scan_secs` | `integer` | clamp `5..=3600` (5 s floor matches the existing env clamp) |
+| `thumb_cache_max_bytes` | `bigint` | clamp `104_857_600..` (100 MiB floor — a 0/near-0 budget would make the sweeper delete every thumbnail every minute, silently defeating the feature) |
+| `thumb_cache_ttl_seconds` | `bigint` | clamp `3600..=31_536_000` (1 h .. 1 y) |
+
+### Stays env-only
+
+- **`THUMB_CACHE_DIR`** — per issue #10, out of scope: it is a filesystem
+  mount (compose volume), not a preference. Changing it live could not work
+  anyway (the path must exist inside the container).
+- **`THUMB_PREGEN_WIDTH`** — **RATIFIED env-only for v1** (D1). The admin
+  console shows it read-only.
+- **`THUMB_EXTRACT_MAX_CONCURRENCY`** — not in issue scope; it sizes a
+  `Semaphore` created once in `AppState::new` (not live-reloadable without
+  semaphore surgery). Explicitly deferred.
+
+---
+
+## 2. Migration 0046
+
+`db/migrations/` currently ends at `0045_update_check.sql`, and the
+`MIGRATIONS` array in `services/common/src/db.rs` (~line 7611) ends with the
+same entry — **0046 is the next free number.**
+
+**File:** `db/migrations/0046_scrub_pregen_settings.sql`
+
+```sql
+-- Admin-console overrides for the scrub-preview runtime tunables (issue #10).
+-- NULL means "the operator has never touched this in the console" -> the
+-- consumers fall back to the THUMB_* env defaults (services/api/src/config.rs).
+-- Nullable + no DEFAULT, matching update_check_enabled (migration 0045):
+-- NULL must be distinguishable from an explicit value, per the house
+-- server_settings precedence rule (admin-set DB value wins over env).
+--
+-- Additive + nullable, so it is safe on an already-running install.
+ALTER TABLE server_settings
+    ADD COLUMN IF NOT EXISTS thumb_pregen_enabled        boolean,
+    ADD COLUMN IF NOT EXISTS thumb_pregen_lookback_hours integer,
+    ADD COLUMN IF NOT EXISTS thumb_pregen_scan_secs      integer,
+    ADD COLUMN IF NOT EXISTS thumb_cache_max_bytes       bigint,
+    ADD COLUMN IF NOT EXISTS thumb_cache_ttl_seconds     bigint;
+```
+
+**Registration (golden rule 4):** append the pair to the `MIGRATIONS` array in
+`services/common/src/db.rs` — an unregistered file silently never runs.
+
+**db.rs accessors** (in `services/common/src/db.rs`, next to
+`get_update_check_enabled` / `set_update_check_enabled`):
+
+- `get_scrub_pregen_settings(pool) -> Result<ScrubPregenOverrides>` — one
+  `query_opt` of all five columns from the single `server_settings` row;
+  returns a struct of `Option<T>`s (each `None` = never set → env fallback).
+- One setter per field (`set_thumb_pregen_enabled`, …), each a single-column
+  `UPDATE server_settings SET <col> = $1`, clamping per the table in §1
+  before writing (same pattern as `set_clip_pre_roll_seconds`). Per-field
+  setters — not one multi-column UPDATE — because the house rule is "console
+  writes ONLY the field it edits", and the PUT handler (§5) forwards only the
+  fields present in the request body.
+
+---
+
+## 3. THE CRUX — live-reload mechanism
+
+### The problem
+
+Both consumers currently read the boot-time `ApiConfig` snapshot:
+
+- `services/api/src/thumb_pregen.rs::run` reads
+  `enabled/width/lookback_hours/scan_secs` **once** before its loop and
+  `return`s immediately when disabled (line 39-42) — so even a restart-free
+  "enable" is impossible today, let alone a live change.
+- The thumbnail cache sweeper is the tail of
+  `export_ttl_sweeper` in `services/api/src/main.rs` (line ~803):
+  `sweep_thumbs_cache(state.config().thumb_cache_base(), ttl, max_bytes)`
+  with ttl/budget pulled from `state.config()` every 1-minute tick — already
+  structurally "per tick", just from the frozen snapshot.
+
+### Options evaluated
+
+**(a) Re-query `server_settings` at the top of each consumer cycle.**
+A single-row, single-`query_opt` SELECT per tick.
+- DB load: worker = 1 query per `scan_secs` (default 60 s); sweeper = 1 query
+  per minute. **~2 tiny queries/min total** against a pool that serves every
+  API request — unmeasurable.
+- Staleness: bounded by one tick (≤ 60 s at defaults), plus the mid-backfill
+  re-check below.
+- Complexity: one shared resolver function; no shared mutable state, no
+  invalidation, no new `AppState` field. Mirrors the existing
+  `updates.rs::resolve_enabled` call-per-use pattern exactly.
+
+**(b) Shared cached-settings struct** (`AppState` field, TTL-refresh à la
+`revoked_jtis`, or PUT-handler invalidation à la `roles_cache`).
+- Saves DB load only where reads are hot-path. These reads are 1-2/min
+  background loops — there is nothing to save.
+- Costs: new `AppState` plumbing, an invalidation seam that can silently
+  break (PUT handler forgets to invalidate → stale forever), and it still
+  needs the TTL fallback for a second API replica sharing the DB.
+
+**Chosen: (a), direct re-query per cycle (D2, ratified).** (b) is machinery
+without a payoff at this read rate; the precedent (`resolve_enabled` queries
+the DB on every `/updates/latest` request) already accepts far more query
+traffic for the same freshness guarantee. Revisit trigger: a future hot-path
+consumer (e.g. per-request settings reads) or measured pool pressure.
+
+### The resolver
+
+New module `services/api/src/scrub_settings.rs`:
+
+```rust
+/// Effective scrub-preview settings: admin-set server_settings values win,
+/// NULL falls back to the THUMB_* env defaults (house precedence rule).
+pub struct ScrubSettings {
+    pub pregen_enabled: bool,
+    pub pregen_lookback_hours: i64,
+    pub pregen_scan_secs: u64,
+    pub cache_max_bytes: u64,
+    pub cache_ttl_seconds: u64,
+    // width stays ApiConfig-only under D1 option A
+}
+
+pub async fn resolve(pool: &Pool, cfg: &ApiConfig) -> anyhow::Result<ScrubSettings>
+```
+
+`resolve` = `get_scrub_pregen_settings` + per-field `unwrap_or(cfg.…)` +
+the same clamps as the setters (defense in depth against a hand-edited row).
+**Failure policy:** consumers treat a resolve error as "keep last-known
+values" (first iteration: env snapshot), log a `warn!`, and continue — a
+transient DB blip must never kill the worker or the sweeper (both are
+best-effort background loops; same ethos as `refresh_revoked_jtis`).
+
+### Worker rework (`thumb_pregen.rs`)
+
+The loop becomes settings-driven instead of snapshot-driven:
+
+1. **Always loop** — never `return` on disabled. Each cycle starts with
+   `scrub_settings::resolve(...)`; when `pregen_enabled` is false, sleep
+   `scan_secs` and `continue` (an idle poll costs one SELECT/min). This is
+   what makes a console "enable" take effect without a restart.
+2. **Log transitions, not every idle tick**: one `info!` when the effective
+   state flips (disabled→enabled with the effective knob values, and back).
+   The current boot message ("disabled (THUMB_PREGEN_ENABLED unset)") becomes
+   "disabled (env default / admin setting); will start if enabled in the
+   admin console".
+3. **Mid-backfill kill switch.** The initial backfill (lookback default 2 h =
+   1,800 grid slots per camera at the 4-second grid) can run for minutes
+   inside one "cycle". Re-check `pregen_enabled` (a fresh 1-row SELECT)
+   **between cameras and every 256 slots** within a camera (piggybacking the
+   existing `steps.is_multiple_of(64)` yield cadence at a 4× multiple); on
+   false, abandon the pass immediately. Worst-case latency for "toggle off"
+   is then a few in-flight extractions, not hours.
+4. **Watermark semantics across a disable window:** on an enabled→disabled
+   transition, **clear the per-camera watermark map.** Re-enabling then
+   behaves exactly like a fresh start (backfill `lookback_hours` from now)
+   instead of grinding through the entire disabled gap — the operator asked
+   for pregen *now*, not a surprise multi-day backfill. (The on-demand path
+   self-heals the gap if anyone scrubs it, as today.)
+5. **Per-cycle values:** `lookback_hours` affects only the
+   `unwrap_or(now_ms - lookback_ms)` default for newly-seen cameras — takes
+   effect naturally. `scan_secs` is read fresh each cycle, so the *next*
+   sleep uses the new value. `width` stays the boot `cfg.thumb_pregen_width`
+   under D1 option A.
+
+### Sweeper rework (`main.rs::export_ttl_sweeper`)
+
+Minimal: at the top of each 1-minute tick, resolve once and pass
+`cache_ttl_seconds` / `cache_max_bytes` into the existing
+`sweep_thumbs_cache(...)` call instead of `state.config().…`. A lowered
+budget is therefore enforced within ≤ 1 minute: `sweep_thumbs_cache` already
+does a full recount + oldest-first eviction every pass, so no extra
+invalidation is needed — the next pass simply evicts down to the new number.
+(The clips-cache sweep and export TTL are untouched; only the two thumbnail
+arguments change source.)
+
+### Mid-run change matrix (what the operator observes)
+
+| Change | Takes effect | Mechanism |
+|---|---|---|
+| Pregen off | seconds (≤ 256 slots / 1 camera of in-flight backfill) | mid-backfill re-check + per-cycle resolve |
+| Pregen on | ≤ `scan_secs` (≤ 60 s default) | idle loop polls instead of exiting |
+| Lookback ± | next newly-seen camera / next post-clear backfill | watermark default |
+| Scan interval ± | next wake | sleep duration re-read per cycle |
+| Cache budget lowered | ≤ 1 min | sweeper full recount per tick |
+| TTL lowered | ≤ 1 min | same |
+
+---
+
+## 4. The WIDTH cache-coherence nuance (decision point D1 — RATIFIED: option A, env-only)
+
+Facts that bound the decision:
+
+- Width is **part of the cache key**:
+  `{thumb_cache_base}/.thumbs/{camera}/{ts_ms}_w{width}.jpg`
+  (`filmstrip.rs` line ~284). A mixed-width cache is therefore *structurally
+  safe* — no file is ever wrong, corrupted, or served at the wrong size, and
+  no invalidation is *required* on a width change. Stale-width files age out
+  via the TTL sweeper.
+- But the clients **pin their requested width**: `THUMB_PREGEN_WIDTH` was
+  raised from 160 to 480 specifically to equal the clients' scrub-still
+  width (`config.rs` doc comment: "Kept equal to the playback clients' scrub
+  width … so the wall and single-camera scrub preview hit the pre-generated
+  cache"). A pregen width ≠ client width means every pregenerated file is a
+  key nobody ever requests: **100% of pregen CPU + storage becomes silent
+  waste**, while scrubbing quietly degrades to on-demand extraction. Nothing
+  breaks loudly; the feature just stops paying for itself.
+- Changing width also does not retro-generate: watermarks track *time*, so
+  history stays at the old width and only new slots use the new one.
+
+**RATIFIED (Option A): `THUMB_PREGEN_WIDTH` stays env-only in v1.**
+A console knob whose wrong value silently defeats the feature it sits next
+to is a foot-gun, and the legitimate use cases (shrink pregen storage on a
+tiny box; a future client with a different tile size) are exactly the
+"read the doc comment first" cases env config is for. The admin console
+*displays* the effective width read-only ("Preview width: 480 px, set
+via `THUMB_PREGEN_WIDTH`") so the operator sees the whole picture.
+
+(Option B — a sixth nullable `thumb_pregen_width` column, exposed with a
+warning — was considered and rejected; see `docs/DECISIONS.md`.)
+
+---
+
+## 5. HTTP surface
+
+One grouped admin-only endpoint (COMPONENT-MAP row A applies), added to the
+router in `services/api/src/config_routes.rs` next to
+`/config/update-check-enabled`:
+
+```
+GET /config/scrub-preview   (AdminUser)
+PUT /config/scrub-preview   (AdminUser)
+```
+
+Grouped rather than five single-field routes (the update-check precedent is
+single-field, but it is a single field; five knobs in one panel warrant one
+round-trip). The doc-comment route table at the top of `config_routes.rs` —
+currently the API reference of record per COMPONENT-MAP row A — gains both
+rows.
+
+**GET response** — effective values plus provenance, so the console can
+annotate "(env default)" vs "(set here)", plus the bounds so the UI clamps
+match the server:
+
+```json
+{
+  "pregen_enabled":       { "value": false,        "source": "env" },
+  "pregen_lookback_hours":{ "value": 2,            "source": "env", "min": 0,         "max": 168 },
+  "pregen_scan_secs":     { "value": 60,           "source": "db",  "min": 5,         "max": 3600 },
+  "cache_max_bytes":      { "value": 21474836480,  "source": "env", "min": 104857600 },
+  "cache_ttl_seconds":    { "value": 2592000,      "source": "db",  "min": 3600,      "max": 31536000 },
+  "pregen_width":         { "value": 480,          "source": "env-only" }
+}
+```
+
+**PUT request** — all fields `Option<…>`; the handler calls the per-field
+db setter **only for fields present** (house rule: write only what was
+edited). Values outside bounds are clamped by the setter (the
+`clip_preroll` precedent clamps rather than rejects; the UI clamps first so
+this is belt-and-braces). Response `204 No Content`.
+
+**Deliberately deferred (D4, ratified):** "clear back to env default"
+(writing SQL `NULL` via JSON `null`) — plain serde cannot distinguish absent
+from `null` without a double-`Option` helper, and update-check shipped
+without a clear either. Once touched, the DB value wins for good; revisit if
+operators ask.
+
+Security posture (golden rule 1): `AdminUser` extractor, JSON router side
+(gzip + timeout + rate limit), no new ports/binds, no secrets involved.
+
+---
+
+## 6. Admin console (`services/api/src/admin.html`)
+
+New "Scrub previews" card in the server-settings section, adjacent to the
+clip pre-roll / bookmarks / update-check controls (same visual family).
+House conventions checklist (from AGENTS.md + COMPONENT-MAP row H):
+
+- Plain functions wired by `on*=` attributes; **every referenced handler
+  must exist**: `loadScrubPreview()`, `saveScrubPreview(field, value)`
+  (or per-control `saveScrubEnabled(checked)` etc. — implementer's choice,
+  the constraint is defined-before-referenced).
+- `api('/config/scrub-preview')` for reads; `api(..., { method:'PUT',
+  body: JSON.stringify({ <only the edited field> }) })` for writes —
+  one field per PUT, matching "console writes ONLY this field".
+- On save failure: message in `var(--danger)` + re-`load…()` to revert the
+  control to server truth (the `saveBookmarksEnabled` pattern, admin.html
+  ~line 5929); on success `var(--ok)` message auto-cleared after 3 s.
+- `esc()` for any interpolated text.
+- Controls: pregen checkbox; lookback `number` input (0–168 h); scan-interval
+  `number` (5–3600 s, labelled "advanced"); cache budget presented in **GiB**
+  (converted to bytes for the API, min 0.1); TTL presented in **days**
+  (converted to seconds, min 1 h). Each control shows the `source`
+  annotation from GET ("env default" in `var(--dim)` until first save).
+- Read-only line for width per §4 option A.
+- Copy must state the cost honestly, mirroring the config.rs doc comment:
+  pregen trades continuous decode CPU + cache storage for instant
+  first-touch scrubbing.
+- Verify: `node --check` on the extracted script block; rebuild the api to
+  see changes (`include_str!`).
+
+Not added to the first-run wizard: pregen is a deliberate opt-in with an
+ongoing CPU cost, not an onboarding decision (COMPONENT-MAP row B "if the
+setting belongs in onboarding" — it does not; stated here as the explicit
+deferral the map requires).
+
+---
+
+## 7. Docs, COMPONENT-MAP walk, DECISIONS entry
+
+### COMPONENT-MAP row B (server setting) + row A (endpoint) walk
+
+| Surface | Action |
+|---|---|
+| `services/api/src/config.rs` | Doc comments on the five fields gain "admin-console override: `server_settings.<col>` wins when set (issue #10)" — the code-side truth stays honest |
+| `.env.example` / `scripts/setup-env.sh` / `docker-compose*.yml` | **No change needed — verified**: the `THUMB_*` keys are not present in any of them today (they are optional tuning keys documented only in the environment reference). State this in the PR |
+| `services/api/src/admin.html` | §6 |
+| First-run wizard | Explicitly deferred (§6) |
+| `docs/AI-INSTALL.md` | **No step changes** (no new required key, port, volume, or secret). Add is NOT required; if the runbook's scrubbing mention exists it gets one line: runtime tunables are console-editable post-install. Implementer verifies with a grep |
+| `docs-site/docs/configuration/environment-reference.md` | Mark the five keys "console-editable (admin console › Scrub previews); the env value is the default until set there, then the console value wins". Mark `THUMB_CACHE_DIR` (+ `THUMB_PREGEN_WIDTH` under D1-A) "env-only". **Fix the stale `THUMB_PREGEN_WIDTH` default: the table says `160`, the code default is `480`** (config.rs line ~357) |
+| `docs-site/docs/playback/scrubbing.md` | New short operator section: enabling/tuning pre-generation from the console, no restart needed; user-facing per the docs rule (plain language, what it costs, what changes when) |
+| `docs/ROADMAP.md` initiative 8 | Tick the follow-up checkbox when shipped |
+| `config_routes.rs` doc-comment route table | Two new rows (row A: the reference of record until OpenAPI exists) |
+| Desktop / Android / iOS | No client work: clients consume `/filmstrip` unchanged. Desktop's embedded `/admin` picks the new card up for free |
+
+### Required `docs/DECISIONS.md` entry (same change as the implementation)
+
+`## 2026-07-XX, Scrub-preview tunables: per-tick server_settings re-query;
+width stays env-only` — recording:
+
+- **Chosen:** nullable `server_settings` columns (DB wins, NULL→env, the
+  0045 pattern); consumers re-resolve from the DB once per cycle plus a
+  mid-backfill enabled re-check; watermarks cleared on disable.
+- **Rejected:** shared cached-settings struct with TTL/invalidation (no
+  hot-path reader to justify it; invalidation is a new failure seam);
+  config-file reload/SIGHUP (no precedent in Crumb, DB is the settings
+  plane); forced cache regeneration on width change (can't safely delete
+  mid-serve; mixed-width keys are already coherent).
+- **Width decision** per D1 outcome, with the "pregen width must equal
+  client scrub width or pregen is silent waste" reasoning.
+- **Revisit triggers:** a hot-path consumer of these settings appears
+  (→ option b caching); a client ships a different scrub width (→ expose
+  width + per-client negotiation); operators request "reset to env default"
+  (→ double-Option clear support); multi-replica API deployments make
+  per-tick staleness visible.
+
+---
+
+## 8. Phased task breakdown (Sonnet-sized; gate green per task)
+
+**Gate for every task** (AGENTS golden rule 3): `cargo fmt --all -- --check`
+&& `cargo clippy --all-targets -- -D warnings` && `cargo test --workspace`
+against the throwaway Postgres (`crumb-test-pg` recipe in AGENTS.md).
+Branch: single feature branch for #10; one reviewable commit per task is
+fine. DCO sign-off on every commit.
+
+**Sequencing constraint (do first):** issue **#9** (coverage-aware
+`list_thumbnail_times`, ~2-3% gap-slot 404s) also edits `thumb_pregen.rs`
+and `services/common/src/db.rs`. **Land #9 first and rebase this branch on
+it** before starting T3 — both touch the worker loop body, and #9 is the
+smaller, independent change. T1/T2 may proceed in parallel with #9 (they
+touch disjoint code), but T3 must start from the post-#9 tree.
+
+(#9 merged 2026-07-09 as PR #38 — this branch is based on that merge commit.)
+
+| # | Task | Files | Acceptance | Model |
+|---|---|---|---|---|
+| T1 | Migration 0046 + db accessors: SQL file, `MIGRATIONS` registration, `ScrubPregenOverrides` struct, `get_scrub_pregen_settings`, five clamping setters | `db/migrations/0046_scrub_pregen_settings.sql`, `services/common/src/db.rs` | Migration listed in `MIGRATIONS` (rule 4); integration tests: fresh-DB columns exist; get→all-`None`; set/get roundtrip per field; out-of-bounds input stored clamped | Sonnet |
+| T2 | Resolver: `scrub_settings.rs` with `ScrubSettings` + `resolve(pool, cfg)` (unwrap_or env, re-clamp, documented failure policy) | `services/api/src/scrub_settings.rs`, `mod` in `main.rs` | Tests: NULL→env fallback per field; DB-set wins; hand-edited out-of-bounds row comes back clamped | Sonnet |
+| T3 | Worker live-reload per §3: always-loop, per-cycle resolve, transition logging, 256-slot/per-camera enabled re-check, watermark clear on disable, resolve-failure = keep-last + warn | `services/api/src/thumb_pregen.rs` | **Starts after #9 is merged/rebased.** Extract the per-cycle decision logic into pure helper(s) with unit tests (enable/disable transitions, watermark clearing); manual smoke: toggle via SQL on a dev stack, observe start/stop in logs within one interval | Sonnet (high effort — the one task touching worker control flow) |
+| T4 | Sweeper live values: resolve at tick top, feed `sweep_thumbs_cache` ttl/budget | `services/api/src/main.rs` (`export_ttl_sweeper`) | Existing `thumb_sweep_tests` still green (function signature unchanged); clips sweep + export TTL untouched | Sonnet |
+| T5 | Endpoint: GET/PUT `/config/scrub-preview` per §5, DTOs, router wiring, route-table doc comment | `services/api/src/config_routes.rs` (+ `dto.rs` if house style puts DTOs there — mirror update-check placement) | Admin-only (auth test); GET reflects env then DB after PUT; PUT with one field leaves others untouched; PUT clamps | Sonnet |
+| T6 | Admin console card per §6 | `services/api/src/admin.html` | `node --check` on extracted script; every `on*=` handler exists; save-failure revert path; source annotations; verified against a rebuilt api on the dev stack | Sonnet |
+| T7 | Docs + decision log per §7: environment-reference (incl. the stale 160→480 width default), scrubbing page, ROADMAP checkbox, config.rs doc comments, DECISIONS entry, AI-INSTALL grep-verify | `docs-site/docs/configuration/environment-reference.md`, `docs-site/docs/playback/scrubbing.md`, `docs/ROADMAP.md`, `docs/DECISIONS.md`, `services/api/src/config.rs` | Every §7 row done or its deferral stated in the PR body; DECISIONS entry present (rule 7); no em-dashes in docs-site copy (house style) | Sonnet |
+
+No task needs Opus: no crypto/authz surface beyond reusing `AdminUser`, no
+recorder-path code (golden rule 2 untouched — this is all API read-side).
+T3 is the correctness-sensitive one; its reviewer should check the
+worst case "disabled mid-backfill" and "resolve error" paths specifically.
+
+---
+
+## 9. Ratified maintainer decisions
+
+- **D1 — WIDTH at runtime: env-only v1** with a read-only console display
+  (§4 option A). **RATIFIED.**
+- **D2 — Live-reload approach: per-tick direct re-query** (§3 option a) over
+  a cached-settings struct. **RATIFIED.**
+- **D3 — Watermark clear on disable→enable** (re-enable = fresh
+  `lookback_hours` backfill, never a surprise multi-day catch-up).
+  **RATIFIED.**
+- **D4 — No "reset to env default"** in v1 (once set in the console, the DB
+  value wins for good, as with `update_check_enabled`). **RATIFIED.**
+- **D5 — Cache-budget floor 100 MiB** (blocks the 0-byte "sweeper deletes
+  everything every minute" foot-gun). **RATIFIED**, floor = 104,857,600 bytes.

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -688,6 +688,9 @@ let CAMS = [], STORAGES = [], POLICIES = [], DEFAULT_POLICY = null, GROUPS = [],
    editing only their own subset of columns. */
 let DETECTION_SERVER = null;
 let SERVER_SETTINGS = null;
+/* Scrub-preview tunables (issue #10) last GET response — kept so the input
+   onchange handlers can re-derive bounds without a re-fetch. */
+let SCRUB_PREVIEW = null;
 const $ = id => document.getElementById(id);
 const esc = s => String(s ?? '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 const redact = u => String(u||'').replace(/\/\/[^@/]+@/, '//••••@');
@@ -5777,10 +5780,21 @@ async function renderServerSettings() {
       <div id="srv-upd-msg" style="font-size:12px;color:var(--dim);margin-top:4px"></div>
       <div id="srv-upd-status" style="font-size:13px;margin-top:8px"></div>
     </div>
+    <div class="policy-section">
+      <div class="policy-section-title">Scrub previews (thumbnail pre-generation)</div>
+      <div class="card-hint" style="margin-bottom:10px">Pre-generates timeline scrub-preview thumbnails ahead of time so the FIRST scrub touch is instant, not just on revisit. Trades continuous decode CPU + cache storage for that instant first touch. Off by default. Changes here take effect within one scan interval, no restart needed.</div>
+      <label class="chk" id="srv-pregen-wrap" style="cursor:default;opacity:.7">
+        <input type="checkbox" id="srv-pregen-enabled" onchange="saveScrubPregenEnabled(this.checked)" />
+        <span>Pre-generate scrub previews</span>
+      </label>
+      <div id="srv-pregen-msg" style="font-size:12px;color:var(--dim);margin-top:4px"></div>
+      <div id="srv-pregen-knobs" style="margin-top:10px"></div>
+    </div>
     <div class="card-hint" style="margin-top:4px">Saving applies immediately. Changing the public address may require toggling a camera (or a recorder restart) to take effect on in-flight recordings.</div>
     <div id="srv-msg" class="form-msg"></div>`;
   loadBookmarksEnabled();
   loadUpdateCheck();
+  loadScrubPreview();
 }
 function onHwaccelChange() {
   const sel = $('srv-hwaccel'); const wrap = $('srv-vaapi-device-wrap');
@@ -6005,6 +6019,112 @@ async function renderUpdateStatus(force) {
 }
 function checkForUpdatesNow() {
   renderUpdateStatus(true);
+}
+
+/* ── Scrub-preview pre-generation tunables (issue #10) ──
+   Five THUMB_PREGEN_ and THUMB_CACHE_ knobs, admin-console override with env
+   fallback (server_settings, DB wins, NULL -> env; see scrub_settings.rs).
+   Live-reload: both the pre-gen worker and the thumbnail cache sweeper
+   re-resolve every cycle, so a save here takes effect without a restart.
+   pregen_width stays env-only (D1) -- shown read-only, no PUT for it.
+   Each PUT writes ONLY the one field being edited (house rule). */
+const SCRUB_BYTES_PER_GIB = 1024 * 1024 * 1024;
+const SCRUB_SECS_PER_DAY = 86400;
+
+function scrubSourceNote(source) {
+  return source === 'db' ? '' : ' <span style="color:var(--dim)">(env default)</span>';
+}
+
+async function loadScrubPreview() {
+  const chk = $('srv-pregen-enabled');
+  const wrap = $('srv-pregen-wrap');
+  const msg = $('srv-pregen-msg');
+  const knobs = $('srv-pregen-knobs');
+  if (!chk) return;
+  let data;
+  try {
+    data = await api('/config/scrub-preview');
+  } catch (e) {
+    if (msg) msg.textContent = 'Could not load: ' + (e.message || e);
+    return;
+  }
+  SCRUB_PREVIEW = data;
+  chk.checked = !!data.pregen_enabled.value;
+  if (wrap) wrap.style.opacity = '1';
+  if (msg) msg.textContent = '';
+
+  const gib = (data.cache_max_bytes.value / SCRUB_BYTES_PER_GIB);
+  const minGib = (data.cache_max_bytes.min / SCRUB_BYTES_PER_GIB);
+  const days = (data.cache_ttl_seconds.value / SCRUB_SECS_PER_DAY);
+  const minDays = (data.cache_ttl_seconds.min / SCRUB_SECS_PER_DAY);
+  const maxDays = Math.round(data.cache_ttl_seconds.max / SCRUB_SECS_PER_DAY);
+
+  if (knobs) knobs.innerHTML = `
+    <div class="form-grid">
+      <label class="fg-label" for="srv-pregen-lookback">Backfill lookback${scrubSourceNote(data.pregen_lookback_hours.source)}</label>
+      <div class="fg-ctl"><input id="srv-pregen-lookback" type="number" min="${data.pregen_lookback_hours.min}" max="${data.pregen_lookback_hours.max}" step="1" value="${data.pregen_lookback_hours.value}" class="mono" style="width:80px" onchange="saveScrubPregenField('pregen_lookback_hours', parseInt(this.value,10))"> hours <span style="color:var(--dim2)">(0–${data.pregen_lookback_hours.max}, default 2)</span></div>
+      <label class="fg-label" for="srv-pregen-scan">Scan interval ${infoHint('How often the worker wakes to generate thumbnails for newly-recorded footage. Advanced.')}${scrubSourceNote(data.pregen_scan_secs.source)}</label>
+      <div class="fg-ctl"><input id="srv-pregen-scan" type="number" min="${data.pregen_scan_secs.min}" max="${data.pregen_scan_secs.max}" step="1" value="${data.pregen_scan_secs.value}" class="mono" style="width:80px" onchange="saveScrubPregenField('pregen_scan_secs', parseInt(this.value,10))"> seconds <span style="color:var(--dim2)">(${data.pregen_scan_secs.min}–${data.pregen_scan_secs.max}, default 60)</span></div>
+      <label class="fg-label" for="srv-pregen-cache-gib">Cache budget${scrubSourceNote(data.cache_max_bytes.source)}</label>
+      <div class="fg-ctl"><input id="srv-pregen-cache-gib" type="number" min="${minGib}" step="0.1" value="${gib.toFixed(2)}" class="mono" style="width:90px" onchange="saveScrubPregenBytes(this.value)"> GiB <span style="color:var(--dim2)">(min ${minGib.toFixed(2)} GiB)</span></div>
+      <label class="fg-label" for="srv-pregen-ttl-days">Cache max age${scrubSourceNote(data.cache_ttl_seconds.source)}</label>
+      <div class="fg-ctl"><input id="srv-pregen-ttl-days" type="number" min="${minDays.toFixed(3)}" max="${maxDays}" step="0.1" value="${days.toFixed(2)}" class="mono" style="width:90px" onchange="saveScrubPregenTtl(this.value)"> days <span style="color:var(--dim2)">(min ~1 hour, max ${maxDays}d)</span></div>
+      <label class="fg-label">Pre-gen width</label>
+      <div class="fg-ctl mono">${esc(String(data.pregen_width.value))} px <span style="color:var(--dim2)">(env-only, THUMB_PREGEN_WIDTH -- must match the clients' scrub width or pre-generated previews go unused)</span></div>
+    </div>`;
+}
+
+async function saveScrubPregenEnabled(enabled) {
+  const msg = $('srv-pregen-msg');
+  try {
+    await api('/config/scrub-preview', { method: 'PUT', body: JSON.stringify({ pregen_enabled: !!enabled }) });
+    if (msg) { msg.style.color = 'var(--ok)'; msg.textContent = enabled ? 'Scrub pre-generation enabled.' : 'Scrub pre-generation disabled.'; setTimeout(() => { if (msg) msg.textContent = ''; }, 3000); }
+    loadScrubPreview();
+  } catch (e) {
+    if (msg) { msg.style.color = 'var(--danger)'; msg.textContent = 'Save failed: ' + (e.message || e); }
+    /* Revert the checkbox to the last-known server state on failure. */
+    loadScrubPreview();
+  }
+}
+
+async function saveScrubPregenField(field, value) {
+  if (!Number.isFinite(value)) { loadScrubPreview(); return; }
+  try {
+    await api('/config/scrub-preview', { method: 'PUT', body: JSON.stringify({ [field]: value }) });
+    toast('Saved.');
+    loadScrubPreview();
+  } catch (e) {
+    toast('Save failed: ' + (e.message || e));
+    loadScrubPreview();
+  }
+}
+
+async function saveScrubPregenBytes(gibStr) {
+  const gib = parseFloat(gibStr);
+  if (!Number.isFinite(gib)) { loadScrubPreview(); return; }
+  const bytes = Math.round(gib * SCRUB_BYTES_PER_GIB);
+  try {
+    await api('/config/scrub-preview', { method: 'PUT', body: JSON.stringify({ cache_max_bytes: bytes }) });
+    toast('Cache budget saved.');
+    loadScrubPreview();
+  } catch (e) {
+    toast('Save failed: ' + (e.message || e));
+    loadScrubPreview();
+  }
+}
+
+async function saveScrubPregenTtl(daysStr) {
+  const days = parseFloat(daysStr);
+  if (!Number.isFinite(days)) { loadScrubPreview(); return; }
+  const secs = Math.round(days * SCRUB_SECS_PER_DAY);
+  try {
+    await api('/config/scrub-preview', { method: 'PUT', body: JSON.stringify({ cache_ttl_seconds: secs }) });
+    toast('Cache max age saved.');
+    loadScrubPreview();
+  } catch (e) {
+    toast('Save failed: ' + (e.message || e));
+    loadScrubPreview();
+  }
 }
 
 /* ── Camera tab 3: Storage & group ──

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -177,10 +177,20 @@ pub struct ApiConfig {
     /// cache (`{export_dir}/.thumbs`). A periodic sweeper evicts oldest-by-mtime
     /// past this budget (and past `THUMB_CACHE_TTL_SECONDS` by age), so scrubbing
     /// can't grow the cache unbounded. Default: `20 GiB`.
+    ///
+    /// Admin-console override (issue #10): `server_settings.thumb_cache_max_bytes`
+    /// wins when set (floored at 100 MiB), `NULL` falls back to this env value.
+    /// Both the sweeper and `GET /config/scrub-preview` resolve the effective
+    /// value live via `scrub_settings::resolve` — this field is only the boot
+    /// snapshot / ultimate fallback.
     pub thumb_cache_max_bytes: u64,
 
     /// `THUMB_CACHE_TTL_SECONDS` -- age past which a cached thumbnail is evicted
     /// by the sweeper regardless of the byte budget. Default: `30 days`.
+    ///
+    /// Admin-console override (issue #10): `server_settings.thumb_cache_ttl_seconds`
+    /// wins when set (clamped 1h..=1y), `NULL` falls back to this env value; see
+    /// `thumb_cache_max_bytes`'s note above.
     pub thumb_cache_ttl_seconds: u64,
 
     /// `THUMB_PREGEN_ENABLED` -- run the background thumbnail pre-generation
@@ -188,14 +198,26 @@ pub struct ApiConfig {
     /// cache) with zero background cost; pre-generation additionally makes COLD
     /// first-touch fast, at the price of continuous decode CPU + cache storage.
     /// Default: `false`.
+    ///
+    /// Admin-console override (issue #10): `server_settings.thumb_pregen_enabled`
+    /// wins when set, `NULL` falls back to this env value; see
+    /// `thumb_cache_max_bytes`'s note above (same live-reload precedence).
     pub thumb_pregen_enabled: bool,
 
     /// `THUMB_PREGEN_LOOKBACK_HOURS` -- on start, and for a newly-seen camera, the
     /// worker backfills thumbnails this far back before rolling forward. Default: `2`.
+    ///
+    /// Admin-console override (issue #10): `server_settings.thumb_pregen_lookback_hours`
+    /// wins when set (clamped 0..=168h), `NULL` falls back to this env value; see
+    /// `thumb_cache_max_bytes`'s note above.
     pub thumb_pregen_lookback_hours: i64,
 
     /// `THUMB_PREGEN_SCAN_SECS` -- how often the worker wakes to generate
     /// thumbnails for newly-recorded footage. Default: `60`.
+    ///
+    /// Admin-console override (issue #10): `server_settings.thumb_pregen_scan_secs`
+    /// wins when set (clamped 5..=3600s), `NULL` falls back to this env value; see
+    /// `thumb_cache_max_bytes`'s note above.
     pub thumb_pregen_scan_secs: u64,
 
     /// `THUMB_PREGEN_WIDTH` -- width the worker pre-generates at. Clients requesting
@@ -208,6 +230,13 @@ pub struct ApiConfig {
     /// original 160 because that looked blurry blown up to wall-tile size on a
     /// large display. Lowering it (to shrink pre-gen storage) is safe but means
     /// those clients fall back to on-demand extraction at their requested width.
+    ///
+    /// **Env-only, deliberately NOT an admin-console override** (issue #10,
+    /// ratified decision D1): width is part of the thumbnail cache key, and a
+    /// console value that drifted from the clients' fixed scrub-still width
+    /// would silently waste all pre-generated CPU + storage (every file would
+    /// sit at a cache key nobody ever requests). The console displays this
+    /// value read-only. See `docs/DECISIONS.md`.
     pub thumb_pregen_width: u32,
 
     /// `THUMB_CACHE_DIR` -- optional override for where the thumbnail cache

--- a/services/api/src/config_routes.rs
+++ b/services/api/src/config_routes.rs
@@ -49,6 +49,22 @@
 //! The public, any-user endpoint clients actually poll is `GET /updates/latest`
 //! (`services/api/src/updates.rs`), not under `/config`.
 //!
+//! ## Scrub-preview runtime tunables (issue #10)
+//! | Method | Path                    | Description                                                |
+//! |--------|-------------------------|-------------------------------------------------------------|
+//! | `GET`  | `/config/scrub-preview` | Effective value + `source` (db/env) + bounds, per knob     |
+//! | `PUT`  | `/config/scrub-preview` | Admin edit; all fields optional, writes only what's sent   |
+//!
+//! Five of the `THUMB_PREGEN_*`/`THUMB_CACHE_*` env knobs move to nullable
+//! `server_settings` overrides (migration 0046), resolved live by
+//! `services/api/src/scrub_settings.rs::resolve` (DB wins, `NULL` falls back
+//! to env) — the pre-generation worker and the thumbnail-cache sweeper both
+//! re-resolve every cycle, so a change here takes effect without a restart.
+//! `THUMB_PREGEN_WIDTH` stays env-only (ratified D1: it is part of the
+//! thumbnail cache key, and a console value that drifted from the clients'
+//! fixed scrub-still width would silently waste all pre-generated output) —
+//! the GET response includes it as a read-only `source: "env-only"` field.
+//!
 //! # Design notes
 //!
 //! * Every handler requires [`crate::auth_mw::AdminUser`] — viewers never reach
@@ -220,6 +236,12 @@ pub fn routes() -> Router<AppState> {
         .route(
             "/update-check-enabled",
             get(get_update_check_enabled_route).put(set_update_check_enabled_route),
+        )
+        // Scrub-preview runtime tunables (issue #10): live-reloaded by the
+        // pre-gen worker + thumbnail cache sweeper via scrub_settings::resolve.
+        .route(
+            "/scrub-preview",
+            get(get_scrub_preview_route).put(set_scrub_preview_route),
         )
         .route("/setup-complete", put(set_setup_complete_route))
         .route("/beta-terms", put(set_beta_terms_route))
@@ -472,6 +494,156 @@ async fn set_update_check_enabled_route(
     db::set_update_check_enabled(state.pool(), body.enabled)
         .await
         .map_err(ApiError::Internal)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ─── scrub-preview runtime tunables (issue #10) ────────────────────────────────
+
+/// One knob's effective value + provenance (+ bounds, when the knob is
+/// clamped) — lets the console annotate "(env default)" vs "(set here)" and
+/// clamp its own inputs to the same bounds the server enforces. `source` is
+/// `"db"` (an explicit console value wins), `"env"` (never touched, falling
+/// back to the env default), or `"env-only"` (`pregen_width`: not stored in
+/// `server_settings` at all, D1).
+#[derive(serde::Serialize)]
+struct ScrubKnobDto<T: serde::Serialize> {
+    value: T,
+    source: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    min: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max: Option<i64>,
+}
+
+#[derive(serde::Serialize)]
+struct ScrubPreviewDto {
+    pregen_enabled: ScrubKnobDto<bool>,
+    pregen_lookback_hours: ScrubKnobDto<i64>,
+    pregen_scan_secs: ScrubKnobDto<i64>,
+    cache_max_bytes: ScrubKnobDto<i64>,
+    cache_ttl_seconds: ScrubKnobDto<i64>,
+    /// Read-only (D1): `THUMB_PREGEN_WIDTH` stays env/compose-only. Included
+    /// here so the console can show the whole picture in one panel.
+    pregen_width: ScrubKnobDto<i64>,
+}
+
+/// All fields optional (house rule: PUT writes only what's present). Byte/
+/// second-count fields accept `u64` from the client (the console converts
+/// GiB/days to bytes/seconds before sending); the per-field db setter does
+/// the authoritative clamping.
+#[derive(serde::Deserialize, Default)]
+struct ScrubPreviewRequest {
+    pregen_enabled: Option<bool>,
+    pregen_lookback_hours: Option<i64>,
+    pregen_scan_secs: Option<i64>,
+    cache_max_bytes: Option<u64>,
+    cache_ttl_seconds: Option<u64>,
+}
+
+fn scrub_source(is_set: bool) -> &'static str {
+    if is_set {
+        "db"
+    } else {
+        "env"
+    }
+}
+
+/// `GET /config/scrub-preview` — the RESOLVED effective value for each of the
+/// five console-editable knobs (DB override, else the matching `THUMB_*` env
+/// default — the same precedence `scrub_settings::resolve` applies to the
+/// pre-gen worker and the cache sweeper), plus `THUMB_PREGEN_WIDTH` read-only
+/// (D1, env-only).
+async fn get_scrub_preview_route(
+    _admin: AdminUser,
+    State(state): State<AppState>,
+) -> Result<Json<ScrubPreviewDto>, ApiError> {
+    let overrides = db::get_scrub_pregen_settings(state.pool())
+        .await
+        .map_err(ApiError::Internal)?;
+    let env = crate::scrub_settings::EnvDefaults::from_config(state.config());
+    let effective = crate::scrub_settings::merge(overrides, env);
+
+    let cache_max_bytes = i64::try_from(effective.cache_max_bytes).unwrap_or(i64::MAX);
+    let cache_ttl_seconds = i64::try_from(effective.cache_ttl_seconds).unwrap_or(i64::MAX);
+    let pregen_scan_secs = i64::try_from(effective.pregen_scan_secs).unwrap_or(i64::MAX);
+
+    Ok(Json(ScrubPreviewDto {
+        pregen_enabled: ScrubKnobDto {
+            value: effective.pregen_enabled,
+            source: scrub_source(overrides.pregen_enabled.is_some()),
+            min: None,
+            max: None,
+        },
+        pregen_lookback_hours: ScrubKnobDto {
+            value: effective.pregen_lookback_hours,
+            source: scrub_source(overrides.pregen_lookback_hours.is_some()),
+            min: Some(0),
+            max: Some(168),
+        },
+        pregen_scan_secs: ScrubKnobDto {
+            value: pregen_scan_secs,
+            source: scrub_source(overrides.pregen_scan_secs.is_some()),
+            min: Some(5),
+            max: Some(3600),
+        },
+        cache_max_bytes: ScrubKnobDto {
+            value: cache_max_bytes,
+            source: scrub_source(overrides.cache_max_bytes.is_some()),
+            min: Some(104_857_600),
+            max: None,
+        },
+        cache_ttl_seconds: ScrubKnobDto {
+            value: cache_ttl_seconds,
+            source: scrub_source(overrides.cache_ttl_seconds.is_some()),
+            min: Some(3600),
+            max: Some(31_536_000),
+        },
+        pregen_width: ScrubKnobDto {
+            value: i64::from(state.config().thumb_pregen_width),
+            source: "env-only",
+            min: None,
+            max: None,
+        },
+    }))
+}
+
+/// `PUT /config/scrub-preview` — admin edit. Writes ONLY the fields present
+/// in the body (house rule), via the clamping per-field db setters; a
+/// hand-crafted out-of-bounds value is clamped server-side, not rejected
+/// (the `clip_preroll` precedent). No "reset to env default" affordance in
+/// v1 (D4) — once set here, the DB value wins for good, matching
+/// `update_check_enabled`.
+async fn set_scrub_preview_route(
+    _admin: AdminUser,
+    State(state): State<AppState>,
+    Json(body): Json<ScrubPreviewRequest>,
+) -> Result<StatusCode, ApiError> {
+    let pool = state.pool();
+    if let Some(v) = body.pregen_enabled {
+        db::set_thumb_pregen_enabled(pool, v)
+            .await
+            .map_err(ApiError::Internal)?;
+    }
+    if let Some(v) = body.pregen_lookback_hours {
+        db::set_thumb_pregen_lookback_hours(pool, v)
+            .await
+            .map_err(ApiError::Internal)?;
+    }
+    if let Some(v) = body.pregen_scan_secs {
+        db::set_thumb_pregen_scan_secs(pool, v)
+            .await
+            .map_err(ApiError::Internal)?;
+    }
+    if let Some(v) = body.cache_max_bytes {
+        db::set_thumb_cache_max_bytes(pool, i64::try_from(v).unwrap_or(i64::MAX))
+            .await
+            .map_err(ApiError::Internal)?;
+    }
+    if let Some(v) = body.cache_ttl_seconds {
+        db::set_thumb_cache_ttl_seconds(pool, i64::try_from(v).unwrap_or(i64::MAX))
+            .await
+            .map_err(ApiError::Internal)?;
+    }
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -97,6 +97,7 @@ mod playback;
 mod ptz;
 mod rate_limit;
 mod roles;
+mod scrub_settings;
 mod state;
 mod stats;
 mod status;
@@ -600,9 +601,11 @@ async fn main() -> anyhow::Result<()> {
         });
     }
 
-    // Phase 1 thumbnail pre-generation (opt-in via THUMB_PREGEN_ENABLED). The
-    // worker logs + returns immediately when disabled, so spawning it here is
-    // always safe.
+    // Thumbnail pre-generation (opt-in via THUMB_PREGEN_ENABLED, or the
+    // admin-console "Scrub previews" toggle, issue #10). The worker always
+    // loops and re-resolves its settings each cycle, idling (one SELECT per
+    // scan interval) while disabled, so spawning it here is always safe and a
+    // console "enable" takes effect without a restart.
     tokio::spawn(thumb_pregen::run(state.clone()));
 
     // ── 7. bind and serve ─────────────────────────────────────────────────────
@@ -800,12 +803,30 @@ async fn export_ttl_sweeper(state: AppState, ttl_seconds: u64) {
         // set); evict by age then byte budget so a long scrubbing history can't
         // grow it unbounded. Only .jpg files inside .thumbs are ever removed
         // (guarded in the sweeper).
+        //
+        // Issue #10: resolve the admin-console overrides (else env default)
+        // fresh each tick rather than reading the boot-time `ApiConfig`
+        // snapshot, so a lowered cache budget/TTL takes effect within this
+        // same minute — no restart needed. A resolve failure falls back to
+        // the env-only settings for this one tick and logs a warning; the
+        // sweep itself is still best-effort (same ethos as the pre-gen
+        // worker's keep-last-known-values policy).
+        let scrub_settings = match scrub_settings::resolve(state.pool(), state.config()).await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "thumb cache sweep: settings resolve failed; using env-only settings for this tick"
+                );
+                scrub_settings::ScrubSettings::from_env(state.config())
+            }
+        };
         sweep_thumbs_cache(
             state.config().thumb_cache_base(),
             chrono::Duration::seconds(
-                i64::try_from(state.config().thumb_cache_ttl_seconds).unwrap_or(2_592_000),
+                i64::try_from(scrub_settings.cache_ttl_seconds).unwrap_or(2_592_000),
             ),
-            state.config().thumb_cache_max_bytes,
+            scrub_settings.cache_max_bytes,
         )
         .await;
     }

--- a/services/api/src/scrub_settings.rs
+++ b/services/api/src/scrub_settings.rs
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Effective scrub-preview runtime tunables (issue #10).
+//!
+//! Five of the `THUMB_PREGEN_*` / `THUMB_CACHE_*` knobs move to admin-console
+//! overrides (migration 0046, nullable `server_settings` columns): the DB
+//! value wins when set, `NULL` (never touched) falls back to the env default
+//! in `ApiConfig`. This mirrors `services/api/src/updates.rs::resolve_enabled`
+//! exactly.
+//!
+//! `THUMB_PREGEN_WIDTH` stays env-only (ratified maintainer decision D1,
+//! issue #10): it is part of the thumbnail cache key, and a console width
+//! that drifted from the playback clients' fixed scrub-still width (480)
+//! would make every pre-generated file a cache key nobody requests — the
+//! pregen CPU and storage would be silently wasted while scrubbing quietly
+//! degraded to on-demand extraction. See `docs/DECISIONS.md`.
+//!
+//! Both background consumers ([`crate::thumb_pregen`]'s worker and the
+//! thumbnail-cache sweeper in `main.rs::export_ttl_sweeper`) call [`resolve`]
+//! once per cycle rather than reading the boot-time `ApiConfig` snapshot, so
+//! an admin-console change takes effect within one tick without a restart
+//! (D2, `docs/SCRUB-PREGEN-TUNABLES-PLAN.md` §3).
+
+use deadpool_postgres::Pool;
+
+use crumb_common::db::ScrubPregenOverrides;
+
+use crate::config::ApiConfig;
+
+/// Effective scrub-preview settings for one cycle: the admin-console DB
+/// override when set, else the matching `THUMB_*` env default. Every field is
+/// re-clamped to the same bounds the console setters enforce (defense in
+/// depth against a hand-edited row).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScrubSettings {
+    pub pregen_enabled: bool,
+    pub pregen_lookback_hours: i64,
+    pub pregen_scan_secs: u64,
+    pub cache_max_bytes: u64,
+    pub cache_ttl_seconds: u64,
+    // Width stays `ApiConfig`-only (D1) — not part of this struct; callers
+    // that need it read `cfg.thumb_pregen_width` directly.
+}
+
+impl ScrubSettings {
+    /// The env-only settings, used as the very first cycle's "last-known"
+    /// value before any resolve has ever succeeded, and as the sweeper's
+    /// fallback on a resolve failure with no prior successful resolve.
+    pub(crate) fn from_env(cfg: &ApiConfig) -> Self {
+        EnvDefaults::from_config(cfg).into_settings()
+    }
+}
+
+/// The env-config side of the precedence merge, split out from [`ApiConfig`]
+/// so [`merge`] is unit-testable without booting a full `ApiConfig` (which
+/// requires `JWT_SECRET`/`GO2RTC_*` env vars via `ApiConfig::from_env`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EnvDefaults {
+    pregen_enabled: bool,
+    pregen_lookback_hours: i64,
+    pregen_scan_secs: u64,
+    cache_max_bytes: u64,
+    cache_ttl_seconds: u64,
+}
+
+impl EnvDefaults {
+    pub(crate) fn from_config(cfg: &ApiConfig) -> Self {
+        Self {
+            pregen_enabled: cfg.thumb_pregen_enabled,
+            pregen_lookback_hours: cfg.thumb_pregen_lookback_hours,
+            pregen_scan_secs: cfg.thumb_pregen_scan_secs,
+            cache_max_bytes: cfg.thumb_cache_max_bytes,
+            cache_ttl_seconds: cfg.thumb_cache_ttl_seconds,
+        }
+    }
+
+    fn into_settings(self) -> ScrubSettings {
+        ScrubSettings {
+            pregen_enabled: self.pregen_enabled,
+            pregen_lookback_hours: self.pregen_lookback_hours,
+            pregen_scan_secs: self.pregen_scan_secs,
+            cache_max_bytes: self.cache_max_bytes,
+            cache_ttl_seconds: self.cache_ttl_seconds,
+        }
+    }
+}
+
+/// Merge DB overrides over the env defaults, re-clamping every field to the
+/// same bounds the console setters enforce. Pure — no DB, no `ApiConfig` —
+/// so precedence + clamping are unit-tested directly (see `tests` below).
+pub(crate) fn merge(overrides: ScrubPregenOverrides, env: EnvDefaults) -> ScrubSettings {
+    let pregen_lookback_hours = overrides
+        .pregen_lookback_hours
+        .unwrap_or(env.pregen_lookback_hours)
+        .clamp(0, 168);
+    let pregen_scan_secs = overrides
+        .pregen_scan_secs
+        .map_or(env.pregen_scan_secs, |v| {
+            u64::try_from(v.clamp(5, 3600)).unwrap_or(60)
+        });
+    let cache_max_bytes = overrides.cache_max_bytes.map_or(env.cache_max_bytes, |v| {
+        u64::try_from(v.max(104_857_600)).unwrap_or(env.cache_max_bytes)
+    });
+    let cache_ttl_seconds = overrides
+        .cache_ttl_seconds
+        .map_or(env.cache_ttl_seconds, |v| {
+            u64::try_from(v.clamp(3600, 31_536_000)).unwrap_or(2_592_000)
+        });
+
+    ScrubSettings {
+        pregen_enabled: overrides.pregen_enabled.unwrap_or(env.pregen_enabled),
+        pregen_lookback_hours,
+        pregen_scan_secs,
+        cache_max_bytes,
+        cache_ttl_seconds,
+    }
+}
+
+/// Resolve the effective scrub-preview settings for this cycle: one
+/// `server_settings` read + per-field `unwrap_or(env default)`.
+///
+/// # Errors
+///
+/// Propagates the underlying DB error. Callers (the pre-gen worker, the
+/// cache sweeper) treat a resolve failure as "keep the last-known settings"
+/// and log a `warn!` rather than aborting — both are best-effort background
+/// loops, and a transient DB blip must never kill either of them.
+pub async fn resolve(pool: &Pool, cfg: &ApiConfig) -> anyhow::Result<ScrubSettings> {
+    let overrides = crumb_common::db::get_scrub_pregen_settings(pool).await?;
+    Ok(merge(overrides, EnvDefaults::from_config(cfg)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env() -> EnvDefaults {
+        EnvDefaults {
+            pregen_enabled: false,
+            pregen_lookback_hours: 2,
+            pregen_scan_secs: 60,
+            cache_max_bytes: 21_474_836_480,
+            cache_ttl_seconds: 2_592_000,
+        }
+    }
+
+    #[test]
+    fn null_overrides_fall_back_to_env_for_every_field() {
+        let settings = merge(ScrubPregenOverrides::default(), env());
+        assert_eq!(settings.pregen_enabled, env().pregen_enabled);
+        assert_eq!(settings.pregen_lookback_hours, env().pregen_lookback_hours);
+        assert_eq!(settings.pregen_scan_secs, env().pregen_scan_secs);
+        assert_eq!(settings.cache_max_bytes, env().cache_max_bytes);
+        assert_eq!(settings.cache_ttl_seconds, env().cache_ttl_seconds);
+    }
+
+    #[test]
+    fn db_set_value_wins_over_env_for_every_field() {
+        let overrides = ScrubPregenOverrides {
+            pregen_enabled: Some(true),
+            pregen_lookback_hours: Some(10),
+            pregen_scan_secs: Some(30),
+            cache_max_bytes: Some(1_000_000_000),
+            cache_ttl_seconds: Some(3600),
+        };
+        let settings = merge(overrides, env());
+        assert!(settings.pregen_enabled);
+        assert_eq!(settings.pregen_lookback_hours, 10);
+        assert_eq!(settings.pregen_scan_secs, 30);
+        assert_eq!(settings.cache_max_bytes, 1_000_000_000);
+        assert_eq!(settings.cache_ttl_seconds, 3600);
+    }
+
+    #[test]
+    fn partial_overrides_only_win_for_the_fields_actually_set() {
+        // Only `pregen_enabled` was ever touched in the console — every other
+        // field must still fall back to env.
+        let overrides = ScrubPregenOverrides {
+            pregen_enabled: Some(true),
+            ..Default::default()
+        };
+        let settings = merge(overrides, env());
+        assert!(settings.pregen_enabled);
+        assert_eq!(settings.pregen_lookback_hours, env().pregen_lookback_hours);
+        assert_eq!(settings.pregen_scan_secs, env().pregen_scan_secs);
+        assert_eq!(settings.cache_max_bytes, env().cache_max_bytes);
+        assert_eq!(settings.cache_ttl_seconds, env().cache_ttl_seconds);
+    }
+
+    #[test]
+    fn hand_edited_out_of_bounds_db_row_comes_back_clamped() {
+        // A hand-edited row (or a future downgrade) could hold a value outside
+        // what the console setters would ever write — `merge` must re-clamp
+        // defensively rather than trust the stored value verbatim.
+        let overrides = ScrubPregenOverrides {
+            pregen_enabled: None,
+            pregen_lookback_hours: Some(-50),
+            pregen_scan_secs: Some(1),
+            cache_max_bytes: Some(0),
+            cache_ttl_seconds: Some(1),
+        };
+        let settings = merge(overrides, env());
+        assert_eq!(settings.pregen_lookback_hours, 0, "clamped to the 0 floor");
+        assert_eq!(settings.pregen_scan_secs, 5, "clamped to the 5s floor");
+        assert_eq!(
+            settings.cache_max_bytes, 104_857_600,
+            "clamped to the 100 MiB floor (D5)"
+        );
+        assert_eq!(settings.cache_ttl_seconds, 3600, "clamped to the 1h floor");
+
+        let overrides_high = ScrubPregenOverrides {
+            pregen_enabled: None,
+            pregen_lookback_hours: Some(999),
+            pregen_scan_secs: Some(999_999),
+            cache_max_bytes: None,
+            cache_ttl_seconds: Some(999_999_999),
+        };
+        let settings_high = merge(overrides_high, env());
+        assert_eq!(
+            settings_high.pregen_lookback_hours, 168,
+            "clamped to the 168h ceiling"
+        );
+        assert_eq!(
+            settings_high.pregen_scan_secs, 3600,
+            "clamped to the 3600s ceiling"
+        );
+        assert_eq!(
+            settings_high.cache_ttl_seconds, 31_536_000,
+            "clamped to the 1-year ceiling"
+        );
+    }
+
+    #[test]
+    fn from_env_matches_the_config_fields_directly() {
+        // Sanity check on `EnvDefaults`/`ScrubSettings` field wiring without
+        // needing a full `ApiConfig::from_env()` boot.
+        let e = env();
+        let settings = e.into_settings();
+        assert_eq!(settings.pregen_enabled, e.pregen_enabled);
+        assert_eq!(settings.pregen_lookback_hours, e.pregen_lookback_hours);
+        assert_eq!(settings.pregen_scan_secs, e.pregen_scan_secs);
+        assert_eq!(settings.cache_max_bytes, e.cache_max_bytes);
+        assert_eq!(settings.cache_ttl_seconds, e.cache_ttl_seconds);
+    }
+}

--- a/services/api/src/thumb_pregen.rs
+++ b/services/api/src/thumb_pregen.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! Background thumbnail pre-generation worker (Phase 1).
+//! Background thumbnail pre-generation worker (Phase 1; live-reload, issue #10).
 //!
-//! Off by default (`THUMB_PREGEN_ENABLED`). When on, it rolls forward over each
-//! enabled camera's recently-recorded footage, extracting a thumbnail per grid
-//! slot so timeline scrubbing is fast on the FIRST touch, not just on revisit.
+//! Off by default (`THUMB_PREGEN_ENABLED`, or the admin-console "Scrub
+//! previews" toggle). When on, it rolls forward over each enabled camera's
+//! recently-recorded footage, extracting a thumbnail per grid slot so timeline
+//! scrubbing is fast on the FIRST touch, not just on revisit.
 //!
 //! It shares the grid interval, the cache path, the singleflight lock, and the
 //! extraction semaphore with the on-demand request path
@@ -16,9 +17,30 @@
 //! produces a slot here in the first place (issue #9) — no wasted ffmpeg spawn
 //! that can only 404.
 //!
-//! Cost note: the FIRST pass backfills `THUMB_PREGEN_LOOKBACK_HOURS` of history
+//! Cost note: the FIRST pass backfills `pregen_lookback_hours` of history
 //! sequentially (gentle, one extraction in flight at a time); steady state only
 //! generates the handful of new slots recorded since the previous scan.
+//!
+//! # Live-reload (issue #10)
+//!
+//! Unlike the original Phase 1 version, this worker never exits when
+//! disabled: it loops forever, calling [`crate::scrub_settings::resolve`] at
+//! the top of every cycle so an admin-console change (enable/disable, or any
+//! of the four tunable knobs) takes effect without a restart:
+//!
+//! * **Enable** takes effect within one `pregen_scan_secs` (idling ticks just
+//!   cost a single settings SELECT).
+//! * **Disable** takes effect within seconds even mid-backfill: the pass
+//!   re-checks the effective `pregen_enabled` between cameras and every 256
+//!   extracted slots within one camera, abandoning immediately on a `false`.
+//! * **Disable → enable** clears the per-camera watermark map (D3), so a
+//!   re-enable always starts a fresh `pregen_lookback_hours` backfill rather
+//!   than grinding through the entire disabled gap.
+//! * A settings-resolve failure keeps the last-known-good values and logs a
+//!   `warn!` — a transient DB blip must never kill this background loop.
+//!
+//! `THUMB_PREGEN_WIDTH` stays the boot-time `ApiConfig` value throughout (D1,
+//! env-only) — it is never resolved per cycle.
 
 use std::collections::HashMap;
 
@@ -27,105 +49,216 @@ use uuid::Uuid;
 
 use crumb_common::db;
 
-use crate::{filmstrip, state::AppState};
+use crate::{filmstrip, scrub_settings::ScrubSettings, state::AppState};
 
-/// Run the pre-generation loop. Returns immediately (after logging) when the
-/// feature is disabled, so it is always safe to spawn.
+/// Run the live-reloading pre-generation loop. Never returns; always safe to
+/// spawn unconditionally (an idle/disabled tick costs one settings SELECT).
 pub async fn run(state: AppState) {
-    let (enabled, width, lookback_hours, scan_secs) = {
-        let cfg = state.config();
-        (
-            cfg.thumb_pregen_enabled,
-            cfg.thumb_pregen_width,
-            cfg.thumb_pregen_lookback_hours,
-            cfg.thumb_pregen_scan_secs,
-        )
-    };
-    if !enabled {
-        tracing::info!("thumb pre-generation: disabled (THUMB_PREGEN_ENABLED unset)");
-        return;
-    }
-
-    let lookback_ms = Duration::hours(lookback_hours).num_milliseconds();
-    let scan = std::time::Duration::from_secs(scan_secs);
     tracing::info!(
-        grid_secs = filmstrip::DEFAULT_THUMB_INTERVAL_SECS,
-        width,
-        lookback_hours,
-        scan_secs,
-        "thumb pre-generation: started"
+        "thumb pre-generation: worker started (settings resolved fresh each cycle; \
+         admin console: Server settings > Scrub previews)"
     );
 
     // Per-camera high-water mark: the newest instant we've generated up to.
     let mut watermark: HashMap<Uuid, i64> = HashMap::new();
+    // Last known good settings — used verbatim, unchanged, whenever a
+    // resolve fails (keep-last-known-values policy). Seeded from the env
+    // defaults so the very first cycle has something sane even if the very
+    // first resolve fails.
+    let mut current = ScrubSettings::from_env(state.config());
+    // `None` until the first successful resolve, so the initial state is
+    // always logged (via `Some(prev) != Some(now)`) without treating it as an
+    // enabled -> disabled TRANSITION (nothing was running before it).
+    let mut was_enabled: Option<bool> = None;
 
     loop {
-        let now_ms = Utc::now().timestamp_millis();
-        let Some(until) = Utc.timestamp_millis_opt(now_ms).single() else {
-            // Should be unreachable (Utc::now() is always in range); skip this
-            // tick rather than panic a background worker over a clock oddity.
-            tokio::time::sleep(scan).await;
-            continue;
-        };
-        let cameras = match db::list_enabled_cameras(state.pool()).await {
-            Ok(c) => c,
+        match crate::scrub_settings::resolve(state.pool(), state.config()).await {
+            Ok(s) => current = s,
             Err(e) => {
-                tracing::warn!(error = %e, "thumb pre-gen: listing cameras failed");
-                tokio::time::sleep(scan).await;
-                continue;
+                tracing::warn!(
+                    error = %e,
+                    "thumb pre-gen: settings resolve failed; keeping last-known values"
+                );
             }
-        };
-
-        for cam in &cameras {
-            let from_ms = watermark
-                .get(&cam.id)
-                .copied()
-                .unwrap_or(now_ms - lookback_ms);
-            let Some(since) = Utc.timestamp_millis_opt(from_ms).single() else {
-                continue;
-            };
-            if since >= until {
-                watermark.insert(cam.id, now_ms);
-                continue;
-            }
-
-            // Coverage-aware grid slots: gap slots (no recorded footage) are
-            // already excluded, so every extraction below has real footage to
-            // read.
-            let slots = match db::list_thumbnail_times(
-                state.pool(),
-                cam.id,
-                since,
-                until,
-                filmstrip::DEFAULT_THUMB_INTERVAL_SECS,
-            )
-            .await
-            {
-                Ok(s) => s,
-                Err(e) => {
-                    tracing::warn!(
-                        camera_id = %cam.id,
-                        error = %e,
-                        "thumb pre-gen: listing thumbnail times failed"
-                    );
-                    continue;
-                }
-            };
-
-            let mut steps: u64 = 0;
-            for ts in slots {
-                // No-op if already cached.
-                let _ = filmstrip::ensure_thumbnail(&state, cam.id, ts, width).await;
-                steps += 1;
-                // Yield periodically so a large initial backfill can't monopolize
-                // the runtime between the semaphore-bounded extractions.
-                if steps.is_multiple_of(64) {
-                    tokio::task::yield_now().await;
-                }
-            }
-            watermark.insert(cam.id, now_ms);
         }
 
-        tokio::time::sleep(scan).await;
+        if let Some(prev) = was_enabled {
+            if should_clear_watermark_on_transition(prev, current.pregen_enabled) {
+                tracing::info!(
+                    "thumb pre-generation: disabled; watermarks cleared \
+                     (re-enable will start a fresh lookback backfill)"
+                );
+                watermark.clear();
+            }
+        }
+        if was_enabled != Some(current.pregen_enabled) {
+            if current.pregen_enabled {
+                tracing::info!(
+                    grid_secs = filmstrip::DEFAULT_THUMB_INTERVAL_SECS,
+                    width = state.config().thumb_pregen_width,
+                    lookback_hours = current.pregen_lookback_hours,
+                    scan_secs = current.pregen_scan_secs,
+                    "thumb pre-generation: enabled"
+                );
+            } else {
+                tracing::info!(
+                    "thumb pre-generation: disabled (enable it in the admin console, \
+                     Server settings > Scrub previews, or THUMB_PREGEN_ENABLED)"
+                );
+            }
+        }
+        was_enabled = Some(current.pregen_enabled);
+
+        if current.pregen_enabled {
+            run_backfill_cycle(&state, &current, &mut watermark).await;
+        }
+
+        tokio::time::sleep(std::time::Duration::from_secs(current.pregen_scan_secs)).await;
+    }
+}
+
+/// Whether the per-camera watermark map must be cleared given the previous
+/// and newly-resolved `pregen_enabled` state (D3): only on an actual
+/// enabled -> disabled transition, never on disabled -> enabled (that's the
+/// normal "start backfilling" case) and never when the state didn't change.
+fn should_clear_watermark_on_transition(was_enabled: bool, now_enabled: bool) -> bool {
+    was_enabled && !now_enabled
+}
+
+/// Re-check the effective `pregen_enabled` state via a fresh settings
+/// resolve (a single 1-row `server_settings` SELECT). Used as the
+/// mid-backfill kill switch so a console "disable" lands within seconds
+/// instead of waiting for the whole cycle to finish.
+///
+/// Fails OPEN (`true`) on a resolve error: this is only a *faster* disable
+/// path — the outer per-cycle resolve in [`run`] already logs the failure and
+/// will re-check (and, if still disabled, stop cleanly) next cycle regardless.
+async fn recheck_enabled(state: &AppState) -> bool {
+    match crate::scrub_settings::resolve(state.pool(), state.config()).await {
+        Ok(s) => s.pregen_enabled,
+        Err(_) => true,
+    }
+}
+
+/// Run one backfill/catch-up pass over every enabled camera, using the
+/// resolved `settings` for this cycle. Re-checks `pregen_enabled` between
+/// cameras and every 256 extracted slots within a camera so a console
+/// "disable" mid-pass is honored within seconds, not after the whole cycle
+/// completes.
+async fn run_backfill_cycle(
+    state: &AppState,
+    settings: &ScrubSettings,
+    watermark: &mut HashMap<Uuid, i64>,
+) {
+    let now_ms = Utc::now().timestamp_millis();
+    let Some(until) = Utc.timestamp_millis_opt(now_ms).single() else {
+        // Should be unreachable (Utc::now() is always in range); skip this
+        // cycle rather than panic a background worker over a clock oddity.
+        return;
+    };
+    let lookback_ms = Duration::hours(settings.pregen_lookback_hours).num_milliseconds();
+    let width = state.config().thumb_pregen_width;
+
+    let cameras = match db::list_enabled_cameras(state.pool()).await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(error = %e, "thumb pre-gen: listing cameras failed");
+            return;
+        }
+    };
+
+    for cam in &cameras {
+        // Mid-backfill kill switch: re-check BETWEEN cameras so a toggle-off
+        // during a large multi-camera pass is honored within one camera, not
+        // after every camera finishes.
+        if !recheck_enabled(state).await {
+            tracing::info!("thumb pre-generation: disabled mid-cycle; abandoning this pass");
+            return;
+        }
+
+        let from_ms = watermark
+            .get(&cam.id)
+            .copied()
+            .unwrap_or(now_ms - lookback_ms);
+        let Some(since) = Utc.timestamp_millis_opt(from_ms).single() else {
+            continue;
+        };
+        if since >= until {
+            watermark.insert(cam.id, now_ms);
+            continue;
+        }
+
+        // Coverage-aware grid slots: gap slots (no recorded footage) are
+        // already excluded, so every extraction below has real footage to
+        // read.
+        let slots = match db::list_thumbnail_times(
+            state.pool(),
+            cam.id,
+            since,
+            until,
+            filmstrip::DEFAULT_THUMB_INTERVAL_SECS,
+        )
+        .await
+        {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(
+                    camera_id = %cam.id,
+                    error = %e,
+                    "thumb pre-gen: listing thumbnail times failed"
+                );
+                continue;
+            }
+        };
+
+        let mut steps: u64 = 0;
+        for ts in slots {
+            // No-op if already cached.
+            let _ = filmstrip::ensure_thumbnail(state, cam.id, ts, width).await;
+            steps += 1;
+            // Yield periodically so a large initial backfill can't monopolize
+            // the runtime between the semaphore-bounded extractions.
+            if steps.is_multiple_of(64) {
+                tokio::task::yield_now().await;
+            }
+            // Mid-backfill kill switch: also re-check WITHIN one camera's
+            // backfill (a 4x multiple of the yield cadence above), so a huge
+            // single-camera initial pass (e.g. a long lookback) still honors
+            // a toggle-off in seconds rather than only after that camera
+            // finishes.
+            if steps.is_multiple_of(256) && !recheck_enabled(state).await {
+                tracing::info!(
+                    camera_id = %cam.id,
+                    "thumb pre-generation: disabled mid-backfill; abandoning this camera's pass"
+                );
+                return;
+            }
+        }
+        watermark.insert(cam.id, now_ms);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn watermark_clears_only_on_enabled_to_disabled_transition() {
+        assert!(
+            should_clear_watermark_on_transition(true, false),
+            "an actual enabled -> disabled transition must clear (D3)"
+        );
+        assert!(
+            !should_clear_watermark_on_transition(false, true),
+            "disabled -> enabled is a normal backfill start, not a clear trigger"
+        );
+        assert!(
+            !should_clear_watermark_on_transition(true, true),
+            "no transition (stayed enabled) must never clear"
+        );
+        assert!(
+            !should_clear_watermark_on_transition(false, false),
+            "no transition (stayed disabled) must never clear"
+        );
     }
 }

--- a/services/api/tests/auth_rbac.rs
+++ b/services/api/tests/auth_rbac.rs
@@ -1191,6 +1191,8 @@ async fn no_protected_route_is_reachable_without_credentials() {
         (Method::PUT, "/config/clip-source-default".into()),
         (Method::GET, "/config/clip-preroll".into()),
         (Method::PUT, "/config/clip-preroll".into()),
+        (Method::GET, "/config/scrub-preview".into()),
+        (Method::PUT, "/config/scrub-preview".into()),
         (Method::PUT, "/config/setup-complete".into()),
         (Method::GET, "/config/camera-brands".into()),
         (Method::POST, "/config/discover".into()),
@@ -1341,4 +1343,137 @@ async fn beta_terms_acceptance_requires_admin() {
         )
         .await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+// ─── scrub-preview runtime tunables (issue #10) ────────────────────────────
+
+/// Build a `PUT` request with a Bearer token and a raw JSON string body
+/// (mirrors the inline builder `beta_terms_acceptance_*` above; kept local
+/// rather than added to `support/mod.rs` since this is the first PUT test
+/// that needs an arbitrary partial JSON body rather than a fixed shape).
+fn put_auth_json(uri: &str, token: &str, body: &str) -> axum::http::Request<axum::body::Body> {
+    axum::http::Request::builder()
+        .method("PUT")
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(body.to_owned()))
+        .unwrap()
+}
+
+/// `GET`/`PUT /config/scrub-preview` is admin-only, same gate as every other
+/// `/config/*` route: a viewer token is refused 403, no token at all is 401.
+#[tokio::test]
+async fn scrub_preview_requires_admin() {
+    let app = TestApp::new().await;
+    let viewer = seed_viewer(app.pool(), &[]).await;
+    let viewer_token = login(&app, &viewer.username, &viewer.password).await;
+
+    let resp = app
+        .send(get_auth("/config/scrub-preview", &viewer_token))
+        .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    let resp = app
+        .send(put_auth_json(
+            "/config/scrub-preview",
+            &viewer_token,
+            r#"{"pregen_enabled":true}"#,
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    let resp = app.send(get("/config/scrub-preview")).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// `GET /config/scrub-preview` reflects the env default (`source: "env"`)
+/// until an admin `PUT`s a value, at which point it reflects the DB override
+/// (`source: "db"`) — the same precedence the pre-gen worker and cache
+/// sweeper resolve live. Also covers: the read-only `pregen_width` field
+/// (`source: "env-only"`, D1); that a `PUT` with only one field leaves every
+/// other field's effective value/source untouched; and that an
+/// out-of-bounds `PUT` value is clamped server-side rather than rejected (the
+/// `clip_preroll` precedent), including the 100 MiB `cache_max_bytes` floor
+/// (D5).
+///
+/// One test function covering the whole GET/PUT round trip rather than
+/// several smaller ones: `server_settings` is a process-wide singleton row
+/// (see the db.rs `scrub_pregen_settings_roundtrip_and_clamps` note), so
+/// asserting "every OTHER field is untouched" only holds if nothing else is
+/// concurrently mutating those same columns — keeping every mutation +
+/// assertion of this row in one sequential test avoids that race entirely.
+#[tokio::test]
+async fn scrub_preview_get_put_roundtrip_and_clamps() {
+    let app = TestApp::new().await;
+    let admin = seed_admin(app.pool()).await;
+    let token = login(&app, &admin.username, &admin.password).await;
+
+    // Fresh DB: every knob falls back to its env default.
+    let resp = app.send(get_auth("/config/scrub-preview", &token)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let before = body_json(resp).await;
+    assert_eq!(before["pregen_enabled"]["source"], "env");
+    assert_eq!(before["pregen_lookback_hours"]["source"], "env");
+    assert_eq!(before["pregen_scan_secs"]["source"], "env");
+    assert_eq!(before["cache_max_bytes"]["source"], "env");
+    assert_eq!(before["cache_ttl_seconds"]["source"], "env");
+    // Read-only, never DB-backed.
+    assert_eq!(before["pregen_width"]["source"], "env-only");
+    let default_scan_secs = before["pregen_scan_secs"]["value"].clone();
+    let default_ttl = before["cache_ttl_seconds"]["value"].clone();
+
+    // PUT only `pregen_enabled` — the house rule is "write only the field
+    // that was edited".
+    let resp = app
+        .send(put_auth_json(
+            "/config/scrub-preview",
+            &token,
+            r#"{"pregen_enabled":true}"#,
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    let resp = app.send(get_auth("/config/scrub-preview", &token)).await;
+    let after_enable = body_json(resp).await;
+    assert_eq!(
+        after_enable["pregen_enabled"],
+        serde_json::json!({"value": true, "source": "db"})
+    );
+    // Every OTHER field must be untouched: still env-sourced.
+    assert_eq!(after_enable["pregen_lookback_hours"]["source"], "env");
+    assert_eq!(after_enable["pregen_scan_secs"]["source"], "env");
+    assert_eq!(after_enable["cache_max_bytes"]["source"], "env");
+    assert_eq!(after_enable["cache_ttl_seconds"]["source"], "env");
+
+    // Now PUT out-of-bounds values for two more fields — clamped, not
+    // rejected, and (again) every field not in this PUT stays untouched.
+    let resp = app
+        .send(put_auth_json(
+            "/config/scrub-preview",
+            &token,
+            r#"{"pregen_lookback_hours":9999,"cache_max_bytes":0}"#,
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    let resp = app.send(get_auth("/config/scrub-preview", &token)).await;
+    let after_clamp = body_json(resp).await;
+    assert_eq!(
+        after_clamp["pregen_lookback_hours"],
+        serde_json::json!({"value": 168, "source": "db", "min": 0, "max": 168}),
+        "must clamp to the 168h (1 week) ceiling, not store the raw 9999"
+    );
+    assert_eq!(
+        after_clamp["cache_max_bytes"]["value"],
+        serde_json::json!(104_857_600_i64),
+        "must clamp to the 100 MiB floor (D5), not store 0"
+    );
+    // pregen_enabled (set earlier) and the fields never touched by any PUT
+    // in this test must still reflect their expected state.
+    assert_eq!(after_clamp["pregen_enabled"]["source"], "db");
+    assert_eq!(after_clamp["pregen_scan_secs"]["source"], "env");
+    assert_eq!(after_clamp["pregen_scan_secs"]["value"], default_scan_secs);
+    assert_eq!(after_clamp["cache_ttl_seconds"]["source"], "env");
+    assert_eq!(after_clamp["cache_ttl_seconds"]["value"], default_ttl);
 }

--- a/services/api/tests/support/mod.rs
+++ b/services/api/tests/support/mod.rs
@@ -79,6 +79,8 @@ pub mod playback;
 pub mod ptz;
 #[path = "../../src/roles.rs"]
 pub mod roles;
+#[path = "../../src/scrub_settings.rs"]
+pub mod scrub_settings;
 #[path = "../../src/state.rs"]
 pub mod state;
 #[path = "../../src/stream_test.rs"]

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -6323,6 +6323,143 @@ pub async fn set_update_check_enabled(pool: &Pool, enabled: bool) -> Result<()> 
     Ok(())
 }
 
+// ─── scrub-preview runtime tunables (issue #10, migration 0046) ────────────────
+//
+// Admin-console overrides for the thumbnail pre-generation worker + cache
+// sweeper. Each field is `None` when the operator has never touched it in the
+// console — the caller (`services/api/src/scrub_settings.rs::resolve`) falls
+// back to the corresponding `THUMB_*` env default, same nullable-column
+// precedence as `update_check_enabled` above. `THUMB_PREGEN_WIDTH` is
+// deliberately NOT here (ratified D1): it stays env-only, see migration
+// 0046's comment and `docs/DECISIONS.md`.
+
+/// Raw `server_settings` overrides for the five scrub-preview knobs. `None` in
+/// any field means "never set in the console" — the resolver falls back to
+/// the matching `ApiConfig` env default.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ScrubPregenOverrides {
+    pub pregen_enabled: Option<bool>,
+    pub pregen_lookback_hours: Option<i64>,
+    pub pregen_scan_secs: Option<i64>,
+    pub cache_max_bytes: Option<i64>,
+    pub cache_ttl_seconds: Option<i64>,
+}
+
+/// Fetch all five scrub-preview overrides in one `server_settings` row read.
+pub async fn get_scrub_pregen_settings(pool: &Pool) -> Result<ScrubPregenOverrides> {
+    let client = get_conn(pool).await?;
+    let row = client
+        .query_opt(
+            "SELECT thumb_pregen_enabled, thumb_pregen_lookback_hours, \
+             thumb_pregen_scan_secs, thumb_cache_max_bytes, thumb_cache_ttl_seconds \
+             FROM server_settings LIMIT 1",
+            &[],
+        )
+        .await
+        .context("get_scrub_pregen_settings")?;
+    Ok(match row {
+        Some(r) => ScrubPregenOverrides {
+            pregen_enabled: r
+                .try_get::<_, Option<bool>>("thumb_pregen_enabled")
+                .ok()
+                .flatten(),
+            pregen_lookback_hours: r
+                .try_get::<_, Option<i32>>("thumb_pregen_lookback_hours")
+                .ok()
+                .flatten()
+                .map(i64::from),
+            pregen_scan_secs: r
+                .try_get::<_, Option<i32>>("thumb_pregen_scan_secs")
+                .ok()
+                .flatten()
+                .map(i64::from),
+            cache_max_bytes: r
+                .try_get::<_, Option<i64>>("thumb_cache_max_bytes")
+                .ok()
+                .flatten(),
+            cache_ttl_seconds: r
+                .try_get::<_, Option<i64>>("thumb_cache_ttl_seconds")
+                .ok()
+                .flatten(),
+        },
+        None => ScrubPregenOverrides::default(),
+    })
+}
+
+/// Set the pre-generation worker's enabled override.
+pub async fn set_thumb_pregen_enabled(pool: &Pool, enabled: bool) -> Result<()> {
+    let client = get_conn(pool).await?;
+    client
+        .execute(
+            "UPDATE server_settings SET thumb_pregen_enabled = $1",
+            &[&enabled],
+        )
+        .await
+        .context("set_thumb_pregen_enabled")?;
+    Ok(())
+}
+
+/// Set the pre-generation backfill lookback (hours). Clamped to 0..=168 (a
+/// week) before storing — larger backfills belong in the env var, where the
+/// operator has read the cost note in `config.rs`.
+pub async fn set_thumb_pregen_lookback_hours(pool: &Pool, hours: i64) -> Result<()> {
+    let client = get_conn(pool).await?;
+    let clamped = i32::try_from(hours.clamp(0, 168)).unwrap_or(2);
+    client
+        .execute(
+            "UPDATE server_settings SET thumb_pregen_lookback_hours = $1",
+            &[&clamped],
+        )
+        .await
+        .context("set_thumb_pregen_lookback_hours")?;
+    Ok(())
+}
+
+/// Set the pre-generation worker's scan interval (seconds). Clamped to
+/// 5..=3600, matching the existing env floor.
+pub async fn set_thumb_pregen_scan_secs(pool: &Pool, secs: i64) -> Result<()> {
+    let client = get_conn(pool).await?;
+    let clamped = i32::try_from(secs.clamp(5, 3600)).unwrap_or(60);
+    client
+        .execute(
+            "UPDATE server_settings SET thumb_pregen_scan_secs = $1",
+            &[&clamped],
+        )
+        .await
+        .context("set_thumb_pregen_scan_secs")?;
+    Ok(())
+}
+
+/// Set the thumbnail cache byte budget. Floored at 100 MiB (D5) — a
+/// near-zero budget would make the sweeper delete every thumbnail every
+/// minute, silently defeating the feature.
+pub async fn set_thumb_cache_max_bytes(pool: &Pool, bytes: i64) -> Result<()> {
+    let client = get_conn(pool).await?;
+    let clamped = bytes.max(104_857_600);
+    client
+        .execute(
+            "UPDATE server_settings SET thumb_cache_max_bytes = $1",
+            &[&clamped],
+        )
+        .await
+        .context("set_thumb_cache_max_bytes")?;
+    Ok(())
+}
+
+/// Set the thumbnail cache max age (seconds). Clamped to 1 hour..=1 year.
+pub async fn set_thumb_cache_ttl_seconds(pool: &Pool, secs: i64) -> Result<()> {
+    let client = get_conn(pool).await?;
+    let clamped = secs.clamp(3600, 31_536_000);
+    client
+        .execute(
+            "UPDATE server_settings SET thumb_cache_ttl_seconds = $1",
+            &[&clamped],
+        )
+        .await
+        .context("set_thumb_cache_ttl_seconds")?;
+    Ok(())
+}
+
 /// Set the deployment-wide default clip source (`"crumb"` | `"frigate"`).
 pub async fn set_default_clip_source(pool: &Pool, source: &str) -> Result<()> {
     let client = get_conn(pool).await?;
@@ -7701,6 +7838,10 @@ async fn run_migrations_locked(pool: &Pool) -> Result<()> {
         (
             "0045_update_check.sql",
             include_str!("../../../db/migrations/0045_update_check.sql"),
+        ),
+        (
+            "0046_scrub_pregen_settings.sql",
+            include_str!("../../../db/migrations/0046_scrub_pregen_settings.sql"),
         ),
     ];
 
@@ -9724,6 +9865,149 @@ mod tests {
             times, expected,
             "gap slots (10, 15) must be excluded; the segment-end boundary (10) \
              must be excluded and the next segment's start boundary (20) included"
+        );
+    }
+
+    // ── scrub-preview settings (issue #10) — get/set roundtrip + clamps ──────
+    //
+    // `server_settings` is a process-wide singleton row (see the `clip_preroll`/
+    // `update_check_enabled` setters above, and `auth_rbac.rs`'s admin-gate walk
+    // in the api integration suite, which also touches this row from a
+    // different test binary). This test therefore asserts only what IT writes
+    // comes back correctly — never the row's state before/after — so it can't
+    // flake against unrelated concurrent writers to the same shared row.
+
+    #[tokio::test]
+    async fn scrub_pregen_settings_roundtrip_and_clamps() {
+        let Some(url) = test_db_url() else {
+            eprintln!("skipping: TEST_DATABASE_URL not set");
+            return;
+        };
+        let pool = migrated_public_pool(&url).await;
+
+        // ── enabled: plain bool roundtrip ──
+        set_thumb_pregen_enabled(&pool, true)
+            .await
+            .expect("set enabled=true");
+        let s = get_scrub_pregen_settings(&pool)
+            .await
+            .expect("get after set enabled=true");
+        assert_eq!(s.pregen_enabled, Some(true));
+        set_thumb_pregen_enabled(&pool, false)
+            .await
+            .expect("set enabled=false");
+        let s = get_scrub_pregen_settings(&pool)
+            .await
+            .expect("get after set enabled=false");
+        assert_eq!(s.pregen_enabled, Some(false));
+
+        // ── lookback hours: in-range roundtrip + clamp on both ends ──
+        set_thumb_pregen_lookback_hours(&pool, 10)
+            .await
+            .expect("set lookback=10");
+        let s = get_scrub_pregen_settings(&pool)
+            .await
+            .expect("get after set lookback=10");
+        assert_eq!(s.pregen_lookback_hours, Some(10));
+        set_thumb_pregen_lookback_hours(&pool, -5)
+            .await
+            .expect("set lookback=-5 (below floor)");
+        let s = get_scrub_pregen_settings(&pool)
+            .await
+            .expect("get after set lookback=-5");
+        assert_eq!(
+            s.pregen_lookback_hours,
+            Some(0),
+            "must clamp to the 0 floor"
+        );
+        set_thumb_pregen_lookback_hours(&pool, 9999)
+            .await
+            .expect("set lookback=9999 (above ceiling)");
+        let s = get_scrub_pregen_settings(&pool)
+            .await
+            .expect("get after set lookback=9999");
+        assert_eq!(
+            s.pregen_lookback_hours,
+            Some(168),
+            "must clamp to the 168h (1 week) ceiling"
+        );
+
+        // ── scan secs: in-range roundtrip + clamp on both ends ──
+        set_thumb_pregen_scan_secs(&pool, 120)
+            .await
+            .expect("set scan=120");
+        let s = get_scrub_pregen_settings(&pool)
+            .await
+            .expect("get after set scan=120");
+        assert_eq!(s.pregen_scan_secs, Some(120));
+        set_thumb_pregen_scan_secs(&pool, 1)
+            .await
+            .expect("set scan=1 (below floor)");
+        let s = get_scrub_pregen_settings(&pool)
+            .await
+            .expect("get after set scan=1");
+        assert_eq!(s.pregen_scan_secs, Some(5), "must clamp to the 5s floor");
+        set_thumb_pregen_scan_secs(&pool, 999_999)
+            .await
+            .expect("set scan=999999 (above ceiling)");
+        let s = get_scrub_pregen_settings(&pool)
+            .await
+            .expect("get after set scan=999999");
+        assert_eq!(
+            s.pregen_scan_secs,
+            Some(3600),
+            "must clamp to the 3600s ceiling"
+        );
+
+        // ── cache max bytes: in-range roundtrip + floor clamp (no ceiling, D5) ──
+        set_thumb_cache_max_bytes(&pool, 10_000_000_000)
+            .await
+            .expect("set cache_max_bytes=10GB");
+        let s = get_scrub_pregen_settings(&pool)
+            .await
+            .expect("get after set cache_max_bytes=10GB");
+        assert_eq!(s.cache_max_bytes, Some(10_000_000_000));
+        set_thumb_cache_max_bytes(&pool, 0)
+            .await
+            .expect("set cache_max_bytes=0 (below floor)");
+        let s = get_scrub_pregen_settings(&pool)
+            .await
+            .expect("get after set cache_max_bytes=0");
+        assert_eq!(
+            s.cache_max_bytes,
+            Some(104_857_600),
+            "must clamp to the 100 MiB floor (D5)"
+        );
+
+        // ── cache ttl seconds: in-range roundtrip + clamp on both ends ──
+        set_thumb_cache_ttl_seconds(&pool, 86_400)
+            .await
+            .expect("set ttl=1 day");
+        let s = get_scrub_pregen_settings(&pool)
+            .await
+            .expect("get after set ttl=1 day");
+        assert_eq!(s.cache_ttl_seconds, Some(86_400));
+        set_thumb_cache_ttl_seconds(&pool, 60)
+            .await
+            .expect("set ttl=60s (below floor)");
+        let s = get_scrub_pregen_settings(&pool)
+            .await
+            .expect("get after set ttl=60s");
+        assert_eq!(
+            s.cache_ttl_seconds,
+            Some(3600),
+            "must clamp to the 1h floor"
+        );
+        set_thumb_cache_ttl_seconds(&pool, 999_999_999)
+            .await
+            .expect("set ttl=999999999 (above ceiling)");
+        let s = get_scrub_pregen_settings(&pool)
+            .await
+            .expect("get after set ttl=999999999");
+        assert_eq!(
+            s.cache_ttl_seconds,
+            Some(31_536_000),
+            "must clamp to the 1-year ceiling"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Moves five `THUMB_PREGEN_*`/`THUMB_CACHE_*` env-only tunables to nullable `server_settings` overrides (migration **0046**: `thumb_pregen_enabled`, `thumb_pregen_lookback_hours`, `thumb_pregen_scan_secs`, `thumb_cache_max_bytes`, `thumb_cache_ttl_seconds`), DB wins when set / `NULL` falls back to env, mirroring `update_check_enabled` (migration 0045).
- Reworks the thumbnail pre-generation worker (`thumb_pregen.rs`) into an always-loop that resolves settings fresh every cycle via a new `scrub_settings::resolve(pool, cfg)`, instead of a one-time boot snapshot: a console "enable" starts within one scan interval, a "disable" is honored within seconds even mid-backfill (re-checked between cameras and every 256 extracted slots), and an enabled→disabled transition clears the per-camera watermark map so re-enabling always does a fresh lookback backfill rather than a surprise catch-up. A resolve failure keeps the last-known-good settings and logs a warning.
- The thumbnail cache sweeper (`main.rs::export_ttl_sweeper`) resolves the same settings once per 1-minute tick so a lowered cache budget/TTL is enforced within a minute.
- `THUMB_PREGEN_WIDTH` stays **env-only** (ratified maintainer decision D1): it's part of the thumbnail cache key, and a console width that drifted from the clients' fixed 480px scrub-still width would silently waste all pre-generated CPU/storage. The console displays it read-only.
- New admin-only `GET`/`PUT /config/scrub-preview` (effective value + `source: db|env|env-only` + bounds per knob; PUT writes only the fields present in the body).
- New "Scrub previews" card in the admin console (Server settings), following house conventions (`esc()`, `api()`, save-failure revert, source annotations).
- Docs: `docs-site/docs/configuration/environment-reference.md` (marks console-editable vs env-only keys, **fixes the stale `THUMB_PREGEN_WIDTH` default: table said 160, code default is 480**), `docs-site/docs/playback/scrubbing.md` (leads with the console toggle), `docs/ROADMAP.md` (ticks the initiative-8 follow-up item), `docs/DECISIONS.md` (new entry recording the live-reload + width-env-only decisions and rejected alternatives), `docs/SCRUB-PREGEN-TUNABLES-PLAN.md` (design doc, reconciled to ratified decisions).
- Verified `.env.example` / `scripts/setup-env.sh` / `docker-compose*.yml` contain no `THUMB_*` keys today — no changes needed there. `docs/AI-INSTALL.md` has no scrubbing mention to update either.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p crumb-api -p crumb-common --all-targets -- -D warnings` clean
- [x] `cargo test -p crumb-common --lib` — all pass, including new `db::tests::scrub_pregen_settings_roundtrip_and_clamps` (DB-integration test, skips gracefully without `TEST_DATABASE_URL`; verify against CI's Postgres)
- [x] `cargo test -p crumb-api --bins` — all pass except one **pre-existing, unrelated** Windows-only failure (`config_routes::fs_list_tests::rejects_relative_path` asserts `Path::new("/data/live").is_absolute()`, which is `false` on Windows path semantics; passes on Linux/CI). New `scrub_settings::tests::*` and `thumb_pregen::tests::*` unit tests all pass.
- [x] `cargo test -p crumb-api --test auth_rbac --no-run` compiles; new `scrub_preview_requires_admin` and `scrub_preview_get_put_roundtrip_and_clamps` integration tests added (need CI's Postgres to actually run)
- [x] `node --check` on the extracted admin.html `<script>` block, clean
- [ ] CI must confirm: the full `cargo test --workspace` DB-integration suite (this workstation has no Docker/Postgres available), and a real admin-console smoke test against a rebuilt api image

Closes #10