### PR TITLE
docs(recorder): audit-hardening decisions + new correctness invariants

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,71 @@ revisit.
 
 ---
 
+## 2026-07-12, Recorder audit hardening: the free-space floor frees real bytes, fail-open survives every seam, boot-reap tolerates contention
+
+**Context.** A two-round adversarial audit of the recorder (issues #70–#84, PR
+#85) found a class of footage-safety bugs. Fixing them forced several decisions
+where a plausible alternative was rejected, and the audit iterated
+(fix → re-audit → fix): a few round-1/round-2 fixes were themselves reverted or
+reshaped once a later pass proved them unsafe — those reversals are decisions too.
+
+**Decision — the free-space (ENOSPC) floor must FREE bytes, not relocate them.**
+When the floor is in deficit and a segment's archive move would land on the SAME
+filesystem as the live storage (the default compose layout: `/data/archive` on
+the live disk) AND that filesystem is the one actually in deficit, the sweep
+DELETES the oldest live segment instead of archive-moving it in place. This is a
+deliberate, narrow exception to correctness item #7 (the live sweep normally
+skips archive-enabled cameras, the archiver owns their deletion), in the exact
+spirit of item #22 (the `max_retention_days` ceiling also overrides #7): losing
+the OLDEST footage beats losing ALL FUTURE footage to a 100%-full disk that
+ENOSPC-halts recording on every camera. It stays bound by every other safety
+rule, oldest-first, protected bookmarks excluded, file-then-row (#10), serialized
+on `ARCHIVE_GUARD` (#8), and only triggers when a move genuinely cannot free the
+deficit disk (`st_dev` identity of segment-fs == archive-fs == floor-fs); a
+segment on a different disk falls through to the normal lossless move. A loud
+`premature_rollover` system event fires so the loss is visible, never silent.
+
+**Decision — fail-open is an invariant across EVERY seam, not just steady state
+(item #19 extended).** Concretely: (a) worker-lifetime motion state, the
+`MotionBuffer` / `MotionUnion` / `pending_signals` are carried across an ffmpeg
+reconnect (the R1 cache sweep gets a keep-set so it won't delete carried pre-roll,
+and a flip-guard prevents a cache/storage-flavour mismatch from self-copy-
+truncating an indexed segment), so a reconnect mid-event no longer drops the event
+tail; (b) the `MotionUnion` is kept consistent through an unhealthy (frozen)
+window, edges are folded and the newest is stashed and replayed on thaw, and a
+STOP replayed onto an Idle buffer enters `PostBuffer` (`apply_replayed_edge`) so
+an event that ran entirely inside the window still keeps its post-roll; (c) a
+detector reports HEALTHY only when it can actually produce a verdict, the Frigate
+source on a granted MQTT SubAck (not ConnAck), the pixel detector after warm-up;
+(d) a panicked motion-source task is supervised (a `JoinSet`, the motion-side twin
+of the service-task watchdog) and immediately reads unhealthy → fail-open; (e) a
+`MotionSignal` dropped on a full channel flips the source to fail-open via an
+interposed health watch rather than being silently lost.
+
+**Rejected / not chosen:**
+
+| Option | Verdict |
+|---|---|
+| Free-space floor **archive-moves** oldest live footage even when the move frees nothing (pre-fix behaviour) | Rejected, on the default shared-fs layout it freed 0 bytes every tick, the disk filled to 100%, and ffmpeg ENOSPC-halted recording on every camera. A no-op that reads as success is worse than a bounded, loud deletion. |
+| Free-space floor deletes any same-archive-fs segment **without checking it is on the deficit disk** (a round-2 fix, reverted in round-3) | Rejected, on a repointed-storage config it deleted footage on a disk that frees nothing on the full disk: unbounded loss, zero benefit. The delete now also requires segment-fs == floor(deficit)-fs. |
+| A **time-based `MotionUnion` stale-key expiry** to un-wedge a lost STOP (a round-2 fix, reverted in round-3) | Rejected, it can't tell a lost STOP from a genuinely-long event (an HA occupancy/contact sensor held on for hours; a pixel event through a storm). On a MULTI-source camera, expiring the long event's key let a second source's STOP close the union and DISCARD footage while a healthy source still asserted motion (golden rule 2). The wedge is covered the footage-safe way (over-record) by the #81 loss-debt fail-open + the motion-source supervision. |
+| Signal a dropped-`MotionSignal` fail-open by writing `false` into `motion.rs`'s `aggregate_health` watch | Rejected, that watch dedups on `last_sent`, so a foreign `false` would never be re-published `true`: permanent fail-open with no recovery. An interposed second watch (`forward_motion_health`) folds signal-loss into health and recovers when the channel drains. |
+| Boot index-reap **permanently skips** any `DROP INDEX` that hits a lock timeout | Rejected, it conflates a real in-progress manual `CREATE INDEX CONCURRENTLY` (must skip) with transient contention (a busy boot, autovacuum), leaving a droppable INVALID index un-dropped so a later `CREATE INDEX IF NOT EXISTS` silently no-ops. The reap now re-checks `pg_stat_progress_create_index` on a timeout: skip only a genuine build, retry transient contention. |
+| Keep the stall watchdog as a per-`select!`-iteration `timeout(read)` | Rejected, a co-scheduled telemetry tick (45s < 90s) returned from the select and rebuilt the timeout every iteration, so it never fired → silent dead recording on a half-open stream. The watchdog is now a dedicated arm anchored to the last segment receipt. |
+
+**Cost accepted.** The shared-fs floor deletes un-archived live footage of
+archive-enabled cameras when the disk would otherwise fill, an explicit, loud
+exception (not silent). Several fail-open paths deliberately OVER-record (a lost
+STOP over-records until the next event; a warm-up window persists idle footage),
+disk-waste bounded by retention, never loss, the correct direction per item #19.
+
+**Revisit triggers.** A source-identity-keyed `MotionUnion` (each open key tagged
+by source) lands → the lost-STOP wedge can be closed without over-record, and the
+"no time-based expiry" rejection can be revisited. Per-GPU decode accounting lands
+→ the floor's single-fs assumption could generalize to multi-disk deficit
+tracking. A hermetic api-integration-test harness lands (issue #88) → the
+`server_settings`-sharing test flakiness surfaced during this work is resolved.
+
 ## 2026-07-10, Desktop client: rewrite native in Flutter (keep the Rust core), retire the Tauri/WebView2 airspace model
 
 **Context.** The desktop client is Tauri 2 + wry/WebView2 with native Win32

--- a/docs/RECORDER-CORRECTNESS.md
+++ b/docs/RECORDER-CORRECTNESS.md
@@ -147,3 +147,49 @@ recorder, and later the API) must satisfy these *by construction*.
     reliable detector is a packet count: the segmenter's audio args are unit-
     tested to keep `-copyinkf:a`, and any integration check must assert
     `nb_read_packets > 0` on the audio stream, not merely that the stream exists.
+
+## free-space floor (ENOSPC safety valve)
+24. **The floor keys off free space AVAILABLE to the recorder, and its response
+    must actually FREE bytes.** Read `statvfs` `f_bavail`/`f_frsize`, NOT `f_bfree`
+    (which includes the ext4 root reserve the non-root recorder cannot use, so the
+    valve would never fire). When the floor is in deficit, an archive-move that
+    lands on the SAME filesystem as the deficit disk frees nothing — on the default
+    compose layout that let the disk fill to 100% and ENOSPC-halt recording. So the
+    deficit path DELETES the oldest live segment (a narrow, loud exception to item
+    7, in the spirit of item 22) when — and only when — the segment's storage
+    shares the archive filesystem AND the deficit filesystem (`st_dev` identity); a
+    segment on any other disk falls through to the normal footage-preserving move.
+    Oldest-first, protected bookmarks excluded, file-then-row (10), serialized on
+    `ARCHIVE_GUARD` (8), and a `premature_rollover` event fires so the loss is
+    visible. See `docs/DECISIONS.md` (2026-07-12).
+
+## fail-open across every seam (extends item 19)
+25. **Fail-open state survives reconnect and stays consistent through an unhealthy
+    window.** `MotionBuffer`/`MotionUnion`/`pending_signals` are worker-lifetime
+    (carried across an ffmpeg reconnect; the R1 cache sweep spares carried pre-roll
+    via a keep-set; a flip-guard blocks a cache/storage-flavour self-copy-truncate),
+    so a reconnect mid-event never drops the tail. Through a frozen window the union
+    is kept in sync — edges fold, the newest is stashed and replayed on thaw, and a
+    replayed STOP onto an Idle buffer enters `PostBuffer` so a full event inside the
+    window keeps its post-roll. Do NOT add a blind time-based `MotionUnion` expiry:
+    it cannot tell a lost STOP from a genuinely-long event and on a multi-source
+    camera would discard footage a healthy source is still asserting (the wedge is
+    covered footage-safe by the loss-debt fail-open + source supervision instead).
+26. **A detector is HEALTHY only when it can produce a keep/discard verdict.** The
+    Frigate source reports healthy on a GRANTED MQTT SubAck, never on ConnAck (a
+    denied subscription is "healthy forever, zero events"); the pixel detector only
+    after warm-up; a panicked source task is supervised and immediately reads
+    unhealthy → fail-open; a `MotionSignal` dropped on a full channel flips the
+    source to fail-open via an interposed health watch (never silently lost).
+
+## stall watchdog & boot reap
+27. **The segment-receipt stall watchdog is anchored to the last received segment,
+    not a per-`select!`-iteration timeout.** A co-scheduled telemetry tick shorter
+    than the timeout must not be able to rebuild/reset the deadline every loop — that
+    left a half-open stream recording nothing indefinitely. It is a dedicated select
+    arm on `sleep_until(last_segment_at + timeout)`.
+28. **Boot index-reap skips only a GENUINE in-progress build.** An INVALID index is
+    dropped so a later `CREATE INDEX IF NOT EXISTS` rebuilds it; on a lock timeout,
+    re-check `pg_stat_progress_create_index` for that index — skip a real manual
+    `CREATE INDEX CONCURRENTLY`, but RETRY transient/foreign contention rather than
+    permanently skipping (which would silently leave a broken catalog entry).


### PR DESCRIPTION
Golden-rule 7/8 follow-up to the recorder audit fixes (#70–#84, merged in #85). Docs only, no code.

- **docs/DECISIONS.md** — a 2026-07-12 entry recording the significant decisions and the round-2→round-3 reversals: the free-space floor **deleting** (not relocating) footage on a shared filesystem, fail-open extended across every seam, the interposed dropped-signal health watch, contention-tolerant boot index-reap, and the receipt-anchored stall watchdog — each with the rejected alternative and revisit triggers.
- **docs/RECORDER-CORRECTNESS.md** — invariants 23–27: the free-space floor must free real bytes (shared-fs delete exception); fail-open survives reconnect and a frozen window with **no** blind `MotionUnion` expiry; a detector is healthy only when it can produce a verdict; the stall watchdog is receipt-anchored; boot reap skips only a genuine in-progress build.

These capture *why* the merged fixes are shaped the way they are so a future session can tell whether the world has changed enough to revisit — especially the deliberate footage-**deleting** floor exception and the rejected time-based union expiry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)