### PR TITLE
docs: pivot #25 to a direct Reolink HTTP-API client (supersede neolink-MQTT)

### DIFF
--- a/docs/NEOLINK-ACTUATOR-PLAN.md
+++ b/docs/NEOLINK-ACTUATOR-PLAN.md
@@ -1,0 +1,811 @@
+> **SUPERSEDED (2026-07-10).** Issue #25 pivoted to a direct Reolink HTTP-API client — see [`REOLINK-ACTUATOR-PLAN.md`](REOLINK-ACTUATOR-PLAN.md) (the plan) and [`REOLINK-CONTROL-ARCH-DECISION.md`](REOLINK-CONTROL-ARCH-DECISION.md) (why). Retained as the rejected-alternative record.
+
+# Neolink actuator control: implementable design + phased plan (issue #25)
+
+Status: DESIGN, ratified by the #26 hardware spike (neolink v0.6.2, Reolink
+CX410 fw v3.1.0.3429) AND by the maintainer on all four open decisions (§13, now
+RESOLVED). This document refines the design sketch in issue #25 against the
+codebase as of 2026-07-09 (post #31/#34/#39: `update_check_enabled` and the
+scrub-preview tunables are the current precedent for settings, and migration
+0046 is taken, so this feature owns **0047**).
+
+**Ratified decisions (detail + consequences threaded through the doc; see §13):**
+
+- **D1 = dedicated broker (CHOSEN).** A separate `mosquitto-neolink` container
+  under the `neolink` profile: no published host ports, `allow_anonymous false`,
+  password from a setup-env-generated `NEOLINK_MQTT_PASSWORD`. This is THE broker
+  for the neolink control plane, never the shared Frigate mosquitto. (§2, §8.)
+- **D2 = yes.** On each successful connect the api publishes an empty retained
+  message to `{prefix}/config` to scrub neolink's retained creds-config,
+  best-effort with caveats. (§2, §4.1.)
+- **D3 = yes, gated.** Siren ships behind the operator-declared `siren` cap with
+  an explicit "unvalidated on real hardware (spike CX410 had none)" note; not
+  blocked. (§4.3, §7.1, docs.)
+- **D4 = live admin-console `server_settings` knob (CHOSEN), not a client-side
+  constant.** The floodlight momentary/auto-revert default is a nullable
+  `server_settings` column resolved per-use (DB wins, NULL -> env, #39 /
+  `update_check_enabled` precedence), with a sane server-side max clamp. (§3.1,
+  §4.3, §4.4, §7.1, §8.2.)
+
+Scope reminder (unchanged from #25): neolink is a **control sidecar only**.
+Cameras keep their native RTSP `source_url` and `served_by='crumb'`. Actuators
+in scope: floodlight, siren, status-LED, IR, PIR, reboot. Out of scope, parked:
+neolink-as-RTSP-source (battery/Baichuan-only cams), two-way audio.
+
+**Non-Reolink operators pay nothing for this feature: it is OFF at three
+independent layers and is a post-setup optional integration, never part of the
+base install or the first-run wizard. See §14 (Setup gating & zero-footprint).**
+
+---
+
+## 1. Verified spike facts (these are load-bearing; do not re-derive)
+
+| Fact | Design consequence |
+|---|---|
+| Control topics `neolink/{name}/control/{floodlight\|led\|ir\|pir\|reboot}`, published **non-retained** | Publish QoS 1, retain=false. A broker restart can never re-fire an actuation. |
+| Status topics `neolink/{name}/status/{floodlight\|motion}` **retained**; `neolink/{name}/status` and `neolink/status` carry `connected` | Subscriber gets current floodlight state immediately on (re)connect. Connected-status drives a health row. |
+| `status/preview` is a base64 JPEG stream (heavy, non-retained) | Never subscribe to `{prefix}/+/status/preview`. Enumerate the wanted status subtopics explicitly; no `status/#` wildcard. |
+| Floodlight `off` restores the camera's prior/auto (night) mode, it does not force-dark | TTL revert payload is plain `off`. No "restore auto" special case. |
+| Actuation latency < 1 s, and `status/floodlight` echoes real state | Optimistic UI on 200-from-publish, with the retained status echo as the confirmed-state backstop via `/status` polling. |
+| CX410 exposes **no siren** (`control/siren` is a no-op) | Capabilities are operator-declared per camera (`neolink_caps`); clients draw buttons only from declared caps. Siren payload semantics remain hardware-unverified (see open decision D3). |
+| **neolink publishes its full config, including the camera username + password, to a RETAINED `neolink/config` topic** | A broker password alone is insufficient: any authed client on a shared broker can read Reolink creds. This forces the broker-isolation decision in §2. |
+| Image entrypoint runs args verbatim: `neolink mqtt --config <toml>`; config schema is v0.6.2 `[mqtt]` + `[[cameras]]` | Compose service pins tag `v0.6.2` (never `latest`/`master`) with an explicit `command`. |
+
+---
+
+## 2. HEADLINE DECISION: broker isolation for the neolink control plane
+
+The retained `neolink/config` topic carries the Reolink camera credentials.
+Threat: on the shared bundled mosquitto (currently `allow_anonymous true`) or
+on an operator's existing broker, any client that can subscribe (the Frigate
+integration, Home Assistant, anything on the LAN reaching the loopback-published
+port) reads camera creds at rest, forever, because the message is retained.
+
+Three candidate mitigations were evaluated:
+
+### Option A (RATIFIED / CHOSEN): dedicated, profile-gated `mosquitto-neolink` broker
+
+A second tiny mosquitto instance under the same `neolink` compose profile.
+Options B and C below are recorded for the decision trail; A is what ships.
+
+- **No published host ports at all.** neolink and the api both reach it over
+  the compose network (`mqtt://mosquitto-neolink:1883`). This is stricter than
+  the Frigate mosquitto (which publishes `127.0.0.1:1883` because Frigate
+  usually runs on another host); neolink runs inside the stack, so nothing
+  needs host reachability.
+- **Password-required** (`allow_anonymous false`, `password_file`). The
+  password is `NEOLINK_MQTT_PASSWORD`, generated by `scripts/setup-env.sh`
+  (never hardcoded, printed, or logged). The password file is created at
+  container start from the env var via a small `entrypoint: sh -c` wrapper
+  running `mosquitto_passwd -b -c` before `exec`ing mosquitto (same in-compose
+  wrapper style as the `backup-offsite` service).
+- The retained-creds topic now lives on a broker whose only two clients are
+  neolink and the Crumb api. The Frigate bus, and anything else on the LAN,
+  never sees it.
+
+Why A over the others: zero behavior change for existing `frigate`-profile
+users (their broker stays as-is), no mosquitto ACL-file surface to author and
+maintain, hard isolation instead of policy isolation, and the marginal cost is
+one ~10 MB idle container that only exists when the profile is active.
+
+### Option B (rejected as the default; documented for BYO-broker operators)
+
+ACLs on a shared broker: `password_file` + `acl_file` giving the neolink user
+`readwrite neolink/#`, the api user `read neolink/#` + its Frigate topics, and
+denying `neolink/#` to everyone else. Rejected as the bundled default because
+it forces auth onto the existing Frigate mosquitto (a breaking change for
+current `frigate`-profile installs) and because ACL files are easy to get
+subtly wrong. It IS the right guidance for operators who insist on one
+existing external broker, so `docs-site/docs/integrations/neolink.md` must
+document the exact ACL requirements and the `neolink/config` retained-creds
+warning prominently.
+
+### Option C (not currently available): suppress the config publish
+
+v0.6.2 has no documented switch to disable the `neolink/config` publish. Do
+not claim otherwise in docs. Filed as a revisit trigger (and a candidate
+upstream contribution): if neolink gains a suppress/redact option, the
+dedicated-broker requirement can be relaxed to a recommendation.
+
+### Retained-config scrub (D2, RATIFIED yes)
+
+On every successful MQTT connect, the api publishes a zero-length retained
+message to `{prefix}/config`, deleting the retained copy from the broker.
+Best-effort, and documented as such: it does not protect against a subscriber
+connected at the moment neolink (re)publishes, and neolink re-publishes on its
+own restart, so this is defense-in-depth layered on top of the dedicated broker,
+not a substitute for it. Cheap (one publish per connect); implemented in §4.1.
+
+---
+
+## 3. Data model
+
+### 3.1 Migration `db/migrations/0047_neolink_binding.sql`
+
+0046 (`scrub_pregen_settings`) is the current tail of the `MIGRATIONS` array in
+`services/common/src/db.rs`; **0047 is confirmed free**. Golden rule 4: the
+file must be added to the `MIGRATIONS` array in the same change or it silently
+never runs. Idempotent style (ADD COLUMN IF NOT EXISTS, CREATE TABLE IF NOT
+EXISTS, CREATE OR REPLACE VIEW), no BEGIN/COMMIT, matching 0042's comments.
+
+```sql
+ALTER TABLE cameras
+    ADD COLUMN IF NOT EXISTS neolink_name text,          -- NULL = not neolink-bound
+    ADD COLUMN IF NOT EXISTS neolink_caps jsonb;         -- e.g. ["floodlight","led","pir"]
+
+-- TTL-revert journal: restart-safe momentary actuations.
+CREATE TABLE IF NOT EXISTS camera_actuations (
+    id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    camera_id      uuid NOT NULL REFERENCES cameras(id) ON DELETE CASCADE,
+    actuator       text NOT NULL,                        -- floodlight|led|ir|pir|siren
+    revert_payload text NOT NULL,                        -- 'off' (spike-confirmed for floodlight)
+    created_at     timestamptz NOT NULL DEFAULT now(),
+    expires_at     timestamptz NOT NULL,
+    reverted_at    timestamptz                           -- NULL = revert still owed
+);
+CREATE INDEX IF NOT EXISTS camera_actuations_pending_idx
+    ON camera_actuations (expires_at) WHERE reverted_at IS NULL;
+
+-- Confirmed-state cache written by the MQTT status subscriber, read by /status.
+CREATE TABLE IF NOT EXISTS neolink_camera_status (
+    camera_id        uuid PRIMARY KEY REFERENCES cameras(id) ON DELETE CASCADE,
+    connected        boolean NOT NULL DEFAULT false,
+    floodlight_state text,                               -- retained-echo value, e.g. 'on'/'off'
+    last_motion_ts   timestamptz,
+    updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+-- D4: floodlight momentary/auto-revert default, a LIVE admin-console knob on the
+-- server_settings singleton. Nullable = "operator never touched it" -> the
+-- resolver falls back to the NEOLINK_FLOODLIGHT_REVERT_SECS env default. DB value
+-- wins when set. Mirrors the scrub-preview tunables (#39) and update_check_enabled
+-- (#31) exactly: nullable column, DB-wins, NULL->env, resolved per-use (no
+-- restart). `server_settings` is the existing id=1 singleton; ADD COLUMN only.
+ALTER TABLE server_settings
+    ADD COLUMN IF NOT EXISTS neolink_floodlight_revert_secs integer;   -- NULL = use env default
+
+CREATE OR REPLACE VIEW v_camera_effective_policy AS
+SELECT
+    -- ... byte-for-byte the 0042 column list, THEN append at the very end:
+    c.neolink_name AS c_neolink_name,
+    c.neolink_caps AS c_neolink_caps
+FROM ...;
+```
+
+**View trap (the one #25 flags, now made precise):** `get_camera` reads
+`v_camera_effective_policy`, not the `cameras` table, so the new columns never
+surface unless the view is re-declared. `CREATE OR REPLACE VIEW` only permits
+APPENDING trailing columns, so `c_neolink_name` / `c_neolink_caps` go at the
+tail, **after** `p_max_retention_days`, even though they are camera columns and
+the c_/p_ grouping looks wrong. 0042 is the template; copy its full column list
+verbatim and append.
+
+Rust side: `Camera` in `services/common/src/types.rs` gains
+`neolink_name: Option<String>` and `neolink_caps: Option<Vec<String>>` (parse
+the jsonb array; unknown strings tolerated, clients just will not render them);
+the row-mapping in `db.rs` reads the two new view columns; the camera
+create/update DTOs and `PUT /config/cameras/{id}` in `config_routes.rs` accept
+them (partial-update semantics identical to the `onvif_*` fields). Wizard and
+console code touch only the fields they edit (config-precedence ground rule).
+
+### 3.2 `neolink_config` singleton (runtime ensure-table, NOT a migration)
+
+Mirror `ensure_frigate_config_table` exactly (`db.rs` ~line 1257): a
+`CREATE TABLE IF NOT EXISTS` + `INSERT ... ON CONFLICT DO NOTHING` seed from
+env, called from `main.rs` at boot next to the frigate ensure.
+
+```
+neolink_config (
+    id            smallint PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+    enabled       boolean NOT NULL DEFAULT false,
+    mqtt_url      text NOT NULL DEFAULT '',      -- e.g. mqtt://mosquitto-neolink:1883
+    mqtt_prefix   text NOT NULL DEFAULT 'neolink',
+    mqtt_user     text,
+    mqtt_password text,                          -- write-only through the API, like frigate
+    version       bigint NOT NULL DEFAULT 1,
+    updated_at    timestamptz NOT NULL DEFAULT now()
+)
+```
+
+Env seed keys (first boot only; DB wins thereafter, per the `update_check_enabled`
+(#31) and scrub-preview (#39) precedent): `NEOLINK_MQTT_URL`,
+`NEOLINK_MQTT_PREFIX`, `NEOLINK_MQTT_USER`, `NEOLINK_MQTT_PASSWORD` (+
+`NEOLINK_MQTT_PASSWORD_B64` fallback, cloning the Frigate `$`-escaping
+workaround). DB accessors mirror the frigate trio: `get_neolink_settings`,
+`update_neolink_settings` (bumps `version`; `mqtt_password = None` leaves the
+stored password unchanged, `Some("")` clears), `neolink_config_version`.
+
+### 3.3 D4: floodlight-revert default as a live `server_settings` knob
+
+The floodlight momentary/auto-revert default is server-owned, not a client
+constant. The `server_settings.neolink_floodlight_revert_secs` column (added in
+0047, §3.1) is resolved at the point of use, exactly like
+`services/api/src/scrub_settings.rs::resolve` and `updates.rs::resolve_enabled`:
+
+- A tiny resolver (new `neolink_settings.rs`, or a helper on the neolink module)
+  reads the nullable column and falls back to `ApiConfig`'s env default
+  (`NEOLINK_FLOODLIGHT_REVERT_SECS`, default 30) when NULL, re-clamping to the
+  same bounds the console setter enforces (**1..=3600 s** server-side max clamp
+  retained; that is the only surviving piece of the old "3600 s clamp" idea).
+- Resolved **per actuation** (the actuator handler in §4.3 calls it when a
+  floodlight `on` arrives without an explicit `duration_s`), so an admin edit
+  takes effect on the very next tap with no restart. The value is NOT cached in
+  the boot-time `ApiConfig` snapshot.
+- Setter: `update_neolink_floodlight_revert_secs(pool, Option<i32>)` (NULL to
+  reset to env), driven by the admin-console field in §7.1. No `version` bump is
+  needed (unlike the MQTT connection settings) because nothing reconnects, the
+  next resolve simply reads the new row.
+
+Client-supplied `duration_s` still overrides for a one-off tap; the knob is the
+default the clients omit-and-inherit, and the revert engine's server-side truth.
+
+---
+
+## 4. Backend: `services/api/src/neolink/`
+
+New module, three files plus `mod.rs`:
+
+### 4.1 `client.rs`: one supervised rumqttc client
+
+Clone the Frigate provider's shape (`detection/frigate.rs`):
+
+- One `AsyncClient` per process. Capped exponential back-off **1 s -> 30 s,
+  reset on ConnAck** in the disconnect/error arm (rumqttc 0.24 inserts no delay
+  itself; without this an unreachable broker hot-spins a core on the box shared
+  with the recorder). Raced against a stop signal for prompt shutdown.
+- Subscriptions (explicit, never `status/#`, to dodge the JPEG preview firehose):
+  `{prefix}/status`, `{prefix}/+/status`, `{prefix}/+/status/floodlight`,
+  `{prefix}/+/status/motion`.
+- A `neolink_name -> camera_id` map loaded from the cameras table, shared via
+  `Arc<RwLock<HashMap>>` and reloaded every 60 s (clone `CAMERA_MAP_RELOAD` +
+  `camera_map_snapshot`; same self-heal rationale: bind a camera after boot and
+  it starts working within a cycle, no restart).
+- Status handling: upsert `neolink_camera_status` (connected from
+  `{name}/status`, floodlight_state from the retained echo, last_motion_ts from
+  `status/motion`). Broker-level disconnect flips a shared "bus down" flag and,
+  after a grace period, raises a `neolink_disconnected` system alert through
+  the existing `system_alert_rules` machinery in `alerts.rs`.
+- Publish path: the route handlers publish through this client (QoS 1,
+  retain=false, payload per §4.3). Expose a small handle
+  (`NeolinkHandle { publish(...), connected() }`) on `AppState` so routes and
+  the revert engine share the one client.
+- On connect (D2, ratified): publish an empty **retained** payload to
+  `{prefix}/config` to scrub neolink's retained creds-config. Best-effort; log at
+  debug, never fail the connect on a publish error.
+
+### 4.2 `main.rs` supervisor (clone the Frigate block, ~line 350)
+
+Poll `neolink_config_version` on the same cadence; on change, stop the current
+client task and (re)start from `get_neolink_settings`. `enabled=false` or empty
+`mqtt_url` means no client runs (log "neolink disabled in settings"). An admin
+edit on the Integrations page reconnects with no api restart.
+
+### 4.3 Actuator endpoint
+
+`POST /cameras/:id/actuator`, mounted via `neolink::routes()` merged in
+`main.rs` next to `ptz::routes()` (axum `:id` path-param style).
+
+Request: `{ "actuator": "floodlight|siren|led|ir|pir", "action": "on|off|auto|trigger", "duration_s": u32? }`
+
+Handler order mirrors `ptz.rs::ptz_command` exactly:
+
+1. `user.require_actuators()?` then `user.assert_camera_access(camera_id)?`
+2. `db::get_camera` -> 404 if absent
+3. 404 `"camera is not neolink-bound"` if `neolink_name` is NULL (parallel to
+   PTZ's "camera is not PTZ"); 404 if the neolink client is not running
+   (integration disabled)
+4. Validate `actuator` against `neolink_caps` -> 400 with the missing cap named
+5. Validate `action` per actuator: floodlight/led/pir accept on/off; ir accepts
+   on/off/auto; **siren accepts `trigger` only** (one-shot; D3, ships gated
+   behind the operator-declared `siren` cap and carries the "unvalidated on real
+   hardware" caveat in docs and in the 400 message if the payload is rejected
+   upstream). `duration_s` only valid with `action=on`; clamp server-side to
+   1..=3600.
+6. Publish `{action}` to `{prefix}/{neolink_name}/control/{actuator}`,
+   retain=false, QoS 1
+7. If `action=on` for the floodlight and `duration_s` is **absent**, resolve the
+   D4 default via §3.3 (`server_settings.neolink_floodlight_revert_secs` ->
+   env). A present `duration_s` overrides. Then insert a `camera_actuations` row
+   (revert_payload `off`) and arm an in-process revert timer. If an un-reverted
+   row already exists for this (camera, actuator), supersede it (mark reverted,
+   note "superseded") so re-tapping extends rather than double-reverts.
+8. `action=off` with a pending row = early cancel: publish `off`, mark the row
+   reverted now. 200 `{}` on publish accept (optimistic; confirmed state
+   arrives via `/status`).
+
+The momentary default is server-owned (D4, §3.3): clients that want the default
+simply omit `duration_s`, and the server resolves the live admin knob. A client
+MAY still send an explicit `duration_s` for a one-off longer/shorter tap.
+
+`POST /cameras/:id/reboot`: `AdminUser` extractor (the existing 403-on-non-admin
+wrapper in `auth_mw.rs`), because a reboot interrupts recording. Same
+neolink-bound checks; publishes to `control/reboot`; no journal row.
+
+### 4.4 `revert.rs`: server-side TTL revert engine
+
+The "closed laptop must not leave the floodlight on all night" invariant. The
+TTL itself is server truth: it comes from the request's `duration_s` or, when
+omitted for a floodlight, the D4 resolved default (§3.3), never from a
+client-held timer. That is precisely why a `server_settings` knob (not a
+client constant) is the right home for the default: the value that actually
+governs the revert lives on the same side as the engine that enforces it.
+
+- **Arm-on-publish:** tokio timer per pending actuation; on expiry, publish
+  `revert_payload` and set `reverted_at`.
+- **Boot sweep:** at api start (and supervisor client restart), scan
+  `camera_actuations WHERE reverted_at IS NULL`: expired rows get the revert
+  published immediately; future rows get timers re-armed. An api restart can
+  never strand an actuator.
+- **Periodic safety sweep** every 30 s over the same partial index, catching
+  lost timers and reverts that failed to publish (defense in depth; the sweep
+  is idempotent because publishing `off` twice is harmless, spike-confirmed
+  that `off` = restore-auto).
+- **Broker down at expiry:** the row stays un-reverted; the sweep retries after
+  reconnect; if a revert stays owed past a grace window (60 s), raise a
+  `neolink_revert_failed` system alert naming the camera and actuator. This is
+  the physical-world analogue of recorder correctness: prefer noisy failure
+  over a silently stuck floodlight.
+
+Unit tests target the pure decision logic (which rows are due, supersede
+semantics, clamp); integration tests exercise journal arm/sweep against
+Postgres (harness rules in §9).
+
+---
+
+## 5. RBAC: new `actuators` capability (NOT reused from PTZ)
+
+Sounding a siren or lighting a floodlight is a physical-world action, distinct
+from "can view" and from PTZ. Changes, all mirroring the `ptz` capability:
+
+- `Capabilities` (`services/common/src/types.rs` ~line 877): add
+  `#[serde(default)] pub actuators: bool`. Serde-default false means every
+  stored role jsonb reads as denied until an admin opts in (forward-compatible,
+  conservative).
+- `Capabilities::all()`: `actuators: true` (admin implies it).
+- `auth_mw.rs`: `can_actuators()` (admin || capability) + `require_actuators()`
+  returning the standard 403; `fallback_caps` stays deny-by-default (the
+  serde default covers it, but keep the explicit `actuators: false` in the two
+  literal `Capabilities { .. }` constructions at ~lines 196/513).
+- Role editor in `admin.html`: one checkbox next to PTZ.
+- Per-camera scoping rides the existing `assert_camera_access` grant check;
+  no new mechanism.
+
+---
+
+## 6. Status surface
+
+No WebSocket/SSE exists; clients poll `GET /status`. Extend
+`CameraStatusEntry` (`services/api/src/dto.rs` ~line 1369) with optional,
+`#[serde(skip_serializing_if = "Option::is_none")]` fields so older clients
+ignore them and non-neolink cameras emit nothing:
+
+```rust
+pub neolink_connected: Option<bool>,       // Some(..) only when neolink-bound
+pub floodlight_state:  Option<String>,     // confirmed state from the retained echo
+pub actuation_expires: Option<DateTime<Utc>>, // pending momentary revert, drives countdown UI
+```
+
+`status.rs` batch-loads `neolink_camera_status` plus the pending-actuation rows
+once (two queries, joined in memory by camera_id), not per-camera inside the
+existing `JoinSet` fan-out. `actuation_expires` lets clients render the
+countdown ring from server truth instead of a local timer that drifts or dies
+with the tab.
+
+---
+
+## 7. Clients (COMPONENT-MAP section 3: parity stated explicitly)
+
+**Web admin + desktop first. Android + iOS are DEFERRED follow-ups, not
+dropped**; tracked as Phase 6 tasks below and in the cross-client parity table
+so the gap stays visible.
+
+### 7.1 Web admin (`services/api/src/admin.html`)
+
+One file, inline script, `on*=` wired plain functions, `esc()` for all
+interpolation, `api()` for authed fetches, semantic colors
+`var(--ok)`/`var(--warn)`/`var(--danger)`; sanity-check with `node --check` on
+the extracted script block; rebuild the api to see changes (it is
+`include_str!`-embedded; `grep -a`).
+
+- **Integrations -> Neolink page**, cloned from the Frigate settings block
+  (backed by `GET/PUT /config/neolink` in `config_routes.rs`, next to
+  `/config/frigate` at ~line 3098; password write-only, never echoed; a
+  `POST /config/neolink/test` TCP-reachability probe cloned from
+  `/config/frigate/test`). Shows bus connected/disconnected state. **Also hosts
+  the D4 "Floodlight auto-revert default (seconds)" field** (empty = inherit the
+  env default; live per-use resolve per §3.3, like the scrub-preview tunables'
+  console fields), backed by the setter in §3.3.
+- **Camera editor:** `neolink_name` text field + capability checkboxes
+  (floodlight, siren, led, ir, pir) persisting to `neolink_caps`. Help text:
+  "must match the `name` in neolink.toml". The siren checkbox carries the D3
+  "unvalidated on real hardware" hint.
+- **Live tile overlay buttons** drawn from `neolink_caps` x `caps.actuators`:
+  floodlight tap = on for the server-resolved default duration (client omits
+  `duration_s`) + countdown (from `actuation_expires`), tap again = revert now;
+  siren (where declared) press-and-hold ~600 ms to arm (accidental-tap guard) +
+  cooldown; LED/PIR plain toggles. No caps, or older server, or 404: no buttons,
+  graceful degrade.
+
+### 7.2 Desktop (`apps/desktop/src/app.js`)
+
+Extend the existing PTZ control-tile pattern (`buildPtzPanelHtml` ~4302 /
+`wirePtzPanel` ~4332, gating as at ~1848 `caps.ptz`): an actuator cluster in
+the pane toolbar, gated on `caps.actuators` AND the camera reporting
+`neolink_caps`, same interactions as web. True on-video mpv ASS-overlay
+buttons (like the PTZ wheel) are polish, deferred; the toolbar cluster ships
+first. Windows note stands: `libmpv-2.dll` beside the exe.
+
+### 7.3 Android (`apps/android`) + iOS/macOS (`apps/ios`): deferred
+
+Actuator bar beside the existing PTZ composables/views + an `actuator()` API
+client method + the `/status` fields. Explicitly listed in Phase 6 and in the
+COMPONENT-MAP parity row so no session "forgets" them.
+
+---
+
+## 8. Deployment (golden rule 5: install guide must not drift)
+
+### 8.1 Compose (`docker-compose.yml`, validated with `docker compose config` on dev1, real docker)
+
+```yaml
+  neolink:
+    profiles: ["neolink"]
+    image: quantumentangledandy/neolink:v0.6.2   # pinned; RE project, never latest/master
+    restart: unless-stopped
+    command: ["mqtt", "--config", "/etc/neolink.toml"]
+    volumes:
+      - ./neolink/neolink.toml:/etc/neolink.toml:ro
+    environment: [ TZ=${TZ:-America/Los_Angeles} ]
+    # No ports. Control-plane only; reaches cameras + broker over the network.
+
+  mosquitto-neolink:            # Option A dedicated broker (see section 2)
+    profiles: ["neolink"]
+    image: eclipse-mosquitto:2
+    restart: unless-stopped
+    # No published host ports: in-stack clients only (neolink + crumb api).
+    # entrypoint wrapper: mosquitto_passwd -b -c from NEOLINK_MQTT_PASSWORD,
+    # write a listener+password_file+allow_anonymous-false conf, exec mosquitto.
+```
+
+The existing `mosquitto` service stays exactly as-is (`profiles: ["frigate"]`,
+anonymous, loopback-published): no breaking change for current installs. It
+does NOT gain the `neolink` profile; the two buses are separate by design.
+
+### 8.2 Secrets + files
+
+- `scripts/setup-env.sh`: generate `NEOLINK_MQTT_PASSWORD` with the existing
+  `gen_secret`/`gen_password` helpers; write a commented `NEOLINK_MQTT_*`
+  block (URL default `mqtt://mosquitto-neolink:1883`, prefix `neolink`, user
+  `neolink`) plus the commented D4 fallback `NEOLINK_FLOODLIGHT_REVERT_SECS=30`
+  (the env floor the admin knob falls back to when the `server_settings` value
+  is NULL). Never printed, never logged; `.env` stays gitignored.
+- `neolink/neolink.example.toml`: committed, commented v0.6.2 `[mqtt]` +
+  `[[cameras]]` skeleton with placeholder creds. The `[mqtt]` block must point at
+  the dedicated broker (`server = "mosquitto-neolink"`, `port = 1883`) and carry
+  the **same** `NEOLINK_MQTT_PASSWORD` (and `neolink` user) the operator put in
+  `.env` and that `mosquitto-neolink` loads into its password file, so a comment
+  spells that coupling out. The real `neolink/neolink.toml` (contains that
+  broker password AND the Reolink camera passwords) is **added to `.gitignore`**
+  in the same change. Crumb-generated TOML stays rejected (the api has no
+  writable config mount); revisit trigger recorded in DECISIONS.
+- `.env.example`: the same commented `NEOLINK_MQTT_*` block.
+
+### 8.3 Install-surface sweep (same change, per golden rule 5)
+
+`docs/AI-INSTALL.md` (optional-integration step with a Verify), `docs/COMPOSE.md`
+(profile table), README manual path, `.env.example`, `scripts/setup-env.sh`,
+`docs-site/docs/integrations/neolink.md` (NEW, operator-facing, cloned in tone
+from `integrations/frigate.md`, including the BYO-broker ACL guidance + the
+retained-creds warning) and `docs-site/docs/configuration/environment-reference.md`
+(the `NEOLINK_*` keys). User-facing docs rule applies: the docs-site page is
+the documentation of record, not this plan.
+
+---
+
+## 9. Testing + CI notes for implementers
+
+Gate before any push (unchanged): `cargo fmt --all -- --check`,
+`cargo clippy --all-targets -- -D warnings`, `cargo test --workspace` against a
+throwaway Postgres (`crumb-test-pg` recipe in AGENTS.md).
+
+**DB-test harness trap (cost issue #9 three CI rounds; do not rediscover):**
+integration tests must `run_migrations` against the real `public` schema and
+isolate by unique keys (unique camera names/uuids per test), NOT by a
+`search_path` schema; and the test pool needs `max_size >= 8` or concurrent
+tests deadlock on connection starvation.
+
+Specific test obligations:
+
+- Migration 0047 registered-and-applies test rides the existing migration
+  test; add an assertion that `v_camera_effective_policy` exposes
+  `c_neolink_name`/`c_neolink_caps`.
+- Revert engine: unit tests for due-row selection, supersede, clamp; an
+  integration test that inserts an expired un-reverted row and asserts the
+  boot sweep marks it reverted (publish mocked through the handle trait).
+- Capability: `require_actuators` denied for a default role, allowed for
+  admin and for an opted-in role; endpoint 403/404/400 matrix.
+- Serde: `CameraStatusEntry` omits the neolink fields when None (byte-level
+  JSON assertion), old-client compatibility proof.
+
+---
+
+## 10. COMPONENT-MAP propagation walk (golden rule 8)
+
+Rows that fire for this change, each updated or satisfied in the change that
+triggers it:
+
+- **A (new endpoint/DTO):** `/cameras/:id/actuator`, `/cameras/:id/reboot`,
+  `/config/neolink`, CameraStatusEntry fields.
+- **B (new setting/env):** `NEOLINK_MQTT_*` seed keys + `neolink_config`
+  singleton; the D4 `server_settings.neolink_floodlight_revert_secs` admin knob
+  + its `NEOLINK_FLOODLIGHT_REVERT_SECS` env fallback; env-reference docs page.
+- **C (new migration):** 0047 + MIGRATIONS registration.
+- **E (new camera capability):** actuators join PTZ/imaging in the camera
+  editor + per-camera caps.
+- **G (RBAC change):** new capability, role editor, deny-by-default.
+- **H (admin console):** Integrations page, camera editor, live-tile buttons.
+- **I (install/compose/secret):** section 8 sweep list.
+- **L (user-visible capability):** announce path (README feature list,
+  docs-site, release notes).
+- **M (decision):** section 11 entry.
+- **Section 3 (cross-client parity):** add an "Actuators (neolink)" row: web
+  admin SHIPPED, desktop SHIPPED, Android DEFERRED, iOS/macOS DEFERRED.
+
+`docs/COMPONENT-MAP.md` itself gains the new surface (the neolink sidecar +
+its example TOML) in §1.3.
+
+## 11. Required DECISIONS.md entry (write in the Phase 1 change)
+
+Title: "Reolink control via neolink sidecar over MQTT; dedicated broker for
+the control plane".
+
+- **Chosen:** unmodified neolink v0.6.2 container, profile-gated, no published
+  ports, control/status plane only; one supervised rumqttc client + version-bump
+  hot reload; `POST /cameras/:id/actuator` mirroring ptz.rs; server-side TTL
+  revert journal + boot sweep; new `actuators` capability; operator-declared
+  per-camera `neolink_name`/`neolink_caps`; **dedicated password-protected
+  `mosquitto-neolink` broker (D1)** because neolink publishes camera credentials
+  to a retained `neolink/config` topic (spike-verified), making a shared broker
+  with password-only auth insufficient; **best-effort retained-config scrub on
+  connect (D2)** as defense-in-depth on top of the dedicated broker; **siren
+  shipped gated behind an operator-declared `siren` cap with an
+  "unvalidated on real hardware" caveat (D3)** rather than held pending
+  siren-capable hardware; **the floodlight momentary/auto-revert default as a
+  live `server_settings` admin knob resolved per-use (D4)**, nullable-column /
+  DB-wins / NULL->env with a 1..=3600 s server clamp, following the #39
+  scrub-preview and #31 `update_check_enabled` precedent.
+- **Rejected:** neolink-as-a-crate (huge dep tree incl. gstreamer tracking a
+  fast-moving RE project; golden rule 6); Home Assistant as control plane
+  (mandatory third service); client-side revert timers (closed laptop = light
+  on all night); read-then-restore revert (racy, model-dependent; spike showed
+  plain `off` restores auto); ACLs on the shared Frigate mosquitto as the
+  default (D1 alternative: breaking change to existing installs, ACL authoring
+  risk; kept as documented BYO-broker guidance); Crumb-generated neolink TOML
+  (api has no writable config mount); **a client-side floodlight-revert constant
+  (D4 alternative: the TTL that governs a physical light would then live on the
+  wrong side of the wire from the engine that enforces it, and could not be
+  retuned without shipping every client).**
+- **Revisit triggers:** neolink gains a config-publish suppress/redact option
+  or a config API; a battery/Baichuan-only camera use case appears
+  (neolink-as-source, parked); clients need push (WebSocket/SSE) rather than
+  `/status` polling for confirmed state; the neolink project stalls or a
+  firmware update breaks the pinned tag; a second MQTT consumer needs the
+  neolink bus (would reopen ACL-vs-dedicated); **reliable Reolink model/actuator
+  detection becomes available, which would unlock the camera-add "enable
+  floodlight/siren control?" proactive nudge currently deferred as a fast-follow
+  (§14).**
+
+---
+
+## 12. Phased task breakdown
+
+Every task ends green on the full gate (fmt, clippy -D warnings, workspace
+tests, §9 harness rules). Model tags: Sonnet unless flagged. One branch per
+task or per phase at the implementer's discretion, but Phase 1 lands before
+anything depending on it.
+
+### Phase 1: schema + capability foundation
+
+**T1. Migration 0047 + Camera plumbing** (Sonnet, M)
+Files: `db/migrations/0047_neolink_binding.sql` (the two `cameras` columns, the
+`camera_actuations` + `neolink_camera_status` tables, the
+`server_settings.neolink_floodlight_revert_secs` D4 column, and the
+`CREATE OR REPLACE VIEW`), `services/common/src/db.rs` (MIGRATIONS array + row
+mapping + camera update), `services/common/src/types.rs` (Camera fields),
+`services/api/src/config_routes.rs` + `dto.rs` (camera create/update DTOs).
+Accept: migration applies on fresh + existing DB; view exposes the two new
+camera columns at the tail; `server_settings` gains the nullable D4 column;
+`PUT /config/cameras/{id}` round-trips `neolink_name`/`neolink_caps`; partial
+update leaves them untouched when omitted.
+
+**T2. `neolink_config` singleton + settings routes** (Sonnet, S)
+Files: `services/common/src/db.rs` (`ensure_neolink_config_table`,
+get/update/version fns), `services/api/src/main.rs` (boot ensure),
+`services/api/src/config_routes.rs` (`GET/PUT /config/neolink`,
+`POST /config/neolink/test`), `dto.rs`.
+Accept: seed-from-env on first boot only; password write-only (GET never
+returns it, None leaves unchanged, `""` clears); PUT bumps version.
+
+**T3. `actuators` RBAC capability** (Sonnet, S)
+Files: `services/common/src/types.rs` (Capabilities + all()),
+`services/api/src/auth_mw.rs` (`can_actuators`/`require_actuators` + the two
+literal constructions), `services/api/src/admin.html` (role-editor checkbox).
+Accept: stored roles without the key deserialize to false; admin true; role
+editor persists it; `node --check` passes on the extracted script.
+
+### Phase 2: MQTT control plane
+
+**T4. Supervised neolink MQTT client + main.rs supervisor** (Sonnet, L)
+Files: `services/api/src/neolink/{mod,client}.rs`, `main.rs` (supervisor block
++ AppState handle), `services/api/src/alerts.rs` (`neolink_disconnected` rule).
+Accept: back-off caps at 30 s and resets on ConnAck; explicit status
+subscriptions only (a `status/preview` publish is never received);
+`neolink_camera_status` upserts from retained echo on connect; version bump
+reconnects without api restart; disabled config runs no client.
+
+**T5. Actuator + reboot endpoints** (Sonnet, M)
+Files: `services/api/src/neolink/routes.rs`, `main.rs` (merge routes),
+`dto.rs`.
+Accept: full 403/404/400 matrix from §4.3 (capability, camera grant, not-bound,
+undeclared cap, bad action, clamp); a floodlight `on` with no `duration_s`
+resolves the D4 default (T5a) rather than a hardcoded number; siren gated on the
+declared `siren` cap; publish is QoS 1 retain=false to the exact spike topic;
+reboot requires AdminUser.
+
+**T5a. D4 floodlight-revert default: `server_settings` resolver + setter**
+(Sonnet, S)
+Files: `services/api/src/neolink_settings.rs` (new resolver, cloning
+`scrub_settings.rs::resolve`: nullable DB column over the
+`NEOLINK_FLOODLIGHT_REVERT_SECS` env default, clamp 1..=3600),
+`services/common/src/db.rs` (`update_neolink_floodlight_revert_secs(Option<i32>)`),
+`services/api/src/config.rs` (env default), `services/api/src/config_routes.rs`
+(field on `GET/PUT /config/neolink`).
+Accept: NULL column resolves to the env default; a set value wins and is
+re-clamped; `""`/null via the API resets to NULL->env; resolve is per-call (no
+`ApiConfig` snapshot), proven by a unit test on the pure merge like the
+scrub-preview tests; no `version` bump required.
+
+**T6. TTL revert engine + boot/periodic sweep** (Sonnet, L; **[OPUS] review
+pass on the failure-mode matrix**, this is the physical-world-safety core)
+Files: `services/api/src/neolink/revert.rs`, `db.rs` (journal accessors),
+`alerts.rs` (`neolink_revert_failed`).
+Accept: §9 revert tests green; kill-the-api-mid-TTL scenario reverts on
+next boot; broker-down revert retries then alerts; supersede + early-cancel
+semantics proven; sweep idempotent.
+
+### Phase 3: status
+
+**T7. `/status` join** (Sonnet, S)
+Files: `services/api/src/status.rs`, `dto.rs`.
+Accept: fields absent (not null) for non-neolink cameras and older payload
+shape unchanged; two batch queries, no per-camera N+1; `actuation_expires`
+reflects the pending journal row.
+
+### Phase 4: clients (web + desktop)
+
+**T8. Web admin: Integrations page + camera editor** (Sonnet, M)
+Files: `services/api/src/admin.html`.
+Accept: page clones the Frigate one (enable, url, prefix, user, write-only
+password, test button, connected badge) plus the D4 "Floodlight auto-revert
+default (seconds)" field (empty = inherit env; live per-use resolve); camera
+editor fields persist incl. the D3-hinted siren checkbox; `esc()` on all
+interpolations; `node --check` green; api rebuilt to verify.
+
+**T9. Web admin: live-tile actuator buttons** (Sonnet, M)
+Files: `services/api/src/admin.html`.
+Accept: buttons drawn only from `neolink_caps` AND `caps.actuators`;
+floodlight countdown driven by `actuation_expires`; tap-again cancels; siren
+press-hold 600 ms guard; no-caps/older-server degrade renders nothing.
+
+**T10. Desktop: actuator cluster on the PTZ tile pattern** (Sonnet, M)
+Files: `apps/desktop/src/app.js` (+ rebuild per
+docs: Tauri bakes ../src into the exe; rebuild + relaunch + CDP-verify before
+claiming done; `libmpv-2.dll` beside the exe).
+Accept: same interaction matrix as T9; gated `caps.actuators`; verified live
+against a dev server via CDP.
+
+### Phase 5: deployment + docs + governance
+
+**T11. Compose + dedicated broker + secrets** (Sonnet, M; **[OPUS] for the
+mosquitto-neolink auth wrapper + a broker-isolation threat-model check**)
+Files: `docker-compose.yml`, `scripts/setup-env.sh`, `.env.example`,
+`.gitignore`, `neolink/neolink.example.toml`.
+Accept: `docker compose config` clean on dev1 (real docker, not a YAML
+parser); plain `up -d` starts neither new service; `--profile neolink` starts
+both; broker rejects anonymous; no published ports on either new service; no
+secret printed or logged.
+
+**T12. Docs sweep** (Sonnet, M)
+Files: `docs/AI-INSTALL.md`, `docs/COMPOSE.md`, README,
+`docs-site/docs/integrations/neolink.md` (new),
+`docs-site/docs/configuration/environment-reference.md`.
+Accept: AI-INSTALL step has a Verify; docs-site page is operator-language and
+carries the BYO-broker ACL + retained-creds warning; env reference lists every
+`NEOLINK_*` key.
+
+**T13. COMPONENT-MAP + DECISIONS entries** (Sonnet, S; ideally folded into the
+Phase 1 and T11 changes rather than a trailing task, per golden rules 7/8)
+Files: `docs/COMPONENT-MAP.md`, `docs/DECISIONS.md`.
+Accept: §10 rows + parity row present; §11 entry verbatim in spirit.
+
+### Phase 6 (deferred, tracked): mobile parity
+
+**T14. Android actuator bar** (Sonnet, L): Compose actuator row by the PTZ
+controls, `actuator()` API method, `/status` fields; build on dev1, verify via
+wireless ADB. **T15. iOS/macOS** (Sonnet, L): SwiftUI equivalent in
+`apps/ios/Crumb/` (NOT apps/desktop), build on macmini.
+
+Effort roughly matches #25's estimate: backend 4-6 focused days (Phases 1-3),
+web+desktop 3-4, deploy/docs 1, mobile 2-3 each when scheduled.
+
+---
+
+## 13. Decisions (all RESOLVED by the maintainer, 2026-07-10)
+
+- **D1 = dedicated broker (RESOLVED).** Ship Option A, a dedicated
+  `mosquitto-neolink` container under the `neolink` profile: no published host
+  ports, `allow_anonymous false`, password from a setup-env-generated
+  `NEOLINK_MQTT_PASSWORD`. This is the neolink control plane's broker, never the
+  shared Frigate mosquitto. Option B (ACLs on a shared broker) is kept only as
+  documented BYO-broker guidance; Option C (upstream config-suppress) is a
+  revisit trigger. Threaded through §2, §8, T11.
+- **D2 = yes (RESOLVED).** The api publishes an empty retained message to
+  `{prefix}/config` on each connect, best-effort with the documented caveats.
+  Implemented in §4.1 / T4.
+- **D3 = yes, gated (RESOLVED).** Siren ships behind the operator-declared
+  `siren` cap with an explicit "unvalidated on real hardware (spike CX410 had
+  none)" note in the camera editor and docs-site page; the feature is not held.
+  §4.3, §7.1, T8, T12.
+- **D4 = live `server_settings` admin knob (RESOLVED).** The floodlight
+  momentary/auto-revert default is `server_settings.neolink_floodlight_revert_secs`
+  (nullable, DB-wins, NULL->`NEOLINK_FLOODLIGHT_REVERT_SECS` env, resolved
+  per-use, 1..=3600 s server clamp), NOT a client-side constant. Threaded
+  through §3.1, §3.3, §4.3, §4.4, §7.1, §8.2, and tasks T1/T5/T5a/T8.
+
+Nothing here remains blocking; the phased breakdown in §12 is cleared to start.
+
+---
+
+## 14. Setup gating & zero-footprint for non-Reolink installs
+
+A maintainer question: does adding neolink cost anything for the operator who
+has no Reolink cameras? Answer: no. The feature is inert until an operator who
+actually wants it turns it on, and it is never presented during base install or
+first-run. Concretely, it is OFF at three independent layers, any one of which
+suffices:
+
+1. **Compose profile (nothing runs).** Both new services carry
+   `profiles: ["neolink"]`. A plain `docker compose up -d` starts neither the
+   `neolink` sidecar nor the dedicated `mosquitto-neolink` broker. Zero extra
+   containers, images, ports, or RAM on a default stack. (The base stack stays
+   the 4-container default; §8.1.)
+2. **Backend dormant unless configured.** The `neolink_config` singleton
+   defaults `enabled=false` with an empty `mqtt_url`, so the §4.2 supervisor
+   starts **no** MQTT client task, exactly like the Frigate provider when
+   `FRIGATE_MQTT_URL` is unset. And no camera has a `neolink_name`, so even a
+   running client has nothing to talk to. The api spins up identically whether
+   or not neolink exists.
+3. **UI gated (no buttons, no page noise).** Live-tile actuator buttons render
+   only when a camera reports `neolink_caps` AND the user holds the `actuators`
+   capability (deny-by-default). A non-Reolink operator sees no actuator UI on
+   any tile. The Integrations -> Neolink page exists but is just another opt-in
+   integration card alongside Frigate, not a step anyone is forced through.
+
+**It is a post-setup OPTIONAL integration, not part of the base install or the
+first-run wizard.** The wizard (migration 0027 onboarding) does not mention
+neolink; a non-Reolink operator never encounters a neolink decision. An operator
+who has Reolinks and wants actuator control enables it on demand: open
+Integrations -> Neolink (Frigate-shaped), turn it on, point it at the dedicated
+broker, then set each Reolink camera's `neolink_name` + caps in the camera
+editor. This mirrors how Frigate detection is opt-in today.
+
+**v1 is manual opt-in.** The proactive camera-add nudge, "we detected a Reolink,
+enable floodlight/siren control?", is recorded as an explicit **FAST-FOLLOW,
+not v1.** Caveat that gates it: Reolink model/actuator detection is not reliable
+(the spike showed the CX410 advertises no siren and neolink does not
+advertise caps), so a nudge risks offering controls a given model does not have.
+The fast-follow would need a confidence check (e.g. ONVIF/Baichuan model probe
+plus a "you can adjust these" confirmation) before it earns its place; until
+then, operator-declared caps in the camera editor are the source of truth and
+manual enablement is the shipped path. Recorded as a revisit trigger in the
+DECISIONS entry (§11) rather than built now.

--- a/docs/REOLINK-ACTUATOR-PLAN.md
+++ b/docs/REOLINK-ACTUATOR-PLAN.md
@@ -1,0 +1,880 @@
+# Reolink actuator control via direct HTTP-API client: implementable design + phased plan (issue #25)
+
+Status: DESIGN, ratified by the maintainer 2026-07-10. This document
+**supersedes `docs/NEOLINK-ACTUATOR-PLAN.md`**, which is retained as the
+rejected-alternative record for the neolink-MQTT sidecar architecture. The
+"why" behind the pivot — the retained-credential leak, the dead siren on the
+spike CX410, the two-container/broker footprint, and the fact that the earlier
+"rejected in-process" alternative was the port-9000 binary Baichuan protocol
+and never the documented HTTP API — lives in
+`docs/REOLINK-CONTROL-ARCH-DECISION.md` and is not re-argued here.
+
+**Ratified decisions baked into this plan (do not re-litigate):**
+
+- **Architecture = direct Reolink HTTP-API client, in-process, reqwest.**
+  Login→token auth, HTTPS-first with HTTP fallback, the documented CGI command
+  set (`AudioAlarmPlay`, `SetWhiteLed`, `SetIrLights`, `SetPowerLed`,
+  `SetPirInfo`, `Reboot`), and **`GetAbility` for per-model capability
+  detection** (replacing the old plan's operator-declared `neolink_caps`).
+  No container, no broker, no MQTT, no new secret.
+- **Battery/Baichuan-only Reolinks are OUT of scope** (parked; revisit
+  trigger). Those cameras also cannot be Crumb RTSP sources today.
+- **Siren ships GATED** behind the detected capability and is documented as
+  model/firmware-flaky (D3 stands; HA core #91517, #98594, #159989).
+- **D4 stands:** the floodlight momentary/auto-revert default is a live
+  `server_settings` admin knob (nullable column, DB-wins, NULL→env, resolved
+  per-use; the #39 / #31 precedent), not a client constant.
+- **Dropped entirely:** the `neolink` container, the dedicated
+  `mosquitto-neolink` broker, D1 (broker isolation) + D2 (retained-config
+  scrub), the rumqttc MQTT client task (old T4), `NEOLINK_MQTT_PASSWORD` and
+  the whole `NEOLINK_MQTT_*` env block, the profile-gated compose services,
+  `neolink.toml`, and every retained-topic concern. None of these have a
+  successor; the problems they solved do not exist without the bus.
+
+Scope (unchanged from #25): actuator **control** only. Cameras keep their
+native RTSP `source_url` and `served_by='crumb'`. Actuators in scope:
+floodlight, siren, status-LED, IR, PIR, reboot. Out of scope, parked:
+Reolink-as-RTSP-source for battery cams, two-way audio.
+
+**Non-Reolink operators pay nothing: no camera bound → completely dormant,
+exactly like ONVIF/PTZ today. See §12.**
+
+---
+
+## 1. Architecture
+
+```
+Crumb api ──HTTPS:443 (fallback HTTP:80)──> Reolink camera  /cgi-bin/api.cgi
+  (reqwest, Login→token, POST JSON command arrays, LAN-only)
+```
+
+One new module, `services/api/src/reolink/`, living entirely inside the api
+process. It is the same authed-device-HTTP shape the api already ships twice:
+
+- `services/api/src/ptz.rs` — per-request ONVIF SOAP to the camera, per-camera
+  creds resolved from DB columns, stateless, `require_ptz()` →
+  `assert_camera_access()` handler order. The actuator endpoint mirrors
+  `ptz_command` line-for-line (§4.3).
+- `services/api/src/detection/frigate.rs:648` — `reqwest::Client::builder()`
+  for an authed service. `reqwest` is already a workspace dependency; **no new
+  crates** (golden rule 6 satisfied by construction).
+
+Control is synchronous request/response: the handler knows success or failure
+before it returns, so there is no optimistic-publish-then-reconcile dance. The
+server-side TTL-revert journal (§4.4) still exists — it enforces the
+closed-laptop invariant — but it arms off a call the server already knows
+landed.
+
+Differences from the neolink plan worth naming once:
+
+| Concern | neolink-MQTT plan | This plan |
+|---|---|---|
+| Transport | fire-and-forget MQTT publish | synchronous HTTP, result in-hand |
+| Confirmed state | retained status-topic echoes | poll `GetWhiteLed` etc. (§4.5) + write-through after each successful command |
+| Capabilities | operator-declared `neolink_caps` checkboxes | **auto-detected** from `GetAbility`, cached (§4.2) |
+| Floodlight surface | `on\|off` only | full mode set (off/auto/onatnight/schedule/adaptive) + brightness |
+| Siren off | did not exist in the protocol | `AudioAlarmPlay manual_switch:0` — a real off |
+| Creds at rest | DB + neolink.toml + retained broker topic | DB only |
+| New processes | 2 containers + broker + supervised MQTT task | none |
+
+---
+
+## 2. Verified facts this design leans on
+
+From `docs/REOLINK-CONTROL-ARCH-DECISION.md` (triangulated across
+`reolink_aio`, `fwestenberg/reolink`, and Reolink community docs; confidence
+high on command shapes):
+
+| Fact | Design consequence |
+|---|---|
+| All commands are `POST /cgi-bin/api.cgi?cmd=<Cmd>&token=<tok>` with a JSON **array** body; `Login` returns `Token{name, leaseTime}` | One small client with a per-camera token cache (§4.1); token rides the query string. |
+| `reolink_aio` tries HTTPS:443 first, falls back to HTTP:80 (old firmwares are HTTP-only) | Mirror it. Accept self-signed certs on the HTTPS path (Reolink certs are self-signed); LAN-only posture, same as ONVIF today. Cache the working scheme per camera in memory. |
+| Siren: `{"cmd":"AudioAlarmPlay","action":0,"param":{"alarm_mode":"manul","manual_switch":1,"times":2,"channel":0}}` — `manual_switch` 1/0 = on/off; `alarm_mode:"times"` plays N cycles. (`"manul"` is Reolink's own spelling; keep it.) | Siren on/off is manual-mode; Crumb's own TTL revert bounds it (§4.4) rather than the camera-side duration, because a duration-started siren cannot be stopped early on some models (HA #159989). |
+| Floodlight: `{"cmd":"SetWhiteLed","param":{"WhiteLed":{"state":1,"channel":0,"mode":1,"bright":100}}}` with modes off/auto/onatnight/schedule/adaptive and `bright` 1..=100; `GetWhiteLed` reads current config | `SetWhiteLed` is an **absolute** setter — there is no neolink-style "off restores auto" magic. The revert engine therefore snapshots the pre-actuation `GetWhiteLed` state and restores it (§4.4). |
+| `SetIrLights` (`state: "Auto"\|"On"\|"Off"`), `SetPowerLed`, `SetPirInfo`, `Reboot` | Straight command mappings; per-actuator action validation in §4.3. |
+| `GetAbility` returns a per-channel abilities map; `reolink_aio`'s `supported(channel, cap)` / `api_version(cap)` gates every control per model | Capability auto-detection (§4.2). Crumb caches the derived caps per camera; clients render buttons only from the cache. |
+| Error shape: HTTP 200 with `[{"cmd":…,"code":1,"error":{"rspCode":-9,"detail":"not support"}}]`; known codes include `-9` not-support (HA #91517), `-17` rcv-failed (HA #98594), auth/lease failures | Central rspCode mapping in the client (§4.1): `-9` → 409 "not supported on this model" + prune the cached cap; auth failure → one re-login retry then 502. |
+| Some firmwares lock accounts after rapid failed logins; leases can be short | Cache tokens per camera, refresh before expiry, back off on repeated auth failure (never hot-loop a login). |
+
+The #26 spike CX410 (fw v3.1.0.3429) remains available as real verification
+hardware for T3/T4.
+
+---
+
+## 3. Data model
+
+### 3.1 Credential storage: dedicated `reolink_*` columns (DECIDED)
+
+Two options were weighed:
+
+- **Reuse the `onvif_*` columns.** Same physical device, usually the same
+  admin credentials. Rejected: the ports/schemes differ (Reolink ONVIF is
+  typically :8000; the HTTP API is :443/:80 with an HTTPS-then-HTTP probe), so
+  `onvif_port` cannot be reused and a scheme column would be needed anyway;
+  it would couple two independent features (an operator must not have to
+  configure ONVIF to get actuator buttons, or vice versa); and NULL-ness of
+  `onvif_host` already means "no PTZ", which would become ambiguous.
+- **Dedicated `reolink_*` columns** (CHOSEN). `reolink_host IS NOT NULL` is
+  the binding sentinel (the direct successor of the old `neolink_name`), the
+  camera editor offers a one-click "copy from ONVIF" prefill for the common
+  same-device case, and the two features stay orthogonal. No env fallback is
+  needed (unlike `ONVIF_CONFIG` there is no legacy deployment to honor).
+
+### 3.2 Migration `db/migrations/0047_reolink_actuators.sql`
+
+0046 (`scrub_pregen_settings`) is the current tail of the `MIGRATIONS` array
+in `services/common/src/db.rs` (verified 2026-07-10); **0047 is confirmed
+free**. Golden rule 4: the file must be added to the `MIGRATIONS` array in the
+same change or it silently never runs. Idempotent style (ADD COLUMN IF NOT
+EXISTS, CREATE TABLE IF NOT EXISTS, CREATE OR REPLACE VIEW), no BEGIN/COMMIT,
+comments matching 0042's.
+
+```sql
+ALTER TABLE cameras
+    ADD COLUMN IF NOT EXISTS reolink_host     text,   -- NULL = not Reolink-bound
+    ADD COLUMN IF NOT EXISTS reolink_user     text,
+    ADD COLUMN IF NOT EXISTS reolink_password text,   -- write-only via API, like onvif_password
+    ADD COLUMN IF NOT EXISTS reolink_caps     jsonb,  -- CACHED GetAbility-derived caps,
+                                                      -- e.g. ["floodlight","siren","ir","pir","power_led"]
+    ADD COLUMN IF NOT EXISTS reolink_caps_updated_at timestamptz;  -- cache freshness
+
+-- TTL-revert journal: restart-safe momentary actuations (ported unchanged in
+-- shape from the neolink plan; revert_payload is now the JSON command param
+-- to replay, not an MQTT payload string — see §4.4).
+CREATE TABLE IF NOT EXISTS camera_actuations (
+    id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    camera_id      uuid NOT NULL REFERENCES cameras(id) ON DELETE CASCADE,
+    actuator       text NOT NULL,          -- floodlight|siren|led|ir|pir
+    revert_payload text NOT NULL,          -- JSON: the SetWhiteLed/AudioAlarmPlay param to restore
+    created_at     timestamptz NOT NULL DEFAULT now(),
+    expires_at     timestamptz NOT NULL,
+    reverted_at    timestamptz             -- NULL = revert still owed
+);
+CREATE INDEX IF NOT EXISTS camera_actuations_pending_idx
+    ON camera_actuations (expires_at) WHERE reverted_at IS NULL;
+
+-- Confirmed-state cache written by the §4.5 poller (and write-through after
+-- each successful command), read by /status. last_motion_ts from the neolink
+-- plan is DROPPED: Crumb's own motion pipeline covers motion; polling
+-- GetMdState would be redundant.
+CREATE TABLE IF NOT EXISTS reolink_camera_status (
+    camera_id        uuid PRIMARY KEY REFERENCES cameras(id) ON DELETE CASCADE,
+    reachable        boolean NOT NULL DEFAULT false,
+    floodlight_state jsonb,                -- last-read WhiteLed object (state/mode/bright)
+    updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+-- D4 (SURVIVES, renamed): floodlight momentary/auto-revert default as a LIVE
+-- admin knob on the server_settings singleton. Nullable = "operator never
+-- touched it" -> resolver falls back to the REOLINK_FLOODLIGHT_REVERT_SECS
+-- env default. Mirrors the scrub-preview tunables (#39) and
+-- update_check_enabled (#31) exactly: nullable column, DB-wins, NULL->env,
+-- resolved per-use (no restart). ADD COLUMN only on the id=1 singleton.
+ALTER TABLE server_settings
+    ADD COLUMN IF NOT EXISTS reolink_floodlight_revert_secs integer;  -- NULL = env default
+
+CREATE OR REPLACE VIEW v_camera_effective_policy AS
+SELECT
+    -- ... byte-for-byte the CURRENT view column list, THEN append at the very end:
+    c.reolink_host            AS c_reolink_host,
+    c.reolink_user            AS c_reolink_user,
+    c.reolink_password        AS c_reolink_password,
+    c.reolink_caps            AS c_reolink_caps,
+    c.reolink_caps_updated_at AS c_reolink_caps_updated_at
+FROM ...;
+```
+
+**View trap (unchanged from the neolink plan, still load-bearing):**
+`get_camera` reads `v_camera_effective_policy`, not the `cameras` table, so
+the new columns never surface unless the view is re-declared. `CREATE OR
+REPLACE VIEW` only permits APPENDING trailing columns, so the `c_reolink_*`
+columns go at the tail — after everything, even though the c_/p_ grouping
+looks wrong. 0042 is the template; copy the current full column list verbatim
+and append.
+
+Rust side: `Camera` in `services/common/src/types.rs` gains
+`reolink_host/user/password: Option<String>`,
+`reolink_caps: Option<Vec<String>>` (parse the jsonb array; unknown strings
+tolerated — clients just don't render them), and
+`reolink_caps_updated_at: Option<DateTime<Utc>>`; the row mapping in `db.rs`
+reads the new view columns; the camera create/update DTOs and
+`PUT /config/cameras/{id}` in `config_routes.rs` accept host/user/password
+with **partial-update semantics identical to the `onvif_*` fields**
+(password write-only: omitted = unchanged, `""` = clear; GET never returns
+it). `reolink_caps` is **not** operator-writable through the camera DTO — it
+is owned by the detection path (§4.2); the DTO exposes it read-only.
+
+### 3.3 D4 resolver (ported, renamed)
+
+`services/api/src/reolink/settings.rs` (or a helper in the module) clones
+`scrub_settings.rs::resolve`: read the nullable
+`server_settings.reolink_floodlight_revert_secs`, fall back to `ApiConfig`'s
+`REOLINK_FLOODLIGHT_REVERT_SECS` env default (default **30**), clamp
+**1..=3600 s** server-side. Resolved **per actuation** (never cached in the
+boot `ApiConfig` snapshot), so an admin edit takes effect on the next tap with
+no restart. Setter `update_reolink_floodlight_revert_secs(pool, Option<i32>)`
+(NULL resets to env), surfaced on the same settings panel that hosts the
+scrub-preview tunables (§7.1). No `version` bump machinery — nothing
+reconnects; the next resolve reads the new row.
+
+There is **no `reolink_config` singleton** and no Integrations-page service
+config (the neolink plan's §3.2 dies with the broker): with direct HTTP there
+is no external service to point at. The per-camera binding IS the entire
+configuration, exactly like ONVIF PTZ.
+
+---
+
+## 4. Backend: `services/api/src/reolink/`
+
+New module: `mod.rs`, `client.rs`, `caps.rs`, `routes.rs`, `revert.rs`,
+`poll.rs`. Merged in `main.rs` next to `ptz::routes()` (axum `:id` path-param
+style).
+
+### 4.1 `client.rs`: the HTTP client + token cache
+
+- **One shared `reqwest::Client`** built like `frigate.rs:648` (timeouts:
+  ~5 s connect, ~10 s total), plus a second builder with
+  `danger_accept_invalid_certs(true)` for the HTTPS path (Reolink ships
+  self-signed certs; this is LAN-only device traffic, the same trust model as
+  cleartext ONVIF SOAP today — document, don't hide).
+- **Scheme probe:** first contact tries `https://host/cgi-bin/api.cgi`, falls
+  back to `http://host` on connect/TLS error; the working scheme is cached in
+  memory per camera (a `DashMap`/`RwLock<HashMap<Uuid, _>>` on `AppState`,
+  same shape as existing shared maps).
+- **Token cache:** `HashMap<Uuid, TokenEntry { token, expires_at }>`. `Login`
+  once per camera, reuse until ~60 s before `leaseTime` expiry, then
+  re-login. On an auth-failure rspCode mid-flight: drop the cached token,
+  re-login **once**, retry the command once, then fail. On repeated login
+  failures, back off (cap ~60 s) before the next attempt — some firmwares
+  lock accounts on rapid failed logins; never hot-loop.
+- **Command surface** (each a typed fn returning `anyhow::Result<Value>` or a
+  typed DTO): `login`, `get_ability`, `get_dev_info` (model/firmware for the
+  editor display and issue reports), `get_white_led`, `set_white_led(state,
+  mode, bright)`, `audio_alarm_play(manual_switch | times)`,
+  `set_ir_lights(state)`, `set_power_led(state)`, `set_pir_info(enabled)`,
+  `reboot`. Request construction and response parsing are **pure functions**
+  (build the JSON array body / parse the `code`/`rspCode` envelope) so they
+  unit-test without a network.
+- **Error mapping**, centralized: transport error → `502`-style
+  `ApiError::Internal` with the camera named; `rspCode -9 / "not support"` →
+  `ApiError::Conflict`-class response `"'<actuator>' is not supported by this
+  camera model/firmware"` **and** prune that cap from the cached
+  `reolink_caps` (self-healing when `GetAbility` over-promised, the E1-Zoom
+  case, HA #91517); auth rspCodes → the retry-once path above; anything else
+  (e.g. `-17 rcv failed`) → 502 with the rspCode + detail surfaced verbatim
+  in the error string so operators can search HA's issue corpus.
+- **Never log credentials or tokens** (the `?token=` query string must be
+  redacted in any logged URL). Passwords stay in memory only, like
+  `OnvifCameraConfig`.
+- Credential resolution mirrors `ptz.rs::resolve_onvif_config` minus the env
+  arm: DB columns only; NULL `reolink_host` → 404 `"camera is not
+  Reolink-bound"` (parallel to "camera is not PTZ").
+
+### 4.2 `caps.rs`: capability auto-detection (replaces operator-declared caps)
+
+- `detect(camera) -> Vec<Cap>`: call `GetAbility` (plus `GetDevInfo` for
+  display), map the abilities to Crumb's actuator caps. The authoritative
+  ability-key → capability mapping is `reolink_aio`'s `supported()` /
+  `api_version()` table (e.g. floodlight ⇔ `GetWhiteLed` api version > 0,
+  siren ⇔ the audio-alarm ability); the implementer lifts the exact key names
+  from `reolink_aio/api.py` and verifies against the CX410. Cap vocabulary:
+  `floodlight`, `siren`, `ir`, `pir`, `power_led` (reboot is not a cap; every
+  Reolink can reboot).
+- **When it runs:** (a) automatically when a camera's `reolink_host`/creds
+  are set or changed (bind-time), (b) on demand via
+  `POST /cameras/:id/reolink/detect` (admin-only; the camera editor's
+  "Detect capabilities" button), (c) lazily refreshed by the §4.5 poller when
+  `reolink_caps_updated_at` is older than ~24 h. Results upsert
+  `reolink_caps` + `reolink_caps_updated_at`.
+- Detection failure (camera unreachable, bad creds) leaves the cache
+  untouched and returns the error to the caller — bind-time detection failing
+  must not block saving the camera (the editor shows the error; the operator
+  can retry).
+- **Siren stays gated AND flagged (D3):** even when detected, the cap is
+  rendered with the "model/firmware-flaky" caveat — `GetAbility` advertising
+  the audio alarm does not guarantee `AudioAlarmPlay` works (HA #91517
+  E1 Zoom `-9/not support`, #98594 RLC-510WA `-17/rcv failed`, #159989 Atlas
+  PT Ultra can't-stop-during-duration). The docs-site page carries the same
+  caveat and links those issues as the compatibility oracle.
+
+### 4.3 `routes.rs`: actuator + reboot + detect endpoints
+
+`POST /cameras/:id/actuator` — request:
+
+```json
+{ "actuator": "floodlight|siren|led|ir|pir",
+  "action":   "on|off|auto",
+  "duration_s": 30,          // optional; only with action=on
+  "brightness": 80 }         // optional; floodlight only, 1..=100
+```
+
+Handler order mirrors `ptz.rs::ptz_command` exactly:
+
+1. `user.require_actuators()?` then `user.assert_camera_access(camera_id)?`
+2. `db::get_camera` → 404 if absent
+3. 404 `"camera is not Reolink-bound"` if `reolink_host` is NULL
+4. Validate `actuator` against the **cached** `reolink_caps` → 400 naming the
+   missing cap (with a hint to run capability detection if the cache is
+   empty)
+5. Validate `action` per actuator: floodlight accepts on/off/auto (+ optional
+   `brightness`); ir accepts on/off/auto; led/pir accept on/off; **siren
+   accepts on/off** (a real off now exists — `manual_switch:0`). `duration_s`
+   only valid with `action=on`; clamp 1..=3600 (floodlight) / 1..=300
+   (siren — a shorter hard cap for the annoyance-critical actuator).
+   `brightness` clamped 1..=100.
+6. Execute the mapped command **synchronously** via `client.rs`; the mapped
+   Reolink calls are: floodlight on → `SetWhiteLed{state:1, mode:manual-on,
+   bright}`; floodlight off → `SetWhiteLed{state:0, mode:off}`; floodlight
+   auto → `SetWhiteLed{mode:auto/night}`; siren on →
+   `AudioAlarmPlay{alarm_mode:"manul", manual_switch:1}`; siren off →
+   `manual_switch:0`; ir/led/pir → their setters. Errors map per §4.1 —
+   the client gets a real result, not an optimistic 200.
+7. **Momentary arming:** if `action=on` for floodlight or siren:
+   - floodlight with `duration_s` absent → resolve the D4 default (§3.3);
+     siren with `duration_s` absent → default **10 s** (env-overridable
+     `REOLINK_SIREN_DEFAULT_SECS`; a siren must never default to minutes).
+   - **Snapshot-then-act:** read the pre-actuation state (`GetWhiteLed` for
+     floodlight; siren's revert is statically `manual_switch:0`) and store it
+     as `revert_payload` JSON in a `camera_actuations` row. If the pre-read
+     fails, store the static fallback (`{state:0, mode:auto}` for
+     floodlight). See §4.4 for why snapshot-restore replaces the neolink
+     plan's plain-`off` revert.
+   - Arm the in-process revert timer. If an un-reverted row already exists
+     for (camera, actuator), supersede it (mark reverted, note "superseded")
+     so re-tapping extends rather than double-reverts.
+8. `action=off` with a pending row = early cancel: execute the off, mark the
+   row reverted now. Respond with the confirmed result plus
+   `actuation_expires` so the client can render the countdown from server
+   truth.
+
+`POST /cameras/:id/reboot` — `AdminUser` extractor (the existing
+403-on-non-admin wrapper in `auth_mw.rs`), because a reboot interrupts
+recording. Same bound-camera checks; calls `Reboot`; no journal row.
+
+`POST /cameras/:id/reolink/detect` — `AdminUser`; runs §4.2 detection on
+demand; returns the detected caps + model/firmware from `GetDevInfo`.
+
+### 4.4 `revert.rs`: server-side TTL revert engine (ported; one semantic change)
+
+The "closed laptop must not leave the floodlight on all night" invariant,
+unchanged in structure from the neolink plan:
+
+- **Arm-on-success:** tokio timer per pending actuation, armed only after the
+  actuating HTTP call succeeded (stronger than the old arm-on-publish); on
+  expiry, replay `revert_payload` via `client.rs` and set `reverted_at`.
+- **Boot sweep:** at api start, scan `camera_actuations WHERE reverted_at IS
+  NULL`: expired rows get the revert executed immediately; future rows get
+  timers re-armed. An api restart can never strand an actuator.
+- **Periodic safety sweep** every 30 s over the same partial index, catching
+  lost timers and reverts whose HTTP call failed. Idempotent: replaying a
+  `SetWhiteLed` restore or a `manual_switch:0` twice is harmless.
+- **Camera unreachable at expiry:** the row stays un-reverted; the sweep
+  retries; if a revert stays owed past a 60 s grace window, raise a
+  `reolink_revert_failed` system alert (existing `system_alert_rules`
+  machinery in `alerts.rs`) naming the camera and actuator. Prefer noisy
+  failure over a silently stuck floodlight.
+
+**Semantic change vs the neolink plan — snapshot-restore instead of plain
+`off` (flagged for the maintainer, recommended):** the neolink revert payload
+was the literal string `off` because the spike showed neolink's `off`
+*restores the camera's auto mode*. The HTTP API has no such magic:
+`SetWhiteLed` is an absolute setter, and `{state:0, mode:off}` would force a
+night-auto camera dark — the revert would *break* the operator's standing
+config. The old DECISIONS text rejected "read-then-restore" as racy and
+model-dependent, but that rejection was reasoned inside neolink's toggle
+semantics; under an absolute-setter API, restoring the snapshotted
+`GetWhiteLed` object is the only revert that provably returns the camera to
+its prior behavior. Race window (operator changes the mode in the Reolink app
+mid-TTL and the revert stomps it) is accepted and documented; the static
+`mode:auto` fallback covers a failed pre-read. Siren needs no snapshot: its
+resting state is always off.
+
+Unit tests target the pure decision logic (due-row selection, supersede,
+clamps); integration tests exercise journal arm/sweep against Postgres, with
+the HTTP execution mocked through a small transport trait on the client (the
+same seam the neolink plan used for its publish handle) — no new dev-deps.
+
+### 4.5 `poll.rs`: confirmed-state poller (replaces the MQTT status subscriber)
+
+A single lightweight tokio task (spawned from `main.rs` beside the other
+background loops), which:
+
+- Every **60 s**, lists Reolink-bound cameras (reusing the existing
+  camera-map reload pattern) and, for each, calls `GetWhiteLed` (only when
+  the `floodlight` cap is cached); upserts `reolink_camera_status`
+  (`reachable`, `floodlight_state`). Failures mark `reachable=false`; a
+  camera that stays unreachable does not spam — back off per camera to 5 min.
+- Refreshes `reolink_caps` per §4.2(c) when stale.
+- **Write-through:** the §4.3 handler and the revert engine also upsert
+  `reolink_camera_status` after every successful command, so /status
+  reflects an actuation within one client poll without waiting for the next
+  poller pass.
+- **Zero cameras bound → the task finds an empty list and sleeps.** No
+  connections, no log noise, no config. (This is the whole "supervisor"
+  story now; the neolink plan's version-bump reconnect loop has no successor
+  because there is no connection to manage.)
+
+No system alert for "integration down" exists anymore as a global concept —
+per-camera unreachability surfaces via `reachable=false` in `/status` (and
+the existing camera-offline signals cover the camera actually being gone).
+`reolink_revert_failed` (§4.4) is the one new alert rule.
+
+---
+
+## 5. RBAC: `actuators` capability (ported UNCHANGED from the neolink plan)
+
+Sounding a siren or lighting a floodlight is a physical-world action, distinct
+from "can view" and from PTZ. All mirroring the `ptz` capability:
+
+- `Capabilities` (`services/common/src/types.rs`, `ptz` is at ~889): add
+  `#[serde(default)] pub actuators: bool`. Serde-default false = every stored
+  role jsonb reads as denied until an admin opts in.
+- `Capabilities::all()`: `actuators: true` (admin implies it).
+- `auth_mw.rs`: `can_actuators()` (admin || capability) + `require_actuators()`
+  returning the standard 403 (clone `can_ptz`/`require_ptz` at ~145/~181);
+  keep the explicit `actuators: false` in the literal `Capabilities { .. }`
+  constructions.
+- Role editor in `admin.html`: one checkbox next to PTZ.
+- Per-camera scoping rides the existing `assert_camera_access` grant check;
+  no new mechanism.
+
+---
+
+## 6. Status surface (ported; field renames only)
+
+No WebSocket/SSE exists; clients poll `GET /status`. Extend
+`CameraStatusEntry` (`services/api/src/dto.rs`) with optional,
+`#[serde(skip_serializing_if = "Option::is_none")]` fields so older clients
+ignore them and non-Reolink cameras emit nothing:
+
+```rust
+pub reolink_reachable: Option<bool>,          // Some(..) only when Reolink-bound
+pub floodlight_state:  Option<Value>,         // last confirmed WhiteLed {state,mode,bright}
+pub actuation_expires: Option<DateTime<Utc>>, // pending momentary revert, drives countdown UI
+```
+
+`status.rs` batch-loads `reolink_camera_status` plus the pending-actuation
+rows once (two queries, joined in memory by camera_id), never per-camera
+inside the existing `JoinSet` fan-out. `actuation_expires` lets clients render
+the countdown ring from server truth instead of a local timer that drifts or
+dies with the tab.
+
+---
+
+## 7. Clients (COMPONENT-MAP section 3: parity stated explicitly)
+
+**Web admin + desktop first. Android + iOS are DEFERRED follow-ups, not
+dropped**; tracked as Phase 5 tasks and in the cross-client parity table so
+the gap stays visible. Clients are transport-agnostic — they see the same
+endpoint + `/status` fields the neolink plan promised, so the client sections
+port nearly verbatim.
+
+### 7.1 Web admin (`services/api/src/admin.html`)
+
+One file, inline script, `on*=` wired plain functions, `esc()` for all
+interpolation, `api()` for authed fetches, semantic colors
+`var(--ok)`/`var(--warn)`/`var(--danger)`; sanity-check with `node --check`
+on the extracted script block; rebuild the api to see changes
+(`include_str!`-embedded; `grep -a`).
+
+- **Camera editor: "Reolink control" section** (replaces the old plan's
+  Integrations→Neolink page — there is no service-level config to host):
+  host, user, write-only password (never echoed), a "copy from ONVIF" prefill
+  button, and a **"Detect capabilities"** button that calls
+  `/cameras/:id/reolink/detect` and renders the detected caps as read-only
+  badges plus the model/firmware from `GetDevInfo`. The siren badge carries
+  the D3 "model/firmware-flaky" hint. No checkboxes: caps are detected, not
+  declared.
+- **D4 knob** — the "Floodlight auto-revert default (seconds)" field (empty =
+  inherit the env default; live per-use resolve per §3.3) lives on the same
+  settings panel as the scrub-preview tunables, since there is no
+  integration page for it to live on.
+- **Live tile overlay buttons** drawn from cached `reolink_caps` ×
+  `caps.actuators`: floodlight tap = on for the server-resolved default
+  (client omits `duration_s`) + countdown from `actuation_expires`, tap again
+  = revert now; optional brightness slider on long-press (polish, may defer);
+  siren press-and-hold ~600 ms to arm (accidental-tap guard) + explicit
+  off button while sounding; LED/PIR/IR plain toggles. No caps, older server,
+  or 404 → no buttons, graceful degrade.
+
+### 7.2 Desktop (`apps/desktop/src/app.js`)
+
+Extend the existing PTZ control-tile pattern (`buildPtzPanelHtml` /
+`wirePtzPanel`, gating as with `caps.ptz`): an actuator cluster in the pane
+toolbar, gated on `caps.actuators` AND the camera reporting `reolink_caps`,
+same interactions as web. True on-video mpv ASS-overlay buttons (like the PTZ
+wheel) are polish, deferred; the toolbar cluster ships first. Windows note
+stands: rebuild the exe (Tauri bakes ../src in) and keep `libmpv-2.dll`
+beside it.
+
+### 7.3 Android (`apps/android`) + iOS/macOS (`apps/ios`): deferred
+
+Actuator bar beside the existing PTZ composables/views + an `actuator()` API
+client method + the `/status` fields. Explicitly listed in Phase 5 and in the
+COMPONENT-MAP parity row so no session "forgets" them.
+
+---
+
+## 8. Deployment + install surface (golden rule 5) — the big win
+
+Compared with the neolink plan, the operator-facing surface nearly vanishes:
+
+| Surface | neolink plan | This plan |
+|---|---|---|
+| `docker-compose.yml` | +2 services, profile, entrypoint wrapper | **no change** |
+| Secrets | `NEOLINK_MQTT_PASSWORD` generated by setup-env | **no new secret** |
+| Config files | `neolink.toml` + example + .gitignore entry | **none** |
+| `.env` keys | `NEOLINK_MQTT_*` block | two optional commented defaults: `REOLINK_FLOODLIGHT_REVERT_SECS=30`, `REOLINK_SIREN_DEFAULT_SECS=10` |
+| Enablement | broker up + toml authored + Integrations page + per-camera name | **per-camera binding in the camera editor. That's it.** |
+
+Concretely, the same-change sweep (golden rule 5) is docs-only:
+
+- `scripts/setup-env.sh` + `.env.example`: the two commented `REOLINK_*`
+  defaults (no generation, nothing secret).
+- `docs/AI-INSTALL.md`: a short optional-integration note ("Reolink actuator
+  control needs no install step; bind cameras in the admin camera editor")
+  with a Verify. No compose, TLS, or backup implications.
+- README manual path: one feature-list line.
+- `docs-site/docs/integrations/reolink.md` (NEW, operator-facing, replaces
+  the planned neolink page): what it does, how to bind a camera, the caps
+  auto-detection, the siren flakiness caveat with the HA issue links, the
+  HTTPS-first/HTTP-fallback + self-signed-cert LAN-only note, battery-cam
+  out-of-scope note.
+- `docs-site/docs/configuration/environment-reference.md`: the two
+  `REOLINK_*` keys.
+
+No `docs/COMPOSE.md` change (nothing in compose changes).
+
+---
+
+## 9. Testing + CI notes for implementers
+
+Gate before any push (unchanged, every task below): `cargo fmt --all --
+--check`, `cargo clippy --all-targets -- -D warnings`,
+`cargo test --workspace` against a throwaway Postgres (`crumb-test-pg` recipe
+in AGENTS.md).
+
+**DB-test harness trap (cost issue #9 three CI rounds; do not rediscover):**
+integration tests must `run_migrations` against the real `public` schema and
+isolate by unique keys (unique camera names/uuids per test), NOT by a
+`search_path` schema; and the test pool needs `max_size >= 8` or concurrent
+tests deadlock on connection starvation.
+
+Specific test obligations:
+
+- Migration 0047 registered-and-applies rides the existing migration test;
+  assert `v_camera_effective_policy` exposes the `c_reolink_*` columns.
+- Client pure functions: command-body construction (exact JSON incl.
+  `"manul"`), envelope parsing, rspCode mapping (`-9` → not-supported +
+  cap-prune, auth → retry-once), token-expiry refresh decision. No network.
+- Revert engine: due-row selection, supersede, clamps, snapshot-vs-fallback
+  payload choice; an integration test that inserts an expired un-reverted row
+  and asserts the boot sweep executes it (transport mocked via the client
+  trait).
+- Capability: `require_actuators` denied for a default role, allowed for
+  admin and an opted-in role; endpoint 403/404/400/409 matrix incl. the
+  not-bound 404 and the `-9` prune path.
+- Serde: `CameraStatusEntry` omits the Reolink fields when None (byte-level
+  JSON assertion), old-client compatibility proof.
+- **Hardware verification (not CI):** run the floodlight on/revert cycle and
+  capability detection against the #26 spike CX410 before calling Phase 2
+  done; record the observed `GetAbility` keys in the PR.
+
+---
+
+## 10. COMPONENT-MAP propagation walk (golden rule 8)
+
+Rows that fire, each updated or satisfied in the change that triggers it:
+
+- **A (new endpoint/DTO):** `/cameras/:id/actuator`, `/cameras/:id/reboot`,
+  `/cameras/:id/reolink/detect`, camera DTO `reolink_*` fields,
+  `CameraStatusEntry` fields.
+- **B (new setting/env):** `server_settings.reolink_floodlight_revert_secs`
+  admin knob + `REOLINK_FLOODLIGHT_REVERT_SECS` / `REOLINK_SIREN_DEFAULT_SECS`
+  env defaults; env-reference docs page.
+- **C (new migration):** 0047 + MIGRATIONS registration.
+- **E (new camera capability):** actuators join PTZ/imaging in the camera
+  editor + per-camera caps (auto-detected).
+- **G (RBAC change):** new capability, role editor, deny-by-default.
+- **H (admin console):** camera-editor section, settings-panel knob,
+  live-tile buttons.
+- **I (install/docs):** §8 sweep list (docs-only; no compose/secret rows).
+- **L (user-visible capability):** announce path (README feature list,
+  docs-site, release notes).
+- **M (decision):** §11 entry.
+- **Section 3 (cross-client parity):** add an "Actuators (Reolink)" row: web
+  admin SHIPPED, desktop SHIPPED, Android DEFERRED, iOS/macOS DEFERRED.
+
+`docs/COMPONENT-MAP.md` itself gains the new surface (the
+`services/api/src/reolink/` device-HTTP client seam) in §1.3. The neolink
+sidecar surface is never added (it never shipped).
+
+## 11. Required DECISIONS.md entry (write in the Phase 1 change) — FINALIZED
+
+> **Title:** Reolink actuator control via a direct in-process HTTP-API client
+> (not a neolink-MQTT sidecar).
+>
+> **Chosen:** A small `services/api/src/reolink/` module using `reqwest`
+> (already in-tree) that logs in for a token and POSTs the documented Reolink
+> CGI commands (`AudioAlarmPlay` siren with a real on AND off, `SetWhiteLed`
+> floodlight with real mode/brightness, `SetIrLights`, `SetPowerLed`,
+> `SetPirInfo`, `Reboot`), with **per-model capability auto-detection from
+> `GetAbility`** cached per camera (replacing operator-declared caps).
+> Mirrors `ptz.rs` (authed device HTTP, per-camera DB creds) and `frigate.rs`
+> (reqwest client). Dedicated `reolink_*` camera columns (not `onvif_*`
+> reuse: ports/schemes differ and the features must stay orthogonal). Reuses
+> the prior plan's `actuators` RBAC capability, the `camera_actuations`
+> TTL-revert journal + boot/periodic sweep (closed-laptop invariant), the
+> `server_settings` floodlight-revert live knob (D4, #39/#31 precedent), and
+> the `/status` surface. Revert is snapshot-restore of the pre-actuation
+> `GetWhiteLed` state (the HTTP API's setters are absolute; neolink's
+> off-restores-auto semantics do not exist here). HTTPS-first with HTTP
+> fallback and self-signed-cert acceptance, LAN-only, same posture as ONVIF
+> today. Siren ships capability-gated with a documented model/firmware-flaky
+> caveat (HA core #91517, #98594, #159989).
+>
+> **Rejected:**
+> - **neolink container over MQTT (the prior #25/PR #44 plan,
+>   `docs/NEOLINK-ACTUATOR-PLAN.md`).** Required two extra containers **and a
+>   dedicated MQTT broker** solely to isolate neolink's **retained
+>   `neolink/config` credential leak** (spike-verified: it publishes camera
+>   user+password to a retained topic any subscriber can read). Its siren has
+>   no off-signal by design and was a **no-op on a siren-equipped CX410** in
+>   the #26 spike. Its floodlight is on/off-only vs the HTTP API's full mode
+>   set. It tracks a fast-moving reverse-engineered Baichuan-protocol binary
+>   pinned at v0.6.2. The entire D1/D2 broker-isolation apparatus existed only
+>   to paper over the bus's credential exposure; the HTTP API removes the
+>   exposure outright and needs zero new processes.
+> - **neolink-as-a-crate (binary Baichuan port-9000 protocol in-process).**
+>   Rejected earlier for its huge dependency tree incl. gstreamer tracking a
+>   fast-moving RE project (golden rule 6). **Note:** that earlier rejection
+>   was of the **binary port-9000 protocol crate, NOT the documented Reolink
+>   HTTP API** — the HTTP API was never weighed until
+>   `docs/REOLINK-CONTROL-ARCH-DECISION.md`, which is why #25 initially
+>   reached for the sidecar.
+> - **Home Assistant as the control plane** — mandatory third service; a
+>   self-hosted VMS should not depend on another platform for a first-party
+>   feature.
+> - **Client-side revert timers** — closed laptop = light on all night; the
+>   TTL must live on the same side as the engine enforcing it.
+> - **Plain-`off` revert payload** (the neolink plan's approach) — valid only
+>   under neolink's off-restores-auto toggle semantics; under the HTTP API's
+>   absolute setters it would force night-auto cameras dark, so
+>   snapshot-restore replaces it (with a static mode-auto fallback when the
+>   pre-read fails).
+>
+> **Revisit triggers:** a battery/Baichuan-only Reolink (no ONVIF/RTSP/HTTP)
+> use case appears with real demand (would reopen neolink-as-source, still
+> parked); Reolink deprecates or auth-gates the CGI API in a firmware line
+> Crumb targets; `reolink_aio`'s issue corpus shows a model class where the
+> light-class actuators (not just siren) are broadly unsupported; clients
+> need push (WebSocket/SSE) rather than `/status` polling for confirmed
+> state; a second, unrelated need for an MQTT control bus emerges in Crumb;
+> reliable model/actuator detection confidence plus UX work unlocks the
+> camera-add "enable floodlight/siren control?" proactive nudge (deferred
+> fast-follow, §12).
+
+---
+
+## 12. Setup gating & zero-footprint for non-Reolink installs
+
+Even simpler than the neolink plan's three layers, because there is no
+service at all — the feature is structurally identical to ONVIF PTZ:
+
+1. **Nothing to run.** No compose service, no broker, no image, no port, no
+   secret. A default install is byte-identical with or without this feature.
+2. **Backend dormant unless a camera is bound.** No camera has a
+   `reolink_host`, so the §4.5 poller finds an empty list and sleeps, the
+   token cache is empty, and no HTTP client ever fires. The api boots
+   identically.
+3. **UI gated.** Live-tile actuator buttons render only when a camera has
+   cached `reolink_caps` AND the user holds the `actuators` capability
+   (deny-by-default). The camera editor's "Reolink control" section is just
+   another collapsed optional block, like ONVIF.
+
+**It is a post-setup OPTIONAL binding, not part of the base install or the
+first-run wizard.** The wizard does not mention Reolink. An operator who has
+Reolinks opens the camera editor, fills in host + credentials (or clicks
+"copy from ONVIF"), hits "Detect capabilities", and gets exactly the buttons
+the camera supports.
+
+**v1 is manual opt-in.** The proactive camera-add nudge ("this looks like a
+Reolink — enable floodlight/siren control?") stays a **FAST-FOLLOW, not v1** —
+but note it got materially easier under this architecture: `GetAbility` +
+`GetDevInfo` give a *reliable* probe (the blocker under neolink was precisely
+that caps were guesswork), so the fast-follow is now mostly UX, not
+detection. Recorded as a revisit trigger in §11.
+
+---
+
+## 13. Phased task breakdown
+
+Every Rust task ends green on the full gate (`cargo fmt --all -- --check`,
+`cargo clippy --all-targets -- -D warnings`, `cargo test --workspace` against
+the throwaway Postgres) and observes the §9 db-test-harness rules (real
+`public` schema + unique-key isolation, NOT search_path schemas; pool
+`max_size >= 8`). Model tags: Sonnet unless flagged. Phase 1 lands before
+anything depending on it.
+
+Gone vs the neolink plan: old T2 (`neolink_config` singleton), T4 (MQTT
+client + supervisor), T11 (compose + broker + secrets), and the Integrations
+page half of T8. New: the client/caps tasks T3/T4.
+
+### Phase 1: schema + capability foundation
+
+**T1. Migration 0047 + Camera plumbing** (Sonnet, M)
+Files: `db/migrations/0047_reolink_actuators.sql` (the five `cameras`
+columns, `camera_actuations`, `reolink_camera_status`, the
+`server_settings.reolink_floodlight_revert_secs` D4 column, the
+`CREATE OR REPLACE VIEW` tail-append), `services/common/src/db.rs`
+(MIGRATIONS array + row mapping + camera update), `services/common/src/types.rs`
+(Camera fields), `services/api/src/config_routes.rs` + `dto.rs` (camera DTOs:
+host/user/password writable with onvif_*-style partial-update + write-only
+password; caps read-only).
+Accept: migration applies on fresh + existing DB; view exposes the
+`c_reolink_*` columns at the tail; `PUT /config/cameras/{id}` round-trips
+host/user/password; omitted fields untouched; password never echoed;
+`reolink_caps` not writable via the DTO.
+
+**T2. `actuators` RBAC capability** (Sonnet, S)
+Files: `services/common/src/types.rs` (Capabilities + all()),
+`services/api/src/auth_mw.rs` (`can_actuators`/`require_actuators` + the
+literal constructions), `services/api/src/admin.html` (role-editor checkbox).
+Accept: stored roles without the key deserialize to false; admin true; role
+editor persists it; `node --check` passes on the extracted script.
+
+### Phase 2: the Reolink HTTP client + endpoints
+
+**T3. `reolink/client.rs`: HTTP client, auth/token cache, command set,
+error mapping** (Sonnet, L; **[OPUS] review pass on credential/token
+handling + the auth-retry/backoff logic** — this is the security-sensitive
+core: creds in memory, token redaction in logs, lockout avoidance)
+Files: `services/api/src/reolink/{mod,client}.rs`, `state.rs` (token/scheme
+caches on AppState).
+Accept: pure-function tests for every command body (exact JSON incl.
+`"manul"`) and the envelope/rspCode parser; HTTPS→HTTP fallback and scheme
+caching proven with the transport trait; token refresh before lease expiry;
+auth failure → single re-login retry → backoff (no hot-loop); `-9` maps to
+the not-supported error; no credential or `?token=` value ever logged.
+
+**T4. `reolink/caps.rs`: GetAbility capability detection + cache +
+`/cameras/:id/reolink/detect`** (Sonnet, M)
+Files: `services/api/src/reolink/{caps,routes}.rs`, `db.rs` (caps upsert).
+Accept: ability→cap mapping lifted from `reolink_aio` and unit-tested against
+recorded `GetAbility` fixtures; bind-time detection best-effort (failure
+doesn't block camera save); detect endpoint AdminUser-gated, returns caps +
+model/firmware; cache prune on `-9` verified. **Hardware check:** run detect
+against the spike CX410 and record the observed ability keys in the PR.
+
+**T5. Actuator + reboot endpoints** (Sonnet, M)
+Files: `services/api/src/reolink/routes.rs`, `main.rs` (merge routes),
+`dto.rs`.
+Accept: full 403/404/400/409 matrix from §4.3 (capability, camera grant,
+not-bound, missing cap, bad action, clamps incl. the siren 1..=300 cap and
+brightness 1..=100); floodlight `on` with no `duration_s` resolves the D4
+default (T5a), siren defaults to `REOLINK_SIREN_DEFAULT_SECS`; synchronous
+error propagation (a failed camera call is not a 200); reboot requires
+AdminUser.
+
+**T5a. D4 floodlight-revert default: `server_settings` resolver + setter**
+(Sonnet, S)
+Files: `services/api/src/reolink/settings.rs` (resolver cloning
+`scrub_settings.rs::resolve`: nullable DB column over the
+`REOLINK_FLOODLIGHT_REVERT_SECS` env default, clamp 1..=3600),
+`services/common/src/db.rs` (setter), `services/api/src/config.rs` (env
+defaults incl. `REOLINK_SIREN_DEFAULT_SECS`), `services/api/src/config_routes.rs`
+(field beside the scrub-preview tunables).
+Accept: NULL resolves to env; set value wins and is re-clamped; null via the
+API resets to NULL→env; resolve is per-call (no ApiConfig snapshot), proven
+by a unit test on the pure merge.
+
+**T6. TTL revert engine + boot/periodic sweep** (Sonnet, L; **[OPUS] review
+pass on the failure-mode matrix** — this is the physical-world-safety core)
+Files: `services/api/src/reolink/revert.rs`, `db.rs` (journal accessors),
+`alerts.rs` (`reolink_revert_failed`).
+Accept: §9 revert tests green; snapshot-then-act stores the `GetWhiteLed`
+state (static fallback on pre-read failure); kill-the-api-mid-TTL reverts on
+next boot; camera-unreachable revert retries then alerts within the grace
+window; supersede + early-cancel semantics proven; sweep idempotent.
+
+### Phase 3: status
+
+**T7. Confirmed-state poller + `/status` join** (Sonnet, M)
+Files: `services/api/src/reolink/poll.rs`, `main.rs` (spawn),
+`status.rs`, `dto.rs`.
+Accept: fields absent (not null) for non-Reolink cameras, older payload shape
+unchanged; two batch queries, no per-camera N+1; write-through after a
+successful actuation; zero bound cameras = idle task, no HTTP, no log noise;
+per-camera backoff on unreachable; `actuation_expires` reflects the pending
+journal row.
+
+### Phase 4: clients (web + desktop)
+
+**T8. Web admin: camera-editor Reolink section + D4 knob** (Sonnet, M)
+Files: `services/api/src/admin.html`.
+Accept: host/user/write-only password + "copy from ONVIF" prefill + "Detect
+capabilities" button rendering cap badges + model/firmware; siren badge
+carries the D3 flaky hint; D4 field on the settings panel (empty = inherit
+env); `esc()` on all interpolations; `node --check` green; api rebuilt to
+verify.
+
+**T9. Web admin: live-tile actuator buttons** (Sonnet, M)
+Files: `services/api/src/admin.html`.
+Accept: buttons drawn only from cached `reolink_caps` AND `caps.actuators`;
+floodlight countdown driven by `actuation_expires`; tap-again cancels; siren
+press-hold 600 ms guard + explicit off while sounding; no-caps/older-server
+degrade renders nothing.
+
+**T10. Desktop: actuator cluster on the PTZ tile pattern** (Sonnet, M)
+Files: `apps/desktop/src/app.js` (+ rebuild: Tauri bakes ../src into the exe;
+rebuild + relaunch + CDP-verify before claiming done; `libmpv-2.dll` beside
+the exe).
+Accept: same interaction matrix as T9; gated on `caps.actuators`; verified
+live against a dev server via CDP.
+
+### Phase 5: docs + governance (+ deferred mobile)
+
+**T11. Docs sweep** (Sonnet, S — was M; no compose/broker/secret content)
+Files: `docs/AI-INSTALL.md` (short optional note + Verify), README feature
+line, `scripts/setup-env.sh` + `.env.example` (two commented `REOLINK_*`
+defaults), `docs-site/docs/integrations/reolink.md` (new, operator-facing:
+binding, auto-detection, siren caveat + HA issue links, HTTPS/self-signed
+LAN-only note, battery-cam scope note),
+`docs-site/docs/configuration/environment-reference.md`.
+Accept: AI-INSTALL Verify present; docs-site page is operator-language; env
+reference lists both `REOLINK_*` keys; no compose docs touched.
+
+**T12. COMPONENT-MAP + DECISIONS entries** (Sonnet, S; ideally folded into
+the Phase 1 change rather than trailing, per golden rules 7/8)
+Files: `docs/COMPONENT-MAP.md`, `docs/DECISIONS.md`.
+Accept: §10 rows + parity row present; §11 entry verbatim in spirit
+(including the binary-Baichuan-vs-HTTP-API clarification and the
+snapshot-restore revert rejection note).
+
+**T13. Android actuator bar** (Sonnet, L, DEFERRED): Compose actuator row by
+the PTZ controls, `actuator()` API method, `/status` fields; build on dev1,
+verify via wireless ADB. **T14. iOS/macOS** (Sonnet, L, DEFERRED): SwiftUI
+equivalent in `apps/ios/Crumb/` (NOT apps/desktop), build on macmini.
+
+Effort: backend 3-5 focused days (Phases 1-3; roughly one day lighter than
+the neolink plan — no MQTT client, no supervisor, no broker), web + desktop
+3-4, docs half a day, mobile 2-3 each when scheduled.
+
+---
+
+## 14. Deltas + open points for the maintainer
+
+Everything above is implementable as written; two design nuances made inside
+this plan (consistent with the ratified direction, flagged for visibility):
+
+1. **Snapshot-restore revert (§4.4)** replaces the neolink plan's plain-`off`
+   revert payload, because `SetWhiteLed` is absolute and plain-off would
+   force night-auto cameras dark. Accepted race (operator edits mode in the
+   Reolink app mid-TTL) is documented; static mode-auto fallback covers a
+   failed pre-read.
+2. **Siren gets its own short default TTL** (`REOLINK_SIREN_DEFAULT_SECS`,
+   default 10 s, hard clamp 300 s) separate from the D4 floodlight knob — a
+   siren inheriting a 30 s+ floodlight default felt wrong, and manual-mode +
+   server revert avoids the camera-side-duration trap (HA #159989). The env
+   default is deliberately not a `server_settings` knob in v1 (YAGNI; add it
+   the first time an operator asks).

--- a/docs/REOLINK-CONTROL-ARCH-DECISION.md
+++ b/docs/REOLINK-CONTROL-ARCH-DECISION.md
@@ -1,0 +1,425 @@
+# Reolink actuator control: neolink-MQTT sidecar vs direct Reolink HTTP-API client
+
+Status: **RESEARCH-BACKED ARCHITECTURE DECISION** for issue #25 (Reolink
+actuator control). This document re-opens exactly one question that
+`docs/NEOLINK-ACTUATOR-PLAN.md` (and PR #44) had treated as settled: **should
+#25 drive Reolink actuators through a neolink container over MQTT, or through a
+direct, in-process Reolink HTTP-API client** (the approach Home Assistant's
+`reolink` integration uses via the `reolink_aio` library)?
+
+The trigger is honest: the #26 hardware spike plus a first read of the prior art
+suggest the neolink-MQTT plan reinvented, at higher cost, something the
+ecosystem already solves with a plain authed HTTP client, the same shape Crumb
+**already uses** for ONVIF PTZ (`services/api/src/ptz.rs`), the Frigate provider
+(`services/api/src/detection/frigate.rs`), and go2rtc reconcile. The
+DECISIONS-relevant nuance (see §7): the alternative that was previously
+"rejected in-process" was **neolink-as-a-crate**, i.e. the reverse-engineered
+**binary Baichuan protocol on port 9000** with its gstreamer tree, **not** the
+documented Reolink HTTP API. The HTTP API was never actually weighed. This doc
+weighs it.
+
+**Bottom line up front: recommend the direct Reolink HTTP-API client.** It
+deletes the sidecar container, the dedicated `mosquitto-neolink` broker, and the
+entire D1/D2 credential-leak apparatus; it uses a documented, HA-validated API;
+and it fits Crumb's existing authed-device-HTTP patterns exactly. The one honest
+caveat, siren reliability, is model-dependent under **both** approaches (see
+§5), so it is not a differentiator that saves the sidecar.
+
+---
+
+## 1. The two architectures, concretely
+
+### Option N — neolink sidecar over MQTT (the current #25 / PR #44 plan)
+
+```
+Crumb api ──MQTT──> mosquitto-neolink ──MQTT──> neolink container ──Baichuan:9000──> Reolink cam
+  (rumqttc)          (dedicated broker,           (RE'd binary proto,
+                      profiles: [neolink])         pinned v0.6.2)
+```
+
+New moving parts on the operator's box: **two extra containers** (`neolink` +
+`mosquitto-neolink`), a **dedicated MQTT broker** with generated password, a
+supervised rumqttc client + version-bump hot-reload loop, a hand-authored
+`neolink.toml` carrying camera creds, and the D1/D2 mitigations for neolink's
+retained-credential leak. Control is fire-and-forget over a message bus; state
+comes back on retained status topics; a server-side TTL-revert journal exists
+partly because MQTT publishes are one-way and the closed-laptop invariant needs
+server truth.
+
+### Option H — direct Reolink HTTP-API client (the HA / `reolink_aio` approach)
+
+```
+Crumb api ──HTTPS(fallback HTTP)──> Reolink cam  /cgi-bin/api.cgi
+  (reqwest, login→token, POST JSON commands)
+```
+
+New moving parts: **zero containers, zero brokers.** A small
+`services/api/src/reolink/` module with one `reqwest` client (mirroring
+`frigate.rs`, which already does `reqwest::Client::builder()` at
+`detection/frigate.rs:648`), a login→token step, and request/response DTOs for
+the documented commands. Control is a synchronous request/response, so the
+handler learns success/failure immediately (no optimistic-then-reconcile dance),
+and the TTL-revert engine still exists for the closed-laptop invariant but arms
+off a call the server already knows landed.
+
+---
+
+## 2. The documented Reolink HTTP API (tested / cited)
+
+All commands are `POST` to `http://<cam>/cgi-bin/api.cgi?cmd=<Cmd>&token=<tok>`
+with a JSON array body. `reolink_aio` (HA's library) and `fwestenberg/reolink`
+agree on the shapes below.
+
+**Auth.** `Login` returns a `Token` (`name` + `leaseTime`); the token rides the
+query string on every later call. `reolink_aio` tries **HTTPS:443 first, falls
+back to HTTP:80**. (Sources: `reolink_aio/api.py`; `fwestenberg/reolink`
+`camera_api.py`.)
+
+```json
+{"cmd":"Login","action":0,"param":{"User":{"userName":"…","password":"…"}}}
+```
+
+**Siren** — `AudioAlarmPlay` (`fwestenberg` `set_siren`, verbatim from code):
+
+```json
+{"cmd":"AudioAlarmPlay","action":0,
+ "param":{"alarm_mode":"manul","manual_switch":1,"times":2,"channel":0}}
+```
+
+`manual_switch:1` = on, `0` = off; `alarm_mode:"times"` plays N cycles then
+stops. (`"manul"` is Reolink's own misspelling, keep it.) Officially documented
+by Reolink community/support and reproduced in `reolink_aio`.
+
+**Floodlight** — `SetWhiteLed`; **modes** off/auto/onatnight/schedule/adaptive
+(+ conditional autoadaptive/scheduleplus), with `state`, `mode`, `bright`,
+`ColorTemp`:
+
+```json
+{"cmd":"SetWhiteLed","param":{"WhiteLed":{"state":1,"channel":0,"mode":1,"bright":100}}}
+```
+
+This is strictly **richer** than neolink's floodlight, which is `on|off` only.
+Crumb could expose the real Reolink mode set (e.g. "on at night", "auto",
+"schedule", brightness) instead of the two-state toggle the sidecar imposes.
+
+**IR lights** — `SetIrLights` (`{"IrLights":{"channel":0,"state":"Auto"}}`,
+also `On`/`Off`). **Status LED** — `SetPowerLed`. **PIR** — `SetPirInfo`.
+**Reboot** — `Reboot`. **Capability gating** — `GetAbility` populates an
+abilities map; `reolink_aio`'s `supported(channel, cap)` / `api_version(cap)`
+decides per-model/per-channel whether each control exists (e.g.
+`api_version("GetWhiteLed") > 0`). This gives Crumb a *queryable* capability
+source instead of neolink's operator-declared `neolink_caps` guesswork.
+(Sources: `reolink_aio/api.py` command/ability tables; `fwestenberg`
+`camera_api.py` payloads.)
+
+---
+
+## 3. Comparison
+
+### 3.1 Security (credential exposure, attack surface)
+
+| | Option N (neolink+MQTT) | Option H (HTTP) |
+|---|---|---|
+| Camera creds at rest | **Leaked**: neolink publishes its full config, incl. camera user+password, to a **retained** `neolink/config` topic (spike-verified on CX410). Any client that can subscribe reads creds forever. | Creds live only in `cameras`/`server_settings` (encrypted-at-rest DB, same as ONVIF creds today). Never on a bus. |
+| Mitigations required | D1 dedicated password broker + D2 best-effort retained-scrub-on-connect. D2 is explicitly "does not protect a subscriber connected at republish; neolink re-publishes on restart." | **None.** The leak topic does not exist. |
+| New network surface | A new MQTT broker + a new long-lived container speaking a **reverse-engineered** binary protocol to the camera. | One outbound HTTPS client from the api, identical trust model to ONVIF PTZ today. |
+| Creds also in | `neolink.toml` (hand-authored, gitignored) **and** the broker password file **and** the retained topic. | DB only. |
+
+Option H is strictly better on security: it removes an at-rest credential leak
+that Option N can only *mitigate*, not eliminate, and it adds no broker to
+attack. (Sources: spike facts; neolink README `/neolink/config` retained topic;
+NEOLINK-ACTUATOR-PLAN §2.)
+
+### 3.2 Footprint / dependencies
+
+| | Option N | Option H |
+|---|---|---|
+| Containers | +2 (`neolink`, `mosquitto-neolink`), profile-gated | **0** |
+| Broker | dedicated mosquitto, generated password, entrypoint wrapper | none |
+| Rust deps | rumqttc client + supervisor + version hot-reload | `reqwest` (**already a workspace dep**), `serde` |
+| Config artifacts | `neolink.toml` (creds), `.env` `NEOLINK_MQTT_*` block, example TOML, `.gitignore` entry | camera DB columns only |
+| Pinned upstream | `quantumentangledandy/neolink:v0.6.2` (must never float to latest) | none |
+| Protocol basis | **reverse-engineered** Baichuan port-9000 binary | **documented** HTTP/CGI API |
+
+Option H is the far lighter footprint, and it is what golden rule 6 ("don't add
+heavyweight dependencies casually", "new background services need an issue
+discussion") points toward. Option N adds a background service *and* a broker.
+
+### 3.3 Capability coverage
+
+| Actuator | Option N (neolink MQTT) | Option H (HTTP API) |
+|---|---|---|
+| Floodlight | `on\|off` only; `off` restores auto (spike-confirmed) | Full `SetWhiteLed`: off/auto/onatnight/schedule/adaptive + brightness + ColorTemp |
+| Siren | `control/siren on` only — **no off signal** in the protocol; **did NOTHING on the spike CX410** (which has a siren) | `AudioAlarmPlay` with explicit on **and** off (`manual_switch 0`) + `times` mode; but model-flaky (see §3.4) |
+| Status LED | `led on\|off` | `SetPowerLed` |
+| IR | `ir on\|off\|auto` | `SetIrLights` On/Off/Auto |
+| PIR | `pir on\|off` | `SetPirInfo` |
+| Reboot | `reboot` | `Reboot` |
+| Motion/state | retained `status/motion`, `status/floodlight` echoes | polled `GetWhiteLed`/`GetAudioAlarm`/etc., or reuse existing motion pipeline |
+
+Two capability facts favor Option H decisively:
+
+1. **neolink's siren has no "off"** (README: "the message is always 'on' as
+   there is no 'off' signal for the siren"). The HTTP API has an explicit off
+   (`manual_switch:0`). For a security VMS, "can sound the siren but can't
+   silence it from the app" is a real defect.
+2. **The spike's neolink siren was a no-op on a siren-equipped CX410.** So
+   Option N does not even reliably deliver the one actuator where it looked
+   comparable.
+
+Option N's only capability edge is *push* status (retained topics) vs Option H's
+*poll*. But Crumb has no WebSocket/SSE anyway, clients already poll `/status`,
+so this edge collapses to "poll the camera on the server side," which the api
+already does for go2rtc/Frigate.
+
+### 3.4 Reliability & model coverage (the honest part)
+
+Siren over the Reolink **HTTP API is itself model/firmware-flaky**, independent
+of neolink:
+
+- **E1 Zoom** — `AudioAlarmPlay` returns `error code 1 … -9/not support`, even
+  though the model is on the supported list and the siren works in Reolink's own
+  app (HA core issue #91517, unresolved).
+- **RLC-510WA** (fw 3.1.0.764) — `AudioAlarmPlay … -17/rcv failed` (HA core
+  issue #98594, unresolved).
+- **Atlas PT Ultra** — siren started with a duration **can't be turned off**
+  until the duration expires; a fix PR was opened then closed (HA core issue
+  #159989).
+
+So siren is the residual risk under **either** architecture. This matters for
+the decision because siren was the one place the sidecar might have claimed an
+advantage, and it does not: neolink's siren failed on the spike hardware, and
+the HTTP siren is inconsistent across models. **Floodlight/LED/IR/PIR/reboot,
+by contrast, are well-exercised over the HTTP API** (that is what HA users run
+daily) and floodlight over neolink was solid in the spike. Neither approach
+makes siren universally reliable; both make the light-class actuators reliable.
+
+Net: reliability is **a wash on siren** and **a slight edge to H on
+everything else** (documented API, no bus/broker/sidecar links that can each
+fail independently, synchronous success/failure instead of fire-and-hope).
+(Sources: HA core #91517, #98594, #159989.)
+
+### 3.5 Maintenance
+
+- **Option N** tracks a **fast-moving, one-maintainer reverse-engineering
+  project** (neolink is a fork of thirtythreeforty's fork; README: "additional
+  features not yet in upstream master"). Crumb must pin `v0.6.2` forever-ish, and
+  a Reolink firmware change or a neolink release can break the pin. Two container
+  images to watch for CVEs (neolink + mosquitto).
+- **Option H** tracks a **documented HTTP API** that Reolink publishes and that
+  HA's integration exercises across hundreds of models and firmwares. When a
+  model quirk appears, `reolink_aio`'s public issue history is a ready-made
+  compatibility oracle Crumb can mine. No image pins, no broker upgrades.
+
+Option H is the lower-maintenance path and the one whose bus-factor risk lives
+in a documented spec rather than in a single RE binary.
+
+### 3.6 Crumb-fit
+
+Option H **is** the existing pattern:
+
+- `services/api/src/ptz.rs` already does per-request authed device HTTP (ONVIF
+  SOAP over `http://host:port/...`), resolving per-camera creds from DB columns
+  with an env fallback. A Reolink client is the same story with a simpler
+  transport (JSON POST instead of SOAP).
+- `services/api/src/detection/frigate.rs:648` already builds a `reqwest` client
+  for an authed device/service. `reqwest` is already in the tree.
+- The endpoint mirrors `ptz.rs::ptz_command` line-for-line: `require_actuators()`
+  → `assert_camera_access()` → `get_camera` → 404-if-not-Reolink → validate →
+  act. The plan's §4.3 handler order is reused wholesale; only the transport
+  under it changes from "publish to MQTT" to "POST to the camera."
+- Per-camera creds slot into the same DB-columns-win-over-env precedence ONVIF
+  already uses (`onvif_host/port/user/password`), so there is a well-worn place
+  to store `reolink_host/port/user/password` (or reuse the ONVIF creds when the
+  camera is the same device).
+
+Option N, by contrast, introduces Crumb's **first** message-bus control plane,
+its **first** dedicated broker, and a hand-authored external config file, none
+of which have precedent in the codebase.
+
+---
+
+## 4. RECOMMENDATION
+
+**Build the direct Reolink HTTP-API client (Option H). Drop the neolink sidecar
+and the dedicated broker from #25.**
+
+Rationale, ranked:
+
+1. **It eliminates, rather than mitigates, the credential-at-rest leak** that
+   forced the entire D1/D2 broker-isolation design. No bus, no retained
+   `neolink/config`, no scrub workaround.
+2. **Zero new containers, zero broker, uses deps already in the tree**, and is
+   the same authed-device-HTTP shape Crumb already ships in `ptz.rs` and
+   `frigate.rs`. Golden rule 6 favors it.
+3. **Richer, documented, HA-validated capability**: real floodlight modes +
+   brightness, a siren with an actual off, `GetAbility`-based per-model gating
+   instead of operator-declared guesses.
+4. **The sidecar's would-be advantages don't hold**: its siren was a no-op on
+   the spike's siren-equipped CX410 and has no off-signal by design; its only
+   real edge (push status) is moot because Crumb polls `/status` anyway.
+5. **Lower long-term maintenance**: a documented API and HA's issue corpus
+   beat pinning a fast-moving reverse-engineered binary plus a broker image.
+
+Honest trade-offs accepted:
+- **Siren stays model-flaky** (HA #91517/#98594/#159989). We ship it gated with
+  the same "unvalidated / model-dependent" caveat the plan already has (D3),
+  and we now have HA's issue trail to set expectations per model.
+- We give up neolink's **battery/Baichuan-only camera** reach (cams with no
+  ONVIF/RTSP/HTTP). Those cameras also can't be Crumb RTSP sources today, so
+  they're out of #25's scope regardless; recorded as a revisit trigger.
+- Some very old firmwares expose the HTTP API only over cleartext HTTP:80.
+  `reolink_aio` handles this with HTTPS-first-then-HTTP fallback; we mirror that
+  and note it's LAN-only traffic (same posture as ONVIF today).
+
+---
+
+## 5. What concretely changes in the #25 plan under each option
+
+### Under Option H (recommended) — what the plan **loses**
+
+Delete from `docs/NEOLINK-ACTUATOR-PLAN.md`:
+
+- **§2 entirely** (broker isolation), and with it **D1** (dedicated
+  `mosquitto-neolink`) and **D2** (retained-config scrub) — there is no bus.
+- **§4.1 rumqttc client, §4.2 MQTT supervisor** → replaced by a small
+  `services/api/src/reolink/client.rs` `reqwest` client + login-token cache
+  (clone `frigate.rs`), no version-bump reconnect loop needed for a stateless
+  HTTP client.
+- **§8.1 compose services** (`neolink`, `mosquitto-neolink`) — gone. No new
+  profile, no `docker compose` surface change at all beyond docs.
+- **§8.2 secrets**: no `NEOLINK_MQTT_*`, no `neolink.toml`, no broker password.
+  Replaced by per-camera `reolink_*` DB columns (or ONVIF-cred reuse) — same
+  shape as the existing `onvif_*` columns, populated via the camera editor.
+- **§3.2 `neolink_config` singleton** → becomes (optionally) nothing, or a tiny
+  `reolink` enable flag; there is no external service to point at.
+
+Keep (near-unchanged) from the plan — this is the load-bearing insight, most of
+the plan survives:
+
+- **§3.1 migration 0047** minus the MQTT bits: `camera_actuations` TTL-revert
+  journal, the `neolink_camera_status`→`reolink_camera_status` state cache, and
+  **D4** (`server_settings.neolink_floodlight_revert_secs` live knob) all still
+  apply. Rename `neolink_*` columns to `reolink_*`; `neolink_caps` becomes
+  `reolink_caps` (or is derived from `GetAbility`).
+- **§4.3 actuator endpoint** handler order — identical; only the publish step
+  becomes an HTTP call whose result the handler can check synchronously.
+- **§4.4 revert engine** — identical and now *simpler*, since arm-on-success is
+  literal (the call returned 200) rather than arm-on-publish-and-hope.
+- **§5 `actuators` RBAC capability, §6 `/status` surface, §7 clients** — all
+  unchanged; clients don't know or care about the transport.
+- **§9 tests, §10 COMPONENT-MAP walk** — unchanged in spirit; drop the
+  broker/compose rows, add a "Reolink HTTP client" seam.
+
+Net effect: **Phase 2's T4 (MQTT client) and most of Phase 5's T11 (broker +
+compose + secrets) evaporate**; the schema, RBAC, revert engine, status, and
+client work is reused almost verbatim. This is a *smaller* build than the
+sidecar, not a larger one.
+
+### Under Option N (status quo) — what stays
+
+Everything in `docs/NEOLINK-ACTUATOR-PLAN.md` as written, including the two
+extra containers, the dedicated broker, D1, D2, the `neolink.toml` handling, and
+the acceptance that the retained-cred leak is *mitigated* not removed and that
+siren was unverified/no-op on the spike hardware.
+
+---
+
+## 6. Proposed revised `docs/DECISIONS.md` entry
+
+> **Title:** Reolink actuator control via a direct in-process HTTP-API client
+> (not a neolink-MQTT sidecar).
+>
+> **Chosen:** A small `services/api/src/reolink/` module using `reqwest`
+> (already in-tree) that logs in for a token and POSTs the documented Reolink
+> CGI commands (`AudioAlarmPlay` siren, `SetWhiteLed` floodlight with real
+> mode/brightness, `SetIrLights`, `SetPowerLed`, `SetPirInfo`, `Reboot`), with
+> per-model capability gating from `GetAbility`. Mirrors `ptz.rs` (authed device
+> HTTP, DB-creds-win-over-env) and `frigate.rs` (reqwest client). Reuses the
+> plan's `actuators` RBAC capability, the `camera_actuations` TTL-revert journal
+> + boot/periodic sweep (closed-laptop invariant), the `server_settings`
+> floodlight-revert live knob (D4), and the `/status` surface. HTTPS-first with
+> HTTP fallback, LAN-only, same posture as ONVIF today.
+>
+> **Rejected:**
+> - **neolink container over MQTT (prior #25/PR #44 plan).** Requires two extra
+>   containers **and a dedicated MQTT broker** solely to isolate neolink's
+>   **retained `neolink/config` credential leak** (spike-verified). Its siren
+>   has no off-signal and was a **no-op on a siren-equipped CX410** in the #26
+>   spike. It tracks a fast-moving reverse-engineered Baichuan-protocol binary
+>   that must be version-pinned. All of D1/D2 exist only to paper over the bus's
+>   credential exposure. The HTTP API removes the exposure outright.
+> - **neolink-as-a-crate (binary Baichuan port-9000 protocol in-process).**
+>   Previously rejected for its huge dependency tree incl. gstreamer against a
+>   fast-moving RE project (golden rule 6). *Note:* this earlier rejection was of
+>   the **binary protocol crate**, NOT the documented HTTP API — the HTTP API was
+>   never weighed until this decision, which is why #25 initially reached for the
+>   sidecar.
+> - **Home Assistant as the control plane** — mandatory third service; a
+>   self-hosted VMS should not depend on another platform for a first-party
+>   feature.
+>
+> **Revisit triggers:** a battery/Baichuan-only Reolink (no ONVIF/RTSP/HTTP)
+> use case appears (would reopen neolink-as-source, still parked); Reolink
+> deprecates or auth-gates the CGI API in a firmware line Crumb targets;
+> `reolink_aio`'s issue corpus shows a model class where the light-actuator
+> commands (not just siren) are broadly unsupported; a second, unrelated need
+> for an MQTT control bus emerges in Crumb (would re-evaluate a shared bus).
+
+---
+
+## 7. Residual risks (both approaches)
+
+- **Siren is model/firmware-dependent regardless of transport.** Ship it gated
+  behind an operator-visible cap with a "may be unsupported on your model"
+  note; lean on HA issue history (#91517 E1 Zoom, #98594 RLC-510WA, #159989
+  Atlas PT Ultra) to set expectations. Not a reason to prefer the sidecar,
+  which failed the same test on the spike CX410.
+- **Per-camera / per-model capability gating stays a real task.** Option H can
+  *query* it (`GetAbility`), which is better than operator-declared caps, but
+  the mapping from ability flags to Crumb's actuator buttons still needs care
+  and a graceful "control not supported on this model" degrade.
+- **Cleartext-HTTP fallback on old firmware.** LAN-only mitigates it (same as
+  ONVIF/PTZ today); document it, don't expose it off-LAN.
+- **Token lease expiry / re-login** must be handled (short leases on some
+  models); `reolink_aio` re-logs-in on expiry, mirror that.
+- **Login rate/lockout**: some firmwares lock an account after rapid failed
+  logins; cache the token and back off on auth failure.
+
+---
+
+## 8. Source list & confidence
+
+**Reached and quoted:**
+- `reolink_aio/api.py` (HA's library): Login/token, HTTPS-then-HTTP,
+  `SetWhiteLed` modes, `AudioAlarmPlay`/`SetAudioAlarm`, `SetIrLights`,
+  `SetPowerLed`, `SetPirInfo`, `Reboot`, `GetAbility`/`supported()` gating.
+- `fwestenberg/reolink` `camera_api.py`: exact `set_siren` /
+  `AudioAlarmPlay` body (`alarm_mode:"manul", manual_switch, times:2,
+  channel:0`), `SetWhiteLed` bodies, `Login` body, token-in-query-string,
+  `SetIrLights` body.
+- neolink `README.md`: reverse-engineered Baichuan port-9000; MQTT control
+  topics incl. `control/siren on` ("no off signal"); retained `/neolink/config`
+  topic; fork lineage.
+- HA core issues #91517 (E1 Zoom `-9/not support`), #98594 (RLC-510WA
+  `-17/rcv failed`), #159989 (Atlas PT Ultra can't-turn-off-after-duration).
+- Reolink community/support: `AudioAlarmPlay` curl examples (manul/times).
+- Crumb repo: `ptz.rs` (ONVIF authed device HTTP, DB-creds precedence),
+  `detection/frigate.rs:648` (reqwest client in-tree), NEOLINK-ACTUATOR-PLAN.md.
+
+**Could not reach / limited:**
+- The **official Reolink HTTP-API PDF** (loxone mirror) was not fetched
+  directly; the CGI command names/params are nonetheless triangulated and
+  agree across `reolink_aio`, `fwestenberg`, and Reolink's own support/community
+  curl examples, so confidence in the command shapes is **high**.
+- The Reolink support page for *manually* triggering the siren documents only
+  the app/client UI, **not** curl; the curl form comes from the community/support
+  search result and `fwestenberg` code instead. Confidence in the siren body is
+  **high** (two independent code sources agree); confidence in siren *behavior
+  across models* is deliberately **low/mixed**, which is exactly what §3.4
+  reports.
+
+Overall confidence in the recommendation: **high.** The two facts that drive it,
+neolink's retained-credential leak and its dead siren on the spike CX410, are
+first-hand spike results, and the HTTP API's command set is corroborated by two
+independent open-source implementations plus HA's production integration.


### PR DESCRIPTION
Pivots #25 from the neolink-MQTT sidecar to a direct Reolink HTTP-API client, after a research pass over the proven ecosystem (reolink_aio / Home Assistant / fwestenberg-reolink) plus the hardware spike. Adds the cited arch-decision doc + the revised (smaller, zero-footprint) implementable plan, and retains the neolink plan as a labeled rejected-alternative record. The finalized reversed DECISIONS entry lands with Phase 1 per the plan. Design-only. refs #25