### PR TITLE
feat(camera-compat): manual make/model/firmware entry (closes #48)

### DIFF
--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -4630,9 +4630,10 @@ async function loadCameraCompat(id) {
 
 function renderCompat(id, r) {
   const contributeBtn = `<button class="ghost sm" onclick="contributeCamera('${esc(id)}')">Contribute this camera</button>`;
+  const manual = manualDeviceInfoBlock(id, r);
   // No make read yet: prompt to identify.
   if (!r.make && !r.model) {
-    return `<div class="card-hint" style="margin:0">Not identified yet. Use <b>Identify (ONVIF)</b> to read this camera's make and model, then Crumb checks the compatibility database. Cameras without ONVIF can't be auto-identified.</div>`;
+    return `<div class="card-hint" style="margin:0">Not identified yet. Use <b>Identify (ONVIF)</b> to read this camera's make and model, then Crumb checks the compatibility database. Cameras without ONVIF can be set manually below.</div>` + manual;
   }
   const idLine = `<div style="margin:0 0 6px 0"><b>${esc(r.make || '(unknown make)')}</b> ${esc(r.model || '')}${r.firmware ? ` <span style="color:var(--dim2)">· firmware ${esc(r.firmware)}</span>` : ''}</div>`;
 
@@ -4654,15 +4655,15 @@ function renderCompat(id, r) {
       out += '</ul>';
     }
     out += `<div class="card-hint" style="margin-top:8px">Full list at <a href="https://docs.crumbvms.com/cameras/compatibility" target="_blank" rel="noopener">docs.crumbvms.com</a>. Something off? ${contributeBtn}</div>`;
-    return out;
+    return out + manual;
   }
 
   if (r.level === 'possible') {
-    return `${idLine}<div class="pill warn" style="margin-bottom:8px">Manufacturer recognized, model not in the database</div><div class="card-hint" style="margin:0">Crumb knows this maker but not this exact model. If it works well or has a quirk worth noting, help the next person: ${contributeBtn}</div>`;
+    return `${idLine}<div class="pill warn" style="margin-bottom:8px">Manufacturer recognized, model not in the database</div><div class="card-hint" style="margin:0">Crumb knows this maker but not this exact model. If it works well or has a quirk worth noting, help the next person: ${contributeBtn}</div>` + manual;
   }
 
   // Detected but not in the DB.
-  return `${idLine}<div class="card-hint" style="margin:0 0 8px 0">This camera isn't in the compatibility database yet. If you've got it working (or hit a quirk), consider adding it: ${contributeBtn}</div>`;
+  return `${idLine}<div class="card-hint" style="margin:0 0 8px 0">This camera isn't in the compatibility database yet. If you've got it working (or hit a quirk), consider adding it: ${contributeBtn}</div>` + manual;
 }
 
 async function identifyCamera(id) {
@@ -4701,6 +4702,48 @@ async function contributeCamera(id) {
 
 function openCompatForm() { if (COMPAT_CONTRIB && COMPAT_CONTRIB.url) window.open(COMPAT_CONTRIB.url, '_blank', 'noopener'); }
 function copyCompatDetails() { if (COMPAT_CONTRIB) copyText(COMPAT_CONTRIB.block); }
+
+/* Manual make/model/firmware entry (issue #48): for cameras without ONVIF, or to
+   correct a wrong probe. Prefilled from the current values; saving writes through
+   the camera-edit PUT (/config/cameras/:id) and re-checks the compatibility DB. */
+function manualDeviceInfoBlock(id, r) {
+  const open = (!r.make && !r.model) ? ' open' : '';
+  return `
+    <details class="detail-section" style="margin-top:10px"${open}>
+      <summary>
+        <span class="ds-chev">&#x25B6;</span>
+        <span class="ds-title">Set make/model manually</span>
+      </summary>
+      <div class="ds-body">
+        <div class="card-hint" style="margin:0 0 8px 0">For cameras without ONVIF (or to correct a wrong probe), type the make and model so Crumb can still check the compatibility database. Clear a field to blank it.</div>
+        <div class="form-grid">
+          <label class="fg-label" for="ce-dev-make">Make</label>
+          <div class="fg-ctl"><input id="ce-dev-make" value="${esc(r.make || '')}" placeholder="e.g. Uniview" maxlength="200" /></div>
+          <label class="fg-label" for="ce-dev-model">Model</label>
+          <div class="fg-ctl"><input id="ce-dev-model" value="${esc(r.model || '')}" placeholder="e.g. IPC2124SR3-ADPF28M" maxlength="200" /></div>
+          <label class="fg-label" for="ce-dev-fw">Firmware</label>
+          <div class="fg-ctl"><input id="ce-dev-fw" value="${esc(r.firmware || '')}" placeholder="optional" maxlength="200" /></div>
+        </div>
+        <div style="margin-top:8px"><button class="primary sm" onclick="saveCameraDeviceInfo('${esc(id)}')">Save make/model</button></div>
+      </div>
+    </details>`;
+}
+
+async function saveCameraDeviceInfo(id) {
+  const make = ($('ce-dev-make').value || '').trim();
+  const model = ($('ce-dev-model').value || '').trim();
+  const firmware = ($('ce-dev-fw').value || '').trim();
+  try {
+    // null clears the column (double-option), a string sets it.
+    await api('/config/cameras/' + id, { method: 'PUT', body: JSON.stringify({
+      make: make || null, model: model || null, firmware: firmware || null,
+    }) });
+    toast('Make/model saved');
+    loadCameraCompat(id);
+  } catch (e) {
+    toast((e && e.message) || 'Could not save make/model', 'err', 5000);
+  }
+}
 
 /* ── Camera <-> Home Assistant entity links (issue #52, Phase 1) ──
    Link this camera to HA motion/door sensors (role 'motion') and lights/switches

--- a/services/api/src/config_routes.rs
+++ b/services/api/src/config_routes.rs
@@ -1005,6 +1005,36 @@ async fn update_camera(
         None => existing.onvif_password.clone(),
     };
 
+    // make/model/firmware (camera compatibility, issue #48): ONVIF `identify`
+    // populates these, but a non-ONVIF camera can also set them by hand here.
+    // Same double-option merge as the onvif_* fields. The `Camera` struct does
+    // not carry these columns, so read the current values directly to honor
+    // "omitted = unchanged".
+    let (cur_make, cur_model, cur_firmware) = db::get_camera_device_info(pool, id)
+        .await
+        .context("get_camera_device_info")?;
+    let make: Option<String> = match &body.make {
+        Some(inner) => inner
+            .clone()
+            .map(|v| v.trim().to_owned())
+            .filter(|v| !v.is_empty()),
+        None => cur_make,
+    };
+    let model: Option<String> = match &body.model {
+        Some(inner) => inner
+            .clone()
+            .map(|v| v.trim().to_owned())
+            .filter(|v| !v.is_empty()),
+        None => cur_model,
+    };
+    let firmware: Option<String> = match &body.firmware {
+        Some(inner) => inner
+            .clone()
+            .map(|v| v.trim().to_owned())
+            .filter(|v| !v.is_empty()),
+        None => cur_firmware,
+    };
+
     // motion_mask: same double-option pattern.
     let motion_mask: Option<serde_json::Value> = match body.motion_mask {
         Some(inner) => inner,
@@ -1122,7 +1152,10 @@ async fn update_camera(
                 onvif_password     = $22,
                 motion_pixel_enabled   = $23,
                 motion_frigate_enabled = $24,
-                motion_ha_enabled      = $25
+                motion_ha_enabled      = $25,
+                make                   = $26,
+                model                  = $27,
+                firmware               = $28
             WHERE id = $1
             ",
             &[
@@ -1151,6 +1184,9 @@ async fn update_camera(
                 &motion_pixel_enabled,
                 &motion_frigate_enabled,
                 &motion_ha_enabled,
+                &make,
+                &model,
+                &firmware,
             ],
         )
         .await
@@ -4281,6 +4317,21 @@ fn validate_update_camera(body: &UpdateCameraRequest) -> Result<(), ApiError> {
             return Err(ApiError::BadRequest(
                 "main_url must not be blank".to_owned(),
             ));
+        }
+    }
+    // make/model/firmware are free text (manual entry, issue #48); cap the length
+    // so a bad value can't bloat the row or the contribute-issue URL.
+    for (field, val) in [
+        ("make", &body.make),
+        ("model", &body.model),
+        ("firmware", &body.firmware),
+    ] {
+        if let Some(Some(v)) = val {
+            if v.chars().count() > 200 {
+                return Err(ApiError::BadRequest(format!(
+                    "{field} must be 200 characters or fewer"
+                )));
+            }
         }
     }
     Ok(())

--- a/services/api/src/dto.rs
+++ b/services/api/src/dto.rs
@@ -427,6 +427,18 @@ pub struct UpdateCameraRequest {
     /// omitted = leave existing password unchanged. Never echo back.
     #[serde(default, deserialize_with = "double_option")]
     pub onvif_password: Option<Option<String>>,
+    /// Camera make (ONVIF `Manufacturer`, or MANUAL entry for a non-ONVIF camera).
+    /// Matched against the bundled compatibility DB (issue #48). `Some(Some(v))`
+    /// sets, `Some(None)` clears, omitted = unchanged.
+    #[serde(default, deserialize_with = "double_option")]
+    pub make: Option<Option<String>>,
+    /// Camera model. Same double-option semantics as [`Self::make`].
+    #[serde(default, deserialize_with = "double_option")]
+    pub model: Option<Option<String>>,
+    /// Camera firmware (informational only, never gates a compat match). Same
+    /// double-option semantics as [`Self::make`].
+    #[serde(default, deserialize_with = "double_option")]
+    pub firmware: Option<Option<String>>,
 }
 
 fn default_true() -> bool {

--- a/services/api/tests/camera_device_info.rs
+++ b/services/api/tests/camera_device_info.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Manual make/model/firmware entry via the camera-edit PUT (`PUT
+//! /config/cameras/:id`), issue #48. A non-ONVIF camera (or one the ONVIF probe
+//! got wrong) can set or clear its compatibility identity by hand; the ONVIF
+//! `identify` endpoint writes the same columns. Verifies the double-option merge:
+//! a value sets, `null` clears, an omitted field is left unchanged.
+
+// The harness (`mod support`) `#[path]`-includes the real `src/` modules, which
+// clippy re-lints in this test binary; mirror auth_rbac.rs's allow-set so the
+// production code is judged under the same policy, not a stricter one.
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::option_option)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::items_after_statements)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::manual_let_else)]
+#![allow(clippy::default_trait_access)]
+#![allow(clippy::struct_excessive_bools)]
+#![allow(clippy::match_same_arms)]
+#![allow(clippy::manual_clamp)]
+#![allow(clippy::format_push_string)]
+
+mod support;
+
+use axum::http::StatusCode;
+use crumb_common::db;
+// Glob so support's `pub mod auth_mw`/`dto`/`state`/… re-export into the crate
+// root, where the `#[path]`-included source resolves them as `crate::…`.
+use support::*;
+
+fn put_auth_json(
+    uri: &str,
+    token: &str,
+    body: &serde_json::Value,
+) -> axum::http::Request<axum::body::Body> {
+    axum::http::Request::builder()
+        .method("PUT")
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(body.to_string()))
+        .unwrap()
+}
+
+#[tokio::test]
+async fn manual_make_model_sets_merges_and_clears() {
+    let app = TestApp::new().await;
+    let admin = seed_admin(app.pool()).await;
+    let token = login(&app, &admin.username, &admin.password).await;
+    let cam = seed_camera(app.pool()).await;
+    let uri = format!("/config/cameras/{cam}");
+
+    // 1. Set all three by hand.
+    let resp = app
+        .send(put_auth_json(
+            &uri,
+            &token,
+            &serde_json::json!({ "make": "Uniview", "model": "IPC2124", "firmware": "1.2.3" }),
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let info = db::get_camera_device_info(app.pool(), cam).await.unwrap();
+    assert_eq!(
+        (info.0.as_deref(), info.1.as_deref(), info.2.as_deref()),
+        (Some("Uniview"), Some("IPC2124"), Some("1.2.3"))
+    );
+
+    // 2. Omitting make/model/firmware (editing an unrelated field) leaves them.
+    let resp = app
+        .send(put_auth_json(
+            &uri,
+            &token,
+            &serde_json::json!({ "name": "front-door" }),
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let info = db::get_camera_device_info(app.pool(), cam).await.unwrap();
+    assert_eq!(
+        (info.0.as_deref(), info.1.as_deref(), info.2.as_deref()),
+        (Some("Uniview"), Some("IPC2124"), Some("1.2.3")),
+        "omitted device fields must stay unchanged"
+    );
+
+    // 3. Explicit null clears a column back to NULL.
+    let resp = app
+        .send(put_auth_json(
+            &uri,
+            &token,
+            &serde_json::json!({ "make": null, "model": null, "firmware": null }),
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let info = db::get_camera_device_info(app.pool(), cam).await.unwrap();
+    assert_eq!((info.0, info.1, info.2), (None, None, None));
+}
+
+#[tokio::test]
+async fn manual_make_over_length_is_rejected() {
+    let app = TestApp::new().await;
+    let admin = seed_admin(app.pool()).await;
+    let token = login(&app, &admin.username, &admin.password).await;
+    let cam = seed_camera(app.pool()).await;
+    let uri = format!("/config/cameras/{cam}");
+
+    let too_long = "x".repeat(201);
+    let resp = app
+        .send(put_auth_json(
+            &uri,
+            &token,
+            &serde_json::json!({ "make": too_long }),
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}


### PR DESCRIPTION
## What

Completes the last actionable item on #48: **manual make/model/firmware entry**, so a non-ONVIF camera (or one the ONVIF probe reports wrongly) can still be matched against the bundled compatibility database.

## Changes

- **API** (`dto.rs`, `config_routes.rs`): `make`/`model`/`firmware` on the camera-edit `PUT /config/cameras/:id`, using the same double-option merge as the `onvif_*` fields — a value sets, `null` clears, omitted leaves unchanged. Persisted in the existing `update_camera` UPDATE (the ONVIF `identify` path already writes the same columns, migration 0047). 200-char length guard so a bad value can't bloat the row or the contribute-issue URL.
- **Admin console** (`admin.html`): a "Set make/model manually" block in the camera Compatibility panel — prefilled from the current values, saves through the PUT, then re-checks the compatibility DB and refreshes the panel.

## Tests

New `services/api/tests/camera_device_info.rs`: set -> merge-on-omit -> clear, plus the length-guard 400. Full gate green locally (`cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --workspace`); admin script passes `node --check`.

## Scope

Closes #48. The remaining checklist item, stream-fingerprint matching, is intentionally deferred (tracked by the `docs/DECISIONS.md` revisit trigger) and not in this PR.
