### PR TITLE
fix(ios): smooth timeline scrubbing (parse filmstrip timestamps once)

### DIFF
--- a/apps/ios/Crumb/Features/Playback/PlaybackViewModel.swift
+++ b/apps/ios/Crumb/Features/Playback/PlaybackViewModel.swift
@@ -37,7 +37,11 @@ final class PlaybackViewModel: ObservableObject {
     @Published var detectionEvents: [DetectionEvent] = []
 
     let container: AppContainer
-    private var filmstrip: [FilmstripFrame] = []
+    /// Filmstrip frames with their `ts` PARSED ONCE to epoch-ms. `onScrub` runs a
+    /// nearest-frame lookup on every drag tick; parsing the ISO8601 strings per
+    /// tick over the whole ±1h window (~1800 frames) janked the scrub (issue #28).
+    /// Parsed on load instead — same idea as the timeline's M5 span precompute.
+    private var filmstrip: [(ms: Int64, url: String)] = []
     private var pendingSeedMs: Int64
 
     private var seekTask: Task<Void, Never>?
@@ -370,7 +374,7 @@ final class PlaybackViewModel: ObservableObject {
 
     func onScrub(_ tsMs: Int64) {
         playheadMs = tsMs
-        if let nearest = filmstrip.min(by: { abs(parseMs($0.ts) - tsMs) < abs(parseMs($1.ts) - tsMs) }) {
+        if let nearest = filmstrip.min(by: { abs($0.ms - tsMs) < abs($1.ms - tsMs) }) {
             resolveScrubFrameURL(nearest.url)
         }
         loadFilmstrip(tsMs)
@@ -427,8 +431,8 @@ final class PlaybackViewModel: ObservableObject {
                 width: MediaUrls.scrubThumbWidth
             ).frames {
                 guard !Task.isCancelled else { return }
-                filmstrip = frames
-                if scrubbing, let nearest = frames.min(by: { abs(parseMs($0.ts) - playheadMs) < abs(parseMs($1.ts) - playheadMs) }) {
+                filmstrip = frames.map { (self.parseMs($0.ts), $0.url) }
+                if scrubbing, let nearest = filmstrip.min(by: { abs($0.ms - playheadMs) < abs($1.ms - playheadMs) }) {
                     resolveScrubFrameURL(nearest.url)
                 }
             }


### PR DESCRIPTION
## Problem
Single-camera playback scrubbing on iOS felt chunky and laggy — the drag stuttered rather than tracking the finger.

## Cause
`onScrub` runs a nearest-frame lookup on **every drag tick**, and the comparator re-parsed the ISO8601 `ts` of every filmstrip frame:

```swift
filmstrip.min(by: { abs(parseMs($0.ts) - tsMs) < abs(parseMs($1.ts) - tsMs) })
```

For a ±1h window at ~4s spacing that's ~1,800 frames → ~3,600 `parseISO8601` calls **per tick, on the main thread**. That stall is the jank.

## Fix (client-only)
Parse each frame's timestamp to epoch-ms **once**, when the filmstrip loads, and run the per-tick nearest lookup with integer math — the same precompute the timeline canvas's "M5" fix already does for spans/detections. No server change.

## Verification
Verified on a physical iOS device — scrubbing is now smooth.

Note: this fixes the main-thread jank. The preview still advances at filmstrip granularity (~4s), so the image itself steps at that spacing; making it finer is a separate, server-side lever (filmstrip interval / scrub pre-gen tunables) and out of scope here.

Fixes #28
