### PR TITLE
chore(ci): leak-scan gate (block homelab identifiers from reaching main)

### DIFF
--- a/.github/workflows/leak-scan.yml
+++ b/.github/workflows/leak-scan.yml
@@ -1,0 +1,77 @@
+# Leak scan — blocks homelab identifiers (and, later, secrets) from reaching main.
+#
+# This is the un-bypassable layer: unlike a local hook, a required status check
+# under branch protection can't be skipped with --no-verify or a stale config.
+# Make `leak-scan / scan` a REQUIRED check on main (Settings → Branches).
+#
+# Rules: generic structural patterns ship in .gitleaks.toml (public, reveal
+# nothing); the maintainer's exact hostnames/labels/ids are injected here from the
+# HOMELAB_DENYLIST_B64 secret so the specific list never lives in the repo.
+#   Set it:  gh secret set HOMELAB_DENYLIST_B64 -b "$(base64 -w0 ~/.claude/homelab-identifiers.txt)"
+#
+# PRs scan only their OWN commit range, so the pre-existing identifiers still on
+# main don't fail every PR — a leak is blocked only when a PR ADDS one. The
+# nightly job scans the whole tree to surface the backlog.
+
+name: leak-scan
+
+on:
+  pull_request:
+  schedule:
+    - cron: "17 9 * * *" # ~02:17 America/Los_Angeles; full-tree backlog sweep
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          VER=8.18.4
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${VER}/gitleaks_${VER}_linux_x64.tar.gz" -o gl.tgz
+          tar -xzf gl.tgz gitleaks
+          sudo install gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Assemble config (public generic rules + private denylist secret)
+        env:
+          DENY_B64: ${{ secrets.HOMELAB_DENYLIST_B64 }}
+        run: |
+          cp .gitleaks.toml /tmp/leaks.toml
+          if [ -n "$DENY_B64" ]; then
+            PATS="$(printf '%s' "$DENY_B64" | base64 -d | grep -vE '^[[:space:]]*#|^[[:space:]]*$' | paste -sd '|' -)"
+            {
+              printf '\n[[rules]]\n'
+              printf 'id = "homelab-private-identifiers"\n'
+              printf 'description = "Private homelab identifiers (injected from HOMELAB_DENYLIST_B64)"\n'
+              printf "regex = '''(%s)'''\n" "$PATS"
+            } >> /tmp/leaks.toml
+          else
+            echo "::warning title=leak-scan::HOMELAB_DENYLIST_B64 not set — scanning with public generic rules only. Set the secret to enforce the full identifier list."
+          fi
+
+      - name: Scan PR commit range
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags --depth=0 origin "${{ github.base_ref }}" || git fetch --no-tags origin "${{ github.base_ref }}"
+          gitleaks detect \
+            --config /tmp/leaks.toml \
+            --redact --no-banner \
+            --log-opts="origin/${{ github.base_ref }}..HEAD" \
+            --exit-code 1
+
+      - name: Scan full tree (scheduled / manual)
+        if: github.event_name != 'pull_request'
+        run: |
+          gitleaks detect \
+            --config /tmp/leaks.toml \
+            --redact --no-banner \
+            --no-git --source . \
+            --exit-code 1

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,51 @@
+# gitleaks config for the crumbvms public repo — homelab-identifier + secret scan.
+#
+# This file is PUBLIC on purpose: it holds only GENERIC structural rules (private
+# IP ranges, NAS mount paths, internal domain suffixes) that reveal nothing
+# specific. The maintainer's exact hostnames / camera labels / VM ids are NOT
+# here — they are injected at CI time from the `HOMELAB_DENYLIST_B64` Actions
+# secret (see .github/workflows/leak-scan.yml), so the specific list never lives
+# in the repo.
+#
+# Run locally:  gitleaks detect --no-git --source . --config .gitleaks.toml
+
+title = "crumbvms leak-scan"
+
+# Deliberately NOT extending gitleaks' default secret rules yet — this gate's job
+# is homelab identifiers, and default rules can false-positive on a Rust codebase
+# and train people to bypass. Flip `useDefault = true` in a follow-up once a
+# baseline scan is triaged.
+# [extend]
+# useDefault = true
+
+[[rules]]
+id = "homelab-rfc1918"
+description = "Private RFC1918 LAN address (four octets — so semver never matches)"
+regex = '''\b(10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b'''
+tags = ["homelab", "network"]
+
+[[rules]]
+id = "homelab-mount-path"
+description = "Internal NAS / array mount path (Synology / Unraid conventions)"
+regex = '''(/volume1|/mnt/user)(/|\b)'''
+tags = ["homelab", "path"]
+
+[[rules]]
+id = "homelab-internal-domain"
+description = "Internal DNS suffix (private ARPA zone or mDNS)"
+regex = '''\b[a-z0-9][a-z0-9-]*\.(home\.arpa|local)\b'''
+tags = ["homelab", "network"]
+
+[allowlist]
+description = "Known-safe: RFC5737/RFC3849 documentation example ranges, app version, env example"
+regexes = [
+  '''\b192\.0\.2\.\d{1,3}\b''',
+  '''\b198\.51\.100\.\d{1,3}\b''',
+  '''\b203\.0\.113\.\d{1,3}\b''',
+  '''\b2001:db8:''',
+]
+paths = [
+  '''(^|/)VERSION$''',
+  '''\.env\.example$''',
+  '''(^|/)\.gitleaks\.toml$''',
+]


### PR DESCRIPTION
Adds the **un-bypassable** layer of the homelab-leak defense: a required CI check that scans every PR server-side, where no local hook, `--no-verify`, stale config, or concurrent session can skip it.

## Why
Local hooks and human care are *advisory* — a different machine or a `--no-verify` slips past them, and that's the observed failure mode with multiple sessions on the tree. Only a required status check under branch protection makes a leak physically unable to reach `main`. This is that check; the local hook stays as fast feedback so this rarely trips.

## How
- **`.gitleaks.toml`** ships only **generic structural rules** (RFC1918 four-octet IPs, NAS mount paths, internal DNS suffixes) — public, revealing nothing specific. Allowlists RFC5737/RFC3849 doc example ranges, `VERSION`, `.env.example`, and itself.
- **`leak-scan.yml`** assembles the runtime config by **appending the maintainer's exact identifiers**, decoded from the `HOMELAB_DENYLIST_B64` Actions secret — so the specific hostname/label/id list **never lives in the repo**. Scans run `--redact`, so a hit never re-prints the identifier in a public Actions log.
- **PRs scan only their own commit range** (`origin/base..HEAD`), so the ~24 identifiers still sitting on `main` don't fail every PR — a leak fails a PR only when that PR *adds* one. A **nightly job** scans the full tree to surface the backlog for cleanup.

## Owner setup (two steps — I can't do these; account/security scope)
1. **Set the secret** from the private list:
   ```
   gh secret set HOMELAB_DENYLIST_B64 -b "$(base64 -w0 ~/.claude/homelab-identifiers.txt)"
   ```
   (Re-run this whenever a new host/camera/id is added to the list.)
2. **Require the check on `main`**: Settings → Branches → branch protection rule for `main` → require status check **`leak-scan / scan`**. (Or: `gh api -X PUT repos/badbread/crumbvms/branches/main/protection/required_status_checks/contexts -f 'contexts[]=scan'`.)

Until step 1 is done the scan runs on the public generic rules only (and prints a warning). Until step 2 it runs but isn't blocking.

## Not in scope here
- Default gitleaks *secret* rules are left off for now (`useDefault` commented) to avoid day-1 false positives; flip on after a baseline triage.
- Scrubbing the ~24 pre-existing lines on `main` is the separate cleanup (task chip) — this gate doesn't require it and won't fail PRs over it.

Part of the leak-prevention hardening (local hook already upgraded to scan staged diffs + Write/Edit into the public tree, reading the same one list).
