### PR TITLE
fix(docs): stop nginx leaking :3000 / http on docs.crumbvms.com redirects

### DIFF
--- a/docs-site/nginx.conf
+++ b/docs-site/nginx.conf
@@ -7,6 +7,11 @@ server {
   # Hide nginx version
   server_tokens off;
 
+  # Behind Cloudflare on 443 while nginx listens on :3000. Emit RELATIVE
+  # redirects (the auto directory trailing-slash 301) so the origin port and
+  # http scheme never leak into the browser URL. (Fixes the :3000 link bug.)
+  absolute_redirect off;
+
   # Docusaurus-friendly routing: try the exact file, then a directory index,
   # then fall back to Docusaurus's generated 404.html (NOT a bare 404) so a
   # client-side navigation to a route Docusaurus pre-rendered still gets a


### PR DESCRIPTION
Fixes #46. `absolute_redirect off;` in `docs-site/nginx.conf` so nginx emits relative redirects instead of stamping its `:3000` listen port + `http` into the `Location` (it sits behind Cloudflare on 443).

Repro: `GET https://docs.crumbvms.com/integrations/frigate` → `301 Location: http://docs.crumbvms.com:3000/integrations/frigate/`. With this change nginx returns a relative `Location`, so the browser keeps `https://docs.crumbvms.com`.

**Needs a docs-site rebuild + redeploy to take effect** (the docs CI here is build-check only).