### PR TITLE
fix(recorder): resolve the 2026-07-12 audit findings (#70–#84)

### DIFF
--- a/db/migrations/0001_initial_schema.sql
+++ b/db/migrations/0001_initial_schema.sql
@@ -2,11 +2,16 @@
 -- Source of truth: docs/00-architecture.md ("Data model"). PostgreSQL 14+.
 -- gen_random_uuid() is in core since PG13. Applied automatically by the postgres
 -- container on first init (mounted at /docker-entrypoint-initdb.d).
+--
+-- Every CREATE here is IF NOT EXISTS: the migration runner's crash-recovery
+-- contract is that a file may be re-applied if the process died after applying
+-- it but before recording it in schema_migrations, so it must be idempotent
+-- (exactly like 0002+).
 
 BEGIN;
 
 -- Dumb named locations. All policy lives on the camera, NOT here.
-CREATE TABLE storages (
+CREATE TABLE IF NOT EXISTS storages (
     id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     name        text NOT NULL UNIQUE,          -- human label, e.g. "NVMe-Live", "NAS-Archive"
                                                -- UNIQUE required: seed is idempotent via ON CONFLICT(name)
@@ -17,7 +22,7 @@ CREATE TABLE storages (
 
 -- The GLOBAL DEFAULT lives here as a single row (is_default=true). Each camera
 -- gets its own policy row cloned from the default, with individual fields overridden.
-CREATE TABLE recording_policies (
+CREATE TABLE IF NOT EXISTS recording_policies (
     id                      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     is_default              boolean NOT NULL DEFAULT false,
     mode                    text    NOT NULL DEFAULT 'continuous'
@@ -39,9 +44,9 @@ CREATE TABLE recording_policies (
 );
 
 -- Enforce exactly one default policy row.
-CREATE UNIQUE INDEX one_default_policy ON recording_policies (is_default) WHERE is_default;
+CREATE UNIQUE INDEX IF NOT EXISTS one_default_policy ON recording_policies (is_default) WHERE is_default;
 
-CREATE TABLE cameras (
+CREATE TABLE IF NOT EXISTS cameras (
     id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     name         text NOT NULL,
     enabled      boolean NOT NULL DEFAULT true,
@@ -57,7 +62,7 @@ CREATE TABLE cameras (
 
 -- THE INDEX. One row per recorded fMP4 segment. Single source of truth for
 -- playback/timeline/export/archive. Moving a file = updating storage_id + path here.
-CREATE TABLE segments (
+CREATE TABLE IF NOT EXISTS segments (
     id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     camera_id   uuid NOT NULL REFERENCES cameras(id) ON DELETE CASCADE,
     storage_id  uuid NOT NULL REFERENCES storages(id),   -- current location; updated on archive move
@@ -72,10 +77,10 @@ CREATE TABLE segments (
 );
 
 -- (camera_id, start_ts) is critical for fast seek.
-CREATE INDEX segments_camera_start       ON segments (camera_id, start_ts);
-CREATE INDEX segments_camera_stage_start ON segments (camera_id, stage, start_ts);
+CREATE INDEX IF NOT EXISTS segments_camera_start       ON segments (camera_id, start_ts);
+CREATE INDEX IF NOT EXISTS segments_camera_stage_start ON segments (camera_id, stage, start_ts);
 
-CREATE TABLE users (
+CREATE TABLE IF NOT EXISTS users (
     id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     username      text NOT NULL UNIQUE,
     password_hash text NOT NULL,
@@ -86,7 +91,7 @@ CREATE TABLE users (
 -- ---------------------------------------------------------------------------
 -- PHASE 2 stubs — seams only, no logic in v1 (see docs/00-architecture.md).
 -- ---------------------------------------------------------------------------
-CREATE TABLE events (                          -- Frigate event markers
+CREATE TABLE IF NOT EXISTS events (            -- Frigate event markers
     id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     camera_id  uuid REFERENCES cameras(id) ON DELETE CASCADE,
     ts         timestamptz NOT NULL,
@@ -94,21 +99,21 @@ CREATE TABLE events (                          -- Frigate event markers
     score      real,
     thumb_path text
 );
-CREATE TABLE bookmarks (
+CREATE TABLE IF NOT EXISTS bookmarks (
     id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     camera_id  uuid REFERENCES cameras(id) ON DELETE CASCADE,
     ts         timestamptz NOT NULL,
     note       text,
     created_at timestamptz NOT NULL DEFAULT now()
 );
-CREATE TABLE evidence_locks (
+CREATE TABLE IF NOT EXISTS evidence_locks (
     id        uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     camera_id uuid REFERENCES cameras(id) ON DELETE CASCADE,
     start_ts  timestamptz NOT NULL,
     end_ts    timestamptz NOT NULL,
     reason    text
 );
-CREATE TABLE smart_search_results (
+CREATE TABLE IF NOT EXISTS smart_search_results (
     id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     camera_id  uuid REFERENCES cameras(id) ON DELETE CASCADE,
     ts         timestamptz NOT NULL,

--- a/db/migrations/0014_frigate_api_split.sql
+++ b/db/migrations/0014_frigate_api_split.sql
@@ -61,7 +61,9 @@ BEGIN
     SELECT c.conname INTO v_conname
     FROM pg_constraint c
     JOIN pg_class t ON t.oid = c.conrelid
+    JOIN pg_namespace nsp ON nsp.oid = t.relnamespace
     WHERE t.relname = 'storage_migrations'
+      AND nsp.nspname = current_schema()
       AND c.contype = 'c'
       AND pg_get_constraintdef(c.oid) LIKE '%pending%'
       AND pg_get_constraintdef(c.oid) LIKE '%running%'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,9 @@ services:
     image: ${CRUMB_IMAGE_PREFIX:-ghcr.io/badbread/crumbvms}/recorder:${CRUMB_VERSION:-latest}
     restart: unless-stopped
     logging: *default-logging
+    # Clean shutdown finalizes in-flight segments and lets an in-progress storage-migration
+    # batch complete (up to ~60s); Docker's default 10s grace would SIGKILL mid-teardown.
+    stop_grace_period: 90s
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/AI-INSTALL.md
+++ b/docs/AI-INSTALL.md
@@ -221,6 +221,10 @@ authenticated with `GO2RTC_USER`/`GO2RTC_PASS`. Don't add a host port for it.
 (Upgrading an install that predates the embedding? `docker compose up -d
 --remove-orphans` removes the old standalone go2rtc container.)
 
+The `recorder` service sets `stop_grace_period: 90s` — its clean shutdown
+finalizes in-flight segments and storage-migration batches, and Docker's
+default 10 s grace would SIGKILL it mid-teardown. Don't remove or shorten it.
+
 Two more things run by default and need no action: the **nightly Postgres
 dump built into the `api` service** (no separate container, see Step 8) and
 the migrations/first-run seed baked into `recorder`/`api` startup.

--- a/services/api/src/alerts.rs
+++ b/services/api/src/alerts.rs
@@ -921,8 +921,12 @@ fn storage_statvfs(path: &str) -> Option<(i64, i64)> {
         let bsize = buf.f_bsize as u64;
         #[allow(clippy::cast_lossless)]
         let total = (buf.f_blocks as u64).saturating_mul(bsize);
+        // f_bavail (available to a NON-root writer), not f_bfree (includes the
+        // ext4 root reserve the recorder's non-root uid can't use) — otherwise
+        // this over-reports free space and the free-space alert fires late
+        // (issue #72; matches the recorder's eviction floor).
         #[allow(clippy::cast_lossless)]
-        let free = (buf.f_bfree as u64).saturating_mul(bsize);
+        let free = (buf.f_bavail as u64).saturating_mul(bsize);
         Some((
             i64::try_from(total).unwrap_or(i64::MAX),
             i64::try_from(free).unwrap_or(i64::MAX),

--- a/services/api/src/stats.rs
+++ b/services/api/src/stats.rs
@@ -917,8 +917,10 @@ fn storage_statvfs(path: &str) -> Option<(i64, i64)> {
         let bsize = buf.f_bsize as u64;
         #[allow(clippy::cast_lossless)]
         let total = (buf.f_blocks as u64).saturating_mul(bsize);
+        // f_bavail (available to a non-root writer), not f_bfree (includes the
+        // ext4 root reserve) — otherwise free space is over-reported (issue #72).
         #[allow(clippy::cast_lossless)]
-        let free = (buf.f_bfree as u64).saturating_mul(bsize);
+        let free = (buf.f_bavail as u64).saturating_mul(bsize);
         Some((
             i64::try_from(total).unwrap_or(i64::MAX),
             i64::try_from(free).unwrap_or(i64::MAX),

--- a/services/api/src/status.rs
+++ b/services/api/src/status.rs
@@ -249,15 +249,17 @@ fn statvfs_bytes(path: &str) -> Option<(i64, i64)> {
             return None;
         }
         // Blocks are `f_bsize` bytes each. `f_blocks` = total data blocks,
-        // `f_bfree` = free blocks. All unsigned; products fit i64 for any
-        // realistic disk size.
+        // `f_bavail` = blocks available to a NON-root writer (we use this, not
+        // `f_bfree`, which includes the ext4 root reserve the non-root services
+        // can't use → over-reported free space; issue #72). All unsigned;
+        // products fit i64 for any realistic disk size.
         // cast_lossless: c_ulong = u64 on x86_64 Linux — alias, not identical type.
         #[allow(clippy::cast_lossless)]
         let bsize = buf.f_bsize as u64;
         #[allow(clippy::cast_lossless)]
         let total = (buf.f_blocks as u64).saturating_mul(bsize);
         #[allow(clippy::cast_lossless)]
-        let free = (buf.f_bfree as u64).saturating_mul(bsize);
+        let free = (buf.f_bavail as u64).saturating_mul(bsize);
         Some((i64::try_from(total).ok()?, i64::try_from(free).ok()?))
     }
 

--- a/services/common/src/config.rs
+++ b/services/common/src/config.rs
@@ -454,10 +454,27 @@ fn require_secret(key: &str) -> Result<String> {
 
 /// Parse an IANA timezone from `key`, falling back to `default` (and to
 /// `America/Los_Angeles` if even that fails to parse).
+///
+/// The fallback is deliberately non-fatal — a typo'd `RECORDER_TZ` must not
+/// stop the recorder from booting — but it must be LOUD: silently swallowing
+/// it runs the archive cron in the wrong timezone with no clue why (audit
+/// #84).
 fn parse_tz_env(key: &str, default: &str) -> chrono_tz::Tz {
-    optional_env(key, default)
-        .parse::<chrono_tz::Tz>()
-        .unwrap_or(chrono_tz::Tz::America__Los_Angeles)
+    let raw = optional_env(key, default);
+    match raw.parse::<chrono_tz::Tz>() {
+        Ok(tz) => tz,
+        Err(_) => {
+            let fallback = default
+                .parse::<chrono_tz::Tz>()
+                .unwrap_or(chrono_tz::Tz::America__Los_Angeles);
+            tracing::error!(
+                "env var '{key}' = '{raw}' is not a valid IANA timezone \
+                 (e.g. 'America/Los_Angeles'); falling back to '{fallback}' — \
+                 the archive cron will run in that zone"
+            );
+            fallback
+        }
+    }
 }
 
 fn optional_env(key: &str, default: &str) -> String {
@@ -501,5 +518,40 @@ fn parse_bool_env(key: &str, default: bool) -> Result<bool> {
             }
         }
         Err(_) => Ok(default),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_tz_env;
+
+    /// Audit #84: an invalid TZ value must fall back (non-fatal, now loudly
+    /// logged) to the caller's default when that parses — never panic, never
+    /// silently pick a surprise zone.
+    #[test]
+    fn parse_tz_env_falls_back_on_invalid_value() {
+        // Unique key name: the process env is shared across parallel tests.
+        std::env::set_var("CRUMB_TEST_TZ_INVALID", "Not/AZone");
+        assert_eq!(
+            parse_tz_env("CRUMB_TEST_TZ_INVALID", "Europe/Berlin"),
+            chrono_tz::Tz::Europe__Berlin,
+            "an invalid env value must fall back to the caller's default"
+        );
+        std::env::remove_var("CRUMB_TEST_TZ_INVALID");
+    }
+
+    /// Control: a valid value parses, and an unset key yields the default.
+    #[test]
+    fn parse_tz_env_parses_valid_value_and_unset_default() {
+        std::env::set_var("CRUMB_TEST_TZ_VALID", "Asia/Tokyo");
+        assert_eq!(
+            parse_tz_env("CRUMB_TEST_TZ_VALID", "America/Los_Angeles"),
+            chrono_tz::Tz::Asia__Tokyo
+        );
+        std::env::remove_var("CRUMB_TEST_TZ_VALID");
+        assert_eq!(
+            parse_tz_env("CRUMB_TEST_TZ_UNSET", "America/Los_Angeles"),
+            chrono_tz::Tz::America__Los_Angeles
+        );
     }
 }

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -7978,7 +7978,8 @@ async fn reap_invalid_indexes(client: &deadpool_postgres::Client) -> Result<()> 
     let rows = client
         .query(
             r"
-            SELECT ci.relname AS index_name, ct.relname AS table_name
+            SELECT ci.relname AS index_name, ct.relname AS table_name,
+                   pi.indexrelid AS index_oid
             FROM pg_index pi
             JOIN pg_class ci ON ci.oid = pi.indexrelid
             JOIN pg_class ct ON ct.oid = pi.indrelid
@@ -8008,6 +8009,7 @@ async fn reap_invalid_indexes(client: &deadpool_postgres::Client) -> Result<()> 
     for row in rows {
         let index_name: String = row.get("index_name");
         let table_name: String = row.get("table_name");
+        let index_oid: u32 = row.get("index_oid");
         tracing::warn!(
             index_name,
             table_name,
@@ -8023,33 +8025,74 @@ async fn reap_invalid_indexes(client: &deadpool_postgres::Client) -> Result<()> 
         // quote them defensively since `format!` can't bind a DDL identifier
         // as a parameter.
         //
-        // Guard 2 (see the doc comment): this DROP runs under the pool's
-        // per-connection `lock_timeout` (set by build_pool's post-create
-        // hook). If a manual CONCURRENTLY build slipped in between the
-        // catalog snapshot above and this DROP, the build's locks make the
-        // DROP time out with 55P03 — treat that as skip-and-warn, never as a
-        // boot-failing error and never as an unbounded queued ACCESS
-        // EXCLUSIVE request stalling the table.
-        let drop_result = client
-            .batch_execute(&format!(
-                r#"DROP INDEX IF EXISTS "{index_name}""#,
-                index_name = index_name.replace('"', "\"\"")
-            ))
-            .await;
-        if let Err(e) = drop_result {
-            if e.code() == Some(&tokio_postgres::error::SqlState::LOCK_NOT_AVAILABLE) {
-                tracing::warn!(
-                    index_name,
-                    table_name,
-                    "run_migrations: DROP of INVALID index timed out waiting \
-                     for a lock — something (likely an in-progress manual \
-                     CREATE INDEX CONCURRENTLY) holds locks on it; leaving it \
-                     alone. It will be re-examined on the next startup"
-                );
-                continue;
+        // Guard 2 (see the doc comment): this DROP runs under the connection's
+        // `lock_timeout` (set by build_pool's post-create hook). A lock timeout
+        // (55P03) has TWO very different causes that must be handled
+        // differently, or the reap is non-deterministic under load:
+        //   (a) a live manual CREATE INDEX CONCURRENTLY holds the index's locks
+        //       — leave it alone (skip-and-warn); or
+        //   (b) transient/foreign contention (a busy boot, autovacuum, a
+        //       concurrent DDL elsewhere) — which must NOT permanently skip a
+        //       droppable INVALID index (that would leave it un-dropped so a
+        //       later CREATE INDEX IF NOT EXISTS silently no-ops against the
+        //       broken catalog entry).
+        // Distinguish them by RE-CHECKING pg_stat_progress_create_index for THIS
+        // index on a timeout: a genuine build → skip; otherwise retry a few
+        // times so momentary contention clears, and only skip (never boot-fail)
+        // if a foreign lock persists.
+        let drop_sql = format!(
+            r#"DROP INDEX IF EXISTS "{index_name}""#,
+            index_name = index_name.replace('"', "\"\"")
+        );
+        const DROP_MAX_ATTEMPTS: u32 = 4;
+        for attempt in 1..=DROP_MAX_ATTEMPTS {
+            match client.batch_execute(&drop_sql).await {
+                Ok(()) => break,
+                Err(e)
+                    if e.code() == Some(&tokio_postgres::error::SqlState::LOCK_NOT_AVAILABLE) =>
+                {
+                    let build_in_progress: bool = client
+                        .query_one(
+                            "SELECT EXISTS (
+                                 SELECT 1 FROM pg_stat_progress_create_index
+                                 WHERE index_relid = $1
+                                   AND datid = (SELECT oid FROM pg_database
+                                                WHERE datname = current_database())
+                             )",
+                            &[&index_oid],
+                        )
+                        .await
+                        .map(|r| r.get(0))
+                        .unwrap_or(false);
+                    if build_in_progress {
+                        tracing::warn!(
+                            index_name,
+                            table_name,
+                            "run_migrations: DROP of INVALID index skipped — a manual \
+                             CREATE INDEX CONCURRENTLY build holds its locks; leaving it \
+                             alone, it will be re-examined on the next startup"
+                        );
+                        break;
+                    }
+                    if attempt == DROP_MAX_ATTEMPTS {
+                        tracing::warn!(
+                            index_name,
+                            table_name,
+                            attempts = DROP_MAX_ATTEMPTS,
+                            "run_migrations: DROP of INVALID index kept timing out on a \
+                             lock with no build in progress; leaving it for the next \
+                             startup rather than boot-failing"
+                        );
+                        break;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                }
+                Err(e) => {
+                    return Err(e).with_context(|| {
+                        format!("reap_invalid_indexes: drop invalid index {index_name}")
+                    });
+                }
             }
-            return Err(e)
-                .with_context(|| format!("reap_invalid_indexes: drop invalid index {index_name}"));
         }
     }
 

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -7920,13 +7920,23 @@ const RUN_MIGRATIONS_LOCK_KEY: i64 = 917_342_002;
 /// just means the planner ignores the index and queries fall back to a slow
 /// path.
 ///
-/// Dropping and recreating is unconditionally safe here: [`run_migrations`]
-/// (the sole caller, via [`run_migrations_locked`]) holds
+/// Dropping is safe here: an INVALID index provided no guarantees anyway (the
+/// planner never uses it, and an invalid UNIQUE index enforces nothing), and
+/// [`run_migrations`] (the sole caller, via [`run_migrations_locked`]) holds
 /// [`RUN_MIGRATIONS_LOCK_KEY`] for the whole call, so no other process can be
-/// concurrently building the same index name, and the migrations that follow
-/// this check all use `CREATE INDEX IF NOT EXISTS` / `CREATE INDEX
-/// CONCURRENTLY IF NOT EXISTS`, which will simply rebuild whatever was just
-/// dropped.
+/// concurrently building the same index name.
+///
+/// Dropping is NOT always self-healing, though. The dropped index is rebuilt
+/// automatically only when the migration that creates it has **not yet been
+/// recorded** in `schema_migrations` (the crash-mid-migration case: the still-
+/// pending file's `CREATE INDEX ... IF NOT EXISTS` re-runs and now finds the
+/// name free). If that migration was ALREADY recorded, nothing re-runs it —
+/// already-applied migrations are skipped forever — so the index stays absent
+/// until an operator recreates it by hand from its `db/migrations/` file. That
+/// is still strictly better than keeping the INVALID index (which LOOKS
+/// present, blocking every future `IF NOT EXISTS` rebuild while guaranteeing
+/// nothing), and the WARN below names exactly what was dropped so the operator
+/// can act.
 ///
 /// Scoped to `current_schema()` only (never touches another tenant's schema
 /// in a shared-cluster / multi-schema test setup).
@@ -7961,8 +7971,11 @@ async fn reap_invalid_indexes(client: &deadpool_postgres::Client) -> Result<()> 
             index_name,
             table_name,
             "run_migrations: found INVALID index (left by an interrupted \
-             CREATE INDEX CONCURRENTLY) — dropping so the migration runner \
-             rebuilds it; the index provided NO guarantees while invalid"
+             CREATE INDEX CONCURRENTLY) — dropping it; it provided NO \
+             guarantees while invalid. It is rebuilt automatically only if \
+             the migration that creates it is still pending; if that \
+             migration is already recorded in schema_migrations, recreate \
+             the index manually from its db/migrations/ file"
         );
         // Index names are catalog-sourced identifiers (not user input), but
         // quote them defensively since `format!` can't bind a DDL identifier
@@ -7979,212 +7992,217 @@ async fn reap_invalid_indexes(client: &deadpool_postgres::Client) -> Result<()> 
     Ok(())
 }
 
+/// The ordered list of (filename, SQL body) migration pairs, applied in order
+/// by [`run_migrations_locked`].  0001–0011 must be included so an EXTERNAL
+/// Postgres (not initdb-seeded) self-provisions.  On an existing prod DB they
+/// are baseline-skipped (see step 2 of [`run_migrations_locked`]).
+///
+/// Module-scoped (rather than local to the runner) so the tests module can
+/// assert that every registered file satisfies the runner's SQL-preprocessing
+/// invariants — see `migrations_satisfy_runner_parsing_invariants`.
+static MIGRATIONS: &[(&str, &str)] = &[
+    (
+        "0001_initial_schema.sql",
+        include_str!("../../../db/migrations/0001_initial_schema.sql"),
+    ),
+    (
+        "0002_views.sql",
+        include_str!("../../../db/migrations/0002_views.sql"),
+    ),
+    (
+        "0003_record_audio.sql",
+        include_str!("../../../db/migrations/0003_record_audio.sql"),
+    ),
+    (
+        "0004_recorder_heartbeat.sql",
+        include_str!("../../../db/migrations/0004_recorder_heartbeat.sql"),
+    ),
+    (
+        "0005_motion_grid.sql",
+        include_str!("../../../db/migrations/0005_motion_grid.sql"),
+    ),
+    (
+        "0006_motion_grid_score.sql",
+        include_str!("../../../db/migrations/0006_motion_grid_score.sql"),
+    ),
+    (
+        "0007_detection_events.sql",
+        include_str!("../../../db/migrations/0007_detection_events.sql"),
+    ),
+    (
+        "0008_segments_repair.sql",
+        include_str!("../../../db/migrations/0008_segments_repair.sql"),
+    ),
+    (
+        "0009_segments_indexes.sql",
+        include_str!("../../../db/migrations/0009_segments_indexes.sql"),
+    ),
+    (
+        "0010_bookmarks.sql",
+        include_str!("../../../db/migrations/0010_bookmarks.sql"),
+    ),
+    (
+        "0011_segments_storage_idx.sql",
+        include_str!("../../../db/migrations/0011_segments_storage_idx.sql"),
+    ),
+    (
+        "0012_server_settings_and_camera_ownership.sql",
+        include_str!("../../../db/migrations/0012_server_settings_and_camera_ownership.sql"),
+    ),
+    (
+        "0013_segments_indexes.sql",
+        include_str!("../../../db/migrations/0013_segments_indexes.sql"),
+    ),
+    (
+        "0014_frigate_api_split.sql",
+        include_str!("../../../db/migrations/0014_frigate_api_split.sql"),
+    ),
+    (
+        "0015_notifications.sql",
+        include_str!("../../../db/migrations/0015_notifications.sql"),
+    ),
+    (
+        "0016_motion_baseline.sql",
+        include_str!("../../../db/migrations/0016_motion_baseline.sql"),
+    ),
+    (
+        "0017_notification_settings.sql",
+        include_str!("../../../db/migrations/0017_notification_settings.sql"),
+    ),
+    (
+        "0018_consolidate_runtime_ensure_ddl.sql",
+        include_str!("../../../db/migrations/0018_consolidate_runtime_ensure_ddl.sql"),
+    ),
+    (
+        "0019_camera_effective_policy_view.sql",
+        include_str!("../../../db/migrations/0019_camera_effective_policy_view.sql"),
+    ),
+    (
+        "0020_grouped_cameras_clear_override.sql",
+        include_str!("../../../db/migrations/0020_grouped_cameras_clear_override.sql"),
+    ),
+    (
+        "0021_grouped_camera_no_override_trigger.sql",
+        include_str!("../../../db/migrations/0021_grouped_camera_no_override_trigger.sql"),
+    ),
+    (
+        "0022_clip_source.sql",
+        include_str!("../../../db/migrations/0022_clip_source.sql"),
+    ),
+    (
+        "0023_clip_views.sql",
+        include_str!("../../../db/migrations/0023_clip_views.sql"),
+    ),
+    (
+        "0024_clip_pre_roll.sql",
+        include_str!("../../../db/migrations/0024_clip_pre_roll.sql"),
+    ),
+    (
+        "0025_clip_motion_highlight.sql",
+        include_str!("../../../db/migrations/0025_clip_motion_highlight.sql"),
+    ),
+    (
+        "0026_segment_motion_bbox.sql",
+        include_str!("../../../db/migrations/0026_segment_motion_bbox.sql"),
+    ),
+    (
+        "0027_setup_complete.sql",
+        include_str!("../../../db/migrations/0027_setup_complete.sql"),
+    ),
+    (
+        "0028_roles.sql",
+        include_str!("../../../db/migrations/0028_roles.sql"),
+    ),
+    (
+        "0029_bookmarks_enabled.sql",
+        include_str!("../../../db/migrations/0029_bookmarks_enabled.sql"),
+    ),
+    (
+        "0030_view_owner.sql",
+        include_str!("../../../db/migrations/0030_view_owner.sql"),
+    ),
+    (
+        "0031_view_shares.sql",
+        include_str!("../../../db/migrations/0031_view_shares.sql"),
+    ),
+    (
+        "0032_system_alerts.sql",
+        include_str!("../../../db/migrations/0032_system_alerts.sql"),
+    ),
+    (
+        "0033_sessions.sql",
+        include_str!("../../../db/migrations/0033_sessions.sql"),
+    ),
+    (
+        "0034_frigate_heartbeat.sql",
+        include_str!("../../../db/migrations/0034_frigate_heartbeat.sql"),
+    ),
+    (
+        "0035_decode_status.sql",
+        include_str!("../../../db/migrations/0035_decode_status.sql"),
+    ),
+    (
+        "0036_embedded_go2rtc_api_base.sql",
+        include_str!("../../../db/migrations/0036_embedded_go2rtc_api_base.sql"),
+    ),
+    (
+        "0037_segment_motion_shadow.sql",
+        include_str!("../../../db/migrations/0037_segment_motion_shadow.sql"),
+    ),
+    (
+        "0038_motion_detector_unhealthy_alert.sql",
+        include_str!("../../../db/migrations/0038_motion_detector_unhealthy_alert.sql"),
+    ),
+    (
+        "0039_motion_cache_status.sql",
+        include_str!("../../../db/migrations/0039_motion_cache_status.sql"),
+    ),
+    (
+        "0040_motion_cache_unavailable_alert.sql",
+        include_str!("../../../db/migrations/0040_motion_cache_unavailable_alert.sql"),
+    ),
+    (
+        "0041_view_icon.sql",
+        include_str!("../../../db/migrations/0041_view_icon.sql"),
+    ),
+    (
+        "0042_policy_max_retention_days.sql",
+        include_str!("../../../db/migrations/0042_policy_max_retention_days.sql"),
+    ),
+    (
+        "0043_storage_persist_failed_alert.sql",
+        include_str!("../../../db/migrations/0043_storage_persist_failed_alert.sql"),
+    ),
+    (
+        "0044_beta_terms_acceptance.sql",
+        include_str!("../../../db/migrations/0044_beta_terms_acceptance.sql"),
+    ),
+    (
+        "0045_update_check.sql",
+        include_str!("../../../db/migrations/0045_update_check.sql"),
+    ),
+    (
+        "0046_scrub_pregen_settings.sql",
+        include_str!("../../../db/migrations/0046_scrub_pregen_settings.sql"),
+    ),
+    (
+        "0047_camera_device_info.sql",
+        include_str!("../../../db/migrations/0047_camera_device_info.sql"),
+    ),
+    (
+        "0048_ha_integration.sql",
+        include_str!("../../../db/migrations/0048_ha_integration.sql"),
+    ),
+    (
+        "0049_additive_motion_sources.sql",
+        include_str!("../../../db/migrations/0049_additive_motion_sources.sql"),
+    ),
+];
+
 /// The actual migration-application body, run while [`run_migrations`] holds
 /// the advisory lock. Split out so the lock/unlock wrapping above has no `?`
 /// early-return between acquire and release.
 async fn run_migrations_locked(pool: &Pool) -> Result<()> {
-    // The ordered list of (filename, SQL body) pairs.  0001–0011 must be
-    // included so an EXTERNAL Postgres (not initdb-seeded) self-provisions.
-    // On an existing prod DB they are baseline-skipped (see step 2 above).
-    static MIGRATIONS: &[(&str, &str)] = &[
-        (
-            "0001_initial_schema.sql",
-            include_str!("../../../db/migrations/0001_initial_schema.sql"),
-        ),
-        (
-            "0002_views.sql",
-            include_str!("../../../db/migrations/0002_views.sql"),
-        ),
-        (
-            "0003_record_audio.sql",
-            include_str!("../../../db/migrations/0003_record_audio.sql"),
-        ),
-        (
-            "0004_recorder_heartbeat.sql",
-            include_str!("../../../db/migrations/0004_recorder_heartbeat.sql"),
-        ),
-        (
-            "0005_motion_grid.sql",
-            include_str!("../../../db/migrations/0005_motion_grid.sql"),
-        ),
-        (
-            "0006_motion_grid_score.sql",
-            include_str!("../../../db/migrations/0006_motion_grid_score.sql"),
-        ),
-        (
-            "0007_detection_events.sql",
-            include_str!("../../../db/migrations/0007_detection_events.sql"),
-        ),
-        (
-            "0008_segments_repair.sql",
-            include_str!("../../../db/migrations/0008_segments_repair.sql"),
-        ),
-        (
-            "0009_segments_indexes.sql",
-            include_str!("../../../db/migrations/0009_segments_indexes.sql"),
-        ),
-        (
-            "0010_bookmarks.sql",
-            include_str!("../../../db/migrations/0010_bookmarks.sql"),
-        ),
-        (
-            "0011_segments_storage_idx.sql",
-            include_str!("../../../db/migrations/0011_segments_storage_idx.sql"),
-        ),
-        (
-            "0012_server_settings_and_camera_ownership.sql",
-            include_str!("../../../db/migrations/0012_server_settings_and_camera_ownership.sql"),
-        ),
-        (
-            "0013_segments_indexes.sql",
-            include_str!("../../../db/migrations/0013_segments_indexes.sql"),
-        ),
-        (
-            "0014_frigate_api_split.sql",
-            include_str!("../../../db/migrations/0014_frigate_api_split.sql"),
-        ),
-        (
-            "0015_notifications.sql",
-            include_str!("../../../db/migrations/0015_notifications.sql"),
-        ),
-        (
-            "0016_motion_baseline.sql",
-            include_str!("../../../db/migrations/0016_motion_baseline.sql"),
-        ),
-        (
-            "0017_notification_settings.sql",
-            include_str!("../../../db/migrations/0017_notification_settings.sql"),
-        ),
-        (
-            "0018_consolidate_runtime_ensure_ddl.sql",
-            include_str!("../../../db/migrations/0018_consolidate_runtime_ensure_ddl.sql"),
-        ),
-        (
-            "0019_camera_effective_policy_view.sql",
-            include_str!("../../../db/migrations/0019_camera_effective_policy_view.sql"),
-        ),
-        (
-            "0020_grouped_cameras_clear_override.sql",
-            include_str!("../../../db/migrations/0020_grouped_cameras_clear_override.sql"),
-        ),
-        (
-            "0021_grouped_camera_no_override_trigger.sql",
-            include_str!("../../../db/migrations/0021_grouped_camera_no_override_trigger.sql"),
-        ),
-        (
-            "0022_clip_source.sql",
-            include_str!("../../../db/migrations/0022_clip_source.sql"),
-        ),
-        (
-            "0023_clip_views.sql",
-            include_str!("../../../db/migrations/0023_clip_views.sql"),
-        ),
-        (
-            "0024_clip_pre_roll.sql",
-            include_str!("../../../db/migrations/0024_clip_pre_roll.sql"),
-        ),
-        (
-            "0025_clip_motion_highlight.sql",
-            include_str!("../../../db/migrations/0025_clip_motion_highlight.sql"),
-        ),
-        (
-            "0026_segment_motion_bbox.sql",
-            include_str!("../../../db/migrations/0026_segment_motion_bbox.sql"),
-        ),
-        (
-            "0027_setup_complete.sql",
-            include_str!("../../../db/migrations/0027_setup_complete.sql"),
-        ),
-        (
-            "0028_roles.sql",
-            include_str!("../../../db/migrations/0028_roles.sql"),
-        ),
-        (
-            "0029_bookmarks_enabled.sql",
-            include_str!("../../../db/migrations/0029_bookmarks_enabled.sql"),
-        ),
-        (
-            "0030_view_owner.sql",
-            include_str!("../../../db/migrations/0030_view_owner.sql"),
-        ),
-        (
-            "0031_view_shares.sql",
-            include_str!("../../../db/migrations/0031_view_shares.sql"),
-        ),
-        (
-            "0032_system_alerts.sql",
-            include_str!("../../../db/migrations/0032_system_alerts.sql"),
-        ),
-        (
-            "0033_sessions.sql",
-            include_str!("../../../db/migrations/0033_sessions.sql"),
-        ),
-        (
-            "0034_frigate_heartbeat.sql",
-            include_str!("../../../db/migrations/0034_frigate_heartbeat.sql"),
-        ),
-        (
-            "0035_decode_status.sql",
-            include_str!("../../../db/migrations/0035_decode_status.sql"),
-        ),
-        (
-            "0036_embedded_go2rtc_api_base.sql",
-            include_str!("../../../db/migrations/0036_embedded_go2rtc_api_base.sql"),
-        ),
-        (
-            "0037_segment_motion_shadow.sql",
-            include_str!("../../../db/migrations/0037_segment_motion_shadow.sql"),
-        ),
-        (
-            "0038_motion_detector_unhealthy_alert.sql",
-            include_str!("../../../db/migrations/0038_motion_detector_unhealthy_alert.sql"),
-        ),
-        (
-            "0039_motion_cache_status.sql",
-            include_str!("../../../db/migrations/0039_motion_cache_status.sql"),
-        ),
-        (
-            "0040_motion_cache_unavailable_alert.sql",
-            include_str!("../../../db/migrations/0040_motion_cache_unavailable_alert.sql"),
-        ),
-        (
-            "0041_view_icon.sql",
-            include_str!("../../../db/migrations/0041_view_icon.sql"),
-        ),
-        (
-            "0042_policy_max_retention_days.sql",
-            include_str!("../../../db/migrations/0042_policy_max_retention_days.sql"),
-        ),
-        (
-            "0043_storage_persist_failed_alert.sql",
-            include_str!("../../../db/migrations/0043_storage_persist_failed_alert.sql"),
-        ),
-        (
-            "0044_beta_terms_acceptance.sql",
-            include_str!("../../../db/migrations/0044_beta_terms_acceptance.sql"),
-        ),
-        (
-            "0045_update_check.sql",
-            include_str!("../../../db/migrations/0045_update_check.sql"),
-        ),
-        (
-            "0046_scrub_pregen_settings.sql",
-            include_str!("../../../db/migrations/0046_scrub_pregen_settings.sql"),
-        ),
-        (
-            "0047_camera_device_info.sql",
-            include_str!("../../../db/migrations/0047_camera_device_info.sql"),
-        ),
-        (
-            "0048_ha_integration.sql",
-            include_str!("../../../db/migrations/0048_ha_integration.sql"),
-        ),
-        (
-            "0049_additive_motion_sources.sql",
-            include_str!("../../../db/migrations/0049_additive_motion_sources.sql"),
-        ),
-    ];
-
     // Baseline filenames: 0001–0011 are marked applied on an existing DB to
     // avoid re-running them.
     const BASELINE_FILENAMES: &[&str] = &[
@@ -8290,9 +8308,12 @@ async fn run_migrations_locked(pool: &Pool) -> Result<()> {
     // silently NEVER rebuilt, so queries either misbehave (a stale/partial
     // index is never used by the planner, which is safe but slow) or, for the
     // UNIQUE index, future inserts lose the duplicate-prevention guarantee
-    // entirely. Drop-and-let-the-migration-below-recreate-it is safe here
-    // because we hold [`RUN_MIGRATIONS_LOCK_KEY`] for the whole call, so no
-    // other process can be mid-build on the same name.
+    // entirely. Dropping is safe (we hold [`RUN_MIGRATIONS_LOCK_KEY`], and an
+    // INVALID index guaranteed nothing to begin with) but only self-HEALING
+    // when the index's migration is still pending in the loop below — an
+    // already-recorded migration never re-runs, so its dropped index must be
+    // recreated manually (see [`reap_invalid_indexes`] docs; the WARN it logs
+    // says so).
     reap_invalid_indexes(&client).await?;
 
     // 3. Apply each migration not yet in schema_migrations.
@@ -9821,6 +9842,200 @@ mod tests {
         assert_ne!(ENSURE_POLICIES_LOCK_KEY, RUN_MIGRATIONS_LOCK_KEY);
         assert_ne!(ENSURE_POLICIES_LOCK_KEY, RECORDER_SINGLETON_LOCK_KEY);
         assert_ne!(RUN_MIGRATIONS_LOCK_KEY, RECORDER_SINGLETON_LOCK_KEY);
+    }
+
+    // ── migration-runner SQL-preprocessing invariants ────────────────────────
+    //
+    // `run_migrations_locked` does two ad-hoc textual transforms on every file
+    // in [`MIGRATIONS`] before sending it to Postgres:
+    //
+    //   1. it strips `--` line comments with a per-line `find("--")` that has
+    //      no quote awareness, and
+    //   2. it routes files containing CONCURRENTLY through a `split(';')`
+    //      statement splitter that likewise has no quote awareness.
+    //
+    // Those transforms are only correct if every migration file obeys a few
+    // lexical invariants. A future file that violates them would sail through
+    // review and CI and then fail AT PROD BOOT when the runner sends the
+    // corrupted SQL. The scanner below makes such a file fail `cargo test`
+    // instead. It deliberately does NOT touch the runner's preprocessor — it
+    // only rejects inputs the preprocessor cannot handle.
+
+    /// Scan one migration's SQL for constructs the runner's preprocessing
+    /// cannot handle. Returns `Err(description)` on the first violation:
+    ///
+    /// * `--` inside a single-quoted literal (the comment stripper would
+    ///   truncate the literal to end-of-line);
+    /// * `/*` block comment outside a literal (the stripper doesn't understand
+    ///   them; a `--` inside one would strip the closing `*/`);
+    /// * in a CONCURRENTLY file: any dollar-quoting, or a `;` inside a literal
+    ///   (the `;` splitter would split mid-statement);
+    /// * an unterminated quote of either kind.
+    ///
+    /// `--` inside a dollar-quoted body is allowed when it is a plpgsql line
+    /// comment (0018 has these): plpgsql shares SQL's comment-to-end-of-line
+    /// rule, so stripping it is semantics-preserving. Only a `--` inside a
+    /// quoted LITERAL (at either level) is corruption.
+    fn check_migration_parsing_invariants(
+        sql: &str,
+        concurrently: bool,
+    ) -> std::result::Result<(), String> {
+        let b = sql.as_bytes();
+        let mut i = 0usize;
+        let mut line = 1usize;
+        let mut in_line_comment = false;
+        let mut in_squote = false;
+        let mut dollar_tag: Option<&[u8]> = None;
+        while i < b.len() {
+            let c = b[i];
+            if c == b'\n' {
+                line += 1;
+            }
+            if in_line_comment {
+                if c == b'\n' {
+                    in_line_comment = false;
+                }
+                i += 1;
+                continue;
+            }
+            if in_squote {
+                if c == b'\'' {
+                    if b.get(i + 1) == Some(&b'\'') {
+                        i += 2; // '' escape stays inside the literal
+                        continue;
+                    }
+                    in_squote = false;
+                    i += 1;
+                    continue;
+                }
+                if c == b'-' && b.get(i + 1) == Some(&b'-') {
+                    return Err(format!(
+                        "line {line}: `--` inside a single-quoted literal \
+                         (the runner's comment stripper would truncate it)"
+                    ));
+                }
+                if c == b';' && concurrently {
+                    return Err(format!(
+                        "line {line}: `;` inside a literal in a CONCURRENTLY \
+                         file (the runner's `;` splitter would split it)"
+                    ));
+                }
+                i += 1;
+                continue;
+            }
+            // Outside literals — identical handling whether or not we are
+            // inside a dollar-quoted body (plpgsql shares SQL's `--` comment
+            // and ''-escaped literal syntax, so the stripper is safe there).
+            match c {
+                b'-' if b.get(i + 1) == Some(&b'-') => {
+                    in_line_comment = true;
+                    i += 2;
+                }
+                b'/' if b.get(i + 1) == Some(&b'*') => {
+                    return Err(format!(
+                        "line {line}: `/*` block comment (the runner's comment \
+                         stripper only understands `--` line comments)"
+                    ));
+                }
+                b'\'' => {
+                    in_squote = true;
+                    i += 1;
+                }
+                b'$' => {
+                    // Try to parse a `$tag$` dollar-quote delimiter.
+                    let mut j = i + 1;
+                    while j < b.len() && (b[j].is_ascii_alphanumeric() || b[j] == b'_') {
+                        j += 1;
+                    }
+                    if j < b.len() && b[j] == b'$' {
+                        let tag = &b[i..=j];
+                        match dollar_tag {
+                            // Matching closer ends the body.
+                            Some(open) if open == tag => dollar_tag = None,
+                            // A different tag inside a body is plain text.
+                            Some(_) => {}
+                            None => {
+                                if concurrently {
+                                    return Err(format!(
+                                        "line {line}: dollar-quoting in a \
+                                         CONCURRENTLY file (the runner's `;` \
+                                         splitter would split inside the body)"
+                                    ));
+                                }
+                                dollar_tag = Some(tag);
+                            }
+                        }
+                        i = j + 1;
+                    } else {
+                        i += 1;
+                    }
+                }
+                _ => {
+                    i += 1;
+                }
+            }
+        }
+        if in_squote {
+            return Err("unterminated single-quoted literal".into());
+        }
+        if dollar_tag.is_some() {
+            return Err("unterminated dollar-quote".into());
+        }
+        Ok(())
+    }
+
+    /// Every registered migration must be processable by the runner's comment
+    /// stripper and CONCURRENTLY splitter — see the invariants on
+    /// [`check_migration_parsing_invariants`]. This is the CI tripwire for a
+    /// FUTURE migration file that would otherwise only fail at prod boot.
+    #[test]
+    fn migrations_satisfy_runner_parsing_invariants() {
+        for (filename, sql) in MIGRATIONS {
+            // Replicate the runner's CONCURRENTLY routing check byte-for-byte
+            // (strip `--` comments per line, then case-insensitive contains).
+            let stripped: String = sql
+                .lines()
+                .map(|l| l.find("--").map_or(l, |pos| &l[..pos]))
+                .collect::<Vec<_>>()
+                .join("\n");
+            let concurrently = stripped.to_ascii_uppercase().contains("CONCURRENTLY");
+            if let Err(violation) = check_migration_parsing_invariants(sql, concurrently) {
+                panic!(
+                    "{filename}: {violation} — the migration runner in db.rs \
+                     cannot preprocess this file safely; rewrite the SQL to \
+                     satisfy the invariant (see run_migrations_locked)"
+                );
+            }
+        }
+    }
+
+    /// The scanner itself must actually catch each class of violation —
+    /// otherwise the tripwire above is a no-op.
+    #[test]
+    fn migration_invariant_scanner_detects_violations() {
+        // `--` inside a quoted literal would be truncated by the stripper.
+        assert!(check_migration_parsing_invariants("SELECT 'a--b';", false).is_err());
+        // ... even when the literal is inside a dollar-quoted body.
+        let in_body = "DO $$ BEGIN PERFORM 'x--y'; END $$;";
+        assert!(check_migration_parsing_invariants(in_body, false).is_err());
+        // Block comments are not understood by the stripper.
+        assert!(check_migration_parsing_invariants("/* hi */ SELECT 1;", false).is_err());
+        // Dollar-quoting in a CONCURRENTLY file would be split on ';'.
+        assert!(check_migration_parsing_invariants("DO $$ BEGIN END $$;", true).is_err());
+        // `;` inside a literal in a CONCURRENTLY file would be split.
+        assert!(check_migration_parsing_invariants("SELECT 'a;b';", true).is_err());
+        // Unterminated literal.
+        assert!(check_migration_parsing_invariants("SELECT 'oops", false).is_err());
+
+        // Clean SQL passes: plpgsql `--` comments inside $$ bodies (0018's
+        // pattern), `''` escapes, `;` in plain statements, and `--` comment
+        // text containing apostrophes.
+        let clean = "-- it's fine\nDO $$ BEGIN -- note\n PERFORM 1; END $$;\nSELECT 'a''b';";
+        assert!(check_migration_parsing_invariants(clean, false).is_ok());
+        // Clean CONCURRENTLY SQL passes: plain statements + comments only
+        // (a `;` inside a comment is stripped before the splitter runs).
+        let conc = "-- build; carefully\nCREATE INDEX CONCURRENTLY i ON t (c);";
+        assert!(check_migration_parsing_invariants(conc, true).is_ok());
     }
 
     // ── reap_invalid_indexes — throwaway-DB integration test ─────────────────

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -60,6 +60,16 @@ fn timeout_ms_env(key: &str, default: u64) -> u64 {
         .unwrap_or(default)
 }
 
+/// The pool's configured `statement_timeout`, in milliseconds — the single
+/// source of truth shared by [`build_pool`]'s post-create hook (which sets it
+/// on every fresh connection) and the migration runner's restore path (which
+/// must re-issue the SAME value after a CONCURRENTLY migration ran with the
+/// timeout disabled; see the "restore" comment in `run_migrations_locked`).
+/// Keeping both call sites on this one function means they cannot drift.
+fn pool_statement_timeout_ms() -> u64 {
+    timeout_ms_env("DB_STATEMENT_TIMEOUT_MS", DEFAULT_STATEMENT_TIMEOUT_MS)
+}
+
 /// Build and return a `deadpool-postgres` connection pool.
 ///
 /// The `database_url` must be a valid `libpq`-style connection string, e.g.:
@@ -104,11 +114,11 @@ pub fn build_pool(database_url: &str, pool_size: usize) -> Result<Pool> {
     // Migrations exemption: `run_migrations_locked` uses this SAME pool to run
     // DDL, including `CREATE INDEX CONCURRENTLY` builds that can legitimately
     // take far longer than 30s on a large table. That function explicitly
-    // raises/clears `statement_timeout` around its own DDL (see the "migration
+    // disables `statement_timeout` around its own DDL and then re-issues this
+    // pool value via [`pool_statement_timeout_ms`] (see the "migration
     // timeout exemption" comments there) rather than us weakening the default
     // here — every other caller keeps the safety net.
-    let statement_timeout_ms =
-        timeout_ms_env("DB_STATEMENT_TIMEOUT_MS", DEFAULT_STATEMENT_TIMEOUT_MS);
+    let statement_timeout_ms = pool_statement_timeout_ms();
     let lock_timeout_ms = timeout_ms_env("DB_LOCK_TIMEOUT_MS", DEFAULT_LOCK_TIMEOUT_MS);
     cfg.builder(NoTls)
         .context("failed to create deadpool-postgres pool builder")?
@@ -7923,8 +7933,25 @@ const RUN_MIGRATIONS_LOCK_KEY: i64 = 917_342_002;
 /// Dropping is safe here: an INVALID index provided no guarantees anyway (the
 /// planner never uses it, and an invalid UNIQUE index enforces nothing), and
 /// [`run_migrations`] (the sole caller, via [`run_migrations_locked`]) holds
-/// [`RUN_MIGRATIONS_LOCK_KEY`] for the whole call, so no other process can be
-/// concurrently building the same index name.
+/// [`RUN_MIGRATIONS_LOCK_KEY`] for the whole call, so no other *Crumb* process
+/// can be concurrently building the same index name.
+///
+/// The advisory lock does NOT cover an **operator's manual**
+/// `CREATE INDEX CONCURRENTLY` running in a plain psql session, though — and a
+/// concurrent build IN PROGRESS is also marked `indisvalid = false` until it
+/// finishes, so a naive reap during an api/recorder restart mid-build would
+/// destroy the operator's hours-long build. Two guards prevent that:
+///
+/// 1. The catalog query excludes any index with a live row in
+///    `pg_stat_progress_create_index` (the build backend's progress entry for
+///    this database) — a healthy in-flight build is skipped, not dropped.
+/// 2. Belt-and-braces for the race where a build starts between that snapshot
+///    and the `DROP`: the pool's per-connection `lock_timeout` (set in
+///    [`build_pool`], default 10s) bounds how long `DROP INDEX` queues behind
+///    the build's locks, and a `55P03 lock_not_available` error is treated as
+///    skip-and-WARN rather than a hard failure — the index is re-examined on
+///    the next boot, when the build has either finished (now VALID, untouched)
+///    or died (truly orphaned, reaped).
 ///
 /// Dropping is NOT always self-healing, though. The dropped index is rebuilt
 /// automatically only when the migration that creates it has **not yet been
@@ -7958,6 +7985,20 @@ async fn reap_invalid_indexes(client: &deadpool_postgres::Client) -> Result<()> 
             JOIN pg_namespace ns ON ns.oid = ci.relnamespace
             WHERE NOT pi.indisvalid
               AND ns.nspname = current_schema()
+              -- Guard 1 (see the doc comment): an in-progress CREATE INDEX
+              -- CONCURRENTLY is ALSO indisvalid=false until it completes.
+              -- Skip any index whose build is live right now — it has a row
+              -- in pg_stat_progress_create_index (scoped to this database;
+              -- the view is cluster-wide and OIDs are only unique per-DB).
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM pg_stat_progress_create_index prog
+                  WHERE prog.index_relid = pi.indexrelid
+                    AND prog.datid = (
+                        SELECT oid FROM pg_database
+                        WHERE datname = current_database()
+                    )
+              )
             ",
             &[],
         )
@@ -7971,22 +8012,45 @@ async fn reap_invalid_indexes(client: &deadpool_postgres::Client) -> Result<()> 
             index_name,
             table_name,
             "run_migrations: found INVALID index (left by an interrupted \
-             CREATE INDEX CONCURRENTLY) — dropping it; it provided NO \
-             guarantees while invalid. It is rebuilt automatically only if \
-             the migration that creates it is still pending; if that \
-             migration is already recorded in schema_migrations, recreate \
-             the index manually from its db/migrations/ file"
+             CREATE INDEX CONCURRENTLY) — dropping it unless its locks are \
+             held; it provided NO guarantees while invalid. It is rebuilt \
+             automatically only if the migration that creates it is still \
+             pending; if that migration is already recorded in \
+             schema_migrations, recreate the index manually from its \
+             db/migrations/ file"
         );
         // Index names are catalog-sourced identifiers (not user input), but
         // quote them defensively since `format!` can't bind a DDL identifier
         // as a parameter.
-        client
+        //
+        // Guard 2 (see the doc comment): this DROP runs under the pool's
+        // per-connection `lock_timeout` (set by build_pool's post-create
+        // hook). If a manual CONCURRENTLY build slipped in between the
+        // catalog snapshot above and this DROP, the build's locks make the
+        // DROP time out with 55P03 — treat that as skip-and-warn, never as a
+        // boot-failing error and never as an unbounded queued ACCESS
+        // EXCLUSIVE request stalling the table.
+        let drop_result = client
             .batch_execute(&format!(
                 r#"DROP INDEX IF EXISTS "{index_name}""#,
                 index_name = index_name.replace('"', "\"\"")
             ))
-            .await
-            .with_context(|| format!("reap_invalid_indexes: drop invalid index {index_name}"))?;
+            .await;
+        if let Err(e) = drop_result {
+            if e.code() == Some(&tokio_postgres::error::SqlState::LOCK_NOT_AVAILABLE) {
+                tracing::warn!(
+                    index_name,
+                    table_name,
+                    "run_migrations: DROP of INVALID index timed out waiting \
+                     for a lock — something (likely an in-progress manual \
+                     CREATE INDEX CONCURRENTLY) holds locks on it; leaving it \
+                     alone. It will be re-examined on the next startup"
+                );
+                continue;
+            }
+            return Err(e)
+                .with_context(|| format!("reap_invalid_indexes: drop invalid index {index_name}"));
+        }
     }
 
     Ok(())
@@ -8397,11 +8461,20 @@ async fn run_migrations_locked(pool: &Pool) -> Result<()> {
                     format!("run_migrations: apply (concurrently stmt) {filename}")
                 })?;
             }
-            // Restore the pool default for the rest of this connection's life
-            // (it is about to be re-acquired fresh below anyway, but this
-            // keeps the invariant explicit rather than relying on that).
+            // Restore the POOL'S configured timeout for the rest of this
+            // connection's life. NOT `RESET`: `RESET statement_timeout`
+            // restores the Postgres SERVER default (typically 0 = disabled),
+            // not the 30s runaway-query backstop [`build_pool`]'s post-create
+            // hook set — the hook runs once per PHYSICAL connection at
+            // creation, not on every checkout, so this connection would
+            // return to the pool with NO statement timeout and a later
+            // hot-path query on it could hang indefinitely (exactly the
+            // pool-starvation hole the backstop exists to close). Re-issue
+            // the same value the hook set, via the shared
+            // [`pool_statement_timeout_ms`] source of truth.
+            let restore_ms = pool_statement_timeout_ms();
             client
-                .batch_execute("RESET statement_timeout")
+                .batch_execute(&format!("SET statement_timeout = '{restore_ms}ms'"))
                 .await
                 .context("run_migrations: restore statement_timeout after CONCURRENTLY")?;
         } else {
@@ -10202,6 +10275,107 @@ mod tests {
         assert!(
             valid_index_survives,
             "reap_invalid_indexes must never touch a VALID index"
+        );
+    }
+
+    /// An INVALID index whose locks are HELD by another session must be
+    /// skipped (with a WARN), not dropped and not turned into a boot-failing
+    /// error — this is the "operator's manual CREATE INDEX CONCURRENTLY is
+    /// running right now" protection (guard 2 in [`reap_invalid_indexes`]'s
+    /// docs).
+    ///
+    /// A real in-progress CONCURRENTLY build can't be reproduced
+    /// deterministically in a test (and guard 1's
+    /// `pg_stat_progress_create_index` row can't be faked — it is a stat
+    /// view, not a table), so this simulates the lock footprint instead: a
+    /// second session holds `SHARE UPDATE EXCLUSIVE` on the table, which is
+    /// exactly the table lock a live `CREATE INDEX CONCURRENTLY` holds, and
+    /// which conflicts with the `ACCESS EXCLUSIVE` that `DROP INDEX` needs.
+    /// The reaper must hit its `lock_timeout`, map the `55P03` to
+    /// skip-and-warn, and reap successfully on the next pass once the lock
+    /// is released.
+    #[tokio::test]
+    async fn reap_invalid_indexes_skips_lock_held_index() {
+        let Some(url) = test_db_url() else {
+            eprintln!("skipping: TEST_DATABASE_URL not set");
+            return;
+        };
+        let fx = setup_schema(&url).await;
+        let client = get_conn(&fx.pool).await.expect("get_conn");
+
+        client
+            .batch_execute(
+                r"
+                CREATE TABLE widgets (id int PRIMARY KEY, name text);
+                CREATE INDEX widgets_name_idx ON widgets (name);
+                UPDATE pg_index SET indisvalid = false
+                WHERE indexrelid = 'widgets_name_idx'::regclass;
+                ",
+            )
+            .await
+            .expect("create table + invalid index");
+
+        // Second session: hold the table lock a live CREATE INDEX
+        // CONCURRENTLY would hold, in an open transaction.
+        let (holder, holder_conn) = tokio_postgres::connect(&fx.base_url, NoTls)
+            .await
+            .expect("connect lock-holder session");
+        tokio::spawn(holder_conn);
+        holder
+            .batch_execute(&format!(
+                "BEGIN; LOCK TABLE {}.widgets IN SHARE UPDATE EXCLUSIVE MODE",
+                fx.schema
+            ))
+            .await
+            .expect("hold SHARE UPDATE EXCLUSIVE on widgets");
+
+        // Shorten the reaper connection's lock_timeout (pool default is 10s)
+        // so the blocked DROP fails fast and the test stays quick. Session-
+        // level SET, same mechanism the pool's post-create hook uses.
+        client
+            .batch_execute("SET lock_timeout = '500ms'")
+            .await
+            .expect("shorten lock_timeout for test");
+
+        // Must return Ok (skip-and-warn), and must NOT have dropped the
+        // lock-held index.
+        reap_invalid_indexes(&client)
+            .await
+            .expect("reap_invalid_indexes must skip a lock-held index, not error");
+        let survives_while_locked: bool = client
+            .query_one(
+                "SELECT EXISTS (SELECT 1 FROM pg_class WHERE relname = 'widgets_name_idx')",
+                &[],
+            )
+            .await
+            .expect("check index survives while locked")
+            .get(0);
+        assert!(
+            survives_while_locked,
+            "reap_invalid_indexes must NOT drop an INVALID index whose locks \
+             are held by another session (a live manual CONCURRENTLY build)"
+        );
+
+        // Release the lock; the next boot's reap pass now truly reaps it.
+        holder
+            .batch_execute("ROLLBACK")
+            .await
+            .expect("release lock");
+        reap_invalid_indexes(&client)
+            .await
+            .expect("reap_invalid_indexes (lock released)");
+        let still_present_after_release: bool = client
+            .query_one(
+                "SELECT EXISTS (SELECT 1 FROM pg_class WHERE relname = 'widgets_name_idx')",
+                &[],
+            )
+            .await
+            .expect("check index reaped after lock release")
+            .get(0);
+        assert!(
+            !still_present_after_release,
+            "once the blocking session is gone, the orphaned INVALID index \
+             must be reaped on the next pass"
         );
     }
 

--- a/services/recorder/src/archive.rs
+++ b/services/recorder/src/archive.rs
@@ -11,8 +11,11 @@
 //!    (correctness item 7 — archive-enabled cameras are excluded here;
 //!    the archiver owns their deletion).
 //! 2. For each camera with `archive_enabled = true`, evaluates whether its
-//!    `archive_schedule` cron is due.  When due, runs [`archive_camera`] then
-//!    [`archive_retention_sweep`].
+//!    `archive_schedule` cron is due (catch-up semantics: an occurrence that
+//!    fell inside a slow/straddled tick window still fires).  When due, runs
+//!    [`archive_camera`] then [`archive_retention_sweep`].  The cron-archive
+//!    work of one tick shares a wall-time budget (issue #80); leftover backlog
+//!    is continued on the NEXT tick without waiting for the next cron fire.
 //! 3. Stops cleanly when the [`CancellationToken`] is cancelled.
 //!
 //! # Archive move ordering (correctness item 8)
@@ -26,9 +29,12 @@
 //! 4. tokio::fs::remove_file(src)             — source deleted
 //! ```
 //!
-//! A crash at any step leaves the system recoverable: the startup reconciler
-//! finds the orphaned dst copy and indexes it, or the src copy is still
-//! indexed — never a missing file with a stale row pointing at it.
+//! A crash at any step leaves the system recoverable: either the source copy
+//! is still indexed (a crash before step 3 leaves an unindexed dst copy that
+//! the next archive run simply overwrites), or the archive copy is indexed (a
+//! crash before step 4 leaves a stray source copy on the live disk — see the
+//! step-4 note in [`move_segment_to_archive`]) — never a missing file with a
+//! stale row pointing at it.
 //!
 //! # Retention delete ordering (correctness item 10)
 //!
@@ -102,9 +108,40 @@ const MAX_RETENTION_BATCH_LIMIT: i64 = 2_000;
 /// loop is ever parallelized or a manual "archive now" trigger is added. It's an
 /// in-process `Mutex` (not a pg lock) because cross-process is already covered by
 /// the single-writer lock. Held only at the top-level archive entry points
-/// (`archive_camera`, `policy_size_eviction_sweep`) — never nested — so it cannot
-/// deadlock.
+/// (`archive_camera` — per bounded batch, see issue #80 —
+/// `policy_size_eviction_sweep`, `max_retention_sweep`, and the migration
+/// drain's bulk flip) — never nested — so it cannot deadlock.
 static ARCHIVE_GUARD: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// How many segments one guarded archive batch moves before [`ARCHIVE_GUARD`]
+/// is released and re-acquired (issue #80). Releasing between batches lets any
+/// concurrent guard-taker (e.g. a "Change storage" drain's bulk flip) interleave
+/// instead of waiting behind an entire catch-up backlog. Small enough that a
+/// batch of large segments on a spinning archive disk stays in the seconds
+/// range; the wall-time budget below bounds the run regardless.
+const ARCHIVE_MOVE_BATCH: usize = 64;
+
+/// Default wall-time budget (seconds) shared by ALL cron-archive work in ONE
+/// scheduler tick (issue #80). A single archive run used to process the whole
+/// backlog while holding [`ARCHIVE_GUARD`] and the scheduler tick — on a large
+/// catch-up (first enable of archiving, or days of downtime) that starved live
+/// retention and the free-space floor for hours. The budget bounds how long a
+/// tick spends moving segments; whatever remains is logged as deferred and the
+/// per-camera tracker's `backlog_pending` flag makes the NEXT tick continue it
+/// without waiting for the next cron fire. Overridable via
+/// `ARCHIVE_TICK_BUDGET_SECONDS`.
+const DEFAULT_ARCHIVE_TICK_BUDGET_SECS: u64 = 30;
+
+/// Read `ARCHIVE_TICK_BUDGET_SECONDS` from the env, falling back to
+/// [`DEFAULT_ARCHIVE_TICK_BUDGET_SECS`]. Parsed per tick (cheap, ~once/60s).
+fn archive_tick_budget() -> std::time::Duration {
+    let secs = std::env::var("ARCHIVE_TICK_BUDGET_SECONDS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|s| *s > 0)
+        .unwrap_or(DEFAULT_ARCHIVE_TICK_BUDGET_SECS);
+    std::time::Duration::from_secs(secs)
+}
 
 /// Read `MIN_FREE_FRACTION` / `MIN_FREE_BYTES` from the env, falling back to the
 /// defaults. Parsed per call (cheap; the sweep runs ~once/60s).
@@ -140,10 +177,18 @@ fn fs_free_and_total(path: &str) -> Option<(i64, i64)> {
         if rc != 0 {
             return None;
         }
+        // Use f_bavail (blocks available to a NON-privileged writer), NOT
+        // f_bfree (total free blocks, which includes the ext4 root reserve — 5%
+        // by default). The recorder runs as a non-root uid, so on a normally
+        // provisioned ext4 volume f_bfree never reaches 0 and the ENOSPC safety
+        // valve could never fire, letting the disk fill until writes failed
+        // (issue #72). f_frsize is the POSIX fundamental block size that
+        // f_bavail/f_blocks are counted in (f_bsize is the "preferred" I/O size,
+        // not the count unit).
         #[allow(clippy::cast_lossless)]
-        let free = (buf.f_bfree as u64).saturating_mul(buf.f_bsize as u64);
+        let free = (buf.f_bavail as u64).saturating_mul(buf.f_frsize as u64);
         #[allow(clippy::cast_lossless)]
-        let total = (buf.f_blocks as u64).saturating_mul(buf.f_bsize as u64);
+        let total = (buf.f_blocks as u64).saturating_mul(buf.f_frsize as u64);
         Some((i64::try_from(free).ok()?, i64::try_from(total).ok()?))
     }
     #[cfg(not(unix))]
@@ -287,11 +332,17 @@ async fn tick(
 
     let now = Utc::now();
 
+    // One shared wall-time budget for ALL of this tick's cron-archive moves
+    // (issue #80): however many cameras fire at once, the tick spends at most
+    // this long moving segments before yielding back to retention / the
+    // free-space floor; the remainder is deferred and continued next tick.
+    let archive_deadline = std::time::Instant::now() + archive_tick_budget();
+
     for camera in &cameras {
         // The cron-driven time-based archive move applies only to archive-enabled
         // cameras with a schedule.
         if camera.policy.archive_enabled {
-            run_cron_archive(pool, config, camera, now, cron_trackers).await;
+            run_cron_archive(pool, config, camera, now, cron_trackers, archive_deadline).await;
         } else {
             // Archive OFF: there is no move to do, but residual stage=archive footage
             // may exist (archive was turned off after footage had been archived).
@@ -359,13 +410,15 @@ async fn tick(
 }
 
 /// Run the cron-driven time-based archive move + archive-retention sweep for one
-/// archive-enabled camera, if its `archive_schedule` cron is due this tick.
+/// archive-enabled camera, if its `archive_schedule` cron is due this tick — or
+/// if a budget-bounded previous run left deferred backlog to continue (#80).
 async fn run_cron_archive(
     pool: &Pool,
     config: &Config,
     camera: &Camera,
     now: DateTime<Utc>,
     cron_trackers: &mut std::collections::HashMap<Uuid, CronTracker>,
+    deadline: std::time::Instant,
 ) {
     // Resolve the cron expression — cameras with no schedule are skipped.
     let schedule = match camera.policy.archive_schedule.as_deref() {
@@ -379,53 +432,57 @@ async fn run_cron_archive(
         }
     };
 
-    // Lazily initialise the CronTracker for this camera.
+    // Initialise or RESYNC the tracker (#82: a runtime edit of
+    // `archive_schedule` must take effect without a recorder restart).
     //
-    // If the cron expression is invalid we log the error and skip this
-    // camera rather than inserting a poisoned tracker.  We do NOT insert
-    // anything into `cron_trackers` on failure — the error will be logged
-    // again on the next tick, which is acceptable (once per minute) and
-    // keeps the operator informed without crashing.
-    if let std::collections::hash_map::Entry::Vacant(e) = cron_trackers.entry(camera.id) {
-        match CronTracker::new(schedule) {
-            Ok(t) => {
-                e.insert(t);
-            }
-            Err(e) => {
-                error!(
-                    camera_id = %camera.id,
-                    schedule  = %schedule,
-                    error     = %e,
-                    "invalid archive_schedule cron expression; \
-                     camera will not be archived until schedule is fixed"
-                );
-                return;
-            }
+    // If the cron expression is invalid we log the error and skip this camera
+    // rather than keeping a poisoned/stale tracker. The error is logged again
+    // on the next tick, which is acceptable (once per minute) and keeps the
+    // operator informed without crashing.
+    let tracker = match ensure_cron_tracker(cron_trackers, camera.id, schedule) {
+        Ok(t) => t,
+        Err(e) => {
+            error!(
+                camera_id = %camera.id,
+                schedule  = %schedule,
+                error     = %e,
+                "invalid archive_schedule cron expression; \
+                 camera will not be archived until schedule is fixed"
+            );
+            return;
         }
-    }
-    // SAFETY: we just inserted above if it was missing, or it was already
-    // present; `get_mut` cannot return None here.
-    let tracker = match cron_trackers.get_mut(&camera.id) {
-        Some(t) => t,
-        None => return, // should not happen
     };
 
-    if !tracker.is_due(now, config.archive_cron_tz) {
+    let due = tracker.is_due(now, config.archive_cron_tz);
+    // Continue a budget-deferred backlog on the next tick even without a cron
+    // fire (#80) — otherwise a deferred catch-up would wait for the next
+    // scheduled occurrence (typically a whole day).
+    if !due && !tracker.backlog_pending {
         return;
     }
 
     info!(
         camera_id   = %camera.id,
         camera_name = %camera.name,
-        "archive cron fired; running archive job"
+        cron_fired  = due,
+        "archive job due (cron fired or continuing deferred backlog); running"
     );
 
-    if let Err(e) = archive_camera(pool, config, camera).await {
-        error!(
-            camera_id = %camera.id,
-            error     = %e,
-            "archive job failed"
-        );
+    match archive_camera(pool, config, camera, deadline).await {
+        Ok(deferred) => {
+            tracker.backlog_pending = deferred > 0;
+        }
+        Err(e) => {
+            // Setup failures (missing storage / bad policy) won't self-heal
+            // within a tick; clear the pending flag so the error is reported
+            // once per cron fire rather than spammed once per tick.
+            tracker.backlog_pending = false;
+            error!(
+                camera_id = %camera.id,
+                error     = %e,
+                "archive job failed"
+            );
+        }
     }
 
     if let Err(e) = archive_retention_sweep(pool, config, camera).await {
@@ -437,30 +494,97 @@ async fn run_cron_archive(
     }
 }
 
+/// Ensure the cached [`CronTracker`] for `camera_id` was parsed from `schedule`,
+/// (re)parsing when the entry is missing or stale (#82: editing a camera's
+/// `archive_schedule` previously never took effect until a restart, because the
+/// tracker was lazily built once and never compared against the current value).
+///
+/// On a re-parse the evaluation window (`last_checked`) and the deferred-backlog
+/// flag are preserved, so an edit can neither retro-fire past occurrences nor
+/// skip one that lands right after the edit, and an in-progress catch-up (#80)
+/// keeps going. An invalid new expression removes the stale entry (the operator
+/// replaced the schedule — keeping the OLD cron firing would be wrong) and
+/// returns the parse error for the caller to log.
+fn ensure_cron_tracker<'a>(
+    trackers: &'a mut std::collections::HashMap<Uuid, CronTracker>,
+    camera_id: Uuid,
+    schedule: &str,
+) -> Result<&'a mut CronTracker> {
+    let needs_parse = trackers
+        .get(&camera_id)
+        .is_none_or(|t| t.schedule != schedule);
+    if needs_parse {
+        let fresh = match CronTracker::new(schedule) {
+            Ok(mut fresh) => {
+                if let Some(old) = trackers.get(&camera_id) {
+                    info!(
+                        camera_id    = %camera_id,
+                        old_schedule = %old.schedule,
+                        new_schedule = %schedule,
+                        "archive_schedule changed; cron tracker re-parsed (no restart needed)"
+                    );
+                    fresh.last_checked = old.last_checked;
+                    fresh.backlog_pending = old.backlog_pending;
+                }
+                fresh
+            }
+            Err(e) => {
+                trackers.remove(&camera_id);
+                return Err(e);
+            }
+        };
+        trackers.insert(camera_id, fresh);
+    }
+    trackers
+        .get_mut(&camera_id)
+        .ok_or_else(|| anyhow::anyhow!("cron tracker missing after ensure (unreachable)"))
+}
+
 // ─── archive job ──────────────────────────────────────────────────────────────
 
-/// Run the archive job for a single camera.
+/// Run the archive job for a single camera, bounded by `deadline`.
 ///
 /// For each live segment older than `live_retention_hours` on an
 /// archive-enabled camera, moves the file from live storage to archive storage
 /// using the safe copy→verify→update→delete sequence (correctness item 8).
+///
+/// **Bounded work (issue #80):** [`ARCHIVE_GUARD`] is held per BATCH of
+/// [`ARCHIVE_MOVE_BATCH`] moves — not for the whole run — and the run stops at
+/// `deadline`, returning how many eligible segments were left unprocessed. A
+/// large catch-up backlog (first enable of archiving, days of downtime) no
+/// longer pins the scheduler tick and the guard for hours, starving live
+/// retention and the free-space floor; the scheduler re-runs the job every
+/// tick (via the tracker's `backlog_pending` flag) until the backlog drains.
+/// Releasing the guard between batches is safe: each move is independently
+/// crash-ordered (copy→verify→index→delete, item 8), and a segment mutated by
+/// a concurrent guard-holder between batches simply fails its own move
+/// (missing source → logged, skipped) — same as any other per-segment failure.
 ///
 /// Errors are logged per-segment and the loop continues.  Partial runs are
 /// safe: the segment index always reflects the actual file location.
 ///
 /// # Arguments
 ///
-/// * `pool`   — database pool.
-/// * `config` — global recorder config.
-/// * `camera` — camera whose archive job is due.
+/// * `pool`     — database pool.
+/// * `config`   — global recorder config.
+/// * `camera`   — camera whose archive job is due.
+/// * `deadline` — wall-clock cutoff for this run (shared across the tick).
+///
+/// # Returns
+///
+/// The number of eligible segments DEFERRED past the deadline (0 = backlog
+/// fully drained this run).
 ///
 /// # Errors
 ///
 /// Returns an error only for setup failures (missing storage, bad policy).
 /// Per-segment errors are logged and not propagated.
-pub async fn archive_camera(pool: &Pool, _config: &Config, camera: &Camera) -> Result<()> {
-    // Serialize against any other archive job process-wide (see ARCHIVE_GUARD).
-    let _archive_guard = ARCHIVE_GUARD.lock().await;
+pub async fn archive_camera(
+    pool: &Pool,
+    _config: &Config,
+    camera: &Camera,
+    deadline: std::time::Instant,
+) -> Result<usize> {
     info!(
         camera_id   = %camera.id,
         camera_name = %camera.name,
@@ -496,7 +620,7 @@ pub async fn archive_camera(pool: &Pool, _config: &Config, camera: &Camera) -> R
             camera_id = %camera.id,
             "no segments eligible for archiving"
         );
-        return Ok(());
+        return Ok(0);
     }
 
     info!(
@@ -514,53 +638,108 @@ pub async fn archive_camera(pool: &Pool, _config: &Config, camera: &Camera) -> R
     let mut storage_cache: std::collections::HashMap<Uuid, Storage> =
         std::collections::HashMap::new();
 
-    for seg in &segments {
-        // Resolve the segment's OWN storage (where it was actually recorded).
-        let src_storage = match resolve_storage(pool, &mut storage_cache, seg.storage_id).await {
-            Ok(s) => s,
-            Err(e) => {
-                failed += 1;
-                error!(
-                    camera_id  = %camera.id,
-                    segment_id = %seg.id,
-                    storage_id = %seg.storage_id,
-                    error      = %e,
-                    "failed to resolve segment storage for archive; skipping"
-                );
-                continue;
+    // Index of the first UNPROCESSED segment; everything past it at the end of
+    // the run is the deferred backlog.
+    let mut next = 0usize;
+    while next < segments.len() && std::time::Instant::now() < deadline {
+        // Serialize ONE bounded batch against any other archive operation
+        // (see ARCHIVE_GUARD) — per batch, not per run (issue #80). The guard
+        // drops at the end of this iteration, letting concurrent guard-takers
+        // interleave between batches.
+        let _archive_guard = ARCHIVE_GUARD.lock().await;
+        let batch_end = (next + ARCHIVE_MOVE_BATCH).min(segments.len());
+        while next < batch_end {
+            // The deadline is also honoured WITHIN a batch so a run of large
+            // files on a slow disk can't blow far past the budget.
+            if std::time::Instant::now() >= deadline {
+                break;
             }
-        };
-        let src_root = Path::new(&src_storage.path);
-        match move_segment_to_archive(pool, seg, src_root, archive_root, archive_storage.id).await {
-            Ok(()) => {
+            let seg = &segments[next];
+            next += 1;
+            if archive_one_segment(
+                pool,
+                camera,
+                seg,
+                archive_root,
+                archive_storage.id,
+                &mut storage_cache,
+            )
+            .await
+            {
                 archived += 1;
-                debug!(
-                    camera_id  = %camera.id,
-                    segment_id = %seg.id,
-                    src        = %seg.path,
-                    "segment archived"
-                );
-            }
-            Err(e) => {
+            } else {
                 failed += 1;
-                error!(
-                    camera_id  = %camera.id,
-                    segment_id = %seg.id,
-                    error      = %e,
-                    "failed to archive segment; skipping"
-                );
             }
         }
+    }
+
+    let deferred = segments.len() - next;
+    if deferred > 0 {
+        info!(
+            camera_id = %camera.id,
+            deferred  = deferred,
+            "archive tick budget exhausted; deferring remaining segments to the next tick"
+        );
     }
 
     info!(
         camera_id = %camera.id,
         archived  = archived,
         failed    = failed,
+        deferred  = deferred,
         "archive job complete"
     );
 
-    Ok(())
+    Ok(deferred)
+}
+
+/// Archive ONE segment for [`archive_camera`]: resolve its OWN source storage
+/// (per-segment — a policy's live storage can be repointed and older footage
+/// still lives on the previous disk), run the crash-ordered move, and log the
+/// outcome. Returns `true` on success, `false` on a (logged) per-segment
+/// failure; the caller only tallies.
+async fn archive_one_segment(
+    pool: &Pool,
+    camera: &Camera,
+    seg: &Segment,
+    archive_root: &Path,
+    archive_storage_id: Uuid,
+    storage_cache: &mut std::collections::HashMap<Uuid, Storage>,
+) -> bool {
+    let src_storage = match resolve_storage(pool, storage_cache, seg.storage_id).await {
+        Ok(s) => s,
+        Err(e) => {
+            error!(
+                camera_id  = %camera.id,
+                segment_id = %seg.id,
+                storage_id = %seg.storage_id,
+                error      = %e,
+                "failed to resolve segment storage for archive; skipping"
+            );
+            return false;
+        }
+    };
+    let src_root = Path::new(&src_storage.path);
+    match move_segment_to_archive(pool, seg, src_root, archive_root, archive_storage_id).await {
+        Ok(()) => {
+            debug!(
+                camera_id  = %camera.id,
+                segment_id = %seg.id,
+                src        = %seg.path,
+                "segment archived"
+            );
+            true
+        }
+        Err(e) => {
+            error!(
+                camera_id  = %camera.id,
+                segment_id = %seg.id,
+                error      = %e,
+                "failed to archive segment; skipping"
+            );
+            false
+        }
+    }
 }
 
 /// Move a single segment from live storage to archive storage.
@@ -594,6 +773,34 @@ async fn move_segment_to_archive(
     let dst_rel = archive_relative_path(&seg.camera_id, &seg.start_ts, &seg.path)?;
     let dst_abs = archive_root.join(&dst_rel);
 
+    // ── SAME-FILE GUARD (issue #70) — never copy a segment onto itself ────────
+    // If src_abs and dst_abs are the SAME file, the streaming copy below opens
+    // the destination for WRITE (truncating the real segment to zero bytes) and
+    // Step 4 then deletes it: permanent, silent footage loss. This is reachable
+    // in normal configs — the seed defaults the `archive` storage to the SAME
+    // path as the live storage (two storage rows, one directory), and the
+    // startup reconciler adopts a file already sitting on the archive disk under
+    // a stage=Live row. In both cases the bytes are ALREADY at their archive
+    // location (dst_abs == archive_root/dst_rel is exactly where the row should
+    // point), so the correct action is to flip the index row to stage=archive in
+    // place: no copy, no delete. dev+ino identity (not textual path equality)
+    // catches symlinks and two storage rows resolving to one directory.
+    if same_file(&src_abs, &dst_abs).await {
+        let dst_rel_str = dst_rel
+            .to_str()
+            .with_context(|| format!("non-UTF-8 archive path: {}", dst_rel.display()))?;
+        // The file is already present; make it (and its dir entry) durable, then
+        // record the archive stage/storage/path. update_segment_archive is an
+        // idempotent no-op if the row already reflects this.
+        fsync_file_and_parent_dir(&dst_abs)
+            .await
+            .with_context(|| format!("fsync in-place archive {}", dst_abs.display()))?;
+        db::update_segment_archive(pool, seg.id, archive_storage_id, dst_rel_str)
+            .await
+            .context("update_segment_archive (in-place, src==dst)")?;
+        return Ok(());
+    }
+
     // Ensure the destination directory exists.
     if let Some(dst_dir) = dst_abs.parent() {
         tokio::fs::create_dir_all(dst_dir)
@@ -607,9 +814,23 @@ async fn move_segment_to_archive(
     // cache). We CRC32 the source stream while copying, then re-hash the written
     // destination and compare before deleting the source — so corruption is
     // caught while the good source still exists.
-    let (bytes_copied, src_crc) = copy_with_crc32(&src_abs, &dst_abs)
-        .await
-        .with_context(|| format!("copy {} -> {}", src_abs.display(), dst_abs.display()))?;
+    let (bytes_copied, src_crc) = match copy_with_crc32(&src_abs, &dst_abs).await {
+        Ok(r) => r,
+        Err(e) => {
+            // A failed/interrupted copy can leave a PARTIAL destination behind
+            // (issue #84). Remove it best-effort before propagating — exactly
+            // as the size/crc verify branches below do — so a half-written
+            // file is never left to be mistaken for a valid archive copy. The
+            // same-file guard above already ruled out src == dst, so this can
+            // never touch the source.
+            let _ = tokio::fs::remove_file(&dst_abs).await;
+            return Err(e.context(format!(
+                "copy {} -> {}",
+                src_abs.display(),
+                dst_abs.display()
+            )));
+        }
+    };
 
     // ── PHASE-2 GROOMING SEAM ─────────────────────────────────────────────────
     // In Phase 2, insert a grooming step here:
@@ -685,8 +906,14 @@ async fn move_segment_to_archive(
     //
     // This runs AFTER the dst is fsync-durable AND the index update so a crash
     // here leaves the archive copy indexed (safe) rather than the live copy with
-    // a stale row.  The startup reconciler's file scan will remove the orphaned
-    // live file on next restart.
+    // a stale row.  NOTE: the reconciler does NOT clean up the leftover source
+    // file after such a crash — its orphan pass sees a row already indexed at
+    // this (camera_id, stream, start_ts) key and conservatively leaves the file
+    // in place (reconcile.rs `OrphanOutcome::AlreadyIndexed`), and no sweep
+    // deletes files that have no row. The cost of this crash window is bounded
+    // and safe-direction: one segment's worth of duplicate bytes on the source
+    // disk, reclaimable only by an operator (or a future
+    // duplicate-of-indexed-key cleanup pass) — never footage loss.
     tokio::fs::remove_file(&src_abs)
         .await
         .with_context(|| format!("remove source {}", src_abs.display()))?;
@@ -1006,8 +1233,47 @@ pub async fn run_storage_migration(pool: &Pool, mig: &StorageMigration) -> Resul
 /// to the destination — one pass, no extra read of the source. Used by the
 /// archive move so the source hash is computed for free during the copy and can
 /// be compared to a re-hash of the destination before the source is deleted.
+/// True when `a` and `b` are the SAME file on disk (identical device + inode),
+/// resolving symlinks, `..`, and two storage rows that point at one directory.
+/// A missing side (the normal cross-storage move, where the destination does
+/// not exist yet) returns false. Used to refuse a copy that would truncate the
+/// only copy of a segment (issue #70).
+async fn same_file(a: &Path, b: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        match (tokio::fs::metadata(a).await, tokio::fs::metadata(b).await) {
+            (Ok(ma), Ok(mb)) => ma.dev() == mb.dev() && ma.ino() == mb.ino(),
+            _ => false,
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        // No dev/ino; fall back to canonical-path equality (CI cross-check only).
+        match (
+            tokio::fs::canonicalize(a).await,
+            tokio::fs::canonicalize(b).await,
+        ) {
+            (Ok(ca), Ok(cb)) => ca == cb,
+            _ => false,
+        }
+    }
+}
+
 async fn copy_with_crc32(src: &Path, dst: &Path) -> Result<(u64, u32)> {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    // Defense in depth for issue #70: `File::create(dst)` truncates, so if a
+    // caller ever reaches here with src == dst it would zero the source before a
+    // single byte is read. `move_segment_to_archive` already guards this, but a
+    // copy that destroys its own source must never be one refactor away.
+    if same_file(src, dst).await {
+        anyhow::bail!(
+            "refusing to copy a segment onto itself: {} == {} (issue #70)",
+            src.display(),
+            dst.display(),
+        );
+    }
 
     let mut reader = tokio::fs::File::open(src)
         .await
@@ -2120,20 +2386,32 @@ async fn resolve_storage(
 
 /// State tracker for per-camera cron schedule.
 ///
-/// Wraps [`croner::Cron`] and remembers the last fire time so that a tick
-/// arriving multiple times within the same cron-minute does not trigger
-/// duplicate archive runs.
+/// Wraps [`croner::Cron`] and remembers the end of the last evaluated window so
+/// each cron occurrence fires exactly once, no matter how the scheduler ticks
+/// land around it.
 ///
 /// # Design
 ///
-/// The scheduler tick interval (default 60 s) is coarser than a cron
-/// minute-boundary; `is_due` compares the *floor* of `now` to the last known
-/// fire time.  Two calls in the same calendar minute both see the same floor
-/// and only the first one fires.
+/// `is_due` uses CATCH-UP semantics (#84): it fires when the cron has an
+/// occurrence in the half-open window `(last_checked, now]`. The old
+/// implementation asked "does the pattern match the CURRENT minute?", which
+/// silently skipped a run whenever two ticks straddled the matching minute (a
+/// slow tick, a suspended VM, an archive run that overran the tick interval).
+/// Duplicate calls within the same minute still fire at most once, because the
+/// window advances to `now` on every evaluation.
 pub struct CronTracker {
     cron: croner::Cron,
-    /// The most recent minute at which this schedule was considered fired.
-    last_fire: Option<DateTime<Utc>>,
+    /// The raw expression `cron` was parsed from, so a runtime edit of
+    /// `archive_schedule` can be detected and re-parsed without a restart
+    /// (#82 — see [`ensure_cron_tracker`]).
+    schedule: String,
+    /// End of the last evaluated window (UTC). `None` until the first
+    /// `is_due` call establishes it.
+    last_checked: Option<DateTime<Utc>>,
+    /// A budget-bounded [`archive_camera`] run deferred part of this camera's
+    /// backlog (issue #80); the scheduler continues it on the next tick
+    /// without waiting for the next cron fire.
+    backlog_pending: bool,
 }
 
 impl CronTracker {
@@ -2159,59 +2437,59 @@ impl CronTracker {
             .map_err(|e| anyhow::anyhow!("invalid cron expression '{schedule}': {e}"))?;
         Ok(Self {
             cron,
-            last_fire: None,
+            schedule: schedule.to_owned(),
+            last_checked: None,
+            backlog_pending: false,
         })
     }
 
-    /// Returns `true` if the cron fired at or before `now` and has not yet
-    /// been marked as fired for this minute.
-    ///
-    /// The method truncates `now` to the current minute (seconds set to zero)
-    /// and compares it against `last_fire`.  On a positive result it updates
-    /// `last_fire` so subsequent calls within the same minute return `false`.
+    /// Returns `true` if the cron has an occurrence in `(last_checked, now]`
+    /// that has not fired yet — CATCH-UP semantics (#84), so a slow tick that
+    /// straddles the matching minute cannot skip a scheduled run.
     ///
     /// # Algorithm
     ///
-    /// 1. Compute `now_minute` = `now` with seconds/nanos zeroed.
-    /// 2. Ask croner: does the cron pattern match `now_minute`?
-    /// 3. If yes and `last_fire` < `now_minute` (or never fired): fire.
-    /// 4. Update `last_fire = now_minute`.
+    /// 1. `window_start` = `last_checked`, or (first call) the start of the
+    ///    current minute minus one second — preserving the original behaviour
+    ///    of firing iff the process was up during the matching minute, and
+    ///    never retro-firing occurrences from before startup.
+    /// 2. Ask croner for the first occurrence STRICTLY AFTER `window_start`,
+    ///    in LOCAL wall-clock time (DST-correct via chrono-tz) so e.g.
+    ///    "0 2 * * *" fires at 02:00 local, not 02:00 UTC.
+    /// 3. Fire iff that occurrence is `<= now`; advance `last_checked = now`
+    ///    either way so each occurrence fires exactly once.
     pub fn is_due(&mut self, now: DateTime<Utc>, tz: chrono_tz::Tz) -> bool {
         use chrono::Timelike;
 
-        // Truncate to the start of the current minute so duplicate calls
-        // within the same minute are idempotent. `last_fire` stays in UTC (a
-        // monotonic instant) — only the cron MATCH uses local wall-clock time.
-        let now_minute = now
-            .with_second(0)
-            .and_then(|t| t.with_nanosecond(0))
-            .unwrap_or(now);
+        // `last_checked` stays in UTC (a monotonic instant) — only the cron
+        // occurrence lookup uses local wall-clock time.
+        let window_start = self.last_checked.unwrap_or_else(|| {
+            let now_minute = now
+                .with_second(0)
+                .and_then(|t| t.with_nanosecond(0))
+                .unwrap_or(now);
+            now_minute - Duration::seconds(1)
+        });
 
-        // Match the cron against LOCAL wall-clock time (DST-correct via chrono-tz)
-        // so e.g. "0 2 * * *" fires at 02:00 local, not 02:00 UTC.
-        let now_local = now_minute.with_timezone(&tz);
-        let matches = match self.cron.is_time_matching(&now_local) {
-            Ok(m) => m,
-            Err(e) => {
-                error!(error = %e, "CronTracker::is_due: cron.is_time_matching error");
-                return false;
-            }
-        };
-
-        if !matches {
+        // Guard against a backwards clock step: never evaluate an
+        // empty/negative window, and never move the window backwards.
+        if now <= window_start {
             return false;
         }
 
-        // Only fire once per minute even if tick() is called more frequently.
-        if let Some(last) = self.last_fire {
-            if last >= now_minute {
-                return false;
+        let after_local = window_start.with_timezone(&tz);
+        match self.cron.find_next_occurrence(&after_local, false) {
+            Ok(next) => {
+                // Advance the window only on a successful evaluation, so a
+                // transient croner error can't swallow an occurrence.
+                self.last_checked = Some(now);
+                next.with_timezone(&Utc) <= now
+            }
+            Err(e) => {
+                error!(error = %e, "CronTracker::is_due: find_next_occurrence error");
+                false
             }
         }
-
-        // Record the fire time.
-        self.last_fire = Some(now_minute);
-        true
     }
 }
 
@@ -2386,6 +2664,41 @@ mod tests {
         );
     }
 
+    /// Regression for issue #70: a copy whose source and destination are the
+    /// SAME file must refuse rather than truncate the file to zero. Reproduces
+    /// the seed-default (archive path == live path) trigger with one on-disk
+    /// file addressed by two paths; the file's bytes must survive intact.
+    #[tokio::test]
+    async fn copy_with_crc32_refuses_same_file_and_preserves_bytes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("seg.bin");
+        let data: Vec<u8> = (0..4096u32).map(|i| (i % 253) as u8).collect();
+        tokio::fs::write(&path, &data).await.expect("write");
+
+        // Same physical file via a symlink alias → dev+ino identical.
+        let alias = dir.path().join("alias.bin");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&path, &alias).expect("symlink");
+        #[cfg(not(unix))]
+        tokio::fs::copy(&path, &alias)
+            .await
+            .map(|_| ())
+            .unwrap_or(());
+
+        let res = copy_with_crc32(&path, &alias).await;
+        assert!(
+            res.is_err(),
+            "copying a file onto itself must error, not truncate"
+        );
+
+        // The original bytes must be completely intact (never opened for write).
+        let after = tokio::fs::read(&path).await.expect("read back");
+        assert_eq!(
+            after, data,
+            "the segment must survive a same-file copy attempt"
+        );
+    }
+
     // ── CronTracker ──────────────────────────────────────────────────────────
 
     #[test]
@@ -2457,6 +2770,88 @@ mod tests {
     fn cron_tracker_rejects_invalid_expression() {
         let result = CronTracker::new("not a cron expression");
         assert!(result.is_err(), "invalid expression should error");
+    }
+
+    /// #84 (catch-up): a slow tick that STRADDLES the matching minute — one
+    /// tick lands just before it, the next lands just after — must still fire
+    /// the schedule exactly once. The old exact-minute matching skipped the
+    /// run for a whole day in this case.
+    #[test]
+    fn cron_tracker_catches_up_when_tick_straddles_the_minute() {
+        let mut tracker = CronTracker::new("0 3 * * *").expect("valid cron");
+        let before = chrono::DateTime::parse_from_rfc3339("2026-01-15T02:59:30Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        // The next tick arrives LATE — the 03:00 minute itself was never sampled.
+        let after = chrono::DateTime::parse_from_rfc3339("2026-01-15T03:01:10Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let later = chrono::DateTime::parse_from_rfc3339("2026-01-15T03:02:10Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        assert!(
+            !tracker.is_due(before, chrono_tz::Tz::UTC),
+            "not due before the boundary"
+        );
+        assert!(
+            tracker.is_due(after, chrono_tz::Tz::UTC),
+            "an occurrence inside the straddled window must fire (catch-up)"
+        );
+        assert!(
+            !tracker.is_due(later, chrono_tz::Tz::UTC),
+            "the caught-up occurrence fires exactly once"
+        );
+    }
+
+    /// #82: editing `archive_schedule` must take effect WITHOUT a recorder
+    /// restart — the cached tracker is re-parsed when the stored expression
+    /// differs, the old schedule stops firing, and an invalid replacement
+    /// removes the entry (reported once per tick until fixed).
+    #[test]
+    fn cron_tracker_resyncs_on_schedule_edit_without_restart() {
+        let mut trackers: std::collections::HashMap<Uuid, CronTracker> =
+            std::collections::HashMap::new();
+        let cam = Uuid::new_v4();
+        let at = |s: &str| {
+            chrono::DateTime::parse_from_rfc3339(s)
+                .unwrap()
+                .with_timezone(&Utc)
+        };
+
+        // Initial schedule: 03:00 daily. Establish the window before the edit.
+        let tracker = ensure_cron_tracker(&mut trackers, cam, "0 3 * * *").expect("parse");
+        assert!(!tracker.is_due(at("2026-01-15T01:59:00Z"), chrono_tz::Tz::UTC));
+
+        // Operator edits the schedule to 02:00 daily: the tracker must be
+        // re-parsed (schedule string updated) and the NEW schedule fires at
+        // 02:00 — pre-fix the stale cached cron kept firing 03:00 forever.
+        let tracker = ensure_cron_tracker(&mut trackers, cam, "0 2 * * *").expect("re-parse");
+        assert_eq!(
+            tracker.schedule, "0 2 * * *",
+            "tracker stores the new expression"
+        );
+        assert!(
+            tracker.is_due(at("2026-01-15T02:00:10Z"), chrono_tz::Tz::UTC),
+            "edited schedule must fire without a restart"
+        );
+        // …and the OLD schedule no longer fires.
+        assert!(
+            !tracker.is_due(at("2026-01-15T03:00:00Z"), chrono_tz::Tz::UTC),
+            "the replaced schedule must not fire any more"
+        );
+
+        // An unchanged schedule is NOT re-parsed (window preserved: the same
+        // occurrence does not fire twice across ensure calls).
+        let tracker = ensure_cron_tracker(&mut trackers, cam, "0 2 * * *").expect("noop");
+        assert!(!tracker.is_due(at("2026-01-15T03:01:00Z"), chrono_tz::Tz::UTC));
+
+        // An INVALID edit errors and removes the stale entry.
+        assert!(ensure_cron_tracker(&mut trackers, cam, "not a cron").is_err());
+        assert!(
+            !trackers.contains_key(&cam),
+            "invalid replacement must drop the stale tracker (old cron must not keep firing)"
+        );
     }
 
     #[test]
@@ -3189,6 +3584,160 @@ mod tests {
                 !archive_path.join(rel).exists(),
                 "incomplete archive dst must be cleaned up"
             );
+        }
+
+        /// Issue #84: a FAILED copy must not leave a partial destination file
+        /// behind. Simulates the retry-after-interruption shape: a stale
+        /// partial dst already sits at the exact archive destination and the
+        /// source file is missing, so `copy_with_crc32` errors at open — the
+        /// copy error path must best-effort remove the destination before
+        /// returning (mirroring the size/crc verify branches).
+        #[tokio::test]
+        async fn archive_move_copy_failure_removes_partial_dst() {
+            let Some(url) = test_db_url() else {
+                eprintln!("skipping: CRUMB_TEST_DATABASE_URL not set");
+                return;
+            };
+            let fx = setup(&url, None, None, true).await;
+
+            let live_path = fx._live_dir.path().to_path_buf();
+            let archive_path = fx._archive_dir.path().to_path_buf();
+            let start = Utc::now() - Duration::hours(5);
+
+            // A row whose SOURCE file does not exist → the streaming copy
+            // fails at `open src` before writing a byte.
+            let rel = "gone.mp4";
+            let seg_id = db::insert_segment(
+                &fx.pool,
+                &db::InsertSegmentParams {
+                    camera_id: fx.camera_id,
+                    storage_id: fx.live_storage_id,
+                    stage: SegmentStage::Live,
+                    path: rel.to_owned(),
+                    stream: SegmentStream::Main,
+                    start_ts: start,
+                    end_ts: start + Duration::seconds(4),
+                    duration_ms: 4000,
+                    has_motion: false,
+                    motion_score: 0.0,
+                    size_bytes: 100,
+                    motion_bbox: None,
+                },
+            )
+            .await
+            .expect("insert");
+            let seg = db::get_segment(&fx.pool, seg_id)
+                .await
+                .unwrap()
+                .expect("seg");
+
+            // Pre-create a stale PARTIAL destination at the exact path the
+            // move computes (leftover of a previously interrupted attempt).
+            let dst_rel =
+                archive_relative_path(&seg.camera_id, &seg.start_ts, &seg.path).expect("dst rel");
+            let dst_abs = archive_path.join(&dst_rel);
+            tokio::fs::create_dir_all(dst_abs.parent().expect("parent"))
+                .await
+                .expect("mkdir dst");
+            tokio::fs::write(&dst_abs, vec![9u8; 37])
+                .await
+                .expect("write stale partial dst");
+
+            let res = move_segment_to_archive(
+                &fx.pool,
+                &seg,
+                &live_path,
+                &archive_path,
+                fx.archive_storage_id,
+            )
+            .await;
+            assert!(res.is_err(), "copying a missing source must error");
+            assert!(
+                !dst_abs.exists(),
+                "the copy error path must remove the partial destination (issue #84)"
+            );
+            // The row is untouched — still live, still pointing at the source.
+            let after = db::get_segment(&fx.pool, seg_id)
+                .await
+                .unwrap()
+                .expect("row survives a failed copy");
+            assert_eq!(after.stage, SegmentStage::Live);
+            assert_eq!(after.storage_id, fx.live_storage_id);
+        }
+
+        /// Issue #80: an archive run is wall-time bounded. With an already-
+        /// expired deadline NOTHING is processed — the whole backlog is
+        /// reported deferred and no footage is touched — and a later run with
+        /// budget headroom drains the SAME backlog to completion, proving
+        /// deferral loses nothing.
+        #[tokio::test]
+        async fn archive_camera_budget_defers_backlog_without_data_loss() {
+            let Some(url) = test_db_url() else {
+                eprintln!("skipping: CRUMB_TEST_DATABASE_URL not set");
+                return;
+            };
+            let fx = setup(&url, None, None, true).await;
+            std::env::set_var("DATABASE_URL", "unused://");
+            let config = Config::from_env().expect("config");
+
+            let live_path = fx._live_dir.path().to_path_buf();
+            // Well past the fixture's default live_retention_hours (48) so all
+            // three segments are archive-eligible.
+            let t0 = Utc::now() - Duration::hours(100);
+            for i in 0..3 {
+                add_segment(
+                    &fx,
+                    fx.live_storage_id,
+                    &live_path,
+                    SegmentStage::Live,
+                    &format!("bud{i}.mp4"),
+                    t0 + Duration::minutes(i),
+                    100,
+                )
+                .await;
+            }
+            let camera = load_camera(&fx).await;
+
+            // (1) Deadline already expired → everything deferred, untouched.
+            let deferred = archive_camera(&fx.pool, &config, &camera, std::time::Instant::now())
+                .await
+                .expect("bounded run ok");
+            assert_eq!(deferred, 3, "an exhausted budget defers the whole backlog");
+            let all = db::list_all_segments_for_camera(&fx.pool, fx.camera_id)
+                .await
+                .unwrap();
+            assert_eq!(all.len(), 3);
+            assert!(
+                all.iter().all(|s| s.stage == SegmentStage::Live),
+                "a deferred backlog must not be touched: {all:?}"
+            );
+            for i in 0..3 {
+                assert!(
+                    live_path.join(format!("bud{i}.mp4")).exists(),
+                    "source bud{i} must be untouched by deferral"
+                );
+            }
+
+            // (2) A later run with headroom drains the same backlog fully.
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3600);
+            let deferred = archive_camera(&fx.pool, &config, &camera, deadline)
+                .await
+                .expect("full run ok");
+            assert_eq!(deferred, 0, "with budget headroom the backlog fully drains");
+            let all = db::list_all_segments_for_camera(&fx.pool, fx.camera_id)
+                .await
+                .unwrap();
+            assert_eq!(all.len(), 3, "no rows lost across deferral + drain");
+            assert!(
+                all.iter().all(|s| s.stage == SegmentStage::Archive),
+                "all segments archived after the follow-up run: {all:?}"
+            );
+            for i in 0..3 {
+                assert!(
+                    !live_path.join(format!("bud{i}.mp4")).exists(),
+                    "source bud{i} removed after the verified move"
+                );
+            }
         }
 
         /// LIVE over-cap with archiving ON ⇒ oldest live segments MOVE to archive

--- a/services/recorder/src/archive.rs
+++ b/services/recorder/src/archive.rs
@@ -2138,12 +2138,25 @@ pub async fn policy_size_eviction_sweep(
                 );
                 let mut storage_cache: std::collections::HashMap<Uuid, Storage> =
                     std::collections::HashMap::new();
-                // Memoized per-source-storage answer to "does an archive move
-                // free real bytes?" for the ENOSPC-rescue exception (see the
-                // SAFETY INVARIANT above). Keyed by the segment's own storage
-                // id; the archive root is fixed for the whole sweep.
+                // Memoized per-source-storage answers for the ENOSPC-rescue
+                // exception (see the SAFETY INVARIANT above), keyed by the
+                // segment's own storage id (the archive root and the floor root
+                // are both fixed for the whole sweep):
+                //   same_fs_cache       — does the segment share the ARCHIVE fs
+                //                          (so a move would free nothing)?
+                //   same_fs_floor_cache — does the segment share the FLOOR fs
+                //                          (the disk actually in deficit)?
+                // The delete rescue requires BOTH: deleting a segment that is
+                // NOT on the deficit disk frees zero bytes there yet destroys it
+                // permanently (a repointed-storage config), so those fall
+                // through to the normal footage-preserving MOVE instead.
                 let mut same_fs_cache: std::collections::HashMap<Uuid, bool> =
                     std::collections::HashMap::new();
+                let mut same_fs_floor_cache: std::collections::HashMap<Uuid, bool> =
+                    std::collections::HashMap::new();
+                let floor_root: Option<&Path> = live_storage_for_floor
+                    .as_ref()
+                    .map(|s| Path::new(s.path.as_str()));
                 for seg in &live {
                     // Stop once BOTH conditions are satisfied: under the live TARGET
                     // (cap - spill, if a cap exists) AND the free-space deficit
@@ -2194,14 +2207,36 @@ pub async fn policy_size_eviction_sweep(
                         // exactly like the archive-off arm (file-then-row, item
                         // 10; protected bookmarks already excluded by the query).
                         let move_frees_nothing = if still_below_floor {
-                            match same_fs_cache.get(&src_storage.id).copied() {
+                            // (a) segment shares the ARCHIVE fs → a move frees
+                            //     nothing on it.
+                            let shares_archive = match same_fs_cache.get(&src_storage.id).copied() {
                                 Some(v) => v,
                                 None => {
                                     let v = same_filesystem(src_root, archive_root).await;
                                     same_fs_cache.insert(src_storage.id, v);
                                     v
                                 }
-                            }
+                            };
+                            // (b) AND the segment lives on the FLOOR fs (the disk
+                            //     actually in deficit) — otherwise deleting it
+                            //     frees zero bytes on the deficit disk while
+                            //     destroying footage permanently. Only checked
+                            //     when (a) already holds and the floor storage is
+                            //     known (it is, whenever still_below_floor).
+                            let shares_floor = match (shares_archive, floor_root) {
+                                (true, Some(fr)) => {
+                                    match same_fs_floor_cache.get(&src_storage.id).copied() {
+                                        Some(v) => v,
+                                        None => {
+                                            let v = same_filesystem(src_root, fr).await;
+                                            same_fs_floor_cache.insert(src_storage.id, v);
+                                            v
+                                        }
+                                    }
+                                }
+                                _ => false,
+                            };
+                            shares_archive && shares_floor
                         } else {
                             false
                         };

--- a/services/recorder/src/archive.rs
+++ b/services/recorder/src/archive.rs
@@ -98,6 +98,17 @@ const EVICTION_BATCH_LIMIT: i64 = 2_000;
 /// huge backlog in one pass. Same rationale as [`EVICTION_BATCH_LIMIT`].
 const MAX_RETENTION_BATCH_LIMIT: i64 = 2_000;
 
+/// Upper bound on rows ONE archive run's eligibility query pulls (the oldest
+/// prefix). The #80 backlog continuation re-runs [`archive_camera`] every tick
+/// until the catch-up drains — but an UNBOUNDED listing re-fetched the entire
+/// eligible set (a 300k-row / ~70MB `Vec` on a large catch-up) once per 60s
+/// tick even though the wall-time budget only processes ~1-2k of them. Sized
+/// to a generous multiple of one tick's realistic throughput (same rationale
+/// as [`EVICTION_BATCH_LIMIT`]); a listing that FILLS the limit is treated as
+/// pending backlog even when fully processed, so the next tick re-queries and
+/// the continuation semantics are unchanged.
+const ARCHIVE_LIST_LIMIT: i64 = 5_000;
+
 /// Process-wide guard ensuring archive operations NEVER run concurrently.
 ///
 /// Today they already can't: the scheduler runs ONE tick at a time and processes
@@ -469,8 +480,11 @@ async fn run_cron_archive(
     );
 
     match archive_camera(pool, config, camera, deadline).await {
-        Ok(deferred) => {
-            tracker.backlog_pending = deferred > 0;
+        Ok(outcome) => {
+            // Deferred segments OR a truncated listing (#80 follow-up: a
+            // fully-processed but LIMIT-filled batch may hide more eligible
+            // rows) both mean "continue next tick without a cron fire".
+            tracker.backlog_pending = outcome.backlog_pending();
         }
         Err(e) => {
             // Setup failures (missing storage / bad policy) won't self-heal
@@ -572,8 +586,10 @@ fn ensure_cron_tracker<'a>(
 ///
 /// # Returns
 ///
-/// The number of eligible segments DEFERRED past the deadline (0 = backlog
-/// fully drained this run).
+/// An [`ArchiveRunOutcome`]: how many LISTED segments were deferred past the
+/// deadline, and whether the listing itself was truncated at
+/// [`ARCHIVE_LIST_LIMIT`] (more eligible rows may exist that were never
+/// listed). Either condition means the backlog is pending.
 ///
 /// # Errors
 ///
@@ -581,10 +597,43 @@ fn ensure_cron_tracker<'a>(
 /// Per-segment errors are logged and not propagated.
 pub async fn archive_camera(
     pool: &Pool,
+    config: &Config,
+    camera: &Camera,
+    deadline: std::time::Instant,
+) -> Result<ArchiveRunOutcome> {
+    archive_camera_bounded(pool, config, camera, deadline, ARCHIVE_LIST_LIMIT).await
+}
+
+/// Outcome of one bounded [`archive_camera`] run (issue #80 + its follow-up).
+#[derive(Debug, Clone, Copy)]
+pub struct ArchiveRunOutcome {
+    /// Eligible segments that were LISTED this run but deferred past the
+    /// wall-time deadline (0 = every listed segment was processed).
+    pub deferred: usize,
+    /// The eligibility listing FILLED [`ARCHIVE_LIST_LIMIT`] — more eligible
+    /// rows may exist behind the truncation that were never listed at all, so
+    /// even a fully-processed run must re-query on the next tick.
+    pub listing_truncated: bool,
+}
+
+impl ArchiveRunOutcome {
+    /// More work may remain: the scheduler continues on the NEXT tick without
+    /// waiting for the next cron fire (#80 continuation).
+    pub fn backlog_pending(self) -> bool {
+        self.deferred > 0 || self.listing_truncated
+    }
+}
+
+/// [`archive_camera`] with an explicit listing bound, so tests can exercise
+/// the truncated-listing continuation without inserting `ARCHIVE_LIST_LIMIT`
+/// rows.
+async fn archive_camera_bounded(
+    pool: &Pool,
     _config: &Config,
     camera: &Camera,
     deadline: std::time::Instant,
-) -> Result<usize> {
+    list_limit: i64,
+) -> Result<ArchiveRunOutcome> {
     info!(
         camera_id   = %camera.id,
         camera_name = %camera.name,
@@ -611,16 +660,25 @@ pub async fn archive_camera(
 
     let cutoff = Utc::now() - Duration::hours(i64::from(camera.policy.live_retention_hours));
 
-    let segments = db::list_live_segments_for_archive(pool, camera.id, cutoff)
+    let segments = list_live_segments_for_archive_limited(pool, camera.id, cutoff, list_limit)
         .await
         .context("listing live segments for archive")?;
+    // A listing that fills the limit may hide more eligible rows behind the
+    // truncation; the caller must treat this run as pending backlog even when
+    // every listed segment is processed within budget.
+    let listing_truncated = usize::try_from(list_limit)
+        .map(|l| segments.len() >= l)
+        .unwrap_or(false);
 
     if segments.is_empty() {
         debug!(
             camera_id = %camera.id,
             "no segments eligible for archiving"
         );
-        return Ok(0);
+        return Ok(ArchiveRunOutcome {
+            deferred: 0,
+            listing_truncated: false,
+        });
     }
 
     info!(
@@ -681,16 +739,87 @@ pub async fn archive_camera(
             "archive tick budget exhausted; deferring remaining segments to the next tick"
         );
     }
+    if listing_truncated {
+        info!(
+            camera_id = %camera.id,
+            list_limit = list_limit,
+            "eligible-segment listing truncated at the per-run limit; \
+             remaining backlog will be re-queried next tick"
+        );
+    }
 
     info!(
         camera_id = %camera.id,
         archived  = archived,
         failed    = failed,
         deferred  = deferred,
+        listing_truncated = listing_truncated,
         "archive job complete"
     );
 
-    Ok(deferred)
+    Ok(ArchiveRunOutcome {
+        deferred,
+        listing_truncated,
+    })
+}
+
+/// Bounded variant of `db::list_live_segments_for_archive` (issue #80
+/// follow-up): the same oldest-first eligibility SELECT with a `LIMIT`, so the
+/// per-tick backlog continuation re-fetches at most [`ARCHIVE_LIST_LIMIT`]
+/// rows instead of the entire eligible set (300k rows / ~70MB per 60s tick on
+/// a large catch-up). Lives here rather than in `common/db.rs` because the
+/// recorder's archive job is its only consumer and this audit fix is scoped to
+/// this file; the projection mirrors the db.rs segment reads (no
+/// `motion_score` / `motion_bbox_*` columns — neither is needed to move a
+/// file, exactly as the unbounded query it replaces).
+async fn list_live_segments_for_archive_limited(
+    pool: &Pool,
+    camera_id: Uuid,
+    older_than: DateTime<Utc>,
+    limit: i64,
+) -> Result<Vec<Segment>> {
+    let client = db::get_conn(pool).await?;
+    let rows = client
+        .query(
+            r"
+            SELECT id, camera_id, storage_id, stage, path,
+                   stream, start_ts, end_ts, duration_ms,
+                   has_motion, size_bytes
+            FROM segments
+            WHERE camera_id = $1
+              AND stage = 'live'
+              AND start_ts < $2
+            ORDER BY start_ts
+            LIMIT $3
+            ",
+            &[&camera_id, &older_than, &limit],
+        )
+        .await
+        .context("list_live_segments_for_archive_limited")?;
+    rows.iter()
+        .map(|row| {
+            let stage_str: String = row.get("stage");
+            let stage = SegmentStage::from_str(&stage_str)
+                .with_context(|| format!("unknown segment stage '{stage_str}'"))?;
+            let stream_str: String = row.get("stream");
+            let stream = crumb_common::types::SegmentStream::from_str(&stream_str)
+                .with_context(|| format!("unknown segment stream '{stream_str}'"))?;
+            Ok(Segment {
+                id: row.get("id"),
+                camera_id: row.get("camera_id"),
+                storage_id: row.get("storage_id"),
+                stage,
+                path: row.get("path"),
+                stream,
+                start_ts: row.get("start_ts"),
+                end_ts: row.get("end_ts"),
+                duration_ms: row.get("duration_ms"),
+                has_motion: row.get("has_motion"),
+                size_bytes: row.get("size_bytes"),
+                motion_bbox: None,
+            })
+        })
+        .collect()
 }
 
 /// Archive ONE segment for [`archive_camera`]: resolve its OWN source storage
@@ -1260,6 +1389,37 @@ async fn same_file(a: &Path, b: &Path) -> bool {
     }
 }
 
+/// True when `a` and `b` live on the SAME filesystem (identical `st_dev`), so a
+/// live→archive "move" between them cannot free a single byte of physical disk
+/// space. This is the default compose layout: `/data/archive` on the same
+/// filesystem as the live `/data` tree, expressed as two storage rows.
+///
+/// Used by the free-space-floor rescue in [`policy_size_eviction_sweep`]: when
+/// the floor is in deficit, freeing space must actually reduce used bytes, and
+/// a same-filesystem archive move does not.
+///
+/// Conservative on failure: if either side cannot be stat'd (unmounted
+/// storage, archive root not yet created) this returns `false`, keeping the
+/// normal footage-preserving archive-move behaviour — the floor deficit then
+/// persists into the next tick, by which time the move will have created the
+/// archive root and the detection works. Also `false` on non-Unix (no
+/// `st_dev`; CI cross-checks only).
+async fn same_filesystem(a: &Path, b: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        match (tokio::fs::metadata(a).await, tokio::fs::metadata(b).await) {
+            (Ok(ma), Ok(mb)) => ma.dev() == mb.dev(),
+            _ => false,
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (a, b);
+        false
+    }
+}
+
 async fn copy_with_crc32(src: &Path, dst: &Path) -> Result<(u64, u32)> {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -1805,6 +1965,21 @@ pub async fn archive_retention_sweep(pool: &Pool, _config: &Config, camera: &Cam
 /// missing/unresolved, this logs an error and SKIPS live eviction entirely —
 /// leaving footage in place rather than deleting un-archived footage.
 ///
+/// **One deliberate, narrow exception — the ENOSPC rescue.** When the
+/// free-space FLOOR is in DEFICIT *and* the archive destination is on the SAME
+/// filesystem as the segment's own storage ([`same_filesystem`]; the default
+/// compose layout puts `/data/archive` beside live `/data`), an archive move
+/// frees ZERO bytes: pre-fix the sweep "moved" the oldest live footage in
+/// place every tick, the deficit read as satisfied, and the disk filled to
+/// 100% until ffmpeg hit ENOSPC and recording halted on EVERY camera — losing
+/// all future footage. In exactly that state the deficit-driven portion of
+/// the sweep DELETES the oldest segments instead (file-then-row, item 10, via
+/// the shared helper; protected bookmarks are still excluded by the candidate
+/// query; the whole sweep still holds [`ARCHIVE_GUARD`]), and emits
+/// `premature_rollover` so the loss is loud. Cap-only pressure (no floor
+/// deficit) still MOVES as before — the exception applies only while real
+/// bytes must be freed and a move cannot free them.
+///
 /// `used` is computed once via `SUM` at entry, then decremented by
 /// `seg.size_bytes` after each disposal so the loop stops exactly at the cap
 /// without re-SUMming every iteration.
@@ -1963,6 +2138,12 @@ pub async fn policy_size_eviction_sweep(
                 );
                 let mut storage_cache: std::collections::HashMap<Uuid, Storage> =
                     std::collections::HashMap::new();
+                // Memoized per-source-storage answer to "does an archive move
+                // free real bytes?" for the ENOSPC-rescue exception (see the
+                // SAFETY INVARIANT above). Keyed by the segment's own storage
+                // id; the archive root is fixed for the whole sweep.
+                let mut same_fs_cache: std::collections::HashMap<Uuid, bool> =
+                    std::collections::HashMap::new();
                 for seg in &live {
                     // Stop once BOTH conditions are satisfied: under the live TARGET
                     // (cap - spill, if a cap exists) AND the free-space deficit
@@ -2001,6 +2182,63 @@ pub async fn policy_size_eviction_sweep(
                         };
                         let src_root = Path::new(&src_storage.path);
                         let archive_root = Path::new(&archive_storage.path);
+
+                        // ── ENOSPC RESCUE (SAFETY INVARIANT exception above) ──
+                        // While the free-space floor is in DEFICIT, the disposal
+                        // must reduce USED bytes on the physical disk. An archive
+                        // move onto the SAME filesystem frees nothing (default
+                        // compose layout: /data/archive on the live disk) — the
+                        // pre-fix sweep "moved" oldest live footage in place every
+                        // tick until the disk hit 100% and ffmpeg ENOSPC-halted
+                        // recording on every camera. Delete oldest-first instead,
+                        // exactly like the archive-off arm (file-then-row, item
+                        // 10; protected bookmarks already excluded by the query).
+                        let move_frees_nothing = if still_below_floor {
+                            match same_fs_cache.get(&src_storage.id).copied() {
+                                Some(v) => v,
+                                None => {
+                                    let v = same_filesystem(src_root, archive_root).await;
+                                    same_fs_cache.insert(src_storage.id, v);
+                                    v
+                                }
+                            }
+                        } else {
+                            false
+                        };
+                        if move_frees_nothing {
+                            match delete_segment_file_then_row(pool, seg, &mut storage_cache).await
+                            {
+                                Ok(()) => {
+                                    used -= seg.size_bytes;
+                                    deficit = (deficit - seg.size_bytes).max(0);
+                                    warn!(
+                                        policy_id  = %policy.id,
+                                        segment_id = %seg.id,
+                                        "free-space floor: archive shares the live \
+                                         filesystem, so a move would free nothing; \
+                                         deleted oldest live segment to free real bytes"
+                                    );
+                                    emit_premature_rollover_if_early(
+                                        pool,
+                                        seg,
+                                        policy.live_retention_hours,
+                                        "free-space floor eviction (archive on same filesystem)",
+                                    )
+                                    .await;
+                                }
+                                Err(e) => {
+                                    error!(
+                                        policy_id  = %policy.id,
+                                        segment_id = %seg.id,
+                                        error      = %e,
+                                        "free-space floor: failed to delete over-floor \
+                                         live segment"
+                                    );
+                                }
+                            }
+                            continue;
+                        }
+
                         match move_segment_to_archive(
                             pool,
                             seg,
@@ -2012,10 +2250,11 @@ pub async fn policy_size_eviction_sweep(
                         {
                             Ok(()) => {
                                 used -= seg.size_bytes;
-                                // Moving frees the source bytes from the live FS
-                                // (when archive is a separate device — the normal
-                                // case; if same-device, next tick's statvfs re-reads
-                                // the true free space and self-corrects).
+                                // Moving frees the source bytes from the live FS.
+                                // A floor-deficit move only reaches here when the
+                                // archive is a DIFFERENT filesystem (the same-fs
+                                // case is deleted by the ENOSPC rescue above), so
+                                // decrementing the deficit is accurate.
                                 deficit = (deficit - seg.size_bytes).max(0);
                                 debug!(
                                     policy_id  = %policy.id,
@@ -3699,10 +3938,17 @@ mod tests {
             let camera = load_camera(&fx).await;
 
             // (1) Deadline already expired → everything deferred, untouched.
-            let deferred = archive_camera(&fx.pool, &config, &camera, std::time::Instant::now())
+            let outcome = archive_camera(&fx.pool, &config, &camera, std::time::Instant::now())
                 .await
                 .expect("bounded run ok");
-            assert_eq!(deferred, 3, "an exhausted budget defers the whole backlog");
+            assert_eq!(
+                outcome.deferred, 3,
+                "an exhausted budget defers the whole backlog"
+            );
+            assert!(
+                outcome.backlog_pending(),
+                "a deferred backlog must flag the continuation"
+            );
             let all = db::list_all_segments_for_camera(&fx.pool, fx.camera_id)
                 .await
                 .unwrap();
@@ -3720,10 +3966,17 @@ mod tests {
 
             // (2) A later run with headroom drains the same backlog fully.
             let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3600);
-            let deferred = archive_camera(&fx.pool, &config, &camera, deadline)
+            let outcome = archive_camera(&fx.pool, &config, &camera, deadline)
                 .await
                 .expect("full run ok");
-            assert_eq!(deferred, 0, "with budget headroom the backlog fully drains");
+            assert_eq!(
+                outcome.deferred, 0,
+                "with budget headroom the backlog fully drains"
+            );
+            assert!(
+                !outcome.backlog_pending(),
+                "a drained, non-truncated run must clear the continuation"
+            );
             let all = db::list_all_segments_for_camera(&fx.pool, fx.camera_id)
                 .await
                 .unwrap();
@@ -3738,6 +3991,90 @@ mod tests {
                     "source bud{i} removed after the verified move"
                 );
             }
+        }
+
+        /// Issue #80 follow-up: the eligibility LISTING itself is bounded. A
+        /// run whose listing FILLED the limit must report the backlog as
+        /// pending even when every listed segment was processed within budget
+        /// (a fully-processed but truncated batch may hide more eligible rows
+        /// behind the LIMIT), so the next tick re-queries; successive bounded
+        /// runs drain the whole backlog with nothing lost.
+        #[tokio::test]
+        async fn archive_camera_truncated_listing_flags_backlog_and_drains() {
+            let Some(url) = test_db_url() else {
+                eprintln!("skipping: CRUMB_TEST_DATABASE_URL not set");
+                return;
+            };
+            let fx = setup(&url, None, None, true).await;
+            std::env::set_var("DATABASE_URL", "unused://");
+            let config = Config::from_env().expect("config");
+
+            let live_path = fx._live_dir.path().to_path_buf();
+            // Well past the fixture's default live_retention_hours (48) so all
+            // three segments are archive-eligible.
+            let t0 = Utc::now() - Duration::hours(100);
+            for i in 0..3 {
+                add_segment(
+                    &fx,
+                    fx.live_storage_id,
+                    &live_path,
+                    SegmentStage::Live,
+                    &format!("lim{i}.mp4"),
+                    t0 + Duration::minutes(i),
+                    100,
+                )
+                .await;
+            }
+            let camera = load_camera(&fx).await;
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3600);
+
+            // Run 1 with list_limit=2: lists exactly 2 (== limit), processes
+            // BOTH within budget → deferred == 0, but the truncated listing
+            // must still flag pending backlog (pre-fix semantics would have
+            // cleared backlog_pending here and stranded lim2 until the next
+            // cron fire).
+            let outcome = archive_camera_bounded(&fx.pool, &config, &camera, deadline, 2)
+                .await
+                .expect("run 1 ok");
+            assert_eq!(outcome.deferred, 0, "both listed segments processed");
+            assert!(
+                outcome.listing_truncated,
+                "a listing that fills the limit must be flagged truncated"
+            );
+            assert!(
+                outcome.backlog_pending(),
+                "a truncated listing IS pending backlog even when fully processed"
+            );
+            let archived_now =
+                db::camera_stage_bytes(&fx.pool, fx.camera_id, SegmentStage::Archive)
+                    .await
+                    .unwrap();
+            assert_eq!(archived_now, 200, "the two oldest were archived in run 1");
+
+            // Run 2: only lim2 remains eligible → lists 1 (< limit), drains it,
+            // and the continuation stops.
+            let outcome = archive_camera_bounded(&fx.pool, &config, &camera, deadline, 2)
+                .await
+                .expect("run 2 ok");
+            assert_eq!(outcome.deferred, 0);
+            assert!(
+                !outcome.listing_truncated,
+                "a short listing means the backlog is fully drained"
+            );
+            assert!(
+                !outcome.backlog_pending(),
+                "the continuation must stop once the backlog drains"
+            );
+
+            // Nothing lost across the bounded runs: all three rows archived.
+            let all = db::list_all_segments_for_camera(&fx.pool, fx.camera_id)
+                .await
+                .unwrap();
+            assert_eq!(all.len(), 3, "no rows lost across bounded runs");
+            assert!(
+                all.iter().all(|s| s.stage == SegmentStage::Archive),
+                "all segments archived after the continuation drains: {all:?}"
+            );
         }
 
         /// LIVE over-cap with archiving ON ⇒ oldest live segments MOVE to archive
@@ -4577,6 +4914,141 @@ mod tests {
             assert_eq!(
                 used2, 300,
                 "between target and cap, eviction must stay quiet (trigger is the cap), got {used2}"
+            );
+        }
+
+        /// ENOSPC rescue (free-space floor × shared filesystem): when the floor
+        /// is in DEFICIT and the archive destination is on the SAME filesystem
+        /// as the live storage (the default compose layout — both fixture
+        /// tempdirs share one fs, same `st_dev`), the sweep must DELETE the
+        /// oldest live segments — actually freeing bytes — instead of
+        /// archive-moving them in place. Pre-fix, the move freed 0 bytes, the
+        /// deficit read as satisfied, and the loop repeated every tick until
+        /// the disk hit 100% and ffmpeg ENOSPC-halted recording on every
+        /// camera. Protected bookmarks still survive, nothing lands on
+        /// stage=archive, and rows go file-then-row.
+        #[tokio::test]
+        async fn floor_deficit_on_shared_fs_deletes_oldest_instead_of_moving() {
+            let Some(url) = test_db_url() else {
+                eprintln!("skipping: CRUMB_TEST_DATABASE_URL not set");
+                return;
+            };
+            // Archive ON, NO byte caps — only the free-space floor drives this
+            // sweep, so the delete can only be the floor-deficit path.
+            let fx = setup_policy(&url, None, None, true).await;
+            std::env::set_var("DATABASE_URL", "unused://");
+            let config = Config::from_env().expect("config");
+
+            // Force the floor into deficit DETERMINISTICALLY: read the live
+            // tempdir filesystem's real free/total and set the per-policy
+            // fractional floor strictly between the current free fraction and
+            // 1.0 — guaranteed below-floor regardless of how full the host
+            // disk is. (`None` ⇒ statvfs unavailable, e.g. non-Unix — skip,
+            // mirroring the floor itself.)
+            let live_path = fx._live_dir.path().to_path_buf();
+            let Some((free, total)) = fs_free_and_total(live_path.to_str().expect("utf8")) else {
+                eprintln!("skipping: statvfs unavailable on this platform");
+                return;
+            };
+            #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+            let frac = (((free as f64 / total as f64) + 1.0) / 2.0) as f32;
+            if !(0.0..1.0).contains(&frac) {
+                eprintln!("skipping: cannot construct a firing floor (free={free}, total={total})");
+                return;
+            }
+            {
+                let client = fx.pool.get().await.expect("conn");
+                client
+                    .execute(
+                        "UPDATE recording_policies SET live_min_free_pct = $2 WHERE id = $1",
+                        &[&fx.policy_id, &frac],
+                    )
+                    .await
+                    .expect("set per-policy floor");
+            }
+
+            // Three old live segments; the OLDEST is pinned by a protected
+            // bookmark (a human pin outranks the automatic rescue).
+            let t0 = Utc::now() - Duration::hours(10);
+            for (rel, offset) in [("pinned.mp4", 0i64), ("old1.mp4", 1), ("old2.mp4", 2)] {
+                add_segment_for(
+                    &fx.pool,
+                    fx.camera_a_id,
+                    fx.live_storage_id,
+                    &live_path,
+                    SegmentStage::Live,
+                    rel,
+                    t0 + Duration::minutes(offset),
+                    100,
+                )
+                .await;
+            }
+            {
+                let client = fx.pool.get().await.expect("conn");
+                client
+                    .execute(
+                        "INSERT INTO bookmarks \
+                             (camera_id, ts, protect_until, protect_start_ts, protect_end_ts) \
+                         VALUES ($1, $2, now() + interval '1 day', $3, $4)",
+                        &[
+                            &fx.camera_a_id,
+                            &t0,
+                            &(t0 - Duration::seconds(5)),
+                            &(t0 + Duration::seconds(5)),
+                        ],
+                    )
+                    .await
+                    .expect("insert protected bookmark");
+            }
+
+            let policy = load_policy(&fx).await;
+            policy_size_eviction_sweep(&fx.pool, &config, &policy)
+                .await
+                .expect("sweep ok");
+
+            // The deficit (GB-scale) dwarfs the 300B of footage, so every
+            // UNPROTECTED candidate must be DELETED — real bytes freed — never
+            // archive-moved in place.
+            assert!(
+                !live_path.join("old1.mp4").exists(),
+                "old1 must be deleted (bytes actually freed), not moved in place"
+            );
+            assert!(
+                !live_path.join("old2.mp4").exists(),
+                "old2 must be deleted (bytes actually freed), not moved in place"
+            );
+            assert!(
+                live_path.join("pinned.mp4").exists(),
+                "the protected segment must survive the ENOSPC rescue"
+            );
+
+            // Rows follow the files (file-then-row): only the protected row
+            // remains, still live — nothing was flipped to stage=archive.
+            let rows = db::list_all_segments_for_camera(&fx.pool, fx.camera_a_id)
+                .await
+                .unwrap();
+            assert_eq!(rows.len(), 1, "only the protected row remains: {rows:?}");
+            assert!(rows[0].path.ends_with("pinned.mp4"));
+            assert_eq!(
+                rows[0].stage,
+                SegmentStage::Live,
+                "the protected segment must not be archive-moved either"
+            );
+            let archive_bytes =
+                db::policy_stage_bytes(&fx.pool, fx.policy_id, SegmentStage::Archive)
+                    .await
+                    .unwrap();
+            assert_eq!(
+                archive_bytes, 0,
+                "a shared-fs floor deficit must never archive-move (0 bytes freed)"
+            );
+            // And the archive directory really received nothing.
+            let mut entries = tokio::fs::read_dir(fx._archive_dir.path())
+                .await
+                .expect("read archive dir");
+            assert!(
+                entries.next_entry().await.expect("read entry").is_none(),
+                "no files may land on the archive dir during a shared-fs floor rescue"
             );
         }
 

--- a/services/recorder/src/frigate_motion.rs
+++ b/services/recorder/src/frigate_motion.rs
@@ -35,7 +35,7 @@ use std::time::Duration;
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Utc};
 use deadpool_postgres::Pool;
-use rumqttc::{AsyncClient, Event, MqttOptions, Packet, QoS};
+use rumqttc::{AsyncClient, Event, MqttOptions, Packet, QoS, SubscribeReasonCode};
 use serde::Deserialize;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -385,12 +385,14 @@ pub(crate) fn emit(motion_tx: &MotionTx, camera_id: Uuid, t: Transition) {
 /// does for the pixel-diff loop. On any teardown an in-progress event is closed
 /// with a STOP so `recording.rs` never sees a dangling event.
 ///
-/// Reports the source HEALTHY (via `health_tx`) only AFTER the broker's `ConnAck`
-/// confirms a live connection — never optimistically before — so a source that
-/// cannot reach the broker stays unhealthy and the supervisor's fail-open grace
-/// accumulates instead of being reset by a premature "healthy" (issue #61, the
-/// `ha_motion.rs` twin). On any exit the supervisor reports unhealthy, so a
-/// Motion-mode camera fails OPEN.
+/// Reports the source HEALTHY (via `health_tx`) only AFTER the broker GRANTS the
+/// events subscription (a `SubAck` whose return codes are all granted-QoS) —
+/// never optimistically before — so a source that cannot reach the broker
+/// (issue #61, the `ha_motion.rs` twin) or that connects but is denied the
+/// subscription (issue #78: ACL deny ⇒ "healthy forever with zero events")
+/// stays unhealthy and the supervisor's fail-open grace accumulates instead of
+/// being reset by a premature "healthy". On any exit the supervisor reports
+/// unhealthy, so a Motion-mode camera fails OPEN.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_frigate_motion_loop(
     camera: &Camera,
@@ -492,24 +494,43 @@ pub async fn run_frigate_motion_loop(
                 match maybe_ev {
                     Some(Event::Incoming(Packet::ConnAck(_))) => {
                         info!(camera_id = %camera.id, "frigate motion: MQTT connected, subscribing");
-                        // Broker confirmed live → NOW healthy. Reported here, not
-                        // before the loop: a source that never connects never
-                        // reaches this, so its health stays false and the fail-open
-                        // grace accumulates instead of being reset by a premature
-                        // "healthy" (issue #61). `report_health` dedups.
+                        // Connected is NOT healthy yet: the broker can still refuse
+                        // the subscription (ACL deny), which would leave the source
+                        // "connected forever with zero events" — health is reported
+                        // only on a granted SubAck below (issue #78). If the
+                        // subscribe request itself cannot be issued, no SubAck will
+                        // ever arrive: bail so the supervisor backs off and the
+                        // camera fails OPEN instead of idling unsubscribed.
+                        if let Err(e) = client.subscribe(&topic, QoS::AtLeastOnce).await {
+                            warn!(camera_id = %camera.id, error = %e, "frigate motion: subscribe failed");
+                            break Err(anyhow!("frigate motion MQTT subscribe request failed: {e}"));
+                        }
+                    }
+                    Some(Event::Incoming(Packet::SubAck(ack))) => {
+                        if !suback_granted(&ack.return_codes) {
+                            warn!(
+                                camera_id = %camera.id,
+                                return_codes = ?ack.return_codes,
+                                "frigate motion: broker denied the events subscription"
+                            );
+                            break Err(anyhow!("frigate motion MQTT subscription denied by broker"));
+                        }
+                        // Broker granted the subscription → NOW healthy. Reported
+                        // here, not on ConnAck: events are only guaranteed to flow
+                        // once the subscribe is acknowledged as granted, so anything
+                        // earlier is a premature "healthy" that resets the fail-open
+                        // grace (issue #78; same shape as the pre-connect healthy of
+                        // issue #61). `report_health` dedups.
                         crate::motion::report_health(
                             health_tx,
                             pool,
                             camera.id,
                             true,
-                            "frigate MQTT connected",
+                            "frigate MQTT subscription granted",
                             alert_gate,
                             alert_after_secs,
                         )
                         .await;
-                        if let Err(e) = client.subscribe(&topic, QoS::AtLeastOnce).await {
-                            warn!(camera_id = %camera.id, error = %e, "frigate motion: subscribe failed");
-                        }
                     }
                     Some(Event::Incoming(Packet::Publish(publish))) => {
                         if let Some(ev) = classify(&publish.payload, cfg.min_score) {
@@ -520,7 +541,7 @@ pub async fn run_frigate_motion_loop(
                             }
                         }
                     }
-                    Some(_) => {} // SubAck, PingResp, outgoing, etc.
+                    Some(_) => {} // PingResp, outgoing, etc.
                     None => {
                         // Poll task ended: a connection error (or shutdown). Treat as
                         // a lost connection → `Err` so the supervisor backs off and
@@ -540,6 +561,20 @@ pub async fn run_frigate_motion_loop(
         emit(motion_tx, camera.id, t);
     }
     result
+}
+
+/// Whether a broker `SubAck` actually GRANTED the subscription. Any `Failure`
+/// return code (0x80 — e.g. an ACL deny) — or an empty grant list — means the
+/// events topic will never be delivered to us no matter how live the
+/// connection is, so the source must not be reported healthy on it (issue #78).
+/// We subscribe to exactly one filter, so all-granted and any-granted coincide;
+/// `all` is the conservative choice.
+#[must_use]
+fn suback_granted(return_codes: &[SubscribeReasonCode]) -> bool {
+    !return_codes.is_empty()
+        && return_codes
+            .iter()
+            .all(|rc| matches!(rc, SubscribeReasonCode::Success(_)))
 }
 
 /// Parse `host` and `port` from an `mqtt://host:port` (or `mqtts://`, or bare
@@ -677,6 +712,28 @@ mod tests {
         t.observe(&ev("a", false), t0);
         assert!(matches!(t.force_stop(t0), Some(Transition::Stop { .. })));
         assert!(t.force_stop(t0).is_none(), "already stopped");
+    }
+
+    #[test]
+    fn suback_granted_requires_all_success() {
+        // Granted QoS (any level) → the subscription is live, healthy allowed.
+        assert!(suback_granted(&[SubscribeReasonCode::Success(
+            QoS::AtLeastOnce
+        )]));
+        assert!(suback_granted(&[SubscribeReasonCode::Success(
+            QoS::AtMostOnce
+        )]));
+        // Broker refusal (0x80, e.g. an ACL deny) → must NOT report healthy:
+        // "connected but unsubscribed" is a zero-event source and the camera
+        // must fail OPEN instead (issue #78).
+        assert!(!suback_granted(&[SubscribeReasonCode::Failure]));
+        // Mixed (defensive — we only subscribe to one filter) → still denied.
+        assert!(!suback_granted(&[
+            SubscribeReasonCode::Success(QoS::AtLeastOnce),
+            SubscribeReasonCode::Failure,
+        ]));
+        // An empty grant list confirms nothing.
+        assert!(!suback_granted(&[]));
     }
 
     #[test]

--- a/services/recorder/src/go2rtc_embed.rs
+++ b/services/recorder/src/go2rtc_embed.rs
@@ -171,20 +171,10 @@ async fn run_once(bin: &str, config: &str, shutdown: &CancellationToken) -> RunE
     // go2rtc writes its own level/timestamp per line, so both pipes log at the
     // same tracing level.
     if let Some(stdout) = child.stdout.take() {
-        tokio::spawn(async move {
-            let mut lines = BufReader::new(stdout).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                info!("go2rtc: {line}");
-            }
-        });
+        tokio::spawn(drain_pipe(stdout, false));
     }
     if let Some(stderr) = child.stderr.take() {
-        tokio::spawn(async move {
-            let mut lines = BufReader::new(stderr).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                warn!("go2rtc: {line}");
-            }
-        });
+        tokio::spawn(drain_pipe(stderr, true));
     }
 
     tokio::select! {
@@ -195,6 +185,49 @@ async fn run_once(bin: &str, config: &str, shutdown: &CancellationToken) -> RunE
         () = shutdown.cancelled() => {
             terminate(&mut child).await;
             RunEnd::Shutdown
+        }
+    }
+}
+
+/// Forward one child pipe into tracing, line by line, until EOF.
+///
+/// The task's contract is "keep the pipe empty for as long as the child
+/// lives" — a full ~64 KB pipe blocks the child's writes and a closed one
+/// SIGPIPEs it into a restart loop (correctness item 5). So reads are
+/// BYTE-oriented: `read_until(b'\n')` + lossy UTF-8 conversion. A UTF-8-strict
+/// `read_line`/`next_line` returns `InvalidData` on the first non-UTF-8 byte
+/// go2rtc emits, silently ending the drain while the child still runs — the
+/// exact failure this replaces. On a genuine (non-`Interrupted`) IO error the
+/// task falls back to a raw copy-to-null so the pipe stays drained even when
+/// line reads are broken; only EOF (child closed its end) ends the task.
+async fn drain_pipe<R>(pipe: R, is_stderr: bool)
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut reader = BufReader::new(pipe);
+    let mut buf: Vec<u8> = Vec::with_capacity(256);
+    loop {
+        buf.clear();
+        match reader.read_until(b'\n', &mut buf).await {
+            Ok(0) => return, // EOF — the child closed its end.
+            Ok(_) => {
+                let raw = String::from_utf8_lossy(&buf);
+                let line = raw.trim_end_matches(['\r', '\n']);
+                if is_stderr {
+                    warn!("go2rtc: {line}");
+                } else {
+                    info!("go2rtc: {line}");
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                // Retry; worst case the partial line in `buf` is dropped at
+                // the top of the loop (cosmetic — the pipe stays drained).
+            }
+            Err(e) => {
+                warn!(error = %e, "go2rtc: log pipe read failed; draining raw to null until EOF");
+                let _ = tokio::io::copy(&mut reader, &mut tokio::io::sink()).await;
+                return;
+            }
         }
     }
 }
@@ -219,4 +252,28 @@ async fn terminate(child: &mut Child) {
     }
     // Non-unix, no pid (already reaped), or SIGTERM grace expired: hard kill.
     let _ = child.kill().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::drain_pipe;
+
+    /// Audit #76 regression: the old UTF-8-strict `next_line()` drain returned
+    /// `InvalidData` on the first non-UTF-8 byte and silently exited, closing
+    /// the pipe under a live child (SIGPIPE → restart loop). The byte drain
+    /// must consume ALL lines — valid and invalid alike — and return only at
+    /// EOF. Completion of this future (rather than a hang or panic) is the
+    /// assertion.
+    #[tokio::test]
+    async fn drain_pipe_survives_invalid_utf8_to_eof() {
+        let input: &[u8] = b"ok line\n\xff\xfe\xfd binary junk\nlast line without newline";
+        drain_pipe(input, false).await;
+        drain_pipe(input, true).await; // stderr path shares the same loop
+    }
+
+    /// An empty pipe (child produced nothing before exiting) is immediate EOF.
+    #[tokio::test]
+    async fn drain_pipe_handles_immediate_eof() {
+        drain_pipe(&b""[..], false).await;
+    }
 }

--- a/services/recorder/src/main.rs
+++ b/services/recorder/src/main.rs
@@ -99,9 +99,17 @@ const MOTION_CHANNEL_CAPACITY: usize = 256;
 /// motion. The wrapper therefore books the loss per HANDLE in shared state
 /// that [`forward_motion_health`] folds into the recording task's fail-open
 /// signal: a lost verdict degrades to record-everything (correctness item 19),
-/// never to silence. The debt clears on this handle's next ACCEPTED signal —
-/// the edge at which the source's transition tracker and the recording task's
-/// union agree again — so recovery is automatic once the channel drains.
+/// never to silence. The debt clears on this handle's next ACCEPTED signal
+/// **after which the source is genuinely idle** — a completed event
+/// (`stopped_at` set) — so recovery is automatic once the channel drains.
+/// Clearing on just *any* next accepted signal would be too early: when the
+/// LOST edge was a START, the very next accepted signal is that same event's
+/// STOP, and ending fail-open at the stop instant would leave the
+/// boundary-spanning tail segment and the `motion_post_seconds` post-roll
+/// exposed (the recording task's union never saw the event). Coordination
+/// boundary (#2/#5): recording.rs treats an unmatched STOP received while
+/// healthy as a synthetic post-buffer trigger, which is what makes clearing
+/// at the accepted STOP footage-safe.
 pub struct MotionTx {
     tx: tokio::sync::mpsc::Sender<crumb_common::MotionSignal>,
     camera_id: Uuid,
@@ -147,18 +155,29 @@ impl MotionTx {
     /// On failure (channel full — or closed, i.e. the recording task is gone,
     /// which is an even less trustworthy state) the signal is lost: mark this
     /// handle's debt so the camera fails OPEN until the same handle delivers a
-    /// fresh edge. The error is still returned so callers keep their existing
-    /// per-drop warning logs.
+    /// fresh accepted signal AFTER WHICH it is genuinely idle (a completed
+    /// event, `stopped_at` set). An accepted START edge does NOT clear the
+    /// debt: if the lost edge was itself a START, the union missed the whole
+    /// event, and ending fail-open before the event has fully closed (and its
+    /// unmatched STOP has reached the recording task, which converts it into a
+    /// synthetic post-buffer trigger — the recording.rs half of this fix)
+    /// could ring-discard the boundary tail + post-roll. The error is still
+    /// returned so callers keep their existing per-drop warning logs.
     pub fn try_send(
         &self,
         signal: crumb_common::MotionSignal,
     ) -> Result<(), tokio::sync::mpsc::error::TrySendError<crumb_common::MotionSignal>> {
+        // Whether, after this signal, the source has no open event. Captured
+        // before the send moves the signal into the channel.
+        let source_idle = signal.stopped_at.is_some();
         match self.tx.try_send(signal) {
             Ok(()) => {
-                if self.lost.swap(false, Ordering::SeqCst) {
-                    // The channel accepted a fresh edge from this handle: the
-                    // recording task's view of this source re-syncs at this
-                    // edge, so the debt (and with it fail-open) can end.
+                if source_idle && self.lost.swap(false, Ordering::SeqCst) {
+                    // The channel accepted a completed event from this handle:
+                    // the source is idle and the recording task's view of it
+                    // re-syncs at this edge (an unmatched STOP is a synthetic
+                    // post-buffer trigger on the recording side), so the debt
+                    // (and with it fail-open) can end.
                     self.shared.lost_handles.fetch_sub(1, Ordering::SeqCst);
                     self.shared.changed.notify_one();
                 }
@@ -884,6 +903,10 @@ impl RecorderSupervisor {
         }
         if service_task_died(&self.migration_handle) {
             error!("migration worker task ended unexpectedly (likely a panic); respawning");
+            // The dead incarnation's claimed migration (if any) is left with
+            // status='running'; the respawned worker's idle poll re-runs the
+            // boot path's guaranteed-stale reset (see `run_migration_worker`)
+            // so the drain resumes instead of freezing at N%.
             self.spawn_migration_worker();
         }
         if service_task_died(&self.reaper_handle) {
@@ -1128,7 +1151,13 @@ const POLICY_REAP_SECONDS: u64 = 3600;
 /// `ARCHIVE_GUARD` (per batch) so footage moves never race archiving/eviction.
 /// A failed run is recorded as `failed` with the error; the loop continues so a
 /// later migration isn't blocked. Cheap when idle (a single indexed query per
-/// poll).
+/// poll, plus the stale-`running` self-heal below — one no-op UPDATE against a
+/// tiny table).
+///
+/// Self-heals a migration orphaned by a PANICKED predecessor: the #75 watchdog
+/// respawns this worker, and the idle poll re-runs the boot path's
+/// guaranteed-stale reset (`reset_stale_migrations`) so the drain the dead
+/// incarnation had claimed resumes instead of freezing at `running` forever.
 async fn run_migration_worker(pool: Pool, cancel: CancellationToken) {
     loop {
         // Claim before sleeping so a freshly-enqueued migration starts promptly on
@@ -1167,6 +1196,37 @@ async fn run_migration_worker(pool: Pool, cancel: CancellationToken) {
                 // Loop straight back to pick up any other pending migration.
             }
             Ok(None) => {
+                // Nothing 'pending' — but a row stuck in 'running' can still
+                // exist: the #75 watchdog respawns this worker after a panic,
+                // and the migration the dead incarnation had claimed stays
+                // 'running' forever (this loop only claims 'pending'), freezing
+                // the operator's storage repoint at N%. This worker is the ONLY
+                // claimer (we hold the recorder singleton advisory lock, R7)
+                // and it is idle right now, so any 'running' row here is
+                // guaranteed stale. Reuse the boot path's reset verbatim — its
+                // 2-minute freshness guard only bounds how quickly a
+                // freshly-orphaned row is recovered (a later idle poll gets it).
+                match db::reset_stale_migrations(&pool).await {
+                    Ok(0) => {}
+                    Ok(n) => {
+                        info!(
+                            reset = n,
+                            "migration worker: reset stale 'running' migration rows to \
+                             'pending' (previous worker incarnation died mid-drain); resuming"
+                        );
+                        // Claim the reset row promptly instead of idling —
+                        // unless shutdown fired meanwhile (never start a fresh
+                        // drain into a teardown).
+                        if cancel.is_cancelled() {
+                            info!("migration worker shutting down");
+                            break;
+                        }
+                        continue;
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "migration worker: reset_stale_migrations failed; will retry next poll");
+                    }
+                }
                 tokio::select! {
                     () = tokio::time::sleep(tokio::time::Duration::from_secs(MIGRATION_POLL_SECONDS)) => {}
                     () = cancel.cancelled() => { info!("migration worker shutting down"); break; }
@@ -1572,7 +1632,7 @@ mod tests {
 
     // ── motion-signal loss → fail-open (audit #81) ────────────────────────────
 
-    /// Minimal signal for the loss-tracking tests.
+    /// Minimal START-edge signal (event still open) for the loss-tracking tests.
     fn mk_signal() -> crumb_common::MotionSignal {
         crumb_common::MotionSignal {
             camera_id: Uuid::nil(),
@@ -1583,8 +1643,23 @@ mod tests {
         }
     }
 
+    /// Minimal STOP-edge signal (completed event — the source is idle after it).
+    fn mk_stop_signal() -> crumb_common::MotionSignal {
+        crumb_common::MotionSignal {
+            camera_id: Uuid::nil(),
+            started_at: Utc::now(),
+            stopped_at: Some(Utc::now()),
+            peak_score: 0.5,
+            bbox: None,
+        }
+    }
+
     /// A signal dropped on a full channel must mark the loss (the camera owes
-    /// a fail-open), and the SAME handle's next accepted signal must clear it.
+    /// a fail-open). The debt must NOT clear on the next accepted signal if
+    /// that signal leaves an event open (a START edge — the lost edge may have
+    /// been the START of an event the union never saw, audit #81); it clears
+    /// only on an accepted signal after which the source is genuinely idle
+    /// (a completed event, `stopped_at` set).
     #[tokio::test]
     async fn motion_tx_overflow_marks_loss_until_resync() {
         let (raw, mut rx) = tokio::sync::mpsc::channel(1);
@@ -1601,9 +1676,18 @@ mod tests {
         assert!(tx.try_send(mk_signal()).is_err());
         assert_eq!(loss.lost_handles.load(Ordering::SeqCst), 1);
 
-        // Drain, then a fresh accepted edge re-syncs the source: debt cleared.
+        // Drain, then an accepted START edge: the source now has an OPEN
+        // event, so the debt (and fail-open) must be HELD, not cleared —
+        // clearing here could end fail-open at the lost event's own STOP and
+        // expose the boundary tail + post-roll.
         assert!(rx.recv().await.is_some());
         assert!(tx.try_send(mk_signal()).is_ok());
+        assert_eq!(loss.lost_handles.load(Ordering::SeqCst), 1);
+
+        // Drain, then an accepted COMPLETED event (stop edge): the source is
+        // genuinely idle — debt cleared, fail-open may end.
+        assert!(rx.recv().await.is_some());
+        assert!(tx.try_send(mk_stop_signal()).is_ok());
         assert_eq!(loss.lost_handles.load(Ordering::SeqCst), 0);
     }
 
@@ -1621,9 +1705,10 @@ mod tests {
         assert!(b.try_send(mk_signal()).is_err()); // b loses a signal
         assert_eq!(loss.lost_handles.load(Ordering::SeqCst), 1);
 
-        // a's accepted send (after a drain) must not clear b's debt.
+        // a's accepted send (after a drain) must not clear b's debt — not even
+        // a stop edge, which WOULD clear a's own debt if a had one.
         assert!(rx.recv().await.is_some());
-        assert!(a.try_send(mk_signal()).is_ok());
+        assert!(a.try_send(mk_stop_signal()).is_ok());
         assert_eq!(loss.lost_handles.load(Ordering::SeqCst), 1);
 
         // Dropping the indebted handle hands the debt back.
@@ -1670,9 +1755,11 @@ mod tests {
         assert!(tx.try_send(mk_signal()).is_err());
         wait_for_health(&mut recording_rx, false).await;
 
-        // Drain + a fresh accepted edge → re-synced → healthy again.
+        // Drain + an accepted COMPLETED event (source idle after it) →
+        // re-synced → healthy again. (An accepted START edge would hold the
+        // debt — see motion_tx_overflow_marks_loss_until_resync.)
         assert!(rx.recv().await.is_some());
-        assert!(tx.try_send(mk_signal()).is_ok());
+        assert!(tx.try_send(mk_stop_signal()).is_ok());
         wait_for_health(&mut recording_rx, true).await;
 
         cancel.cancel();

--- a/services/recorder/src/main.rs
+++ b/services/recorder/src/main.rs
@@ -44,7 +44,7 @@
 //! actually changed, preventing needless ring-buffer destruction.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
@@ -88,8 +88,173 @@ const MOTION_CHANNEL_CAPACITY: usize = 256;
 
 /// Sender half of the per-camera motion signal channel.
 ///
-/// Produced by `CameraWorker::spawn`; owned by the motion task.
-pub type MotionTx = tokio::sync::mpsc::Sender<crumb_common::MotionSignal>;
+/// Produced by `CameraWorker::spawn`; owned by the motion task (one clone per
+/// enabled source loop).
+///
+/// Wraps the raw mpsc sender so a full channel can never *silently* corrupt
+/// the keep/discard verdict (audit #81). The send must stay non-blocking (a
+/// blocking send would stall the frame-diff loop and deadlock ffmpeg —
+/// correctness item 5), so on overflow the signal really is lost — but a lost
+/// START edge would let a Motion-mode camera discard footage during real
+/// motion. The wrapper therefore books the loss per HANDLE in shared state
+/// that [`forward_motion_health`] folds into the recording task's fail-open
+/// signal: a lost verdict degrades to record-everything (correctness item 19),
+/// never to silence. The debt clears on this handle's next ACCEPTED signal —
+/// the edge at which the source's transition tracker and the recording task's
+/// union agree again — so recovery is automatic once the channel drains.
+pub struct MotionTx {
+    tx: tokio::sync::mpsc::Sender<crumb_common::MotionSignal>,
+    camera_id: Uuid,
+    /// This handle's un-resynced-loss flag. Per handle (not shared): each
+    /// source loop holds its own clone, and only a signal from the SAME source
+    /// re-syncs that source's verdict stream.
+    lost: AtomicBool,
+    /// Camera-wide loss bookkeeping, shared by every clone.
+    shared: Arc<MotionLossShared>,
+}
+
+/// Camera-wide bookkeeping for lost motion signals, shared by every clone of
+/// one camera's [`MotionTx`] and read by [`forward_motion_health`].
+#[derive(Default)]
+struct MotionLossShared {
+    /// Number of sender handles whose most recent `try_send` failed and which
+    /// have not delivered a signal since — each such source's verdict stream
+    /// is missing an edge until its next accepted signal re-syncs it.
+    lost_handles: AtomicUsize,
+    /// Wakes the health forwarder whenever `lost_handles` moves. `notify_one`
+    /// stores a permit, so a wake between the forwarder's recompute and its
+    /// re-arm is never missed.
+    changed: tokio::sync::Notify,
+}
+
+impl MotionTx {
+    fn new(tx: tokio::sync::mpsc::Sender<crumb_common::MotionSignal>, camera_id: Uuid) -> Self {
+        Self {
+            tx,
+            camera_id,
+            lost: AtomicBool::new(false),
+            shared: Arc::new(MotionLossShared::default()),
+        }
+    }
+
+    /// The shared loss state, handed to this camera's [`forward_motion_health`].
+    fn loss_state(&self) -> Arc<MotionLossShared> {
+        Arc::clone(&self.shared)
+    }
+
+    /// Non-blocking send of a motion signal to the recording task.
+    ///
+    /// On failure (channel full — or closed, i.e. the recording task is gone,
+    /// which is an even less trustworthy state) the signal is lost: mark this
+    /// handle's debt so the camera fails OPEN until the same handle delivers a
+    /// fresh edge. The error is still returned so callers keep their existing
+    /// per-drop warning logs.
+    pub fn try_send(
+        &self,
+        signal: crumb_common::MotionSignal,
+    ) -> Result<(), tokio::sync::mpsc::error::TrySendError<crumb_common::MotionSignal>> {
+        match self.tx.try_send(signal) {
+            Ok(()) => {
+                if self.lost.swap(false, Ordering::SeqCst) {
+                    // The channel accepted a fresh edge from this handle: the
+                    // recording task's view of this source re-syncs at this
+                    // edge, so the debt (and with it fail-open) can end.
+                    self.shared.lost_handles.fetch_sub(1, Ordering::SeqCst);
+                    self.shared.changed.notify_one();
+                }
+                Ok(())
+            }
+            Err(e) => {
+                if !self.lost.swap(true, Ordering::SeqCst) {
+                    // Once per loss episode, not per dropped signal — the
+                    // caller already warns on every drop.
+                    error!(
+                        camera_id = %self.camera_id,
+                        "motion signal LOST (channel full/closed); failing open \
+                         (recording everything) until this source re-syncs"
+                    );
+                    self.shared.lost_handles.fetch_add(1, Ordering::SeqCst);
+                    self.shared.changed.notify_one();
+                }
+                Err(e)
+            }
+        }
+    }
+}
+
+impl Clone for MotionTx {
+    fn clone(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+            camera_id: self.camera_id,
+            // Loss is per handle: a fresh clone has lost nothing yet.
+            lost: AtomicBool::new(false),
+            shared: Arc::clone(&self.shared),
+        }
+    }
+}
+
+impl Drop for MotionTx {
+    fn drop(&mut self) {
+        // A handle dropped mid-debt can never re-sync, so return its debt —
+        // otherwise the camera would fail open forever on a vanished handle.
+        // A dying source has its own fail-open path (the per-source health
+        // watch in motion.rs), which is the correct one from here on.
+        if self.lost.load(Ordering::SeqCst) {
+            self.shared.lost_handles.fetch_sub(1, Ordering::SeqCst);
+            self.shared.changed.notify_one();
+        }
+    }
+}
+
+/// Fold the motion task's health watch AND the motion-channel loss state into
+/// the single fail-open bool the recording task reads (audit #81).
+///
+/// `recording_tx` has exactly ONE writer — this task — so a detector-health
+/// flip and a loss flip can never interleave into a stale healthy reading.
+/// The recording task fails open (`healthy == false`) whenever the detector
+/// itself is unhealthy (motion.rs's aggregator, forwarded from `detector_rx`)
+/// OR any sender handle has an un-resynced lost signal. Mirrors the
+/// aggregator's teardown rule: publish a final unhealthy so the recording task
+/// never trusts a stale healthy reading.
+async fn forward_motion_health(
+    mut detector_rx: MotionHealthRx,
+    recording_tx: MotionHealthTx,
+    loss: Arc<MotionLossShared>,
+    camera_id: Uuid,
+    cancel: CancellationToken,
+) {
+    loop {
+        let lossy = loss.lost_handles.load(Ordering::SeqCst) > 0;
+        let healthy = *detector_rx.borrow() && !lossy;
+        if *recording_tx.borrow() != healthy {
+            if !healthy && lossy {
+                // Detector-driven transitions are already logged by motion.rs
+                // (RECOVERED / FAIL-OPEN); only the loss-driven one is ours.
+                warn!(
+                    camera_id = %camera_id,
+                    "motion health: FAIL-OPEN (motion signal lost on a full channel; \
+                     recording everything until the source re-syncs)"
+                );
+            }
+            // Only errors when the recording task dropped its receiver
+            // (worker teardown) — nothing left to protect.
+            let _ = recording_tx.send(healthy);
+        }
+        tokio::select! {
+            () = cancel.cancelled() => break,
+            res = detector_rx.changed() => {
+                if res.is_err() {
+                    break; // motion task gone — teardown
+                }
+            }
+            () = loss.changed.notified() => {}
+        }
+    }
+    // Teardown: the recording task must not trust a stale healthy reading
+    // (same rule as motion.rs's aggregator).
+    let _ = recording_tx.send(false);
+}
 
 /// Receiver half of the per-camera motion signal channel.
 ///
@@ -237,8 +402,8 @@ impl CameraWorker {
             &config.motion_vaapi_device,
         );
 
-        let (motion_tx, motion_rx): (MotionTx, MotionRx) =
-            tokio::sync::mpsc::channel(MOTION_CHANNEL_CAPACITY);
+        let (raw_motion_tx, motion_rx) = tokio::sync::mpsc::channel(MOTION_CHANNEL_CAPACITY);
+        let motion_tx = MotionTx::new(raw_motion_tx, camera.id);
 
         // Health channel: starts `false` (unhealthy / unconfirmed) until the
         // motion task's first successful frame analysis flips it `true`. This
@@ -247,6 +412,20 @@ impl CameraWorker {
         // trusting an unproven detector from the first segment.
         let (health_tx, health_rx): (MotionHealthTx, MotionHealthRx) =
             tokio::sync::watch::channel(false);
+
+        // Interposed fail-open rail (audit #81): the recording task reads a
+        // SECOND watch that folds the detector health above together with the
+        // motion channel's loss state, written only by `forward_motion_health`.
+        // Same initial `false` — the worker starts fail-open either way.
+        let (rec_health_tx, rec_health_rx): (MotionHealthTx, MotionHealthRx) =
+            tokio::sync::watch::channel(false);
+        tokio::spawn(forward_motion_health(
+            health_rx,
+            rec_health_tx,
+            motion_tx.loss_state(),
+            camera.id,
+            cancel.clone(),
+        ));
 
         // Clone the cancellation token for each child task.
         let rec_cancel = cancel.clone();
@@ -257,7 +436,12 @@ impl CameraWorker {
         let rec_config = config.clone();
         let recording_handle = tokio::spawn(async move {
             recording::run(
-                rec_camera, rec_pool, rec_config, motion_rx, health_rx, rec_cancel,
+                rec_camera,
+                rec_pool,
+                rec_config,
+                motion_rx,
+                rec_health_rx,
+                rec_cancel,
             )
             .await;
         });
@@ -515,56 +699,15 @@ impl RecorderSupervisor {
         //     decode-status panel. Telemetry only, best-effort, once per boot.
         decode_probe::publish(&self.pool).await;
 
-        // 3. Spawn the archive scheduler.
-        {
-            let sched_pool = self.pool.clone();
-            let sched_config = self.config.clone();
-            let sched_cancel = self.shutdown.clone();
-            let handle = tokio::spawn(async move {
-                archive::run_scheduler(sched_pool, sched_config, sched_cancel).await;
-            });
-            self.archive_handle = Some(handle);
-        }
-
-        // 3b. Spawn the liveness heartbeat task.
-        {
-            let hb_pool = self.pool.clone();
-            let hb_cancel = self.shutdown.clone();
-            let hb_active = Arc::clone(&self.active_cameras);
-            let handle = tokio::spawn(async move {
-                run_heartbeat(hb_pool, hb_active, hb_cancel).await;
-            });
-            self.heartbeat_handle = Some(handle);
-        }
-
-        // 3c. Spawn the per-camera resource sampler (CPU / mem / GPU). Reads /proc
-        //     + nvidia-smi out-of-band; never touches the recording/motion path.
-        self.resource_handle = Some(resource_stats::spawn(
-            self.pool.clone(),
-            self.shutdown.clone(),
-        ));
-
-        // 3d. Spawn the "Change storage" drain worker — claims pending
-        //     storage_migrations and relocates footage under ARCHIVE_GUARD so it
-        //     never races archiving/eviction. Idle-polls; cheap when no migration.
-        {
-            let mig_pool = self.pool.clone();
-            let mig_cancel = self.shutdown.clone();
-            self.migration_handle = Some(tokio::spawn(async move {
-                run_migration_worker(mig_pool, mig_cancel).await;
-            }));
-        }
-
-        // 3e. Spawn the policy-fork reaper — periodically deletes orphaned anonymous
-        //     per-camera COW policy rows no camera/group references (the "separate
-        //     vacuum" the config-routes COW design refers to). Cheap; hourly.
-        {
-            let reap_pool = self.pool.clone();
-            let reap_cancel = self.shutdown.clone();
-            self.reaper_handle = Some(tokio::spawn(async move {
-                run_policy_reaper(reap_pool, reap_cancel).await;
-            }));
-        }
+        // 3. Spawn the long-lived service tasks (archive scheduler, heartbeat,
+        //    resource sampler, migration worker, policy reaper). Each spawn is a
+        //    method so the poll-loop watchdog (`respawn_dead_services`, audit
+        //    #75) can respawn one that panicked, exactly like camera workers.
+        self.spawn_archive_scheduler();
+        self.spawn_heartbeat();
+        self.spawn_resource_sampler();
+        self.spawn_migration_worker();
+        self.spawn_policy_reaper();
 
         // 4. Initial camera sync.
         self.sync_cameras().await;
@@ -577,6 +720,7 @@ impl RecorderSupervisor {
         loop {
             tokio::select! {
                 _ = interval.tick() => {
+                    self.respawn_dead_services();
                     self.sync_cameras().await;
                 }
                 () = self.shutdown.cancelled() => {
@@ -659,6 +803,93 @@ impl RecorderSupervisor {
         }
 
         Ok(())
+    }
+
+    /// Spawn the archive scheduler task.
+    fn spawn_archive_scheduler(&mut self) {
+        let sched_pool = self.pool.clone();
+        let sched_config = self.config.clone();
+        let sched_cancel = self.shutdown.clone();
+        self.archive_handle = Some(tokio::spawn(async move {
+            archive::run_scheduler(sched_pool, sched_config, sched_cancel).await;
+        }));
+    }
+
+    /// Spawn the liveness heartbeat task.
+    fn spawn_heartbeat(&mut self) {
+        let hb_pool = self.pool.clone();
+        let hb_cancel = self.shutdown.clone();
+        let hb_active = Arc::clone(&self.active_cameras);
+        self.heartbeat_handle = Some(tokio::spawn(async move {
+            run_heartbeat(hb_pool, hb_active, hb_cancel).await;
+        }));
+    }
+
+    /// Spawn the per-camera resource sampler (CPU / mem / GPU). Reads /proc
+    /// + nvidia-smi out-of-band; never touches the recording/motion path.
+    fn spawn_resource_sampler(&mut self) {
+        self.resource_handle = Some(resource_stats::spawn(
+            self.pool.clone(),
+            self.shutdown.clone(),
+        ));
+    }
+
+    /// Spawn the "Change storage" drain worker — claims pending
+    /// storage_migrations and relocates footage under ARCHIVE_GUARD so it
+    /// never races archiving/eviction. Idle-polls; cheap when no migration.
+    fn spawn_migration_worker(&mut self) {
+        let mig_pool = self.pool.clone();
+        let mig_cancel = self.shutdown.clone();
+        self.migration_handle = Some(tokio::spawn(async move {
+            run_migration_worker(mig_pool, mig_cancel).await;
+        }));
+    }
+
+    /// Spawn the policy-fork reaper — periodically deletes orphaned anonymous
+    /// per-camera COW policy rows no camera/group references (the "separate
+    /// vacuum" the config-routes COW design refers to). Cheap; hourly.
+    fn spawn_policy_reaper(&mut self) {
+        let reap_pool = self.pool.clone();
+        let reap_cancel = self.shutdown.clone();
+        self.reaper_handle = Some(tokio::spawn(async move {
+            run_policy_reaper(reap_pool, reap_cancel).await;
+        }));
+    }
+
+    /// Watchdog for the long-lived service tasks (audit #75). Each of them
+    /// loops until `shutdown` fires, so a finished handle outside shutdown
+    /// means the task died unexpectedly — in practice a panic (panics unwind
+    /// and fail just that task's future; the process survives because
+    /// `panic = "abort"` is forbidden). Without this check a panicked archive
+    /// scheduler silently stops retention/eviction until the whole recorder
+    /// restarts. Mirrors the camera-worker resurrection in `sync_cameras`
+    /// (audit 2026-07-05); called from the same poll loop.
+    fn respawn_dead_services(&mut self) {
+        if self.shutdown.is_cancelled() {
+            // Shutting down — finished service tasks are expected, and the
+            // shutdown path below joins them; never respawn into a teardown.
+            return;
+        }
+        if service_task_died(&self.archive_handle) {
+            error!("archive scheduler task ended unexpectedly (likely a panic); respawning");
+            self.spawn_archive_scheduler();
+        }
+        if service_task_died(&self.heartbeat_handle) {
+            error!("heartbeat task ended unexpectedly (likely a panic); respawning");
+            self.spawn_heartbeat();
+        }
+        if service_task_died(&self.resource_handle) {
+            error!("resource sampler task ended unexpectedly (likely a panic); respawning");
+            self.spawn_resource_sampler();
+        }
+        if service_task_died(&self.migration_handle) {
+            error!("migration worker task ended unexpectedly (likely a panic); respawning");
+            self.spawn_migration_worker();
+        }
+        if service_task_died(&self.reaper_handle) {
+            error!("policy reaper task ended unexpectedly (likely a panic); respawning");
+            self.spawn_policy_reaper();
+        }
     }
 
     /// Diff enabled DB cameras vs running workers; start new ones, stop
@@ -793,14 +1024,19 @@ impl RecorderSupervisor {
         }
     }
 
-    /// Cancel and join all running workers.
+    /// Cancel and join all running workers, concurrently.
+    ///
+    /// Each `CameraWorker::stop` is individually bounded (8 s join + abort),
+    /// so stopping concurrently bounds the WHOLE fleet's shutdown at ~one
+    /// worker's budget instead of N × 8 s of sequential joins — the total
+    /// shutdown must fit inside compose's `stop_grace_period` or Docker
+    /// SIGKILLs the recorder mid-teardown (audit #84).
     async fn stop_all_workers(&mut self) {
-        let ids: Vec<Uuid> = self.workers.keys().copied().collect();
-        for id in ids {
-            if let Some(worker) = self.workers.remove(&id) {
-                worker.stop().await;
-            }
+        let mut stops = tokio::task::JoinSet::new();
+        for (_, worker) in self.workers.drain() {
+            stops.spawn(worker.stop());
         }
+        while stops.join_next().await.is_some() {}
     }
 
     /// Ensure the two named storage rows exist (idempotent via `ON CONFLICT`).
@@ -832,6 +1068,14 @@ impl RecorderSupervisor {
         );
         Ok(())
     }
+}
+
+/// True when a stored long-lived service handle has ended and must be
+/// respawned (see [`RecorderSupervisor::respawn_dead_services`]). `None`
+/// (never spawned / already taken for shutdown) is NOT "died" — there is
+/// nothing to resurrect.
+fn service_task_died(handle: &Option<tokio::task::JoinHandle<()>>) -> bool {
+    handle.as_ref().is_some_and(|h| h.is_finished())
 }
 
 // ─── heartbeat task ───────────────────────────────────────────────────────────
@@ -1124,11 +1368,13 @@ async fn main() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::CameraFingerprint;
+    use super::{forward_motion_health, service_task_died, CameraFingerprint, MotionTx};
     use chrono::Utc;
     use crumb_common::types::{
         Camera, MotionSensitivity, RecordStream, RecordingMode, RecordingPolicy,
     };
+    use std::sync::atomic::Ordering;
+    use tokio_util::sync::CancellationToken;
     use uuid::Uuid;
 
     /// Build a minimal default policy for fingerprint tests.
@@ -1292,5 +1538,143 @@ mod tests {
             CameraFingerprint::from_camera(&cam_b, "auto", ""),
             "fingerprint must be stable when no fingerprinted field changes"
         );
+    }
+
+    // ── service-task watchdog (audit #75) ─────────────────────────────────────
+
+    /// The watchdog's liveness predicate: a panicked service task must read as
+    /// died (so `respawn_dead_services` resurrects it); a live task and a
+    /// never-spawned/taken-for-shutdown slot must not.
+    #[tokio::test]
+    async fn service_watchdog_detects_dead_task() {
+        // A task that panics: its JoinHandle finishes with a JoinError.
+        let mut dead = tokio::spawn(async { panic!("service task panicked (test)") });
+        let joined = (&mut dead).await;
+        assert!(joined.is_err(), "panicked task must join with an error");
+        assert!(
+            service_task_died(&Some(dead)),
+            "a panicked service task must be detected as died"
+        );
+
+        // A live task must NOT read as died.
+        let alive = Some(tokio::spawn(std::future::pending::<()>()));
+        assert!(
+            !service_task_died(&alive),
+            "a running service task must not be respawned"
+        );
+        if let Some(h) = alive {
+            h.abort();
+        }
+
+        // Never spawned / already taken for shutdown: nothing to resurrect.
+        assert!(!service_task_died(&None));
+    }
+
+    // ── motion-signal loss → fail-open (audit #81) ────────────────────────────
+
+    /// Minimal signal for the loss-tracking tests.
+    fn mk_signal() -> crumb_common::MotionSignal {
+        crumb_common::MotionSignal {
+            camera_id: Uuid::nil(),
+            started_at: Utc::now(),
+            stopped_at: None,
+            peak_score: 0.5,
+            bbox: None,
+        }
+    }
+
+    /// A signal dropped on a full channel must mark the loss (the camera owes
+    /// a fail-open), and the SAME handle's next accepted signal must clear it.
+    #[tokio::test]
+    async fn motion_tx_overflow_marks_loss_until_resync() {
+        let (raw, mut rx) = tokio::sync::mpsc::channel(1);
+        let tx = MotionTx::new(raw, Uuid::nil());
+        let loss = tx.loss_state();
+
+        assert!(tx.try_send(mk_signal()).is_ok());
+        assert_eq!(loss.lost_handles.load(Ordering::SeqCst), 0);
+
+        // Channel full → the signal is lost → the handle owes a re-sync.
+        assert!(tx.try_send(mk_signal()).is_err());
+        assert_eq!(loss.lost_handles.load(Ordering::SeqCst), 1);
+        // Repeated drops in the same episode must not double-count.
+        assert!(tx.try_send(mk_signal()).is_err());
+        assert_eq!(loss.lost_handles.load(Ordering::SeqCst), 1);
+
+        // Drain, then a fresh accepted edge re-syncs the source: debt cleared.
+        assert!(rx.recv().await.is_some());
+        assert!(tx.try_send(mk_signal()).is_ok());
+        assert_eq!(loss.lost_handles.load(Ordering::SeqCst), 0);
+    }
+
+    /// Loss is tracked per handle — another source's accepted signal must NOT
+    /// clear a debt it didn't incur — and a handle dropped mid-debt returns it
+    /// (a dead source's fail-open is motion.rs's per-source health watch).
+    #[tokio::test]
+    async fn motion_tx_loss_is_per_handle_and_returned_on_drop() {
+        let (raw, mut rx) = tokio::sync::mpsc::channel(1);
+        let a = MotionTx::new(raw, Uuid::nil());
+        let b = a.clone();
+        let loss = a.loss_state();
+
+        assert!(a.try_send(mk_signal()).is_ok()); // fill the only slot
+        assert!(b.try_send(mk_signal()).is_err()); // b loses a signal
+        assert_eq!(loss.lost_handles.load(Ordering::SeqCst), 1);
+
+        // a's accepted send (after a drain) must not clear b's debt.
+        assert!(rx.recv().await.is_some());
+        assert!(a.try_send(mk_signal()).is_ok());
+        assert_eq!(loss.lost_handles.load(Ordering::SeqCst), 1);
+
+        // Dropping the indebted handle hands the debt back.
+        drop(b);
+        assert_eq!(loss.lost_handles.load(Ordering::SeqCst), 0);
+    }
+
+    /// Await the forwarded health watch reaching `want`, with a hard timeout so
+    /// a broken forwarder fails the test instead of hanging it.
+    async fn wait_for_health(rx: &mut super::MotionHealthRx, want: bool) {
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            rx.wait_for(|&v| v == want),
+        )
+        .await
+        .expect("timed out waiting for the forwarded health value")
+        .expect("health watch sender dropped");
+    }
+
+    /// End-to-end: the recording-side health watch must go false while a lost
+    /// signal is un-resynced, and recover once the same handle delivers a fresh
+    /// edge — even though the detector stayed healthy throughout.
+    #[tokio::test]
+    async fn health_forwarder_folds_signal_loss_into_fail_open() {
+        let (detector_tx, detector_rx) = tokio::sync::watch::channel(false);
+        let (recording_tx, mut recording_rx) = tokio::sync::watch::channel(false);
+        let (raw, mut rx) = tokio::sync::mpsc::channel(1);
+        let tx = MotionTx::new(raw, Uuid::nil());
+        let cancel = CancellationToken::new();
+        tokio::spawn(forward_motion_health(
+            detector_rx,
+            recording_tx,
+            tx.loss_state(),
+            Uuid::nil(),
+            cancel.clone(),
+        ));
+
+        // Detector healthy, nothing lost → forwarded healthy.
+        detector_tx.send(true).unwrap();
+        wait_for_health(&mut recording_rx, true).await;
+
+        // Overflow: fill the one slot, then lose a signal → fail-open.
+        assert!(tx.try_send(mk_signal()).is_ok());
+        assert!(tx.try_send(mk_signal()).is_err());
+        wait_for_health(&mut recording_rx, false).await;
+
+        // Drain + a fresh accepted edge → re-synced → healthy again.
+        assert!(rx.recv().await.is_some());
+        assert!(tx.try_send(mk_signal()).is_ok());
+        wait_for_health(&mut recording_rx, true).await;
+
+        cancel.cancel();
     }
 }

--- a/services/recorder/src/motion.rs
+++ b/services/recorder/src/motion.rs
@@ -1357,6 +1357,20 @@ fn should_emit_unhealthy_alert(
     !already_alerted && unhealthy_elapsed_secs >= threshold_secs
 }
 
+/// Pure gate for the pixel detector's healthy report: a real keep/discard
+/// verdict is only possible once the warm-up window has elapsed (section g's
+/// `warming_up = !pixel_verdict_capable(..)` forces `motion_detected = false`
+/// through frame `WARMUP_FRAMES`), so health must not flip `true` before then.
+/// Reporting healthy on the first post-seed frame (the old behaviour) ended
+/// fail-open while the detector was still verdict-blind — a Motion-mode camera
+/// gating footage on a detector that cannot yet say KEEP, after every
+/// (re)connect (correctness item 19: "detector state unknown" must resolve to
+/// keep-everything, never keep-nothing).
+#[must_use]
+fn pixel_verdict_capable(frames_seen: u64) -> bool {
+    frames_seen > WARMUP_FRAMES
+}
+
 // ─── public entry point ───────────────────────────────────────────────────────
 
 /// Run the motion detection task for `camera` until `cancel` is triggered.
@@ -1556,12 +1570,14 @@ async fn run_one_source(
                         Some("motion source is Frigate (no local decode)"),
                     )
                     .await;
-                    // Start PESSIMISTIC: not healthy until the broker's ConnAck
-                    // confirms a live connection — run_frigate_motion_loop flips it
-                    // healthy then. Reporting healthy here (before connecting) would
-                    // make a source that can't reach the broker flap healthy on
-                    // every retry and reset the fail-open grace so it never fires
-                    // (issue #61, the ha_motion twin).
+                    // Start PESSIMISTIC: not healthy until the broker GRANTS the
+                    // events subscription (SubAck) — run_frigate_motion_loop flips
+                    // it healthy then. Reporting healthy here (before connecting)
+                    // would make a source that can't reach the broker flap healthy
+                    // on every retry and reset the fail-open grace so it never
+                    // fires (issue #61, the ha_motion twin); reporting on ConnAck
+                    // would trust a connection whose subscription the broker may
+                    // still deny (issue #78).
                     report_health(
                         &health_tx,
                         &pool,
@@ -2224,32 +2240,7 @@ async fn run_pixel_diff_loop(
     // a background task, logging at DEBUG level.
     let camera_id_log = camera.id;
     let stderr_handle = tokio::spawn(async move {
-        let mut reader = tokio::io::BufReader::new(stderr);
-        let mut line = String::new();
-        loop {
-            line.clear();
-            match reader.read_line(&mut line).await {
-                Ok(0) => break, // EOF — ffmpeg has exited.
-                Ok(_) => {
-                    let trimmed = line.trim_end();
-                    if !trimmed.is_empty() {
-                        debug!(
-                            camera_id     = %camera_id_log,
-                            ffmpeg_stderr = trimmed,
-                            "motion ffmpeg"
-                        );
-                    }
-                }
-                Err(e) => {
-                    debug!(
-                        camera_id = %camera_id_log,
-                        error     = %e,
-                        "motion ffmpeg stderr drain error"
-                    );
-                    break;
-                }
-            }
-        }
+        drain_motion_stderr(stderr, camera_id_log).await;
     });
 
     // ── 7. Initialise per-loop state ──────────────────────────────────────────
@@ -2440,21 +2431,27 @@ async fn run_pixel_diff_loop(
             continue; // seed frame — nothing to compare yet
         }
 
-        // Fail-open recovery: the FIRST post-seed frame proves the detector is
-        // genuinely analysing content again (not just that ffmpeg connected —
-        // seeding only copies raw bytes, it does not run the detection
-        // pipeline). Cheap to call every frame; `report_health` no-ops after
+        // Fail-open recovery: report healthy only once the warm-up window has
+        // elapsed — the first frame where a keep/discard verdict is actually
+        // possible. Analysing frames is not enough: through `WARMUP_FRAMES`
+        // section g forces `motion_detected = false`, so a healthy report on
+        // the first post-seed frame (the old behaviour) opened a "healthy but
+        // verdict-blind" window after every (re)connect in which Motion mode
+        // gated footage on a detector that could not yet say KEEP (correctness
+        // item 19). Cheap to call every frame; `report_health` no-ops after
         // the first transition since the value no longer changes.
-        report_health(
-            health_tx,
-            pool,
-            camera.id,
-            true,
-            "analysing frames",
-            alert_gate,
-            alert_after_secs,
-        )
-        .await;
+        if pixel_verdict_capable(frames_seen) {
+            report_health(
+                health_tx,
+                pool,
+                camera.id,
+                true,
+                "analysing frames (warm-up complete)",
+                alert_gate,
+                alert_after_secs,
+            )
+            .await;
+        }
 
         // ── a2. Adaptive-rate skip (Part B) ────────────────────────────────────
         // When the scene has been quiet for QUIET_SECS, we skip analysis on every
@@ -2508,7 +2505,9 @@ async fn run_pixel_diff_loop(
         let score = largest_blob as f32 / total_pixels;
 
         // ── g. Decision: largest-blob fraction vs the effective floor ─────────
-        let warming_up = frames_seen <= WARMUP_FRAMES;
+        // Kept in lockstep with the healthy report above: verdict-capable and
+        // "no longer warming up" are the same predicate by construction.
+        let warming_up = !pixel_verdict_capable(frames_seen);
 
         // Adaptive threshold: drive recompute on a ~15 s wall-clock schedule.
         // `now` here is the Utc timestamp used by the state machine below — the
@@ -2891,6 +2890,77 @@ async fn read_exact_frame(
     Ok(true)
 }
 
+/// Consecutive read errors after which [`drain_motion_stderr`] gives up. An
+/// `Err` from a pipe read is transient by nature (EOF is delivered as `Ok(0)`,
+/// not `Err`), so this bound only exists to keep a pathological fd from
+/// spinning the drain task forever — which would also hang the worker's
+/// teardown `stderr_handle.await`.
+const STDERR_DRAIN_MAX_CONSECUTIVE_ERRORS: u32 = 100;
+
+/// Drain the motion ffmpeg child's stderr to DEBUG logs until EOF, returning
+/// the number of lines drained (exercised by tests).
+///
+/// Drains BYTES (`read_until`), NOT UTF-8 lines: ffmpeg's stderr is not
+/// guaranteed to be valid UTF-8 (stream metadata, dumped packet bytes), and
+/// the previous `read_line` failed the whole read on the first invalid byte,
+/// ending the drain early — the pipe closed while ffmpeg kept writing, ffmpeg
+/// blocked on the full ~64 KB pipe buffer, and the stdout frame reader stalled:
+/// the exact deadlock this task exists to prevent (correctness item 5). Lines
+/// are rendered lossily for logging; a read error is logged and skipped (with
+/// a short pause, bounded by [`STDERR_DRAIN_MAX_CONSECUTIVE_ERRORS`]) rather
+/// than ending the drain, because only EOF (`Ok(0)` — the child exited) means
+/// there is nothing left to drain.
+async fn drain_motion_stderr(
+    stderr: impl tokio::io::AsyncRead + Unpin,
+    camera_id: uuid::Uuid,
+) -> u64 {
+    let mut reader = tokio::io::BufReader::new(stderr);
+    let mut line: Vec<u8> = Vec::new();
+    let mut drained: u64 = 0;
+    let mut consecutive_errors: u32 = 0;
+    loop {
+        line.clear();
+        match reader.read_until(b'\n', &mut line).await {
+            Ok(0) => break, // EOF — ffmpeg has exited.
+            Ok(_) => {
+                consecutive_errors = 0;
+                drained += 1;
+                let text = String::from_utf8_lossy(&line);
+                let trimmed = text.trim_end();
+                if !trimmed.is_empty() {
+                    debug!(
+                        camera_id     = %camera_id,
+                        ffmpeg_stderr = trimmed,
+                        "motion ffmpeg"
+                    );
+                }
+            }
+            Err(e) => {
+                // Do NOT break while the child may still be alive — an
+                // abandoned stderr pipe recreates the fill-and-deadlock this
+                // task prevents. Pause briefly so a persistently erroring fd
+                // cannot busy-spin, and give up only past the error bound.
+                consecutive_errors += 1;
+                debug!(
+                    camera_id = %camera_id,
+                    error     = %e,
+                    consecutive_errors,
+                    "motion ffmpeg stderr drain error (continuing)"
+                );
+                if consecutive_errors >= STDERR_DRAIN_MAX_CONSECUTIVE_ERRORS {
+                    warn!(
+                        camera_id = %camera_id,
+                        "motion ffmpeg stderr drain giving up after repeated errors"
+                    );
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        }
+    }
+    drained
+}
+
 // ─── motion state ─────────────────────────────────────────────────────────────
 
 /// Internal state of the per-frame motion detector.
@@ -2905,7 +2975,7 @@ enum MotionState {
 /// Try to send a [`MotionSignal`] on `tx`; log a warning if the channel is full.
 ///
 /// The channel is bounded at [`MOTION_CHANNEL_CAPACITY`](crate::MOTION_CHANNEL_CAPACITY)
-/// (64).  Using `try_send` prevents the frame-diff loop from blocking, which
+/// (256).  Using `try_send` prevents the frame-diff loop from blocking, which
 /// would stall the stdout pipe and eventually deadlock ffmpeg (correctness
 /// item 5).
 #[inline]
@@ -3954,6 +4024,42 @@ mod tests {
             + 1;
         assert_ne!(g1, g2);
         assert_ne!(g0, g2);
+    }
+
+    // ── pixel healthy report deferred past warm-up (pixel_verdict_capable) ──────
+
+    #[test]
+    fn pixel_health_waits_out_warmup() {
+        // Warm-up frames are verdict-blind (section g forces
+        // `motion_detected = false`), so reporting healthy there would end
+        // fail-open on a detector that cannot yet say KEEP (correctness
+        // item 19) — a "healthy but blind" window after every (re)connect.
+        assert!(!pixel_verdict_capable(1)); // first post-seed frame
+        assert!(!pixel_verdict_capable(WARMUP_FRAMES)); // last warm-up frame
+                                                        // The first frame past warm-up can produce a real keep/discard
+                                                        // verdict — healthy may be reported from here on.
+        assert!(pixel_verdict_capable(WARMUP_FRAMES + 1));
+    }
+
+    // ── stderr drain (byte-based, UTF-8 tolerant) ────────────────────────────────
+
+    #[tokio::test]
+    async fn stderr_drain_survives_invalid_utf8() {
+        // ffmpeg stderr with invalid UTF-8 mid-stream. The old `read_line`
+        // drain errored on line 2 and STOPPED draining — the pipe closed while
+        // ffmpeg kept writing, ffmpeg blocked on the full pipe buffer, and the
+        // stdout frame reader stalled (correctness item 5). The byte drain
+        // must reach EOF having seen all three lines.
+        let stderr: &[u8] = b"frame=1 fps=5\n\xff\xfe bad bytes\nframe=2 fps=5\n";
+        assert_eq!(drain_motion_stderr(stderr, uuid::Uuid::nil()).await, 3);
+    }
+
+    #[tokio::test]
+    async fn stderr_drain_counts_final_unterminated_line() {
+        // A child that dies mid-line leaves a final chunk without '\n' — it is
+        // still drained (read_until returns Ok(n>0) for it) before the Ok(0) EOF.
+        let stderr: &[u8] = b"line one\ntruncated";
+        assert_eq!(drain_motion_stderr(stderr, uuid::Uuid::nil()).await, 2);
     }
 
     // ── frame_absdiff ─────────────────────────────────────────────────────────

--- a/services/recorder/src/motion.rs
+++ b/services/recorder/src/motion.rs
@@ -1455,25 +1455,39 @@ pub async fn run(
     // One supervised loop per enabled source. Each publishes to its OWN per-source
     // health watch (so a per-source alert fires by name) and feeds the shared
     // motion channel; the aggregator collapses the watches into camera health.
-    let mut supervisors = tokio::task::JoinSet::new();
+    //
+    // We keep a CLONE of every per-source health sender here (`src_txs`). A
+    // panicked source task drops ITS sender clone without ever running its
+    // "motion source exiting" unhealthy report — without our retained clone the
+    // aggregator's watch would close on the source's last-known value (often
+    // healthy) and a Motion-mode camera would stay motion-gated on a dead
+    // detector, silently missing footage (correctness item 19). The retained
+    // clone (a) keeps the watch channel open, (b) lets the supervision loop
+    // below force the dead source unhealthy the instant its task ends, and
+    // (c) lets the respawned task publish onto the SAME watch the aggregator
+    // already reads.
+    let mut supervisors: tokio::task::JoinSet<SourceKind> = tokio::task::JoinSet::new();
     let mut pixel_rx: Option<tokio::sync::watch::Receiver<bool>> = None;
     let mut frigate_rx: Option<tokio::sync::watch::Receiver<bool>> = None;
     let mut ha_rx: Option<tokio::sync::watch::Receiver<bool>> = None;
+    let mut src_txs: std::collections::HashMap<SourceKind, MotionHealthTx> =
+        std::collections::HashMap::new();
+    let mut task_kinds: std::collections::HashMap<tokio::task::Id, SourceKind> =
+        std::collections::HashMap::new();
 
-    for kind in enabled.iter().copied() {
-        // Start unhealthy: a source is not trusted until its loop proves healthy.
-        let (src_tx, src_rx) = tokio::sync::watch::channel(false);
-        match kind {
-            SourceKind::Pixel => pixel_rx = Some(src_rx),
-            SourceKind::Frigate => frigate_rx = Some(src_rx),
-            SourceKind::Ha => ha_rx = Some(src_rx),
-        }
+    // Spawn (or respawn) ONE source task; the returned SourceKind lets the
+    // supervision loop identify a cleanly-returned task, and `task_kinds` maps
+    // a panicked task's id back to its source.
+    let spawn_source = |supervisors: &mut tokio::task::JoinSet<SourceKind>,
+                        task_kinds: &mut std::collections::HashMap<tokio::task::Id, SourceKind>,
+                        kind: SourceKind,
+                        src_tx: MotionHealthTx| {
         let camera = camera.clone();
         let pool = pool.clone();
         let config = config.clone();
         let motion_tx = motion_tx.clone();
         let cancel = cancel.clone();
-        supervisors.spawn(async move {
+        let handle = supervisors.spawn(async move {
             run_one_source(
                 kind,
                 camera,
@@ -1485,7 +1499,21 @@ pub async fn run(
                 alert_after_secs,
             )
             .await;
+            kind
         });
+        task_kinds.insert(handle.id(), kind);
+    };
+
+    for kind in enabled.iter().copied() {
+        // Start unhealthy: a source is not trusted until its loop proves healthy.
+        let (src_tx, src_rx) = tokio::sync::watch::channel(false);
+        match kind {
+            SourceKind::Pixel => pixel_rx = Some(src_rx),
+            SourceKind::Frigate => frigate_rx = Some(src_rx),
+            SourceKind::Ha => ha_rx = Some(src_rx),
+        }
+        src_txs.insert(kind, src_tx.clone());
+        spawn_source(&mut supervisors, &mut task_kinds, kind, src_tx);
     }
 
     // Health aggregator: collapses the per-source watches into the single camera
@@ -1501,9 +1529,72 @@ pub async fn run(
         })
     };
 
-    // Wait for cancellation; the source loops observe the same token and exit,
-    // then the aggregator (also watching the token) publishes a final unhealthy.
-    cancel.cancelled().await;
+    // Supervise the source tasks until cancellation (the motion-task twin of
+    // main.rs's `respawn_dead_services`, audit #75). `run_one_source` loops
+    // until the token fires, so a task that ends OUTSIDE shutdown died
+    // unexpectedly — in practice a panic (panics unwind and kill just that
+    // task's future). Without this, a panicked source never runs its exit
+    // report, and a Motion-mode camera would sit motion-gated on a dead
+    // detector forever (correctness item 19). On a dead source we (1) force
+    // its health watch to unhealthy IMMEDIATELY — the aggregator drives the
+    // camera to fail-open (record everything) while the source is down — and
+    // (2) respawn it after a short delay onto the same watch.
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => break,
+            joined = supervisors.join_next_with_id() => {
+                let Some(joined) = joined else {
+                    // No source task left to supervise (unreachable while every
+                    // dead source is respawned below); just await shutdown.
+                    cancel.cancelled().await;
+                    break;
+                };
+                if cancel.is_cancelled() {
+                    break;
+                }
+                let kind = match joined {
+                    Ok((id, kind)) => {
+                        task_kinds.remove(&id);
+                        warn!(
+                            camera_id = %camera_id,
+                            source = kind.as_str(),
+                            "motion source task ended unexpectedly; failing open and respawning"
+                        );
+                        Some(kind)
+                    }
+                    Err(e) => {
+                        let kind = task_kinds.remove(&e.id());
+                        error!(
+                            camera_id = %camera_id,
+                            source = kind.map_or("unknown", SourceKind::as_str),
+                            error = %e,
+                            "motion source task PANICKED; failing open and respawning"
+                        );
+                        kind
+                    }
+                };
+                let Some(kind) = kind else { continue };
+                // Force the dead source unhealthy NOW (its panic skipped the
+                // "motion source exiting" report): the aggregator must never
+                // keep trusting the last-known health of a dead detector.
+                if let Some(src_tx) = src_txs.get(&kind) {
+                    let _ = src_tx.send(false);
+                }
+                // Brief pause so a source that panics on entry cannot hot-spin;
+                // the source reads unhealthy (fail-open) for the whole gap.
+                tokio::select! {
+                    () = cancel.cancelled() => break,
+                    () = tokio::time::sleep(tokio::time::Duration::from_secs(BACKOFF_BASE_SECS)) => {}
+                }
+                if let Some(src_tx) = src_txs.get(&kind) {
+                    spawn_source(&mut supervisors, &mut task_kinds, kind, src_tx.clone());
+                }
+            }
+        }
+    }
+
+    // Shutdown: the source loops observe the same token and exit, then the
+    // aggregator (also watching the token) publishes a final unhealthy.
     while supervisors.join_next().await.is_some() {}
     let _ = aggregator.await;
 
@@ -1799,8 +1890,21 @@ async fn aggregate_health(
             (SourceKind::Frigate, &frigate_rx),
             (SourceKind::Ha, &ha_rx),
         ] {
-            let Some(rx) = rx else { continue };
-            let cur = *rx.borrow();
+            if !enabled.contains(&kind) {
+                continue;
+            }
+            // An enabled source whose slot is `None` had its sender DROPPED
+            // (the source task panicked/ended and `changed_opt` cleared the
+            // slot). Its last-known health — often healthy — must never be
+            // trusted: read it as down so the gate fails open (record
+            // everything, correctness item 19) instead of leaving a
+            // Motion-mode camera gated on a dead detector. Belt-and-braces:
+            // `run` retains a sender clone and respawns dead sources, so this
+            // path only fires if the motion task itself is dying.
+            let cur = match rx {
+                Some(rx) => *rx.borrow(),
+                None => false,
+            };
             let was = last_healthy.insert(kind, cur).unwrap_or(false);
             if !cur && was {
                 down_since.insert(kind, now); // just transitioned down
@@ -1842,7 +1946,10 @@ async fn aggregate_health(
 
 /// Await the next change on an optional per-source health watch. A `None` slot
 /// never resolves (that source isn't enabled); if the sender is dropped the slot
-/// is cleared so it stops being polled.
+/// is cleared so it stops being polled — and the aggregator's scan reads a
+/// cleared ENABLED slot as down (never its stale last value), so a dead source
+/// task drives the gate to fail-open rather than freezing its last-known
+/// health (correctness item 19).
 async fn changed_opt(rx: &mut Option<tokio::sync::watch::Receiver<bool>>) {
     match rx {
         Some(r) => {
@@ -5564,5 +5671,52 @@ mod tests {
             }
             println!();
         }
+    }
+
+    // ── health aggregator: dropped source sender ⇒ fail-open ────────────────────
+
+    /// Await the camera health watch reaching `want`, with a hard timeout so a
+    /// broken aggregator fails the test instead of hanging it.
+    async fn wait_for_camera_health(rx: &mut tokio::sync::watch::Receiver<bool>, want: bool) {
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            rx.wait_for(|&v| v == want),
+        )
+        .await
+        .expect("timed out waiting for the aggregated camera health value")
+        .expect("camera health watch sender dropped");
+    }
+
+    /// A source task that panics drops its health sender without ever running
+    /// its "motion source exiting" unhealthy report. The aggregator must NOT
+    /// keep the source's last-known (healthy) reading — the gate has to fail
+    /// open (record everything, correctness item 19), never leave a
+    /// Motion-mode camera gated on a dead detector.
+    #[tokio::test]
+    async fn dropped_source_sender_drives_fail_open() {
+        let (src_tx, src_rx) = tokio::sync::watch::channel(false);
+        let (cam_tx, mut cam_rx) = tokio::sync::watch::channel(false);
+        let cancel = CancellationToken::new();
+        let aggregator = tokio::spawn(aggregate_health(
+            vec![SourceKind::Pixel],
+            Some(src_rx),
+            None,
+            None,
+            cam_tx,
+            uuid::Uuid::nil(),
+            cancel.clone(),
+        ));
+
+        // The source proves healthy → the camera is healthy (motion-gated).
+        src_tx.send(true).expect("aggregator holds the receiver");
+        wait_for_camera_health(&mut cam_rx, true).await;
+
+        // The source task "panics": its sender is dropped mid-healthy. The
+        // camera must flip to fail-open, not freeze on the stale healthy.
+        drop(src_tx);
+        wait_for_camera_health(&mut cam_rx, false).await;
+
+        cancel.cancel();
+        let _ = aggregator.await;
     }
 }

--- a/services/recorder/src/reconcile.rs
+++ b/services/recorder/src/reconcile.rs
@@ -50,7 +50,7 @@ use chrono::{DateTime, Duration, Utc};
 use crumb_common::{
     config::Config,
     db,
-    types::{SegmentStage, SegmentStream},
+    types::{RecordStream, SegmentStage, SegmentStream},
 };
 use deadpool_postgres::Pool;
 use tokio_util::sync::CancellationToken;
@@ -214,7 +214,9 @@ async fn run_periodic(pool: Pool, config: Config, shutdown: CancellationToken) {
 async fn run_background(pool: Pool, config: Config, shutdown: CancellationToken) {
     info!("reconcile phase 2: starting background pass (dangling rows + orphan indexing)");
 
-    // ── 2× segment-length, used to bound in-flight skips + duration clamps ────
+    // ── segment lengths: 1× for end_ts fallbacks + future-mtime slop, 2× to
+    //    bound in-flight skips + duration plausibility ─────────────────────────
+    let segment_len = Duration::seconds(i64::from(config.segment_seconds));
     let twice_segment = Duration::seconds(i64::from(config.segment_seconds) * 2);
 
     // ── dangling-row pass (paginated) ─────────────────────────────────────────
@@ -529,25 +531,66 @@ async fn run_background(pool: Pool, config: Config, shutdown: CancellationToken)
     };
 
     // `stage` is a RETENTION label, not a location selector — but a newly-adopted
-    // truly-orphan row still needs one. Label files found under the configured
-    // ARCHIVE-default disk as Archive; everything else (the live default and any
-    // per-policy disk) as Live (the conservative recording stage). The archive
-    // scheduler re-stages footage by policy regardless of this initial guess.
-    let archive_default_id = match db::get_storage_by_name(&pool, &config.archive_storage_name)
-        .await
-    {
-        Ok(opt) => opt.map(|s| s.id),
-        Err(e) => {
-            // Non-fatal: without it we just label everything Live (safe default).
-            warn!(error = %e, "reconcile phase 2: cannot resolve archive-default storage; labelling all orphans Live");
-            None
+    // truly-orphan row still needs one. An orphan found on an ARCHIVE destination
+    // disk must be adopted as stage=archive: labelling it Live mis-scoped its
+    // retention (archive tiers often keep footage far longer than live) and
+    // pointed the next cron archive run at a "live" segment already sitting at
+    // its archive destination (the issue-#70 family — archive.rs now also guards
+    // that self-copy, but the label should simply be right at adoption).
+    //
+    // Archive destinations are the configured ARCHIVE-default disk PLUS every
+    // policy's `archive_storage_id` (previously only the config-name default was
+    // labelled Archive, so orphans on a per-policy archive disk were adopted as
+    // Live). A storage that is ALSO a live destination (some policy's
+    // `live_storage_id`, or the configured live default — e.g. a shared
+    // live==archive directory expressed as one row) stays labelled Live, the
+    // conservative recording stage, exactly as before.
+    let mut archive_storage_ids: HashSet<Uuid> = HashSet::new();
+    let mut live_storage_ids: HashSet<Uuid> = HashSet::new();
+    match db::get_storage_by_name(&pool, &config.archive_storage_name).await {
+        Ok(opt) => {
+            if let Some(s) = opt {
+                archive_storage_ids.insert(s.id);
+            }
         }
-    };
+        Err(e) => {
+            // Non-fatal: without it we just label fewer disks Archive (safe).
+            warn!(error = %e, "reconcile phase 2: cannot resolve archive-default storage");
+        }
+    }
+    match db::get_storage_by_name(&pool, &config.live_storage_name).await {
+        Ok(opt) => {
+            if let Some(s) = opt {
+                live_storage_ids.insert(s.id);
+            }
+        }
+        Err(e) => {
+            warn!(error = %e, "reconcile phase 2: cannot resolve live-default storage");
+        }
+    }
+    match db::list_policies(&pool).await {
+        Ok(policies) => {
+            for p in &policies {
+                if let Some(id) = p.archive_storage_id {
+                    archive_storage_ids.insert(id);
+                }
+                if let Some(id) = p.live_storage_id {
+                    live_storage_ids.insert(id);
+                }
+            }
+        }
+        Err(e) => {
+            // Non-fatal: fall back to the storage-name defaults resolved above.
+            warn!(error = %e, "reconcile phase 2: cannot list policies for archive-stage labelling; using storage-name defaults only");
+        }
+    }
 
     let storages_to_scan: Vec<(Uuid, PathBuf, SegmentStage)> = all_storages
         .into_iter()
         .map(|s| {
-            let stage = if Some(s.id) == archive_default_id {
+            let is_archive_dest =
+                archive_storage_ids.contains(&s.id) && !live_storage_ids.contains(&s.id);
+            let stage = if is_archive_dest {
                 SegmentStage::Archive
             } else {
                 SegmentStage::Live
@@ -618,12 +661,14 @@ async fn run_background(pool: Pool, config: Config, shutdown: CancellationToken)
             // 2×segment_seconds of NOW is almost certainly one ffmpeg is STILL
             // writing — indexing it produced the prod 28-byte ftyp-only rows.
             // Skip it; the recorder's own boundary insert (or a later reconcile)
-            // will index it once it is complete.
+            // will index it once it is complete. A FUTURE mtime beyond one
+            // segment length of clock slop is implausible, not "recent" — see
+            // [`mtime_in_flight`] — and must not gate the file forever.
             match tokio::fs::metadata(&abs_path).await {
                 Ok(meta) => {
                     if let Ok(mtime) = meta.modified() {
                         let mtime_utc: DateTime<Utc> = mtime.into();
-                        if Utc::now() - mtime_utc < twice_segment {
+                        if mtime_in_flight(Utc::now(), mtime_utc, segment_len, twice_segment) {
                             debug!(
                                 path = %rel_path,
                                 "orphan file modified too recently (in-flight); skipping this boot"
@@ -691,6 +736,7 @@ async fn run_background(pool: Pool, config: Config, shutdown: CancellationToken)
             entry.storage_id,
             &entry.rel_path,
             &entry.stage,
+            segment_len,
             twice_segment,
         )
         .await
@@ -796,6 +842,33 @@ enum OrphanOutcome {
     NotIndexable,
 }
 
+/// In-flight gate for the ORPHAN pass: `true` when `mtime` says the file may
+/// still be actively written, so adoption must wait for a later pass.
+///
+/// A file modified within `twice_segment` of `now` is almost certainly one
+/// ffmpeg is still writing (indexing those produced the prod 28-byte ftyp-only
+/// rows). But an mtime more than one segment length in the FUTURE is not
+/// "recent" — it is implausible (a clock step, a copied/restored file) — and
+/// the pre-fix arithmetic (`now - mtime < twice_segment`, which is trivially
+/// true when the difference is negative) kept such files "in flight" FOREVER:
+/// never adopted, never counted toward any budget, silently eating disk
+/// (issue #84). Treat them as settled and adoptable; [`try_index_orphan`]
+/// already ignores an implausible mtime and derives timestamps from the
+/// filename. Up to one segment length of future skew is still tolerated as
+/// ordinary clock slop (a segment being written right now legitimately carries
+/// an mtime a moment ahead of a slightly-behind reader clock).
+fn mtime_in_flight(
+    now: DateTime<Utc>,
+    mtime: DateTime<Utc>,
+    segment_len: Duration,
+    twice_segment: Duration,
+) -> bool {
+    if mtime > now + segment_len {
+        return false; // implausible future mtime — settled, adoptable
+    }
+    now - mtime < twice_segment
+}
+
 /// Attempt to index an orphan file.
 ///
 /// Returns [`OrphanOutcome::Indexed`] if a new row was inserted,
@@ -804,8 +877,12 @@ enum OrphanOutcome {
 /// is genuine junk (caller should quarantine), or `Err` on a database /
 /// filesystem error.
 ///
+/// `segment_len` is the nominal segment length (the `end_ts` fallback);
+/// `max_segment_len` (2×) is the mtime plausibility window only.
+///
 /// The path structure is expected to be:
 /// `{storage_root}/{camera_id}/{YYYY}/{MM}/{DD}/{timestamp}.mp4`
+#[allow(clippy::too_many_arguments)]
 async fn try_index_orphan(
     pool: &Pool,
     abs_path: &Path,
@@ -813,6 +890,7 @@ async fn try_index_orphan(
     storage_id: Uuid,
     rel_path: &str,
     stage: &SegmentStage,
+    segment_len: Duration,
     max_segment_len: Duration,
 ) -> Result<OrphanOutcome> {
     // Parse the segment start timestamp from the filename.
@@ -853,8 +931,9 @@ async fn try_index_orphan(
         }
     };
 
-    // Verify the camera exists in the DB.
-    match db::get_camera(pool, camera_id).await {
+    // Verify the camera exists in the DB (and keep it: its effective policy
+    // tells us which stream this camera records — issue #84 below).
+    let camera = match db::get_camera(pool, camera_id).await {
         Ok(None) => {
             warn!(
                 camera_id = %camera_id,
@@ -866,8 +945,8 @@ async fn try_index_orphan(
         Err(e) => {
             return Err(e.context("looking up camera for orphan indexing"));
         }
-        Ok(Some(_)) => {}
-    }
+        Ok(Some(cam)) => cam,
+    };
 
     // Get file size.
     let metadata = tokio::fs::metadata(abs_path)
@@ -890,8 +969,11 @@ async fn try_index_orphan(
     // For end_ts: use the file's modification time as a best-effort estimate,
     // CLAMPED so a reset/copied mtime can't manufacture a multi-hour duration
     // (audit GAP / P1 #6 — prod had 806 rows up to 49h). Falls back to
-    // start_ts + segment length when mtime is unavailable or implausible.
-    let fallback_end = start_ts + max_segment_len;
+    // start_ts + ONE nominal segment length when mtime is unavailable or
+    // implausible — NOT the 2× plausibility window, which would manufacture a
+    // double-length segment (issue #84); 2× is only how far an mtime may
+    // legitimately land past start_ts (a real segment can run somewhat long).
+    let fallback_end = start_ts + segment_len;
     let end_ts = match metadata.modified() {
         Ok(mtime) => {
             let mtime_utc: DateTime<Utc> = mtime.into();
@@ -908,12 +990,23 @@ async fn try_index_orphan(
 
     let duration_ms = (end_ts - start_ts).num_milliseconds().max(0) as i32;
 
+    // Adopt with the STREAM the camera's effective policy actually records
+    // (issue #84): hardcoding Main mislabelled sub-stream cameras' footage and
+    // weakened the (camera_id, stream, start_ts) AlreadyIndexed guard — a
+    // sub-stream camera's real row never collided with a Main-labelled adopt.
+    // The RecordStream→SegmentStream mapping is total, so Main remains the
+    // value only for cameras that record main (the previous default).
+    let stream = match camera.policy.record_stream {
+        RecordStream::Main => SegmentStream::Main,
+        RecordStream::Sub => SegmentStream::Sub,
+    };
+
     let params = db::InsertSegmentParams {
         camera_id,
         storage_id,
         stage: *stage,
         path: rel_path.to_owned(),
-        stream: SegmentStream::Main, // conservative default — main stream is recorded
+        stream,
         start_ts,
         end_ts,
         duration_ms,
@@ -1161,13 +1254,16 @@ mod tests {
 
     /// Pure-logic test of the mtime-derived-duration clamp the orphan reindexer
     /// applies (audit P1 #6). Mirrors `try_index_orphan`'s clamp arithmetic so the
-    /// boundary is verifiable without a DB/filesystem.
+    /// boundary is verifiable without a DB/filesystem: the fallback is ONE
+    /// nominal segment length; `max_segment_len` (2×) is only the plausibility
+    /// window an observed mtime may land in (issue #84).
     fn clamp_end_ts(
         start_ts: DateTime<Utc>,
         mtime: DateTime<Utc>,
+        segment_len: Duration,
         max_segment_len: Duration,
     ) -> DateTime<Utc> {
-        let fallback = start_ts + max_segment_len;
+        let fallback = start_ts + segment_len;
         if mtime <= start_ts || (mtime - start_ts) > max_segment_len {
             fallback
         } else {
@@ -1178,18 +1274,80 @@ mod tests {
     #[test]
     fn orphan_clamps_absurd_mtime_duration() {
         let start = Utc::now() - Duration::hours(50);
-        let seg_len = Duration::seconds(8); // 2× a 4s segment
-                                            // A 49h mtime (copied/recovered file) must clamp to start+seg_len.
+        let seg_len = Duration::seconds(4); // nominal segment
+        let window = Duration::seconds(8); // 2× plausibility window
+
+        // A 49h mtime (copied/recovered file) must clamp to the fallback.
         let bad_mtime = start + Duration::hours(49);
-        assert_eq!(clamp_end_ts(start, bad_mtime, seg_len), start + seg_len);
-        // mtime before start → also fallback.
         assert_eq!(
-            clamp_end_ts(start, start - Duration::seconds(1), seg_len),
+            clamp_end_ts(start, bad_mtime, seg_len, window),
             start + seg_len
         );
-        // A plausible mtime (within seg_len) is kept verbatim.
-        let good = start + Duration::seconds(4);
-        assert_eq!(clamp_end_ts(start, good, seg_len), good);
+        // mtime before start → also fallback.
+        assert_eq!(
+            clamp_end_ts(start, start - Duration::seconds(1), seg_len, window),
+            start + seg_len
+        );
+        // A plausible mtime (within the 2× window) is kept verbatim — even one
+        // somewhat past the nominal length (a real segment can run long).
+        let good = start + Duration::seconds(6);
+        assert_eq!(clamp_end_ts(start, good, seg_len, window), good);
+    }
+
+    /// Issue #84: the end_ts FALLBACK is one NOMINAL segment, not the 2×
+    /// plausibility window — the old code manufactured a double-length
+    /// duration for every adopted orphan whose mtime was implausible.
+    #[test]
+    fn orphan_end_ts_fallback_is_one_segment_not_double() {
+        let start = Utc::now() - Duration::hours(50);
+        let seg_len = Duration::seconds(4);
+        let window = Duration::seconds(8);
+        let implausible = start + Duration::hours(49);
+        let end = clamp_end_ts(start, implausible, seg_len, window);
+        assert_eq!(
+            end,
+            start + seg_len,
+            "fallback must be start + segment_seconds"
+        );
+        assert_ne!(
+            end,
+            start + window,
+            "fallback must NOT be the 2× window (the manufactured 2×-duration bug)"
+        );
+    }
+
+    /// Issue #84: the orphan in-flight gate must not skip FUTURE-mtime files
+    /// forever. Pre-fix, `now - mtime` was negative for any future mtime and
+    /// therefore always `< twice_segment`, so the file was gated on EVERY
+    /// pass — never adopted, never counted, silently eating disk.
+    #[test]
+    fn inflight_gate_treats_far_future_mtime_as_adoptable() {
+        let now = Utc::now();
+        let seg = Duration::seconds(4);
+        let twice = Duration::seconds(8);
+
+        // Just written → genuinely in flight.
+        assert!(mtime_in_flight(now, now, seg, twice));
+        // Written 1s ago → still in flight.
+        assert!(mtime_in_flight(now, now - Duration::seconds(1), seg, twice));
+        // Settled (older than the 2× window) → adoptable.
+        assert!(!mtime_in_flight(
+            now,
+            now - Duration::seconds(9),
+            seg,
+            twice
+        ));
+        // Slight future skew (within one segment of clock slop) → still gated.
+        assert!(mtime_in_flight(now, now + Duration::seconds(3), seg, twice));
+        // FAR-future mtime (beyond one segment ahead): implausible, must be
+        // treated as settled/adoptable instead of gated forever.
+        assert!(!mtime_in_flight(now, now + Duration::hours(5), seg, twice));
+        assert!(!mtime_in_flight(
+            now,
+            now + Duration::seconds(5),
+            seg,
+            twice
+        ));
     }
 
     /// Prefers `CRUMB_TEST_DATABASE_URL`, falling back to the workspace-wide
@@ -1806,6 +1964,7 @@ mod tests {
             disk_b.id,
             &rel_path,
             &SegmentStage::Live,
+            Duration::seconds(15),
             Duration::seconds(30),
         )
         .await
@@ -2013,6 +2172,157 @@ mod tests {
             .expect("row must still exist — dangling re-verify must not delete a row whose file is present");
         assert!(row.path.ends_with(filename));
         assert!(abs_path.exists(), "file itself must be untouched");
+    }
+
+    /// Issue #84: orphan adoption must index with the STREAM the camera's
+    /// effective policy actually records — hardcoding Main mislabelled
+    /// sub-stream cameras' footage and weakened the (camera_id, stream,
+    /// start_ts) AlreadyIndexed guard.
+    #[tokio::test]
+    async fn orphan_adoption_uses_policy_record_stream() {
+        let Some(url) = test_db_url() else {
+            eprintln!("skipping: CRUMB_TEST_DATABASE_URL not set");
+            return;
+        };
+        let fx = setup_reconcile(&url).await;
+
+        // Flip the camera's effective policy to record the SUB stream.
+        {
+            let client = fx.pool.get().await.expect("conn");
+            client
+                .execute("UPDATE recording_policies SET record_stream = 'sub'", &[])
+                .await
+                .expect("set record_stream = sub");
+        }
+
+        let live = crumb_common::db::get_storage_by_name(&fx.pool, "NVMe-Live")
+            .await
+            .expect("get live storage")
+            .expect("live storage exists");
+
+        let cam_dir = fx.live_path.join(fx.camera_id.to_string());
+        tokio::fs::create_dir_all(&cam_dir)
+            .await
+            .expect("mkdir cam");
+        let filename = "20260101T000100Z.mp4";
+        let abs_path = cam_dir.join(filename);
+        tokio::fs::write(&abs_path, vec![0u8; 4096])
+            .await
+            .expect("write orphan");
+        backdate(&abs_path, 3600).await;
+
+        let rel_path = format!("{}/{filename}", fx.camera_id);
+        let outcome = try_index_orphan(
+            &fx.pool,
+            &abs_path,
+            &fx.live_path,
+            live.id,
+            &rel_path,
+            &SegmentStage::Live,
+            Duration::seconds(15),
+            Duration::seconds(30),
+        )
+        .await
+        .expect("try_index_orphan must not error");
+        assert_eq!(outcome, OrphanOutcome::Indexed, "truly-orphan key adopted");
+
+        let rows = crumb_common::db::list_all_segments_for_camera(&fx.pool, fx.camera_id)
+            .await
+            .expect("list segments");
+        assert_eq!(rows.len(), 1, "one adopted row: {rows:?}");
+        assert_eq!(
+            rows[0].stream,
+            SegmentStream::Sub,
+            "adopted orphan must carry the policy's record_stream (sub), not a hardcoded Main"
+        );
+    }
+
+    /// Issue #70 family: an orphan found on an ARCHIVE destination disk (a
+    /// policy's `archive_storage_id`, not just the config-name default) must be
+    /// adopted as stage=archive — pre-fix it was labelled Live, which
+    /// mis-scoped its retention and pointed the next cron archive run at a
+    /// "live" segment already sitting at its archive destination. A control
+    /// orphan on the live disk stays stage=live.
+    #[tokio::test]
+    async fn orphan_on_policy_archive_storage_adopts_as_archive_stage() {
+        let Some(url) = test_db_url() else {
+            eprintln!("skipping: CRUMB_TEST_DATABASE_URL not set");
+            return;
+        };
+        let fx = setup_reconcile(&url).await;
+        let config = recon_config();
+
+        // A per-policy archive disk that is NOT the config-name default
+        // ("Bulk-Archive") — the case the old labelling missed.
+        let policy_arch_dir = tempfile::Builder::new()
+            .prefix("crumb-recon-policy-arch")
+            .tempdir()
+            .expect("policy archive tmp");
+        let policy_arch = crumb_common::db::upsert_storage(
+            &fx.pool,
+            "Policy-Archive",
+            policy_arch_dir.path().to_str().expect("utf8"),
+        )
+        .await
+        .expect("policy archive storage");
+        {
+            let client = fx.pool.get().await.expect("conn");
+            client
+                .execute(
+                    "UPDATE recording_policies SET archive_storage_id = $1",
+                    &[&policy_arch.id],
+                )
+                .await
+                .expect("point policy at the archive storage");
+        }
+
+        // Orphan on the POLICY ARCHIVE disk → must adopt as stage=archive.
+        let arch_cam_dir = policy_arch_dir.path().join(fx.camera_id.to_string());
+        tokio::fs::create_dir_all(&arch_cam_dir)
+            .await
+            .expect("mkdir arch cam");
+        let arch_file = arch_cam_dir.join("20260101T000200Z.mp4");
+        tokio::fs::write(&arch_file, vec![0u8; 4096])
+            .await
+            .expect("write archive orphan");
+        backdate(&arch_file, 3600).await;
+
+        // Control orphan on the LIVE disk → must adopt as stage=live.
+        let live_cam_dir = fx.live_path.join(fx.camera_id.to_string());
+        tokio::fs::create_dir_all(&live_cam_dir)
+            .await
+            .expect("mkdir live cam");
+        let live_file = live_cam_dir.join("20260101T000210Z.mp4");
+        tokio::fs::write(&live_file, vec![0u8; 4096])
+            .await
+            .expect("write live orphan");
+        backdate(&live_file, 3600).await;
+
+        run_background(fx.pool.clone(), config, CancellationToken::new()).await;
+
+        let rows = crumb_common::db::list_all_segments_for_camera(&fx.pool, fx.camera_id)
+            .await
+            .expect("list segments");
+        let by_suffix = |suffix: &str| {
+            rows.iter()
+                .find(|r| r.path.ends_with(suffix))
+                .unwrap_or_else(|| panic!("adopted row for {suffix} missing: {rows:?}"))
+        };
+
+        let arch_row = by_suffix("20260101T000200Z.mp4");
+        assert_eq!(
+            arch_row.stage,
+            SegmentStage::Archive,
+            "orphan on a policy archive disk must be adopted as stage=archive"
+        );
+        assert_eq!(arch_row.storage_id, policy_arch.id);
+
+        let live_row = by_suffix("20260101T000210Z.mp4");
+        assert_eq!(
+            live_row.stage,
+            SegmentStage::Live,
+            "orphan on the live disk must stay stage=live"
+        );
     }
 
     /// Set a file's mtime `secs_ago` seconds into the past so it falls OUTSIDE

--- a/services/recorder/src/reconcile.rs
+++ b/services/recorder/src/reconcile.rs
@@ -319,9 +319,19 @@ async fn run_background(pool: Pool, config: Config, shutdown: CancellationToken)
                     // The recorder's own boundary insert keeps the row accurate
                     // meanwhile. This matters now that reconcile runs periodically,
                     // not just at a quiescent startup.
+                    //
+                    // #84 follow-up: this gate must use the SAME future-mtime-aware
+                    // helper as the orphan pass ([`mtime_in_flight`]). The raw
+                    // `now - mtime < twice_segment` check it previously used is
+                    // trivially true for ANY future mtime (the difference is
+                    // negative), so after a backwards clock step the file was
+                    // "in flight" on every pass FOREVER — a torn 28-byte skeleton
+                    // row+file was never reconciled. An mtime more than one segment
+                    // length in the future is implausible, not "recent": treat it
+                    // as settled and reconcile it normally.
                     if let Ok(mtime) = meta.modified() {
                         let mtime_utc: DateTime<Utc> = mtime.into();
-                        if Utc::now() - mtime_utc < twice_segment {
+                        if mtime_in_flight(Utc::now(), mtime_utc, segment_len, twice_segment) {
                             debug!(
                                 segment_id = %seg.id,
                                 path = %abs_path.display(),
@@ -842,8 +852,9 @@ enum OrphanOutcome {
     NotIndexable,
 }
 
-/// In-flight gate for the ORPHAN pass: `true` when `mtime` says the file may
-/// still be actively written, so adoption must wait for a later pass.
+/// In-flight gate shared by the ORPHAN pass and the DANGLING-ROW pass: `true`
+/// when `mtime` says the file may still be actively written, so adoption (or a
+/// row mutation / sub-floor delete) must wait for a later pass.
 ///
 /// A file modified within `twice_segment` of `now` is almost certainly one
 /// ffmpeg is still writing (indexing those produced the prod 28-byte ftyp-only
@@ -1811,6 +1822,79 @@ mod tests {
         );
     }
 
+    /// #84 follow-up: the DANGLING-ROW pass's in-flight gate must be
+    /// future-mtime-aware, exactly like the orphan pass. Pre-fix it used the
+    /// raw `now - mtime < twice_segment` arithmetic, which is trivially true
+    /// for ANY future mtime (negative difference) — so after a backwards clock
+    /// step a torn 28-byte skeleton whose row claimed a full segment was
+    /// "in flight" on EVERY pass, forever: never size-repaired, never removed.
+    /// With [`mtime_in_flight`] a far-future mtime is implausible → settled →
+    /// the sub-floor branch reconciles it (file + row deleted).
+    #[tokio::test]
+    async fn dangling_pass_reconciles_future_mtime_file_instead_of_gating_forever() {
+        let Some(url) = test_db_url() else {
+            eprintln!("skipping: CRUMB_TEST_DATABASE_URL not set");
+            return;
+        };
+        let fx = setup_reconcile(&url).await;
+        let config = recon_config(); // segment_seconds = 4 → slop allowance = 4s
+
+        let cam_dir = fx.live_path.join(fx.camera_id.to_string());
+        tokio::fs::create_dir_all(&cam_dir)
+            .await
+            .expect("mkdir cam");
+
+        let live = crumb_common::db::get_storage_by_name(&fx.pool, "NVMe-Live")
+            .await
+            .expect("get live storage")
+            .expect("live storage exists");
+
+        // A 28-byte torn skeleton whose row claims a full 800KB segment, with
+        // an mtime 5 HOURS in the future — far beyond the one-segment clock
+        // slop mtime_in_flight tolerates.
+        let torn = cam_dir.join("20260101T000000Z.mp4");
+        tokio::fs::write(&torn, vec![0u8; 28])
+            .await
+            .expect("write torn skeleton");
+        futuredate(&torn, 5 * 3600).await;
+        crumb_common::db::insert_segment(
+            &fx.pool,
+            &crumb_common::db::InsertSegmentParams {
+                camera_id: fx.camera_id,
+                storage_id: live.id,
+                stage: SegmentStage::Live,
+                path: format!("{}/20260101T000000Z.mp4", fx.camera_id),
+                stream: SegmentStream::Main,
+                start_ts: "2026-01-01T00:00:00Z".parse().expect("start ts"),
+                end_ts: "2026-01-01T00:00:04Z".parse().expect("end ts"),
+                duration_ms: 4000,
+                has_motion: false,
+                motion_score: 0.0,
+                size_bytes: 800_000, // the row's claim; on disk it is 28 bytes
+                motion_bbox: None,
+            },
+        )
+        .await
+        .expect("insert torn row");
+
+        run_background(fx.pool.clone(), config, CancellationToken::new()).await;
+
+        // Post-fix: the future mtime does NOT gate the file; the sub-floor
+        // branch removes the unusable file + its row in one pass. Pre-fix both
+        // survived every pass indefinitely.
+        assert!(
+            !torn.exists(),
+            "a far-future-mtime torn file must be reconciled (deleted), not gated forever"
+        );
+        let rows = crumb_common::db::list_all_segments_for_camera(&fx.pool, fx.camera_id)
+            .await
+            .unwrap();
+        assert!(
+            rows.is_empty(),
+            "the torn row must be deleted, not kept alive by the in-flight gate: {rows:?}"
+        );
+    }
+
     /// R3b regression: a PERSISTENTLY sub-floor file — one whose row was ALSO
     /// indexed at the sub-floor size (`on_disk == seg.size_bytes`, both 28
     /// bytes) — must still be deleted. Before the fix, the sub-floor check
@@ -2328,7 +2412,26 @@ mod tests {
     /// Set a file's mtime `secs_ago` seconds into the past so it falls OUTSIDE
     /// the in-flight window. Uses `filetime`-free approach via std on Unix.
     async fn backdate(path: &Path, secs_ago: u64) {
-        let when = std::time::SystemTime::now() - std::time::Duration::from_secs(secs_ago);
+        set_mtime(
+            path,
+            std::time::SystemTime::now() - std::time::Duration::from_secs(secs_ago),
+        )
+        .await;
+    }
+
+    /// Set a file's mtime `secs_ahead` seconds into the FUTURE — models a
+    /// backwards clock step / restored file whose mtime is ahead of the
+    /// recorder's clock (issue #84).
+    async fn futuredate(path: &Path, secs_ahead: u64) {
+        set_mtime(
+            path,
+            std::time::SystemTime::now() + std::time::Duration::from_secs(secs_ahead),
+        )
+        .await;
+    }
+
+    /// Shared mtime setter for [`backdate`] / [`futuredate`].
+    async fn set_mtime(path: &Path, when: std::time::SystemTime) {
         let path = path.to_path_buf();
         let ft = when;
         tokio::task::spawn_blocking(move || {
@@ -2362,6 +2465,6 @@ mod tests {
             }
         })
         .await
-        .expect("backdate join");
+        .expect("set_mtime join");
     }
 }

--- a/services/recorder/src/recording.rs
+++ b/services/recorder/src/recording.rs
@@ -296,15 +296,25 @@ pub async fn run(
         )
         .await;
 
-        if indexed_ok && backoff != BACKOFF_INIT {
+        // "Stream healthy again" is determined by `saw_segment` (ffmpeg produced
+        // at least one segment-list line this run), NOT `indexed_ok` (a segment
+        // was KEPT). A Motion-mode camera on a healthy stream with no motion
+        // rings/discards every segment and never indexes one, so keying the
+        // reset on `indexed_ok` left its backoff ratcheting toward BACKOFF_MAX
+        // (30s) across idle-night blips forever — and a real event starting
+        // during one of those 30s windows lost its opening seconds with an empty
+        // pre-roll ring. A stream that demonstrably produced and processed
+        // segments is healthy regardless of the keep/discard verdict.
+        let stream_healthy = saw_segment;
+        if stream_healthy && backoff != BACKOFF_INIT {
             debug!(
                 camera_id   = %camera.id,
                 camera_name = %camera.name,
-                "stream healthy again (segment indexed); resetting reconnect backoff"
+                "stream healthy again (segments produced); resetting reconnect backoff"
             );
             backoff = BACKOFF_INIT;
         }
-        if indexed_ok {
+        if stream_healthy {
             // A confirmed-healthy stream is by definition not in the cold-start
             // window anymore; a later failure starts the fast-retry count fresh.
             cold_start_retries = 0;
@@ -803,14 +813,28 @@ async fn run_ffmpeg_loop(
     // unconditionally and log at debug level.
     let camera_id_for_stderr = camera.id;
     let stderr_drain = tokio::spawn(async move {
+        // Drain BYTES, not UTF-8 lines. ffmpeg warning lines can contain
+        // non-UTF-8 bytes (camera-supplied stream metadata); `read_line`
+        // returns InvalidData on those and the old `break` closed the pipe
+        // under the LIVE recording child — the ~64 KB stderr buffer then fills,
+        // ffmpeg blocks writing video, and the stdout segment reader blocks →
+        // deadlock (correctness item 5). The task's contract is "keep the pipe
+        // empty until EOF", not "log every line", so we read raw bytes, lossy-
+        // decode only for the debug log, and CONTINUE (bounded) on an IO error
+        // instead of breaking. (#76 fixed the go2rtc and motion drains the same
+        // way; this recording-child drain was missed in the first pass.)
+        const MAX_CONSECUTIVE_ERRORS: u32 = 100;
         let mut reader = BufReader::new(ffmpeg_stderr);
-        let mut line = String::new();
+        let mut buf: Vec<u8> = Vec::with_capacity(256);
+        let mut consecutive_errors: u32 = 0;
         loop {
-            line.clear();
-            match reader.read_line(&mut line).await {
-                Ok(0) => break, // EOF
+            buf.clear();
+            match reader.read_until(b'\n', &mut buf).await {
+                Ok(0) => break, // EOF — child's stderr closed
                 Ok(_) => {
-                    let trimmed = line.trim_end();
+                    consecutive_errors = 0;
+                    let text = String::from_utf8_lossy(&buf);
+                    let trimmed = text.trim_end();
                     if !trimmed.is_empty() {
                         debug!(
                             camera_id = %camera_id_for_stderr,
@@ -820,12 +844,18 @@ async fn run_ffmpeg_loop(
                     }
                 }
                 Err(e) => {
-                    debug!(
-                        camera_id = %camera_id_for_stderr,
-                        error = %e,
-                        "error reading ffmpeg recording stderr"
-                    );
-                    break;
+                    // A pathologically erroring fd is bounded so teardown
+                    // (`stderr_drain.await`) can never hang.
+                    consecutive_errors += 1;
+                    if consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
+                        debug!(
+                            camera_id = %camera_id_for_stderr,
+                            error = %e,
+                            "ffmpeg recording stderr drain giving up after repeated errors"
+                        );
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_millis(10)).await;
                 }
             }
         }
@@ -1531,9 +1561,6 @@ pub(crate) fn redact_rtsp_credentials(url: &str) -> String {
     }
 }
 
-/// Read one line from the segment-list stdout reader.
-///
-/// Returns `Ok(None)` on EOF, `Ok(Some(line))` on a line, `Err` on IO error.
 /// Drain all currently-available items from `motion_rx` into `out`.
 ///
 /// This is non-blocking: it empties the channel without yielding or sleeping.
@@ -1589,7 +1616,10 @@ async fn drain_and_persist_motion(
             // Recording is a re-trigger; a STOP on Idle is stale-ignored), so
             // this can only make the buffer persist MORE, never less.
             if let Some(replay) = motion_union.take_pending_replay() {
-                let d = buf.apply_signal(&replay);
+                // apply_replayed_edge (not apply_signal): a replayed STOP onto an
+                // Idle buffer means a full event ran inside the frozen window and
+                // we owe its post-roll → PostBuffer, not stale-ignore (#74).
+                let d = buf.apply_replayed_edge(&replay);
                 decision.persist.extend(d.persist);
                 decision.discard.extend(d.discard);
             }
@@ -1598,6 +1628,21 @@ async fn drain_and_persist_motion(
                 // the FIRST open and a falling edge on the LAST close reach apply_signal.
                 if let Some(union_sig) = motion_union.fold(sig) {
                     let d = buf.apply_signal(&union_sig);
+                    decision.persist.extend(d.persist);
+                    decision.discard.extend(d.discard);
+                } else if sig.stopped_at.is_some()
+                    && motion_union.open.is_empty()
+                    && matches!(buf.state, MotionBufferState::Idle)
+                {
+                    // Unmatched STOP while the union AND the buffer are idle: its
+                    // matching START was lost to channel overflow, so fail-open
+                    // (the #81 loss debt) held health false and persisted the
+                    // event body directly, the union never opened, and fold()
+                    // returned None. The debt clears at exactly this accepted STOP
+                    // (main.rs #5), so without this the post-roll would drop —
+                    // treat it as a synthetic PostBuffer trigger (persist-more).
+                    // This is the recording.rs half of the #5 coordination.
+                    let d = buf.apply_replayed_edge(sig);
                     decision.persist.extend(d.persist);
                     decision.discard.extend(d.discard);
                 }
@@ -2810,6 +2855,30 @@ impl MotionBuffer {
         }
     }
 
+    /// Apply a union edge REPLAYED after a fail-open freeze thaws (#74). Differs
+    /// from [`apply_signal`](Self::apply_signal) in exactly one cell: a STOP
+    /// replayed while the buffer is Idle. A *fresh* STOP while Idle is a spurious
+    /// stop with no matching START and is correctly ignored — but a *replayed*
+    /// STOP while Idle means a full motion event opened AND closed inside the
+    /// unhealthy window (fail-open already persisted its body directly) and we
+    /// are now in its post-roll, so the buffer must enter `PostBuffer` to keep
+    /// segments within `motion_post_seconds` after the stop (MOTION-RECORDING.md
+    /// §4's post-roll keep verdict; invariant #19). The ring is empty at thaw
+    /// (#77 drains it on the transition), so this can only persist MORE, never
+    /// discard. Every other case (a START replay, or a STOP replay while already
+    /// Recording/PostBuffer) is identical to `apply_signal`.
+    pub fn apply_replayed_edge(&mut self, signal: &MotionSignal) -> MotionDecision {
+        if let Some(stopped_at) = signal.stopped_at {
+            if matches!(self.state, MotionBufferState::Idle) {
+                self.state = MotionBufferState::PostBuffer {
+                    motion_stopped: stopped_at,
+                };
+                return MotionDecision::empty();
+            }
+        }
+        self.apply_signal(signal)
+    }
+
     /// Evict pre-buffer segments older than `pre_seconds + RING_SLACK_SECS` to
     /// bound memory, returning the evicted segments as discards (RAM
     /// pre-buffer mode: an aged-out cache segment is deleted, never written to
@@ -2902,6 +2971,30 @@ impl MotionUnion {
     /// `None` for a re-trigger / an unmatched STOP / an interleaved edge that
     /// leaves the union state unchanged.
     pub fn fold(&mut self, sig: &MotionSignal) -> Option<MotionSignal> {
+        // Wedge net (#7): before processing, expire any open source key older
+        // than MAX_OPEN_SIGNAL_SECS relative to this signal's time. A source
+        // whose STOP was lost (channel overflow at the STOP edge, or a source
+        // dropped mid-event) would otherwise keep its `started_at` in `open`
+        // forever, so the union never falls to zero and the MotionBuffer stays
+        // pinned in Recording 24/7 on a "healthy" Motion-mode camera. Expiring
+        // here re-syncs the union whenever any later signal arrives; the buffer
+        // then leaves Recording on the next real STOP. (A camera that goes
+        // permanently silent immediately after a lost STOP keeps over-recording
+        // until the next signal — disk waste bounded by retention, never footage
+        // loss, the fail-open-safe direction.)
+        let now = sig.stopped_at.unwrap_or(sig.started_at);
+        let cutoff = now - chrono::Duration::seconds(MAX_OPEN_SIGNAL_SECS);
+        let before_len = self.open.len();
+        self.open.retain(|k| *k >= cutoff);
+        if self.open.len() != before_len {
+            warn!(
+                expired = before_len - self.open.len(),
+                "MotionUnion: expired stale open key(s) with no STOP within MAX_OPEN_SIGNAL_SECS"
+            );
+            if self.open.is_empty() {
+                self.union_started_at = None;
+            }
+        }
         match sig.stopped_at {
             None => {
                 // START: union rises only on the first open.
@@ -3316,12 +3409,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn full_event_inside_unhealthy_window_is_a_noop_replay_on_thaw() {
+    async fn full_event_inside_unhealthy_window_replays_stop_into_post_buffer() {
         // #74 boundary: an event opens AND closes entirely inside the frozen
-        // window (its footage was persisted directly by fail-open). Only the
-        // newest edge (the STOP) is stashed; replaying it onto an Idle buffer
-        // is stale-ignored — no state change, no discard, and the union ends
-        // consistent (empty).
+        // window (its body was persisted directly by fail-open). Only the newest
+        // edge (the STOP) is stashed. On thaw, replaying that STOP onto the Idle
+        // buffer must enter PostBuffer — NOT stale-ignore it — so the event's
+        // post-roll (segments within motion_post_seconds after the stop) is kept
+        // (MOTION-RECORDING.md §4). The union ends consistent (empty).
         let (tx, mut rx) = motion_channel();
         let mut buf = MotionBuffer::new(5, 10);
         let mut union = MotionUnion::default();
@@ -3336,10 +3430,46 @@ mod tests {
         let mut d2 = MotionDecision::empty();
         drain_and_persist_motion(&mut rx, &mut out, Some(&mut buf), &mut union, &mut d2).await;
         assert!(
-            matches!(buf.state, MotionBufferState::Idle),
-            "a stale replayed STOP on an Idle buffer must be ignored"
+            matches!(buf.state, MotionBufferState::PostBuffer { .. }),
+            "a replayed STOP after a full in-window event must enter PostBuffer to keep the post-roll"
         );
+        // The ring was empty at thaw (fail-open persisted the body directly), so
+        // entering PostBuffer produces no immediate persist/discard here — the
+        // post-roll is kept by subsequent push_segment calls within the window.
         assert!(d2.persist.is_empty() && d2.discard.is_empty());
+    }
+
+    #[test]
+    fn motion_union_expires_stale_open_key_on_later_signal() {
+        // #7 wedge net: source A opens, its STOP is lost, then much later another
+        // signal arrives. The stale A key must be expired so the union is not
+        // pinned open forever (which would hold the buffer Recording 24/7).
+        let mut union = MotionUnion::default();
+        let t0 = utc(2026, 1, 1, 0, 0, 0);
+        let a_start = make_signal(t0, None);
+        assert!(
+            union.fold(&a_start).is_some(),
+            "first open emits a union START"
+        );
+        assert_eq!(union.open.len(), 1);
+
+        // A's STOP is lost; > MAX_OPEN_SIGNAL_SECS later, source B opens.
+        let late = t0 + chrono::Duration::seconds(MAX_OPEN_SIGNAL_SECS + 60);
+        let b_start = make_signal(late, None);
+        assert!(
+            union.fold(&b_start).is_some(),
+            "B is a fresh first-open once the stale A key is expired"
+        );
+        assert_eq!(
+            union.open.len(),
+            1,
+            "only B remains; the stale A key was expired, not left pinning the union"
+        );
+
+        // B closes cleanly → union falls to empty (no stuck-open key).
+        let b_stop = make_signal(late, Some(late + chrono::Duration::seconds(4)));
+        assert!(union.fold(&b_stop).is_some(), "B's STOP closes the union");
+        assert!(union.open.is_empty());
     }
 
     // ── prune_pending_signals (the "stuck motion" regression) ───────────────────

--- a/services/recorder/src/recording.rs
+++ b/services/recorder/src/recording.rs
@@ -1664,6 +1664,14 @@ async fn drain_and_persist_motion(
             for sig in &out[before..] {
                 if let Some(union_sig) = motion_union.fold(sig) {
                     motion_union.stash_replay(union_sig);
+                } else if sig.stopped_at.is_some() && motion_union.open.is_empty() {
+                    // Unmatched STOP (its START was lost to channel overflow, so
+                    // the union never opened) drained while the buffer is frozen.
+                    // Stash it so the thaw replay turns it into a PostBuffer
+                    // trigger (apply_replayed_edge keeps the post-roll) — the
+                    // frozen-window twin of the healthy-arm #5 coordination
+                    // above. Newest-edge-wins: a later real START supersedes it.
+                    motion_union.stash_replay(sig.clone());
                 }
             }
         }
@@ -2971,30 +2979,24 @@ impl MotionUnion {
     /// `None` for a re-trigger / an unmatched STOP / an interleaved edge that
     /// leaves the union state unchanged.
     pub fn fold(&mut self, sig: &MotionSignal) -> Option<MotionSignal> {
-        // Wedge net (#7): before processing, expire any open source key older
-        // than MAX_OPEN_SIGNAL_SECS relative to this signal's time. A source
-        // whose STOP was lost (channel overflow at the STOP edge, or a source
-        // dropped mid-event) would otherwise keep its `started_at` in `open`
-        // forever, so the union never falls to zero and the MotionBuffer stays
-        // pinned in Recording 24/7 on a "healthy" Motion-mode camera. Expiring
-        // here re-syncs the union whenever any later signal arrives; the buffer
-        // then leaves Recording on the next real STOP. (A camera that goes
-        // permanently silent immediately after a lost STOP keeps over-recording
-        // until the next signal — disk waste bounded by retention, never footage
-        // loss, the fail-open-safe direction.)
-        let now = sig.stopped_at.unwrap_or(sig.started_at);
-        let cutoff = now - chrono::Duration::seconds(MAX_OPEN_SIGNAL_SECS);
-        let before_len = self.open.len();
-        self.open.retain(|k| *k >= cutoff);
-        if self.open.len() != before_len {
-            warn!(
-                expired = before_len - self.open.len(),
-                "MotionUnion: expired stale open key(s) with no STOP within MAX_OPEN_SIGNAL_SECS"
-            );
-            if self.open.is_empty() {
-                self.union_started_at = None;
-            }
-        }
+        // NOTE (#7, deliberately NOT a time-based expiry): a blind expiry of
+        // open keys older than MAX_OPEN_SIGNAL_SECS is NOT footage-safe on a
+        // MULTI-source camera. Genuinely-long open events are real — an HA
+        // occupancy/contact sensor held "on" for hours (ha_motion.rs: "real,
+        // not a dropped end"), or a pixel event through a sustained storm. If
+        // such a long event's key were expired, a SECOND source's short event
+        // closing would empty the union, drive the buffer Recording→PostBuffer→
+        // Idle, and DISCARD segments while a healthy source is still asserting
+        // motion (golden rule 2 / invariant #19 — never bet footage on a buffer
+        // change; "unknown" resolves to keep). The wedge a blind expiry targets
+        // (a lost STOP pinning Recording) is already covered the footage-safe
+        // way: a STOP lost to channel overflow trips the #81 loss debt →
+        // fail-open (over-record); a panicked source is respawned by the
+        // motion-source supervision and its health goes false for the gap. What
+        // remains is only over-record (disk waste, bounded by retention), never
+        // loss — the correct direction. Do NOT reintroduce a time-based expiry
+        // here; a proper fix keys `open` by source identity and expires a key
+        // only when the SAME source re-opens (definitive lost-STOP evidence).
         match sig.stopped_at {
             None => {
                 // START: union rises only on the first open.
@@ -3440,35 +3442,43 @@ mod tests {
     }
 
     #[test]
-    fn motion_union_expires_stale_open_key_on_later_signal() {
-        // #7 wedge net: source A opens, its STOP is lost, then much later another
-        // signal arrives. The stale A key must be expired so the union is not
-        // pinned open forever (which would hold the buffer Recording 24/7).
+    fn motion_union_keeps_long_event_open_across_a_second_sources_event() {
+        // #7 regression guard: a genuinely-long open event on one source must
+        // NOT be closed by a second source's short event — recording continues
+        // as long as ANY source asserts motion. (This is why the blind
+        // time-based expiry was reverted: it discarded footage here.)
         let mut union = MotionUnion::default();
         let t0 = utc(2026, 1, 1, 0, 0, 0);
-        let a_start = make_signal(t0, None);
+        // Source A opens a long event (e.g. an HA occupancy sensor held on).
         assert!(
-            union.fold(&a_start).is_some(),
-            "first open emits a union START"
+            union.fold(&make_signal(t0, None)).is_some(),
+            "A opens the union"
         );
-        assert_eq!(union.open.len(), 1);
-
-        // A's STOP is lost; > MAX_OPEN_SIGNAL_SECS later, source B opens.
+        // Much later (> MAX_OPEN_SIGNAL_SECS) source B has a short event while A
+        // is still open. B's START is a re-trigger (union already open → None);
+        // B's STOP must NOT fall the union, because A is still open.
         let late = t0 + chrono::Duration::seconds(MAX_OPEN_SIGNAL_SECS + 60);
-        let b_start = make_signal(late, None);
         assert!(
-            union.fold(&b_start).is_some(),
-            "B is a fresh first-open once the stale A key is expired"
+            union.fold(&make_signal(late, None)).is_none(),
+            "B is a re-trigger"
         );
-        assert_eq!(
-            union.open.len(),
-            1,
-            "only B remains; the stale A key was expired, not left pinning the union"
+        assert!(
+            union
+                .fold(&make_signal(
+                    late,
+                    Some(late + chrono::Duration::seconds(4))
+                ))
+                .is_none(),
+            "B's STOP must NOT close the union while A is still open (no footage loss)"
         );
-
-        // B closes cleanly → union falls to empty (no stuck-open key).
-        let b_stop = make_signal(late, Some(late + chrono::Duration::seconds(4)));
-        assert!(union.fold(&b_stop).is_some(), "B's STOP closes the union");
+        assert_eq!(union.open.len(), 1, "A's long event stays open");
+        // Only A's own STOP closes the union.
+        assert!(
+            union
+                .fold(&make_signal(t0, Some(late + chrono::Duration::seconds(30))))
+                .is_some(),
+            "A's real STOP finally closes the union"
+        );
         assert!(union.open.is_empty());
     }
 

--- a/services/recorder/src/recording.rs
+++ b/services/recorder/src/recording.rs
@@ -170,8 +170,13 @@ fn classify_failure(saw_segment: bool, eof_no_data: bool) -> FailureClass {
 ///   no EOF or error, so it stops producing segments silently.
 /// * A freshly started (or live-reconfig-restarted) worker whose ffmpeg child
 ///   connects to go2rtc but never opens the source (live-reconfig half-init):
-///   ffmpeg hangs before writing the first segment line, blocking
-///   `read_segment_line` indefinitely.
+///   ffmpeg hangs before writing the first segment line, so the `seg_lines`
+///   reader never yields and the anchored watchdog arm fires.
+///
+/// The watchdog is a dedicated `select!` arm anchored to the last segment
+/// receipt (`last_segment_at`), NOT a per-iteration `timeout` wrapper — the
+/// latter was silently reset by the motion-cache telemetry tick every 45 s and
+/// so never fired (issue #71); see the `run_ffmpeg_loop` select loop.
 ///
 /// A healthy camera on a 4–10 s segment produces a new stdout line every 4–10 s.
 /// Any gap this long (90 s = ~9–22 missed segments) is unambiguously a dead
@@ -230,6 +235,28 @@ pub async fn run(
 
     let mut backoff = BACKOFF_INIT;
 
+    // #73 (reconnect mid-motion-event): the motion state machine must SURVIVE
+    // ffmpeg reconnects. These three used to be locals of `run_ffmpeg_loop`,
+    // rebuilt on every reconnect — so an ffmpeg error/stall mid-event reset the
+    // buffer to Idle and the union to "no open sources", the event's queued
+    // STOP then hit the fresh union as an unmatched edge (ignored), and every
+    // segment of the event's remainder went into the Idle ring and was
+    // eventually DISCARDED (the detector task keeps running across the
+    // reconnect and does not re-emit a START for an already-open event).
+    // Owning them here — one instance per worker lifetime, passed `&mut` into
+    // each `run_ffmpeg_loop` run — keeps the Recording/PostBuffer state, the
+    // union's open-source set, and the accumulated `pending_signals` (for
+    // `has_motion` stamping) intact across the reconnect, so an ongoing motion
+    // event keeps persisting. A worker RESPAWN (config change / process
+    // restart) still starts fresh, exactly as before, and starts fail-open
+    // (the health watch is seeded `false`) until the detector proves itself.
+    let mut motion_buf = MotionBuffer::new(
+        camera.policy.motion_pre_seconds as i64,
+        camera.policy.motion_post_seconds as i64,
+    );
+    let mut motion_union = MotionUnion::default();
+    let mut pending_signals: Vec<MotionSignal> = Vec::new();
+
     // Cold-start fast-retry counter (see `classify_failure` / `COLD_START_MAX_FAST_RETRIES`).
     // Counts CONSECUTIVE cold-start-classified failures; reset to 0 the instant
     // a failure classifies as anything else, or a segment is ever indexed, so
@@ -260,6 +287,9 @@ pub async fn run(
             &mut motion_rx,
             &health_rx,
             &cancel,
+            &mut motion_buf,
+            &mut motion_union,
+            &mut pending_signals,
             &mut indexed_ok,
             &mut saw_segment,
             &mut eof_no_data,
@@ -377,6 +407,13 @@ pub async fn run(
 /// setup/IO error. A dedicated out-param (rather than matching on the error
 /// string) keeps `classify_failure` decoupled from this function's exact
 /// error message wording.
+///
+/// `motion_buf` / `motion_union` / `pending_signals` are the worker-lifetime
+/// motion state, owned by [`run`] and passed `&mut` so they SURVIVE ffmpeg
+/// reconnects (#73) — an ongoing motion event's Recording state, the union's
+/// open-source set, and the accumulated signals all carry across an
+/// error/stall restart of the ffmpeg child instead of being silently reset
+/// (which used to discard the remainder of the event).
 #[allow(clippy::too_many_arguments)]
 async fn run_ffmpeg_loop(
     camera: &Camera,
@@ -385,6 +422,9 @@ async fn run_ffmpeg_loop(
     motion_rx: &mut MotionRx,
     health_rx: &MotionHealthRx,
     cancel: &CancellationToken,
+    motion_buf: &mut MotionBuffer,
+    motion_union: &mut MotionUnion,
+    pending_signals: &mut Vec<MotionSignal>,
     indexed_ok: &mut bool,
     saw_segment: &mut bool,
     eof_no_data: &mut bool,
@@ -480,7 +520,20 @@ async fn run_ffmpeg_loop(
                     // clean is logged and does not block recording (the stale
                     // files just linger; they are never indexed since they are
                     // not in a storage root, so reconcile never sees them).
-                    if let Err(e) = clear_dir_contents(&dir).await {
+                    //
+                    // #73: the motion buffer now SURVIVES ffmpeg reconnects
+                    // (see `run`), so on a reconnect the carried ring's
+                    // segments still reference live files in this cache dir —
+                    // the sweep must skip exactly those (deleting them would
+                    // make every later persist of a ring segment fail, losing
+                    // the pre-roll). A fresh worker spawn has an empty ring,
+                    // so the keep-set is empty and the sweep behaves exactly
+                    // as before.
+                    let mut keep = std::collections::HashSet::new();
+                    for seg in &motion_buf.pending {
+                        keep.insert(PathBuf::from(&seg.path));
+                    }
+                    if let Err(e) = clear_dir_contents(&dir, &keep).await {
                         warn!(
                             camera_id = %camera.id,
                             dir = ?dir,
@@ -552,6 +605,53 @@ async fn run_ffmpeg_loop(
     // was requested — mirrors `write_dir.is_some()` but names the concept used
     // throughout the rest of this function.)
     let caching_active = write_dir.is_some();
+
+    // ── 2c. #73 flip-guard: settle carried ring entries this run cannot manage
+    //
+    // The motion ring now survives reconnects (see `run`). Within one worker a
+    // ring entry's file lives in exactly one of two places: this camera's
+    // cache dir (buffered by a caching-active run) or the storage camera dir
+    // (a fallback/direct-to-storage run drives the buffer for shadow
+    // bookkeeping only). If the cache-dir resolution FLIPPED across the
+    // reconnect, entries of the other flavor must be settled NOW, footage-safe:
+    //
+    // * fallback→caching: a storage-dir entry was already persisted AND
+    //   indexed by the fallback run (fallback indexes every segment), so it
+    //   simply leaves the ring with no file operation. Leaving it in would be
+    //   DESTRUCTIVE: a later pre-roll flush would run the cache persist's
+    //   copy-then-delete on a storage path — a self-copy that truncates, then
+    //   deletes, an already-indexed segment file.
+    // * caching→fallback: a cache-dir entry is unmanageable this run (the
+    //   fallback path never executes cache file ops), which would leak the
+    //   buffered pre-roll — persist it to storage right away instead (same
+    //   footage-safe mechanics as a cache-pressure spill; at worst this
+    //   writes a few segments of idle pre-roll).
+    //
+    // On a same-mode reconnect every entry lives under `effective_write_dir`
+    // and the ring is carried through completely untouched.
+    if !motion_buf.pending.is_empty() {
+        let mut carried = VecDeque::new();
+        for seg in motion_buf.drain_ring() {
+            if ring_entry_lives_under(&seg, effective_write_dir) {
+                carried.push_back(seg);
+            } else if !caching_active {
+                // Cache-dir entry while this run is fallback → persist now.
+                persist_cached_segment(
+                    &seg,
+                    camera,
+                    &live_storage.id,
+                    &live_storage.path,
+                    &camera_dir,
+                    pool,
+                    pending_signals,
+                )
+                .await;
+            }
+            // else: a storage-dir entry in a caching run — already indexed by
+            // the fallback run that buffered it; it safely leaves the ring.
+        }
+        motion_buf.pending = carried;
+    }
 
     // strftime pattern for segment filenames (UTC), flat under the EFFECTIVE
     // write dir (cache dir when caching_active, else camera_dir as before).
@@ -739,17 +839,18 @@ async fn run_ffmpeg_loop(
     // We process segments as a sliding window: when segment N+1 is reported,
     // segment N is complete.  At shutdown we handle the final segment specially.
 
-    let mut stdout_reader = BufReader::new(ffmpeg_stdout);
+    // A PERSISTENT, cancellation-safe line reader. `tokio::io::Lines` keeps its
+    // partial-line state inside the iterator, so when a competing `select!` arm
+    // (the telemetry tick, or the stall watchdog) wins and drops the in-flight
+    // `next_line()` future, no half-read segment-list line is lost — unlike the
+    // old per-call `read_line` into a fresh `String`, which was NOT
+    // cancellation-safe and could drop a partial line every time the tick fired.
+    let mut seg_lines = BufReader::new(ffmpeg_stdout).lines();
 
-    // Initialise the motion buffer for motion-mode cameras. `finish_completed_segment`
+    // The motion buffer / union / pending-signal state for motion-mode cameras
+    // is owned by `run` (worker lifetime) and passed in `&mut` so it survives
+    // reconnects (#73) — see the parameter docs above. `finish_completed_segment`
     // reads `camera.policy.mode` directly, so no local copy is kept here.
-    let pre_secs = camera.policy.motion_pre_seconds as i64;
-    let post_secs = camera.policy.motion_post_seconds as i64;
-
-    let mut motion_buf = MotionBuffer::new(pre_secs, post_secs);
-    // Unions the additive sources' edges before they reach the buffer (a second
-    // source's STOP must not end recording while another source is still open).
-    let mut motion_union = MotionUnion::default();
 
     // Motion-cache telemetry tick (read-only reporter — see
     // `report_motion_cache_status`). Only meaningful for Motion-mode cameras,
@@ -762,12 +863,20 @@ async fn run_ffmpeg_loop(
         tokio::time::interval(Duration::from_secs(MOTION_CACHE_STATUS_INTERVAL_SECS));
     cache_status_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
-    // Accumulated motion signals drained from the channel during each segment.
-    let mut pending_signals: Vec<MotionSignal> = Vec::new();
+    // Accumulated motion signals drained from the channel during each segment:
+    // `pending_signals`, carried across reconnects by `run` (#73).
 
     // Sliding window: the previous segment whose end_ts we derive from the
     // current segment's start_ts.
     let mut prev_segment: Option<PendingSegment> = None;
+
+    // Stall-watchdog anchor: the instant of the last received segment-list line
+    // (seeded at loop entry so a cold start that never produces a first segment
+    // still trips the watchdog within the timeout). Bumped ONLY when a real line
+    // arrives — never by the telemetry tick — so the watchdog deadline below is
+    // stable across tick-only iterations. This is the fix for the gap-#1
+    // silent-reset regression (see the watchdog `select!` arm).
+    let mut last_segment_at = tokio::time::Instant::now();
 
     // A single closure-like helper (defined as a local async fn below rather
     // than a real closure, since it needs many `&`/`&mut` borrows of locals
@@ -782,12 +891,13 @@ async fn run_ffmpeg_loop(
         // this block since it is `async { }` not `async move { }` — mutations
         // here are visible after `.await` below and to the caller.
         loop {
-            // We select between three events:
-            // a) ffmpeg reports a new segment (stdout line), subject to the
-            //    SEGMENT_RECEIPT_TIMEOUT_SECS watchdog (gap #1 silent-reset +
-            //    gap #2 live-reconfig half-init — see constant definition above)
-            // b) the cancellation token fires (shutdown)
-            // c) we drain pending motion signals while waiting
+            // We select between four events:
+            // a) ffmpeg reports a new segment (stdout line via `seg_lines`)
+            // b) the SEGMENT_RECEIPT_TIMEOUT_SECS stall watchdog (its own arm,
+            //    anchored to `last_segment_at` — not a per-read timeout, which
+            //    the telemetry tick used to silently reset, issue #71)
+            // c) the cancellation token fires (shutdown)
+            // d) the motion-cache telemetry tick
             //
             // tokio::select! polls all branches simultaneously.
             tokio::select! {
@@ -840,9 +950,9 @@ async fn run_ffmpeg_loop(
                             pool,
                             motion_rx,
                             health_rx,
-                            &mut pending_signals,
-                            &mut motion_buf,
-                            &mut motion_union,
+                            pending_signals,
+                            motion_buf,
+                            motion_union,
                             &live_storage.id,
                             &live_storage.path,
                             &camera_dir,
@@ -861,22 +971,10 @@ async fn run_ffmpeg_loop(
                 // We use try_recv in a non-blocking fashion via a zero-timeout
                 // select arm instead — see motion draining below the select.
 
-                // Segment-receipt watchdog: wrap read_segment_line in a timeout
-                // so a silently stalled ffmpeg (no EOF, no error, no segments)
-                // forces a reconnect instead of blocking forever.
-                timed_read = tokio::time::timeout(
-                    Duration::from_secs(SEGMENT_RECEIPT_TIMEOUT_SECS),
-                    read_segment_line(&mut stdout_reader),
-                ) => {
-                    let read_result = match timed_read {
-                        Ok(inner) => inner,
-                        Err(_elapsed) => {
-                            return Err(anyhow::anyhow!(
-                                "recording stream stalled: no segment for {}s; forcing reconnect",
-                                SEGMENT_RECEIPT_TIMEOUT_SECS
-                            ));
-                        }
-                    };
+                // Next segment-list line (cancellation-safe; see `seg_lines`).
+                // The stall watchdog is now a SEPARATE arm below, so this read
+                // is a plain await with no per-iteration timeout wrapper.
+                read_result = seg_lines.next_line() => {
                     match read_result {
                         Ok(None) => {
                             // EOF on stdout: ffmpeg exited (either error or normal),
@@ -889,6 +987,10 @@ async fn run_ffmpeg_loop(
                             return Err(anyhow::anyhow!("ffmpeg stdout closed (process exited)"));
                         }
                         Ok(Some(raw_line)) => {
+                            // A segment-list line arrived → the stream is alive.
+                            // Bump the watchdog anchor so its deadline moves
+                            // forward off THIS receipt (the only place it does).
+                            last_segment_at = tokio::time::Instant::now();
                             // First (or any) segment-list line received: ffmpeg
                             // did open the RTSP source this run. Set unconditionally
                             // (not just on the first line) — cheap, and correctness
@@ -944,9 +1046,9 @@ async fn run_ffmpeg_loop(
                                     pool,
                                     motion_rx,
                                     health_rx,
-                                    &mut pending_signals,
-                                    &mut motion_buf,
-                                    &mut motion_union,
+                                    pending_signals,
+                                    motion_buf,
+                                    motion_union,
                                     &live_storage.id,
                                     &live_storage.path,
                                     &camera_dir,
@@ -981,9 +1083,31 @@ async fn run_ffmpeg_loop(
                             });
                         }
                         Err(e) => {
-                            return Err(e.context("reading ffmpeg segment list"));
+                            return Err(
+                                anyhow::Error::from(e).context("reading ffmpeg segment list")
+                            );
                         }
                     }
+                }
+
+                // Segment-receipt stall watchdog. Fires when no new segment-list
+                // line has arrived within SEGMENT_RECEIPT_TIMEOUT_SECS of the
+                // last one, forcing the loop to error out → reconnect. The
+                // deadline is anchored to `last_segment_at` (bumped ONLY by a
+                // real line in the read arm above), NOT rebuilt from "now" each
+                // iteration, so the telemetry tick below — which returns from
+                // the `select!` every MOTION_CACHE_STATUS_INTERVAL_SECS (45s <
+                // 90s) — can no longer push the deadline out and starve the
+                // watchdog forever. That silent-reset was the gap-#1 regression:
+                // a half-open RTSP stream (no EOF, no error, no segments) left
+                // the camera recording NOTHING indefinitely with no reconnect.
+                () = tokio::time::sleep_until(
+                    last_segment_at + Duration::from_secs(SEGMENT_RECEIPT_TIMEOUT_SECS)
+                ) => {
+                    return Err(anyhow::anyhow!(
+                        "recording stream stalled: no segment for {}s; forcing reconnect",
+                        SEGMENT_RECEIPT_TIMEOUT_SECS
+                    ));
                 }
 
                 // Motion-cache telemetry tick (read-only; see
@@ -995,7 +1119,7 @@ async fn run_ffmpeg_loop(
                         pool,
                         camera,
                         config,
-                        &motion_buf,
+                        &*motion_buf,
                         caching_active,
                         write_dir.as_deref(),
                     )
@@ -1046,8 +1170,11 @@ async fn run_ffmpeg_loop(
         // Spec item 6: same reasoning as the cancel-branch comment above —
         // MotionBuffer's state at this instant (Idle vs Recording/PostBuffer)
         // correctly decides whether this reconnect-orphaned in-flight segment
-        // should persist or simply be left buffered in the cache (R1's startup
-        // sweep cleans it up on the next worker restart if it's never claimed).
+        // should persist or simply be left buffered in the cache. Since the
+        // buffer now survives the reconnect (#73), an Idle-buffered segment
+        // stays a live ring entry into the next run (the R1 sweep skips
+        // ring-referenced files) and gets its keep/discard verdict through the
+        // normal path there.
         if finish_completed_segment(
             &completed,
             camera,
@@ -1055,9 +1182,9 @@ async fn run_ffmpeg_loop(
             pool,
             motion_rx,
             health_rx,
-            &mut pending_signals,
-            &mut motion_buf,
-            &mut motion_union,
+            pending_signals,
+            motion_buf,
+            motion_union,
             &live_storage.id,
             &live_storage.path,
             &camera_dir,
@@ -1121,15 +1248,25 @@ async fn finish_completed_segment(
     // healthy and the other see unhealthy.
     let detector_healthy = *health_rx.borrow();
     // Fail-open (spec item 4): while the CACHE is active and the detector is
-    // unhealthy, `motion_buf` must NOT be touched at all — neither by signals
-    // nor by the segment push — so its ring/state resumes EXACTLY where it
-    // left off once health returns. Signals arriving during an unhealthy
-    // window come from the same untrusted detector, so trusting them to drive
-    // Idle→Recording transitions would be exactly the failure mode this rail
-    // exists to prevent. Health is irrelevant when the cache is NOT active
-    // (shadow/fallback): there is no real persist-on-motion behaviour to
-    // fail-open FROM in that case, so the buffer keeps running (for the
-    // shadow verdict) regardless of detector health.
+    // unhealthy, `motion_buf`'s STATE must not be driven — neither by signals
+    // nor by the segment push — so it resumes where it left off once health
+    // returns. Signals arriving during an unhealthy window come from the same
+    // untrusted detector, so trusting them to drive Idle→Recording transitions
+    // would be exactly the failure mode this rail exists to prevent. Two
+    // footage-safety carve-outs to that freeze (both persist-only, and
+    // neither drives a state transition during the window):
+    // * #77 — segments already sitting in the ring at the transition are
+    //   drained to PERSIST (see `decide_persist_for_segment`); they were
+    //   awaiting a verdict the detector can no longer render, and "unknown"
+    //   must resolve to "keep", never to a later age-out discard.
+    // * #74 — drained signals are still FOLDED through `motion_union` (see
+    //   `drain_and_persist_motion`) so its open-source accounting stays
+    //   exact; the resulting synthetic edge is stashed and replayed to the
+    //   buffer when it thaws, instead of being applied to the frozen buffer.
+    // Health is irrelevant when the cache is NOT active (shadow/fallback):
+    // there is no real persist-on-motion behaviour to fail-open FROM in that
+    // case, so the buffer keeps running (for the shadow verdict) regardless
+    // of detector health.
     let unhealthy_while_caching = caching_active && !detector_healthy;
     let drive_buffer = recording_mode == RecordingMode::Motion && !unhealthy_while_caching;
 
@@ -1140,7 +1277,9 @@ async fn finish_completed_segment(
     // `actual`. When shadow/fallback (cache inactive, buffer still driven for
     // validation only), accumulate into `shadow` instead so it never touches
     // file operations. When unhealthy-while-caching, `drive_buffer` is false
-    // so the buffer isn't fed at all and this call is a pure no-op for it.
+    // so the buffer isn't fed — but the drain still folds every edge through
+    // `motion_union` and stashes the newest synthetic edge for replay when
+    // the buffer thaws (#74; see `drain_and_persist_motion`).
     let mut actual = MotionDecision::empty();
     let mut shadow = MotionDecision::empty();
     if caching_active && detector_healthy {
@@ -1182,9 +1321,9 @@ async fn finish_completed_segment(
     // healthy only). Nothing to spill for continuous/shadow/fallback (which
     // never accumulate a ring), and nothing to spill while unhealthy-and-
     // caching either — that path already persists every segment directly and
-    // deliberately leaves `motion_buf`'s ring frozen (see the fail-open
-    // reasoning above), so touching the ring here would violate that same
-    // invariant.
+    // its transition drain (#77, in `decide_persist_for_segment`) has already
+    // emptied the ring into the persist set, so there is nothing left in the
+    // ring to relieve pressure with.
     if caching_active && detector_healthy && recording_mode == RecordingMode::Motion {
         if let Some(cache_dir) = write_dir {
             let spilled =
@@ -1395,17 +1534,6 @@ pub(crate) fn redact_rtsp_credentials(url: &str) -> String {
 /// Read one line from the segment-list stdout reader.
 ///
 /// Returns `Ok(None)` on EOF, `Ok(Some(line))` on a line, `Err` on IO error.
-async fn read_segment_line(
-    reader: &mut BufReader<tokio::process::ChildStdout>,
-) -> Result<Option<String>> {
-    let mut line = String::new();
-    match reader.read_line(&mut line).await {
-        Ok(0) => Ok(None),
-        Ok(_) => Ok(Some(line)),
-        Err(e) => Err(anyhow::Error::from(e)),
-    }
-}
-
 /// Drain all currently-available items from `motion_rx` into `out`.
 ///
 /// This is non-blocking: it empties the channel without yielding or sleeping.
@@ -1449,14 +1577,49 @@ async fn drain_and_persist_motion(
 ) {
     let before = out.len();
     drain_motion_channel(rx, out);
-    if let Some(buf) = motion_buf {
-        for sig in &out[before..] {
-            // Union the per-source edges before the buffer: only a rising edge on
-            // the FIRST open and a falling edge on the LAST close reach apply_signal.
-            if let Some(union_sig) = motion_union.fold(sig) {
-                let d = buf.apply_signal(&union_sig);
+    match motion_buf {
+        Some(buf) => {
+            // #74: FIRST replay the newest union edge that was produced while
+            // the buffer was frozen (the fail-open unhealthy window stashes it
+            // below instead of dropping it), so the buffer's Recording/Idle
+            // regime resyncs to the union's before any of this call's fresh
+            // edges — or the segment push that follows in
+            // `finish_completed_segment` — are applied. Replaying an edge the
+            // buffer effectively already agrees with is a no-op (a START on
+            // Recording is a re-trigger; a STOP on Idle is stale-ignored), so
+            // this can only make the buffer persist MORE, never less.
+            if let Some(replay) = motion_union.take_pending_replay() {
+                let d = buf.apply_signal(&replay);
                 decision.persist.extend(d.persist);
                 decision.discard.extend(d.discard);
+            }
+            for sig in &out[before..] {
+                // Union the per-source edges before the buffer: only a rising edge on
+                // the FIRST open and a falling edge on the LAST close reach apply_signal.
+                if let Some(union_sig) = motion_union.fold(sig) {
+                    let d = buf.apply_signal(&union_sig);
+                    decision.persist.extend(d.persist);
+                    decision.discard.extend(d.discard);
+                }
+            }
+        }
+        None => {
+            // #74 (fail-open desync): the buffer is frozen (unhealthy-while-
+            // caching) or absent (Continuous mode), but the UNION must still
+            // see every drained edge — this drain consumes the signals from
+            // the channel, so an open/close that is not folded here is lost to
+            // the union forever, leaving its open-source set out of sync with
+            // the detector (a later STOP arrives unmatched, or a stale open
+            // key pins the union open across every subsequent event). Fold
+            // each edge to keep the accounting exact, and STASH the newest
+            // synthetic edge so the buffer can resync to the union's regime
+            // when it thaws (see the `Some` arm above). The frozen buffer
+            // itself is deliberately NOT driven — segments during the window
+            // already persist directly via fail-open.
+            for sig in &out[before..] {
+                if let Some(union_sig) = motion_union.fold(sig) {
+                    motion_union.stash_replay(union_sig);
+                }
             }
         }
     }
@@ -1634,8 +1797,16 @@ struct SegmentDecision {
 ///   from `motion_buf.push_segment` — this is the actual persist-on-motion
 ///   behaviour.
 /// * **Motion mode, cache active, detector UNHEALTHY**: fail-open (spec item
-///   4) — persist every segment, exactly like Continuous, WITHOUT touching the
-///   buffer's ring/state, so it resumes cleanly once health returns.
+///   4) — persist every segment, exactly like Continuous, AND (#77) drain any
+///   segments still sitting in the ring awaiting a verdict into the persist
+///   set too (same footage-safe mechanics as the cache-pressure spill):
+///   "detector state unknown" must resolve to "keep everything", and that
+///   includes the buffered pre-roll — before this, those ring segments sat
+///   frozen through the unhealthy window and then aged out as DISCARDS once
+///   health returned, without ever getting a real verdict. At worst this
+///   persists ~`motion_pre_seconds` of idle footage per unhealthy episode.
+///   The buffer's STATE is still never touched, so it resumes exactly where
+///   it left off (with an empty ring, as after a spill) once health returns.
 /// * **Motion mode, cache NOT active** (shadow mode, or a cache-dir failure):
 ///   file operations always persist (byte-for-byte continuous-mode behaviour
 ///   — there is no cache file to discard). `motion_buf.push_segment` is STILL
@@ -1666,9 +1837,20 @@ fn decide_persist_for_segment(
             }
             if !detector_healthy {
                 // Fail-open (spec item 4): persist every segment, exactly like
-                // Continuous, without touching the buffer's ring state.
+                // Continuous. #77: ALSO drain the ring — segments buffered
+                // before the healthy→unhealthy transition were awaiting a
+                // keep/discard verdict the detector can no longer render, so
+                // they persist too (oldest first, then `completed`), exactly
+                // like a cache-pressure spill. Idempotent across the unhealthy
+                // window: the first call empties the ring, later calls drain
+                // nothing. The buffer's STATE is deliberately untouched.
+                let mut persist = motion_buf.drain_ring();
+                persist.push(completed.clone());
                 return SegmentDecision {
-                    actual: MotionDecision::persist_one(completed.clone()),
+                    actual: MotionDecision {
+                        persist,
+                        discard: Vec::new(),
+                    },
                     shadow: None,
                 };
             }
@@ -1851,6 +2033,16 @@ async fn resolve_motion_cache_dir(
     Ok(cache_root.join(camera_id.to_string()))
 }
 
+/// Pure check for the #73 flip-guard: does this carried ring entry's file live
+/// DIRECTLY under `dir` (this run's effective write dir)? The cache and
+/// storage layouts are both flat under the per-camera dir, so a simple parent
+/// comparison is exact — an entry whose parent is not `dir` was produced by a
+/// run in the OTHER caching mode and must be settled before the ring is used
+/// (see the flip-guard in `run_ffmpeg_loop`).
+fn ring_entry_lives_under(seg: &PendingSegment, dir: &Path) -> bool {
+    Path::new(&seg.path).parent() == Some(dir)
+}
+
 /// Pure guard check: does `cache_root` equal or nest under any storage root in
 /// `storage_roots`? Returns the first conflicting `(name, path)` found, or
 /// `None` if the cache dir is safely outside every storage root. Extracted
@@ -1867,16 +2059,22 @@ fn cache_dir_conflicts_with_storage(
 }
 
 /// Delete every regular file directly inside `dir` (non-recursive — the cache
-/// layout is flat, matching the storage layout). Used at worker start to clear
-/// stale files from a previous in-process restart (R1). Best-effort per file:
-/// one failed delete is logged and does not stop the sweep.
+/// layout is flat, matching the storage layout), EXCEPT paths listed in
+/// `keep`. Used at ffmpeg-(re)start to clear stale files from a previous
+/// in-process restart (R1). `keep` carries the reconnect-surviving motion
+/// ring's file paths (#73): those cache files are still awaiting a
+/// keep/discard verdict from the carried `MotionBuffer`, so deleting them here
+/// would silently lose the buffered pre-roll (every later persist of a ring
+/// segment would fail). A fresh worker spawn passes an empty `keep`, making
+/// this exactly the original R1 sweep. Best-effort per file: one failed delete
+/// is logged and does not stop the sweep.
 ///
 /// # Errors
 ///
 /// Returns an error only if the directory itself cannot be read (e.g. it does
 /// not exist yet, which the caller has already created, or a permissions
 /// problem) — individual file-delete failures are swallowed with a warning.
-async fn clear_dir_contents(dir: &Path) -> Result<()> {
+async fn clear_dir_contents(dir: &Path, keep: &std::collections::HashSet<PathBuf>) -> Result<()> {
     let mut entries = tokio::fs::read_dir(dir)
         .await
         .with_context(|| format!("read_dir {:?}", dir))?;
@@ -1886,6 +2084,9 @@ async fn clear_dir_contents(dir: &Path) -> Result<()> {
         .with_context(|| format!("read_dir next_entry {:?}", dir))?
     {
         let path = entry.path();
+        if keep.contains(&path) {
+            continue;
+        }
         if let Ok(meta) = entry.metadata().await {
             if meta.is_file() {
                 if let Err(e) = tokio::fs::remove_file(&path).await {
@@ -2640,6 +2841,16 @@ impl MotionBuffer {
         let bytes = self.pending.iter().map(|s| s.size_bytes).sum();
         (self.pending.len(), bytes)
     }
+
+    /// Drain the ENTIRE ring (oldest first), leaving the buffer's state
+    /// untouched. The caller persists every returned segment — this is the
+    /// footage-safe "flush everything awaiting a verdict" primitive shared by
+    /// the healthy→unhealthy fail-open transition (#77): the ring's segments
+    /// have not been through a keep/discard decision, so the only safe exits
+    /// for them are a real verdict or a persist, never silent deletion.
+    pub fn drain_ring(&mut self) -> Vec<PendingSegment> {
+        self.pending.drain(..).collect()
+    }
 }
 
 /// Unions the START/STOP edges from N **additive** motion sources into the single
@@ -2671,6 +2882,18 @@ pub struct MotionUnion {
     /// used as the synthetic START/STOP `started_at` so pre-buffer flush covers
     /// from the earliest motion.
     union_started_at: Option<DateTime<Utc>>,
+    /// #74 (fail-open desync): the most recent synthetic union edge produced
+    /// while the [`MotionBuffer`] was frozen (the unhealthy-while-caching
+    /// window), held until the buffer thaws and can be resynced. Only the
+    /// NEWEST edge matters: [`fold`](Self::fold) emits strictly alternating
+    /// START/STOP edges (it fires only on the 0→1 and 1→0 open-count
+    /// transitions), and the buffer only needs to converge to the union's
+    /// current regime — a final START means "an event is open, resume
+    /// Recording" (any intermediate events' footage was already persisted
+    /// directly by fail-open), a final STOP means "closed, run the post-roll
+    /// down from its `stopped_at`". Replay can therefore only add persisted
+    /// footage relative to dropping the edges, never remove any.
+    pending_replay: Option<MotionSignal>,
 }
 
 impl MotionUnion {
@@ -2715,18 +2938,22 @@ impl MotionUnion {
             }
         }
     }
-}
 
-// ─── watchdog helpers ─────────────────────────────────────────────────────────
+    /// Stash a synthetic edge produced by [`fold`](Self::fold) while the
+    /// buffer was frozen (fail-open unhealthy window), overwriting any older
+    /// stashed edge — only the newest one matters (see
+    /// [`pending_replay`](Self::pending_replay)'s doc for why that is
+    /// footage-safe).
+    pub fn stash_replay(&mut self, edge: MotionSignal) {
+        self.pending_replay = Some(edge);
+    }
 
-/// Pure predicate: returns `true` when `elapsed_secs` meets or exceeds
-/// `timeout_secs`.
-///
-/// Extracted from the `run_ffmpeg_loop` timing decision so the boundary
-/// conditions can be verified in unit tests without spawning ffmpeg or
-/// real timers.
-pub(crate) fn is_watchdog_deadline_exceeded(elapsed_secs: u64, timeout_secs: u64) -> bool {
-    elapsed_secs >= timeout_secs
+    /// Take (and clear) the stashed frozen-window edge, if any — applied to
+    /// the buffer by `drain_and_persist_motion` the first time the buffer is
+    /// driven again after a frozen window.
+    pub fn take_pending_replay(&mut self) -> Option<MotionSignal> {
+        self.pending_replay.take()
+    }
 }
 
 // ─── unit tests ───────────────────────────────────────────────────────────────
@@ -2957,6 +3184,162 @@ mod tests {
         // A later source opens: a brand-new union event (fresh START).
         let re = u.fold(&make_signal(t(10), None)).expect("fresh START");
         assert_eq!(re.started_at, t(10));
+    }
+
+    // ── #74: fail-open window must not desync MotionUnion / MotionBuffer ───────
+
+    /// Build a bounded motion channel like main.rs's, for driving
+    /// `drain_and_persist_motion` directly in tests.
+    fn motion_channel() -> (tokio::sync::mpsc::Sender<MotionSignal>, MotionRx) {
+        tokio::sync::mpsc::channel(16)
+    }
+
+    #[tokio::test]
+    async fn source_opened_while_unhealthy_resyncs_buffer_and_closes_cleanly() {
+        // #74 (H3): a source OPENS during an unhealthy (fail-open) window —
+        // the drain consumes the signal from the channel, so pre-fix the union
+        // never saw the open: when health returned, the buffer sat Idle while
+        // motion was ongoing (segments ringed → aged out → DISCARDED), and the
+        // eventual STOP hit the union unmatched. Post-fix: the union folds the
+        // edge even while the buffer is frozen, stashes it, and replays it on
+        // thaw, so the buffer resumes Recording and the STOP matches.
+        let (tx, mut rx) = motion_channel();
+        let mut buf = MotionBuffer::new(5, 10);
+        let mut union = MotionUnion::default();
+        let mut out: Vec<MotionSignal> = Vec::new();
+
+        // Pre-freeze: one idle ring segment (pre-roll for the coming event).
+        buf.push_segment(pending(0, 4));
+
+        // UNHEALTHY window: source opens at t=6. Buffer frozen (None).
+        tx.try_send(motion_start(6)).expect("send START");
+        let mut d1 = MotionDecision::empty();
+        drain_and_persist_motion(&mut rx, &mut out, None, &mut union, &mut d1).await;
+        assert!(
+            d1.persist.is_empty() && d1.discard.is_empty(),
+            "the frozen window itself must not produce buffer decisions"
+        );
+        assert!(
+            matches!(buf.state, MotionBufferState::Idle),
+            "the frozen buffer must not be driven while unhealthy"
+        );
+        assert!(!union.open.is_empty(), "the union must see the open edge");
+
+        // HEALTHY again: first drive replays the stashed START → the buffer
+        // resyncs to Recording and flushes the pre-roll ring as PERSISTS.
+        let mut d2 = MotionDecision::empty();
+        drain_and_persist_motion(&mut rx, &mut out, Some(&mut buf), &mut union, &mut d2).await;
+        assert!(
+            matches!(buf.state, MotionBufferState::Recording { .. }),
+            "the buffer must resync to the union's open regime on thaw"
+        );
+        assert_eq!(
+            d2.persist.len(),
+            1,
+            "the pre-roll ring segment must be flushed as a PERSIST: {d2:?}"
+        );
+        assert!(d2.discard.is_empty(), "no spurious discard on resync");
+
+        // Segments during the resynced ongoing event persist (this is exactly
+        // the footage the pre-fix desync silently discarded).
+        let d3 = buf.push_segment(pending(8, 12));
+        assert_eq!(d3.persist.len(), 1, "event-tail segments must persist");
+
+        // The source CLOSES while healthy: the STOP must match the open key
+        // folded during the unhealthy window — no stuck-open union.
+        tx.try_send(motion_stop(6, 12)).expect("send STOP");
+        let mut d4 = MotionDecision::empty();
+        drain_and_persist_motion(&mut rx, &mut out, Some(&mut buf), &mut union, &mut d4).await;
+        assert!(
+            union.open.is_empty(),
+            "the union must not be left stuck open after the close"
+        );
+        assert!(
+            matches!(buf.state, MotionBufferState::PostBuffer { .. }),
+            "the STOP must reach the buffer and start the post-roll"
+        );
+        assert!(d4.discard.is_empty());
+    }
+
+    #[tokio::test]
+    async fn stop_drained_while_unhealthy_replays_on_thaw_without_wedging() {
+        // #74 inverse direction: the event opened while HEALTHY, then its STOP
+        // was drained during the unhealthy window. Pre-fix the union kept the
+        // event's key open forever (the STOP was consumed unfolded), so every
+        // subsequent event's STOP left the union non-empty → no synthetic STOP
+        // ever again → the buffer wedged in Recording across every future
+        // fail-open episode. Post-fix: the union sees the close, and the thaw
+        // replays it as a post-roll rundown (persist-more, never less).
+        let (tx, mut rx) = motion_channel();
+        let mut buf = MotionBuffer::new(5, 10);
+        let mut union = MotionUnion::default();
+        let mut out: Vec<MotionSignal> = Vec::new();
+
+        // Healthy: the event opens normally.
+        tx.try_send(motion_start(0)).expect("send START");
+        let mut d0 = MotionDecision::empty();
+        drain_and_persist_motion(&mut rx, &mut out, Some(&mut buf), &mut union, &mut d0).await;
+        assert!(matches!(buf.state, MotionBufferState::Recording { .. }));
+
+        // Unhealthy: the STOP is drained with the buffer frozen.
+        tx.try_send(motion_stop(0, 8)).expect("send STOP");
+        let mut d1 = MotionDecision::empty();
+        drain_and_persist_motion(&mut rx, &mut out, None, &mut union, &mut d1).await;
+        assert!(
+            union.open.is_empty(),
+            "the union's accounting must see the close even while frozen"
+        );
+        assert!(
+            matches!(buf.state, MotionBufferState::Recording { .. }),
+            "the frozen buffer itself must not be driven"
+        );
+
+        // Healthy again: the replayed STOP runs the post-roll down instead of
+        // leaving the buffer Recording forever with a desynced union.
+        let mut d2 = MotionDecision::empty();
+        drain_and_persist_motion(&mut rx, &mut out, Some(&mut buf), &mut union, &mut d2).await;
+        assert!(
+            matches!(buf.state, MotionBufferState::PostBuffer { .. }),
+            "the stashed STOP must be replayed on thaw"
+        );
+
+        // A brand-new event afterwards opens AND closes cleanly (no stale keys).
+        tx.try_send(motion_start(30)).expect("send START 2");
+        let mut d3 = MotionDecision::empty();
+        drain_and_persist_motion(&mut rx, &mut out, Some(&mut buf), &mut union, &mut d3).await;
+        assert!(matches!(buf.state, MotionBufferState::Recording { .. }));
+        tx.try_send(motion_stop(30, 35)).expect("send STOP 2");
+        let mut d4 = MotionDecision::empty();
+        drain_and_persist_motion(&mut rx, &mut out, Some(&mut buf), &mut union, &mut d4).await;
+        assert!(union.open.is_empty(), "no stuck-open key after the fix");
+        assert!(matches!(buf.state, MotionBufferState::PostBuffer { .. }));
+    }
+
+    #[tokio::test]
+    async fn full_event_inside_unhealthy_window_is_a_noop_replay_on_thaw() {
+        // #74 boundary: an event opens AND closes entirely inside the frozen
+        // window (its footage was persisted directly by fail-open). Only the
+        // newest edge (the STOP) is stashed; replaying it onto an Idle buffer
+        // is stale-ignored — no state change, no discard, and the union ends
+        // consistent (empty).
+        let (tx, mut rx) = motion_channel();
+        let mut buf = MotionBuffer::new(5, 10);
+        let mut union = MotionUnion::default();
+        let mut out: Vec<MotionSignal> = Vec::new();
+
+        tx.try_send(motion_start(2)).expect("send START");
+        tx.try_send(motion_stop(2, 6)).expect("send STOP");
+        let mut d1 = MotionDecision::empty();
+        drain_and_persist_motion(&mut rx, &mut out, None, &mut union, &mut d1).await;
+        assert!(union.open.is_empty());
+
+        let mut d2 = MotionDecision::empty();
+        drain_and_persist_motion(&mut rx, &mut out, Some(&mut buf), &mut union, &mut d2).await;
+        assert!(
+            matches!(buf.state, MotionBufferState::Idle),
+            "a stale replayed STOP on an Idle buffer must be ignored"
+        );
+        assert!(d2.persist.is_empty() && d2.discard.is_empty());
     }
 
     // ── prune_pending_signals (the "stuck motion" regression) ───────────────────
@@ -3271,8 +3654,9 @@ mod tests {
     #[test]
     fn motion_mode_unhealthy_detector_fails_open_and_freezes_buffer() {
         // Fail-open (spec item 4): an unhealthy detector must persist the
-        // segment directly, exactly like Continuous, and must NOT touch the
-        // buffer's ring/state at all.
+        // segment directly, exactly like Continuous, and must NOT drive the
+        // buffer's STATE (the ring — empty here — is drained-to-persist on
+        // the transition; see the #77 companion test below).
         let mut buf = MotionBuffer::new(5, 10);
         let seg = pending(0, 4);
         let decision = decide_persist_for_segment(
@@ -3291,7 +3675,84 @@ mod tests {
         assert!(decision.shadow.is_none());
         assert!(
             buf.pending.is_empty() && matches!(buf.state, MotionBufferState::Idle),
-            "the buffer's ring/state must be completely untouched while unhealthy"
+            "the buffer's state must be untouched (and the empty ring stay empty) while unhealthy"
+        );
+    }
+
+    #[test]
+    fn unhealthy_transition_drains_pending_ring_to_persist_not_discard() {
+        // #77 (fail-open transition): segments sitting in the Idle ring when
+        // the detector goes healthy→unhealthy were awaiting a keep/discard
+        // verdict the detector can no longer render. They must be PERSISTED
+        // (same footage-safe mechanics as the cache-pressure spill), never
+        // left frozen to age out as discards once health returns.
+        let mut buf = MotionBuffer::new(5, 10);
+        buf.push_segment(pending(0, 4));
+        buf.push_segment(pending(4, 8));
+        assert_eq!(buf.pending.len(), 2, "ring holds two segments");
+
+        // First segment completed while unhealthy: ring + completed all persist.
+        let seg = pending(8, 12);
+        let decision = decide_persist_for_segment(
+            RecordingMode::Motion,
+            /* caching_active */ true,
+            /* detector_healthy */ false,
+            &mut buf,
+            &seg,
+        );
+        assert_eq!(
+            decision.actual.persist.len(),
+            3,
+            "ring segments + the completed segment must ALL persist: {:?}",
+            decision.actual.persist
+        );
+        // Oldest-first, completed last (matches the spill's drain order).
+        let persisted = &decision.actual.persist;
+        assert_eq!(persisted[0].start_ts, utc(2026, 1, 1, 0, 0, 0));
+        assert_eq!(persisted[1].start_ts, utc(2026, 1, 1, 0, 0, 4));
+        assert_eq!(persisted[2].start_ts, utc(2026, 1, 1, 0, 0, 8));
+        assert!(
+            decision.actual.discard.is_empty(),
+            "the fail-open transition must never discard anything"
+        );
+        assert!(buf.pending.is_empty(), "the ring must be drained");
+        assert!(
+            matches!(buf.state, MotionBufferState::Idle),
+            "the buffer's STATE must still be untouched (resumes where it left off)"
+        );
+
+        // Idempotent across the unhealthy window: the next unhealthy segment
+        // persists only itself (the ring is already empty).
+        let d2 = decide_persist_for_segment(
+            RecordingMode::Motion,
+            true,
+            false,
+            &mut buf,
+            &pending(12, 16),
+        );
+        assert_eq!(d2.actual.persist.len(), 1);
+        assert!(d2.actual.discard.is_empty());
+    }
+
+    #[test]
+    fn unhealthy_during_recording_keeps_state_for_resume() {
+        // #77 companion: if the buffer was mid-event (Recording) when health
+        // was lost, the ring is empty (Recording persists as it goes) and the
+        // Recording state must survive the frozen window so the event resumes
+        // persisting on thaw.
+        let mut buf = MotionBuffer::new(5, 10);
+        buf.apply_signal(&motion_start(0));
+        let d = decide_persist_for_segment(
+            RecordingMode::Motion,
+            true,
+            /* detector_healthy */ false,
+            &mut buf,
+            &pending(4, 8),
+        );
+        assert_eq!(d.actual.persist.len(), 1);
+        assert!(
+            matches!(buf.state, MotionBufferState::Recording { .. }),
+            "Recording state must be preserved through the unhealthy window"
         );
     }
 
@@ -3562,6 +4023,125 @@ mod tests {
         assert!(spilled.is_empty());
     }
 
+    // ── #73: motion state survives an ffmpeg reconnect ─────────────────────────
+    //
+    // The reconnect path itself (`run`'s outer loop re-invoking
+    // `run_ffmpeg_loop` with the CARRIED `MotionBuffer`/`MotionUnion`/
+    // `pending_signals`) is not unit-reachable: it needs a live DB pool for
+    // storage resolution and a spawnable ffmpeg child before it ever touches
+    // the motion state. What IS unit-testable is each property the fix is
+    // composed of: (a) the carried state machine keeps an open event alive
+    // across an arbitrary gap in segment arrivals (nothing auto-expires it),
+    // (b) the carried union still matches the event's STOP after the gap
+    // (a FRESH union — the pre-fix behaviour — provably does not), and
+    // (c) the R1 cache sweep at the top of the next run spares exactly the
+    // carried ring's files (deleting them would fail every later persist of
+    // the pre-roll).
+
+    #[test]
+    fn carried_buffer_keeps_ongoing_event_persisting_across_reconnect_gap() {
+        let mut buf = MotionBuffer::new(5, 10);
+        buf.apply_signal(&motion_start(0));
+        assert_eq!(buf.push_segment(pending(0, 4)).persist.len(), 1);
+        // ... ffmpeg dies here; the worker backs off and reconnects; the
+        // buffer is CARRIED as-is (that is the fix) ...
+        let d = buf.push_segment(pending(40, 44));
+        assert_eq!(
+            d.persist.len(),
+            1,
+            "the event tail after a reconnect gap must keep persisting"
+        );
+        assert!(d.discard.is_empty());
+    }
+
+    #[test]
+    fn carried_union_matches_event_stop_after_reconnect_where_fresh_union_cannot() {
+        // The carried union closes the event properly...
+        let mut carried = MotionUnion::default();
+        assert!(carried.fold(&motion_start(0)).is_some());
+        // ... reconnect gap ...
+        assert!(
+            carried.fold(&motion_stop(0, 42)).is_some(),
+            "the carried union must emit the synthetic STOP for the ongoing event"
+        );
+        // ...while a FRESH union (the pre-fix reconnect behaviour) drops the
+        // STOP as unmatched — pinning exactly why the state must be carried.
+        let mut fresh = MotionUnion::default();
+        assert!(
+            fresh.fold(&motion_stop(0, 42)).is_none(),
+            "a fresh union cannot close an event it never saw open"
+        );
+    }
+
+    #[test]
+    fn ring_entry_dir_check_separates_cache_and_storage_flavors() {
+        // #73 flip-guard: the parent-dir check must tell a cache-dir ring
+        // entry apart from a storage-dir one exactly, in both directions —
+        // this is what prevents a storage-path entry from ever being run
+        // through the cache persist's copy-then-delete (which would truncate
+        // and then delete an already-indexed segment file).
+        let cache_dir = Path::new("/cache/motion/cam-1");
+        let storage_dir = Path::new("/data/live/cam-1");
+        let cache_seg = PendingSegment {
+            path: "/cache/motion/cam-1/20260101T000000Z.mp4".to_owned(),
+            start_ts: utc(2026, 1, 1, 0, 0, 0),
+            end_ts: utc(2026, 1, 1, 0, 0, 4),
+            size_bytes: 1024,
+        };
+        let storage_seg = PendingSegment {
+            path: "/data/live/cam-1/20260101T000000Z.mp4".to_owned(),
+            start_ts: utc(2026, 1, 1, 0, 0, 0),
+            end_ts: utc(2026, 1, 1, 0, 0, 4),
+            size_bytes: 1024,
+        };
+        assert!(ring_entry_lives_under(&cache_seg, cache_dir));
+        assert!(!ring_entry_lives_under(&cache_seg, storage_dir));
+        assert!(ring_entry_lives_under(&storage_seg, storage_dir));
+        assert!(!ring_entry_lives_under(&storage_seg, cache_dir));
+    }
+
+    #[tokio::test]
+    async fn r1_sweep_preserves_carried_ring_files_and_removes_stale_ones() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let kept_path = dir.path().join("20260101T000000Z.mp4");
+        let stale_path = dir.path().join("20260101T000004Z.mp4");
+        tokio::fs::write(&kept_path, b"ring-referenced")
+            .await
+            .expect("write kept");
+        tokio::fs::write(&stale_path, b"stale-leftover")
+            .await
+            .expect("write stale");
+
+        let keep: std::collections::HashSet<PathBuf> = [kept_path.clone()].into_iter().collect();
+        clear_dir_contents(dir.path(), &keep).await.expect("sweep");
+
+        assert!(
+            tokio::fs::metadata(&kept_path).await.is_ok(),
+            "a ring-referenced cache file must survive the R1 sweep"
+        );
+        assert!(
+            tokio::fs::metadata(&stale_path).await.is_err(),
+            "a stale leftover file must still be swept"
+        );
+    }
+
+    #[tokio::test]
+    async fn r1_sweep_with_empty_keep_set_clears_everything() {
+        // A fresh worker spawn has an empty ring → the sweep must behave
+        // exactly like the original R1 (clear everything).
+        let dir = tempfile::tempdir().expect("tempdir");
+        let a = dir.path().join("20260101T000000Z.mp4");
+        let b = dir.path().join("20260101T000004Z.mp4");
+        tokio::fs::write(&a, b"x").await.expect("write a");
+        tokio::fs::write(&b, b"y").await.expect("write b");
+
+        let keep = std::collections::HashSet::new();
+        clear_dir_contents(dir.path(), &keep).await.expect("sweep");
+
+        assert!(tokio::fs::metadata(&a).await.is_err());
+        assert!(tokio::fs::metadata(&b).await.is_err());
+    }
+
     // ── segment-receipt watchdog ───────────────────────────────────────────────
 
     /// The watchdog timeout must be strictly larger than a typical multi-segment
@@ -3593,31 +4173,57 @@ mod tests {
         }
     }
 
-    /// `is_watchdog_deadline_exceeded` is the pure predicate extracted from the
-    /// timing decision in `run_ffmpeg_loop`.  We test its boundary conditions
-    /// directly so the logic is verifiable without spinning up ffmpeg.
-    #[test]
-    fn watchdog_deadline_not_exceeded_before_timeout() {
-        assert!(!is_watchdog_deadline_exceeded(
-            SEGMENT_RECEIPT_TIMEOUT_SECS - 1,
-            SEGMENT_RECEIPT_TIMEOUT_SECS
-        ));
-    }
+    /// Regression for the gap-#1 silent-reset (issue #71): the segment-receipt
+    /// watchdog must fire on a stalled stream EVEN THOUGH the motion-cache
+    /// telemetry tick keeps returning from the `select!`. The pre-fix loop
+    /// rebuilt `timeout(90s, read)` every iteration, so the 45 s tick reset the
+    /// deadline before it could elapse and the watchdog never fired → silent
+    /// dead recording on a half-open stream (2026-06-17 incident). This
+    /// reproduces `run_ffmpeg_loop`'s arm structure — a never-ready read, a tick
+    /// shorter than the watchdog, and the deadline anchored to a FIXED
+    /// `last_segment_at` (never bumped, mimicking "no segments arriving") — and
+    /// asserts the watchdog still resolves after ticks have fired. On paused
+    /// time this is deterministic and instant. The pre-fix structure (a fresh
+    /// `timeout` rebuilt each iteration) would loop forever here.
+    #[tokio::test]
+    async fn watchdog_fires_despite_faster_telemetry_tick() {
+        // Scaled down from the real 45 s tick < 90 s watchdog so the test runs
+        // in ~120 ms of real time (no `test-util`/paused-clock dependency). The
+        // STRUCTURE is the point: the watchdog deadline is anchored to a fixed
+        // `last_segment_at` (never bumped here — a stream producing no further
+        // segments) while the tick keeps returning from the `select!`. Pre-fix,
+        // a per-iteration `timeout(read)` was rebuilt every loop and reset by
+        // each tick so it never fired; this loop must still resolve to stalled.
+        let timeout = Duration::from_millis(120);
+        let tick_period = Duration::from_millis(40);
+        assert!(
+            tick_period < timeout,
+            "tick must be shorter than the watchdog"
+        );
 
-    #[test]
-    fn watchdog_deadline_exceeded_at_timeout() {
-        assert!(is_watchdog_deadline_exceeded(
-            SEGMENT_RECEIPT_TIMEOUT_SECS,
-            SEGMENT_RECEIPT_TIMEOUT_SECS
-        ));
-    }
+        // Anchor fixed at entry and NEVER bumped: a stream that produces no
+        // further segment-list lines.
+        let last_segment_at = tokio::time::Instant::now();
+        let mut tick = tokio::time::interval(tick_period);
+        tick.tick().await; // consume the immediate first tick
+        let mut ticks = 0u32;
 
-    #[test]
-    fn watchdog_deadline_exceeded_past_timeout() {
-        assert!(is_watchdog_deadline_exceeded(
-            SEGMENT_RECEIPT_TIMEOUT_SECS + 60,
-            SEGMENT_RECEIPT_TIMEOUT_SECS
-        ));
+        let stalled = loop {
+            tokio::select! {
+                biased;
+                // Never-ready read stand-in (a silently stalled ffmpeg).
+                _ = std::future::pending::<()>() => unreachable!("read never ready"),
+                // Watchdog anchored to last_segment_at, NOT rebuilt from now().
+                () = tokio::time::sleep_until(last_segment_at + timeout) => break true,
+                _ = tick.tick() => { ticks += 1; }
+            }
+        };
+
+        assert!(stalled, "watchdog must fire on a stalled stream");
+        assert!(
+            ticks >= 1,
+            "telemetry ticks fired before the watchdog but must not reset it"
+        );
     }
 
     // ── redact_rtsp_credentials (#18) ─────────────────────────────────────────

--- a/services/recorder/src/resource_stats.rs
+++ b/services/recorder/src/resource_stats.rs
@@ -42,12 +42,15 @@
 //! container. The container has the NVIDIA `utility` driver capability
 //! (`NVIDIA_DRIVER_CAPABILITIES=…,utility`) so `libnvidia-ml` is injected.
 //!
-//! Each tick we call `Device::process_utilization_stats` over a short trailing
-//! window, which yields one [`ProcessUtilizationSample`] per GPU process with a
-//! `pid` and a `dec_util` (decode-engine %). We attribute **`dec_util`** — the
-//! quantity that actually moves when ffmpeg NVDEC-decodes a sub-stream — to a
-//! camera by summing over that camera's ffmpeg child pids, reusing the exact
-//! PID→camera mapping already built for CPU/mem.
+//! Each tick we call `Device::process_utilization_stats` for the samples newer
+//! than the ones the previous tick consumed, which yields a batch of
+//! [`ProcessUtilizationSample`]s — typically SEVERAL per GPU process (the
+//! driver buffers at sub-second cadence) — each with a `pid` and a `dec_util`
+//! (decode-engine %). We attribute **`dec_util`** — the quantity that actually
+//! moves when ffmpeg NVDEC-decodes a sub-stream — to a camera by averaging each
+//! pid's samples over the tick and summing those means across the camera's
+//! ffmpeg child pids, reusing the exact PID→camera mapping already built for
+//! CPU/mem.
 //!
 //! ## Host-PID → container-PID translation
 //!
@@ -185,12 +188,23 @@ mod linux {
     pub(super) struct LinuxSampler {
         /// pid → cumulative `utime + stime` (clock ticks) from the previous tick.
         prev_jiffies: HashMap<i32, u64>,
+        /// When the previous successful sample was taken. CPU% divides the
+        /// jiffies delta by the MEASURED wall time since then, not the nominal
+        /// [`SAMPLE_INTERVAL_SECONDS`]: with `MissedTickBehavior::Skip` a
+        /// delayed/skipped tick can make the real gap much longer than 10 s,
+        /// and dividing by the nominal interval would overstate CPU%.
+        prev_sample_at: Option<std::time::Instant>,
+        /// Newest NVML sample timestamp (µs) already consumed, passed back to
+        /// `process_utilization_stats` so each tick only sees NEW samples.
+        last_gpu_sample_ts: u64,
     }
 
     impl LinuxSampler {
         pub(super) fn new() -> Self {
             Self {
                 prev_jiffies: HashMap::new(),
+                prev_sample_at: None,
+                last_gpu_sample_ts: 0,
             }
         }
 
@@ -210,7 +224,10 @@ mod linux {
                 .collect();
             let camera_ids: Vec<Uuid> = cameras.iter().map(|c| c.id).collect();
 
-            // 2. Walk /proc for ffmpeg children of THIS recorder process.
+            // 2. Walk /proc for ffmpeg children of THIS recorder process,
+            //    noting WHEN the jiffies were sampled so CPU% can divide by the
+            //    real elapsed time (see `prev_sample_at`).
+            let sampled_at = std::time::Instant::now();
             let my_pid = std::process::id() as i32;
             let procs = collect_ffmpeg_children(my_pid);
 
@@ -229,13 +246,25 @@ mod linux {
                 entry.pids.push(p.pid);
             }
 
-            // 4. Best-effort per-PID GPU utilisation (pid → gpu %, summed/clamped
-            //    per camera). Missing/empty ⇒ None for every camera.
-            let gpu_by_pid = sample_gpu_by_pid(gpu_warned);
+            // 4. Best-effort per-PID GPU utilisation (pid → gpu %, averaged over
+            //    the tick's NVML samples, then summed/clamped per camera).
+            //    Missing/empty ⇒ None for every camera.
+            let gpu_by_pid = sample_gpu_by_pid(gpu_warned, &mut self.last_gpu_sample_ts);
 
             // 5. Compute CPU% from the jiffies delta vs the previous tick, mem MB,
             //    and GPU% (sum over the camera's pids), then upsert.
-            let interval_secs = SAMPLE_INTERVAL_SECONDS as f64;
+            //
+            // CPU% divides by the MEASURED elapsed time since the previous
+            // successful sample. On the first tick there is no previous sample;
+            // every per-pid delta is 0 there anyway (prev defaults to now), so
+            // the nominal-interval fallback only avoids a 0/0.
+            #[allow(clippy::cast_precision_loss)]
+            let elapsed_secs = self
+                .prev_sample_at
+                .map_or(SAMPLE_INTERVAL_SECONDS as f64, |prev| {
+                    sampled_at.duration_since(prev).as_secs_f64()
+                })
+                .max(0.001);
             let mut new_prev: HashMap<i32, u64> = HashMap::with_capacity(procs.len());
             for p in &procs {
                 new_prev.insert(p.pid, p.jiffies);
@@ -243,7 +272,7 @@ mod linux {
 
             for (camera_id, usage) in &per_camera {
                 // CPU%: Σ (this-tick jiffies − prev-tick jiffies) over the camera's
-                // pids, divided by (interval × CLK_TCK), ×100. New pids (no prev
+                // pids, divided by (elapsed × CLK_TCK), ×100. New pids (no prev
                 // entry) contribute 0 this tick and a real value next tick.
                 let mut delta_jiffies: u64 = 0;
                 for pid in &usage.pids {
@@ -251,8 +280,7 @@ mod linux {
                     let prev = self.prev_jiffies.get(pid).copied().unwrap_or(now);
                     delta_jiffies = delta_jiffies.saturating_add(now.saturating_sub(prev));
                 }
-                #[allow(clippy::cast_precision_loss)]
-                let cpu_pct = (delta_jiffies as f64) / (interval_secs * CLK_TCK) * 100.0;
+                let cpu_pct = cpu_pct_from_delta(delta_jiffies, elapsed_secs);
 
                 #[allow(clippy::cast_precision_loss)]
                 let mem_mb = (usage.mem_kb as f64) / 1024.0;
@@ -288,12 +316,25 @@ mod linux {
                 }
             }
 
-            // 6. Carry forward this tick's jiffies, pruning pids that have exited
-            //    so the map can't grow without bound.
+            // 6. Carry forward this tick's jiffies (pruning pids that have exited
+            //    so the map can't grow without bound) and its sample instant.
             self.prev_jiffies = new_prev;
+            self.prev_sample_at = Some(sampled_at);
 
             Ok(())
         }
+    }
+
+    /// CPU% for one camera over one tick: the summed jiffies delta of its pids,
+    /// over the MEASURED wall-clock seconds those jiffies accumulated in.
+    ///
+    /// Pure arithmetic, split out for unit testing: `delta / (elapsed × CLK_TCK)
+    /// × 100` — e.g. 500 jiffies (5 s of CPU at USER_HZ=100) over 5 s elapsed is
+    /// one fully-busy core = 100%.
+    fn cpu_pct_from_delta(delta_jiffies: u64, elapsed_secs: f64) -> f64 {
+        #[allow(clippy::cast_precision_loss)]
+        let delta = delta_jiffies as f64;
+        delta / (elapsed_secs * CLK_TCK) * 100.0
     }
 
     /// A single ffmpeg child of the recorder.
@@ -452,6 +493,15 @@ mod linux {
     ///   one-time NVML-init-failure warning is logged via the `gpu_warned` latch so a
     ///   GPU-less host doesn't spam the log.
     ///
+    /// The driver buffers MANY `ProcessUtilizationSample`s per process (it
+    /// samples internally at sub-second cadence), so each pid typically appears
+    /// several times per query. `last_gpu_sample_ts` is the newest sample
+    /// timestamp (µs) consumed by the previous tick: it is passed as
+    /// `last_seen_timestamp` so only NEW samples come back, and those are
+    /// **averaged** per pid (see [`average_util_per_pid`]) — summing them would
+    /// overcount utilisation by the number of buffered samples. On return it is
+    /// advanced to the newest timestamp seen this tick.
+    ///
     /// We read `dec_util` (NVDEC engine %) per pid. Unlike `nvidia-smi pmon -s u`,
     /// NVML's per-process utilisation works **without root**, so it actually
     /// populates inside the non-root (uid 1001) recorder container, which has the
@@ -464,7 +514,10 @@ mod linux {
     /// to its container pid (see [`host_pid_to_container_pid`]); otherwise the
     /// raw host pid is used, which only matches when the recorder shares the host
     /// PID namespace.
-    fn sample_gpu_by_pid(gpu_warned: &mut bool) -> Option<HashMap<i32, f64>> {
+    fn sample_gpu_by_pid(
+        gpu_warned: &mut bool,
+        last_gpu_sample_ts: &mut u64,
+    ) -> Option<HashMap<i32, f64>> {
         let Some(nvml) = super::NVML.as_ref() else {
             warn_once_nvml(gpu_warned);
             return None;
@@ -472,12 +525,17 @@ mod linux {
 
         let device = nvml.device_by_index(0).ok()?;
 
-        // `last_seen_timestamp = None` asks for samples since boot, but the driver
-        // caps the internal ring buffer to a short trailing window (~last second of
-        // activity), which is exactly the per-tick utilisation we want. A
-        // `NotFound` (no processes have used the GPU yet) is a legitimate empty
+        // Ask only for samples NEWER than the previous tick's newest (the driver
+        // filters on `last_seen_timestamp`). First tick: `None` = everything the
+        // driver still buffers (a short trailing window). A `NotFound` (no
+        // process has used the GPU since the cursor) is a legitimate empty
         // result, not a telemetry failure → return an empty map (all cameras 0%).
-        let samples = match device.process_utilization_stats(None) {
+        let since = if *last_gpu_sample_ts == 0 {
+            None
+        } else {
+            Some(*last_gpu_sample_ts)
+        };
+        let samples = match device.process_utilization_stats(since) {
             Ok(s) => s,
             Err(nvml_wrapper::error::NvmlError::NotFound) => return Some(HashMap::new()),
             Err(_) => return None,
@@ -489,11 +547,15 @@ mod linux {
         // report NULL rather than a misleading 0%.
         let translate = std::path::Path::new(HOST_PROC).is_dir();
         // `?` early-returns None if we can't establish our own namespace, i.e.
-        // can't safely translate host↔container pids.
+        // can't safely translate host↔container pids. (Before the cursor is
+        // advanced, so an aborted tick re-reads the same samples next time.)
         let my_ns = if translate { Some(my_pid_ns()?) } else { None };
 
-        let mut map: HashMap<i32, f64> = HashMap::new();
+        let mut per_pid: Vec<(i32, f64)> = Vec::with_capacity(samples.len());
         for s in samples {
+            // Advance the cursor over EVERY returned sample — including ones we
+            // skip below — so the next tick never re-consumes this window.
+            *last_gpu_sample_ts = (*last_gpu_sample_ts).max(s.timestamp);
             let key = if translate {
                 // Only host processes in OUR pid namespace yield a key; others
                 // (Frigate, host daemons) are skipped — never misattributed.
@@ -509,11 +571,32 @@ mod linux {
                     Err(_) => continue,
                 }
             };
-            // dec_util is the NVDEC engine % for this process over the window.
-            *map.entry(key).or_insert(0.0) += f64::from(s.dec_util);
+            // dec_util is the NVDEC engine % for this process at this sample.
+            per_pid.push((key, f64::from(s.dec_util)));
         }
 
-        Some(map)
+        Some(average_util_per_pid(&per_pid))
+    }
+
+    /// Collapse `(pid, utilisation)` samples into one **mean** utilisation per
+    /// pid.
+    ///
+    /// `process_utilization_stats` returns every buffered sample per process
+    /// since the given timestamp, so one pid usually contributes several
+    /// samples per tick. Summing them (the old behaviour) overcounted by the
+    /// number of buffered samples (e.g. three 40% samples → "120%"); the mean
+    /// is the process's utilisation over the tick. Pure arithmetic, split out
+    /// for unit testing.
+    fn average_util_per_pid(samples: &[(i32, f64)]) -> HashMap<i32, f64> {
+        let mut acc: HashMap<i32, (f64, u32)> = HashMap::new();
+        for &(pid, util) in samples {
+            let entry = acc.entry(pid).or_insert((0.0, 0));
+            entry.0 += util;
+            entry.1 += 1;
+        }
+        acc.into_iter()
+            .map(|(pid, (sum, n))| (pid, sum / f64::from(n)))
+            .collect()
     }
 
     /// Read-only bind mount of the **host** `/proc` (the node_exporter pattern),
@@ -574,6 +657,42 @@ mod linux {
                  'utility' driver capability); reporting gpu_pct = NULL for all \
                  cameras. Warning logged once."
             );
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{average_util_per_pid, cpu_pct_from_delta};
+
+        /// CPU% must be computed against the MEASURED elapsed time: the same
+        /// jiffies delta over a longer real gap is a lower utilisation. (The old
+        /// code always divided by the nominal 10 s interval, overstating CPU%
+        /// whenever a tick ran late or was skipped.)
+        #[test]
+        fn cpu_pct_uses_measured_elapsed_time() {
+            // 500 jiffies = 5 s of CPU at USER_HZ=100. Over 5 s elapsed that is
+            // one fully-busy core: 100%.
+            assert!((cpu_pct_from_delta(500, 5.0) - 100.0).abs() < 1e-9);
+            // The same 500 jiffies over a real gap of 20 s (one skipped tick) is
+            // 25% — dividing by the nominal 10 s would have claimed 50%.
+            assert!((cpu_pct_from_delta(500, 20.0) - 25.0).abs() < 1e-9);
+            // No work → 0%, whatever the elapsed time.
+            assert!(cpu_pct_from_delta(0, 7.3).abs() < 1e-9);
+        }
+
+        /// A pid's buffered NVML samples must be AVERAGED into one utilisation,
+        /// never summed. (The old code summed: three 40% samples became "120%".)
+        #[test]
+        fn gpu_samples_are_averaged_per_pid_not_summed() {
+            let samples = [(10, 30.0), (10, 50.0), (10, 40.0), (20, 12.0)];
+            let map = average_util_per_pid(&samples);
+            assert_eq!(map.len(), 2);
+            // pid 10: mean(30, 50, 40) = 40 — a sum would have said 120.
+            assert!((map[&10] - 40.0).abs() < 1e-9);
+            // A single sample is its own mean.
+            assert!((map[&20] - 12.0).abs() < 1e-9);
+            // No samples at all → empty map (a valid all-0% state).
+            assert!(average_util_per_pid(&[]).is_empty());
         }
     }
 }


### PR DESCRIPTION
Implements every finding from the 2026-07-12 adversarial recorder audit. One branch, one PR (six thematic, DCO-signed commits).

## Gate (Linux build host + Postgres 16)
`cargo build --workspace --tests` ✅ · `cargo fmt --all -- --check` ✅ · `cargo clippy --all-targets -- -D warnings` ✅ · `cargo test --workspace` ✅ (737 pre-existing tests pass; the new footage-critical + fail-open + DB-gated tests all execute and pass).

## Critical — permanent footage loss
- **#70** archive move truncated+deleted a segment when src path == dst path (seed default archive==live path; orphan adopted on the archive disk). dev+ino same-file guard flips the row in place; `copy_with_crc32` bails on src==dst; reconcile labels archive-disk orphans `stage=archive`. Regression test proves the bytes survive.
- **#71** the 90s stall watchdog never fired (the 45s telemetry tick reset the per-iteration `timeout(read)` every loop) → silent dead-recording on a half-open stream. Watchdog is now its own arm anchored to last-segment-receipt + a cancellation-safe `Lines` reader; regression test added.

## High — footage-threatening
- **#72** free-space floor / API statvfs read `f_bfree` (incl. the ext4 root reserve) so the ENOSPC valve never fired → `f_bavail`/`f_frsize`.
- **#73** reconnect mid-motion-event dropped the event's tail → carry motion state across reconnect + R1 keep-set + flip-guard.
- **#74** motion signals drained during a fail-open window desynced `MotionUnion` → keep the union consistent (fold-through + stash/replay).

## Medium
- **#75** long-lived service tasks never restarted on panic → is_finished watchdog respawn.
- **#76** go2rtc/ffmpeg/motion stderr drains died on invalid UTF-8 (SIGPIPE churn) → byte drains.
- **#77** ring segments pending a verdict at healthy→unhealthy were discarded → drain-to-persist on the transition.
- **#78** Frigate reported healthy on ConnAck before subscribing → healthy only on a granted SubAck.
- **#79** pixel detector healthy-but-blind for WARMUP_FRAMES → defer health past warm-up.
- **#80** unbounded archive held ARCHIVE_GUARD for hours → per-tick budget + per-batch release + backlog continuation.
- **#81** dropped MotionSignal on a full channel corrupted the verdict → fail-open via an interposed health watch.
- **#82** archive_schedule edits needed a restart → CronTracker re-parses on change.
- **#83** migration 0001 not idempotent (fresh-install crash → boot loop) → `IF NOT EXISTS`.

## Low (#84)
Cancellation-safe read; one-segment orphan end_ts; policy `record_stream` on adoption; far-future-mtime adoptable; partial-dst cleanup; catch-up cron `is_due`; 0014 schema-scoped catalog query; corrected reap/reconciler comments; CPU%/GPU% telemetry accuracy; loud invalid `RECORDER_TZ`; recorder `stop_grace_period: 90s` (+ AI-INSTALL note); a migration-runner parsing-invariant tripwire test.

Fixes #70, #71, #72, #73, #74, #75, #76, #77, #78, #79, #80, #81, #82, #83, #84

## Follow-ups
- A fresh adversarial re-audit of this branch is queued to verify each fix and check for regressions (esp. the fail-open union/ring/health-watch interaction) before this is called done.
- Doc propagation for the two design-level changes (the #81 interposed health watch; the #73 carry-across-reconnect) into `docs/DECISIONS.md` / `docs/RECORDER-CORRECTNESS.md` is a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)