### PR TITLE
fix(recorder): capture audio in recorded segments (-copyinkf:a)

### DIFF
--- a/docs/RECORDER-CORRECTNESS.md
+++ b/docs/RECORDER-CORRECTNESS.md
@@ -121,3 +121,29 @@ recorder, and later the API) must satisfy these *by construction*.
     (a human pin outranks the automatic cap); and batch-limited so first enabling a
     short cap converges over ticks instead of one mass delete. When set it can only
     remove footage *sooner* than the other knobs would, never keep it longer.
+
+## declared tracks must carry decodable packets (audio-integrity)
+23. **A recorded segment MUST contain decodable media PACKETS for every track it
+    declares — a declared-but-empty track is a silent footage-integrity failure,
+    and `-copyinkf:a` on the `-c copy` audio path is load-bearing against it.**
+    Under stream-copy, ffmpeg's CLI silently discards every packet on a stream
+    until it sees the first packet flagged as a keyframe. Video packets are
+    key-flagged at each IDR (so video records), but the RTSP/RTP AAC
+    (MPEG4-GENERIC) depacketizer never sets the key flag on ANY audio packet, so
+    without `-copyinkf:a` ("copy initial non-keyframes", audio streams only) 100%
+    of audio packets are dropped before the muxer — while the moov still declares
+    the aac track from the stream's SDP. The result probes as a healthy segment
+    (ffprobe lists an aac stream) but has ZERO audio samples: silent playback,
+    silent export, no warning at any normal log level. So `-copyinkf:a` is emitted
+    on **both** `-c copy` audio sites (recorder `audio_segmenter_args`, and the
+    export's `-f concat … -c:a copy` in `services/api/src/export.rs` — mandatory
+    there too because the recorded fMP4's `trun` sample flags faithfully preserve
+    the missing key flag, so even a correctly-recorded segment reads back with its
+    audio unflagged and a plain concat-copy re-drops it). Decode paths (re-encode
+    exports, clip playback/preview/thumbnails) are unaffected — the keyframe gate
+    is a stream-copy behavior only. This is zero-transcode; it only ungates the
+    copy. It does NOT touch the fMP4 crash-safety flags (item 1). Because a
+    declared-but-empty track looks healthy to ffprobe's stream listing, the only
+    reliable detector is a packet count: the segmenter's audio args are unit-
+    tested to keep `-copyinkf:a`, and any integration check must assert
+    `nb_read_packets > 0` on the audio stream, not merely that the stream exists.

--- a/services/api/src/export.rs
+++ b/services/api/src/export.rs
@@ -599,7 +599,20 @@ fn build_codec_args(
             "128k".to_owned(),
         ]);
     } else {
-        args.extend(["-c:a".to_owned(), "copy".to_owned()]);
+        // `-copyinkf:a` is MANDATORY on the audio copy path, same reason as the
+        // recorder (see recording.rs / docs/RECORDER-CORRECTNESS.md): under
+        // `-c copy` ffmpeg drops every packet until the first keyframe-flagged
+        // one, and RTP-AAC audio is never key-flagged. The recorded fMP4's trun
+        // sample flags faithfully preserve that missing key flag, so even a
+        // correctly-recorded segment reads back with its audio unflagged — a
+        // plain `-f concat … -c:a copy` would silently drop the audio all over
+        // again. (The export output is non-fragmented mp4, so it re-writes
+        // proper key flags and stays remux-safe in third-party tools.)
+        args.extend([
+            "-c:a".to_owned(),
+            "copy".to_owned(),
+            "-copyinkf:a".to_owned(),
+        ]);
     }
 
     // MP4-specific: move the moov atom to the front for fast web streaming.
@@ -1594,5 +1607,50 @@ mod tests {
         let token = CancellationToken::new(); // not cancelled
         let outcome = wait_or_cancel(&mut child, &token).await;
         assert!(matches!(outcome, WaitOutcome::Finished(Ok(s)) if s.success()));
+    }
+
+    // ── build_codec_args audio handling ─────────────────────────────────────────
+
+    /// The audio-copy path MUST carry `-copyinkf:a`. The recorder writes fMP4
+    /// whose trun sample flags faithfully record that RTP-AAC audio was never
+    /// key-flagged, so a plain `-f concat … -c:a copy` re-drops the audio (every
+    /// packet before the first "keyframe" is discarded, and none is flagged) —
+    /// producing a silent export even from correctly-recorded footage. Guards
+    /// the fix from being cleaned away.
+    #[test]
+    fn copy_audio_export_keeps_initial_non_keyframes() {
+        let a = build_codec_args(false, true, "copy", "mp4").args;
+        // -c:a copy present, immediately followed/accompanied by -copyinkf:a.
+        assert!(
+            a.windows(2).any(|w| w == ["-c:a", "copy"]),
+            "expected -c:a copy; got {a:?}"
+        );
+        assert!(
+            a.iter().any(|s| s == "-copyinkf:a"),
+            "copy-audio export MUST include -copyinkf:a; got {a:?}"
+        );
+    }
+
+    /// Dropping audio (`include_audio=false`) still emits `-an` and never the
+    /// copy flag; the re-encode path transcodes (`-c:a aac`) so the keyframe
+    /// gate doesn't apply and the flag is neither needed nor emitted.
+    #[test]
+    fn no_audio_and_reencode_paths_omit_copyinkf() {
+        let dropped = build_codec_args(false, false, "copy", "mp4").args;
+        assert!(dropped.iter().any(|s| s == "-an"), "got {dropped:?}");
+        assert!(
+            !dropped.iter().any(|s| s == "-copyinkf:a"),
+            "no audio → no copy flag; got {dropped:?}"
+        );
+
+        let reencoded = build_codec_args(true, true, "copy", "mp4").args;
+        assert!(
+            reencoded.windows(2).any(|w| w == ["-c:a", "aac"]),
+            "burn_timestamp forces a re-encode → -c:a aac; got {reencoded:?}"
+        );
+        assert!(
+            !reencoded.iter().any(|s| s == "-copyinkf:a"),
+            "re-encode path decodes audio, no keyframe gate; got {reencoded:?}"
+        );
     }
 }

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -10259,6 +10259,21 @@ mod tests {
             .await
             .expect("create table + index");
 
+        // De-flake under `cargo test --workspace` parallelism (CI): the reap's
+        // `DROP INDEX` needs ACCESS EXCLUSIVE on `widgets`, and the only session
+        // that can otherwise contend for it on this test's private-schema table
+        // is autovacuum (SHARE UPDATE EXCLUSIVE, which conflicts). Under heavy
+        // parallel load a freshly created + catalog-UPDATE'd table can draw an
+        // autovacuum that holds that lock past the connection's `lock_timeout`,
+        // so the reap exhausts its retries and (correctly, safe-direction) SKIPS
+        // the drop — making this assertion flaky. Turning autovacuum off for the
+        // table removes the sole external lock contender so the drop is
+        // deterministic; it does not weaken what the test checks.
+        client
+            .batch_execute("ALTER TABLE widgets SET (autovacuum_enabled = false)")
+            .await
+            .expect("disable autovacuum on the fixture table");
+
         // Simulate the catalog state a killed CREATE INDEX CONCURRENTLY
         // leaves behind: the index exists but is marked NOT VALID.
         client

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -10296,22 +10296,42 @@ mod tests {
             .get(0);
         assert!(still_present_before, "fixture setup: index should exist");
 
-        reap_invalid_indexes(&client)
+        // De-flake under `cargo test --workspace`: this test races ~16 parallel
+        // DDL-heavy tests on a single Postgres, so a reap pass can hit transient
+        // contention and (correctly, safe-direction) SKIP the drop that pass.
+        // The production reaper runs on EVERY boot, so the real contract is
+        // "drops within a few passes", not "drops on the very first". Use a short
+        // per-attempt lock_timeout so a contended pass fails fast instead of
+        // stalling, and retry the idempotent reap until the index is gone.
+        // (Disabling autovacuum on the fixture table above was not enough on its
+        // own — the remaining contention is catalog-wide from the parallel DDL.)
+        client
+            .batch_execute("SET lock_timeout = '1s'")
             .await
-            .expect("reap_invalid_indexes");
+            .expect("shorten lock_timeout for the reap retries");
 
-        let still_present_after: bool = client
-            .query_one(
-                "SELECT EXISTS (SELECT 1 FROM pg_class WHERE relname = 'widgets_name_idx')",
-                &[],
-            )
-            .await
-            .expect("check index exists after reap")
-            .get(0);
+        let mut still_present_after = true;
+        for _ in 0..40 {
+            reap_invalid_indexes(&client)
+                .await
+                .expect("reap_invalid_indexes");
+            still_present_after = client
+                .query_one(
+                    "SELECT EXISTS (SELECT 1 FROM pg_class WHERE relname = 'widgets_name_idx')",
+                    &[],
+                )
+                .await
+                .expect("check index exists after reap")
+                .get(0);
+            if !still_present_after {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        }
         assert!(
             !still_present_after,
-            "reap_invalid_indexes must DROP an INVALID index so a later \
-             CREATE INDEX IF NOT EXISTS rebuilds it"
+            "reap_invalid_indexes must DROP an INVALID index (within a few \
+             passes) so a later CREATE INDEX IF NOT EXISTS rebuilds it"
         );
 
         // A VALID index must be left completely alone.

--- a/services/recorder/src/recording.rs
+++ b/services/recorder/src/recording.rs
@@ -424,6 +424,30 @@ pub async fn run(
 /// open-source set, and the accumulated signals all carry across an
 /// error/stall restart of the ffmpeg child instead of being silently reset
 /// (which used to discard the remainder of the event).
+/// The audio ffmpeg args for the `-c copy` segmenter, given the camera's
+/// `record_audio` policy.
+///
+/// When `record_audio` is false → `-an` (drop the audio output stream).
+///
+/// When true → `-copyinkf:a` ("copy initial non-keyframes", audio streams
+/// only), which is **LOAD-BEARING, not a nicety**. Under `-c copy` ffmpeg's CLI
+/// silently discards every packet on a stream until it sees the first packet
+/// flagged as a keyframe. Video packets get that flag at each IDR, so video
+/// records; but the RTSP/RTP AAC (MPEG4-GENERIC) depacketizer never sets the
+/// key flag on ANY audio packet, so without this flag 100% of audio packets are
+/// dropped before the muxer. The moov still declares the aac track (from the
+/// stream's SDP), so the result is a declared-but-EMPTY audio track — silent
+/// footage, with no warning at any normal log level. See
+/// `docs/RECORDER-CORRECTNESS.md`: a declared track must carry decodable
+/// packets. Zero-transcode is preserved (this only ungates copying).
+fn audio_segmenter_args(record_audio: bool) -> &'static [&'static str] {
+    if record_audio {
+        &["-copyinkf:a"]
+    } else {
+        &["-an"]
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_ffmpeg_loop(
     camera: &Camera,
@@ -765,14 +789,10 @@ async fn run_ffmpeg_loop(
         // pure container-level retag (no transcode); harmless for H.264 streams.
         .args(["-tag:v", "hvc1"]);
 
-    // Drop audio when the policy says so.  `-an` must come after `-c copy` so
-    // ffmpeg interprets it as "disable audio output stream" rather than
-    // overriding a stream-specifier codec.  When `record_audio` is true the
-    // `-c copy` codec selection already carries the audio track through without
-    // transcoding — no extra flag needed.
-    if !camera.policy.record_audio {
-        ffmpeg_cmd.arg("-an");
-    }
+    // Audio handling (see [`audio_segmenter_args`]).  These must come after
+    // `-c copy` so ffmpeg reads `-an` as "disable audio output" rather than
+    // overriding a stream-specifier codec.
+    ffmpeg_cmd.args(audio_segmenter_args(camera.policy.record_audio));
 
     ffmpeg_cmd
         // Segmenter muxer
@@ -3061,6 +3081,41 @@ mod tests {
     // Helper to build a UTC DateTime quickly.
     fn utc(y: i32, mo: u32, d: u32, h: u32, m: u32, s: u32) -> DateTime<Utc> {
         Utc.with_ymd_and_hms(y, mo, d, h, m, s).unwrap()
+    }
+
+    // ── audio segmenter args (declared-track-must-carry-packets invariant) ──────
+
+    #[test]
+    fn audio_args_copy_initial_non_keyframes_when_recording_audio() {
+        // The load-bearing case: with `-c copy`, ffmpeg drops every packet
+        // until the first keyframe-flagged one, and RTP-AAC audio is NEVER
+        // key-flagged — so without `-copyinkf:a` the recorded segment declares
+        // an aac track (from the SDP) but contains ZERO audio packets. This
+        // guards against a future cleanup silently dropping the flag and
+        // reintroducing the empty-audio-track footage bug.
+        let args = audio_segmenter_args(true);
+        assert!(
+            args.contains(&"-copyinkf:a"),
+            "record_audio=true must pass -copyinkf:a so audio packets aren't \
+             gated out of the copy; got {args:?}"
+        );
+        assert!(
+            !args.contains(&"-an"),
+            "record_audio=true must NOT disable audio; got {args:?}"
+        );
+    }
+
+    #[test]
+    fn audio_args_disable_audio_when_not_recording_audio() {
+        let args = audio_segmenter_args(false);
+        assert!(
+            args.contains(&"-an"),
+            "record_audio=false must pass -an; got {args:?}"
+        );
+        assert!(
+            !args.contains(&"-copyinkf:a"),
+            "record_audio=false has no audio to copy; got {args:?}"
+        );
     }
 
     // ── classify_failure (cold-start fast retry) ────────────────────────────────


### PR DESCRIPTION
Fixes #92.

## What was wrong

Recorded segments had a **declared-but-empty audio track** — playback and export
were silent on audio-enabled cameras, while live audio worked. Under `-c copy`,
ffmpeg's CLI silently discards every packet on a stream until it sees the first
one flagged as a keyframe. Video is key-flagged at each IDR (so video records),
but the RTSP/RTP AAC (MPEG4-GENERIC) depacketizer never key-flags audio, so 100%
of audio packets were dropped before the muxer — while the `moov` still declared
the aac track from the stream's SDP. It probed as a healthy segment with zero
audio samples, no warning at any normal log level. (Live works because it plays
via WebRTC/Opus — a decode path with no keyframe gate.)

Root-caused and server-verified on the operator's recorder (packet dumps,
`-loglevel debug` "381 read … 0 muxed", every audio RTP packet flagged `___`,
and a re-recording with the fix carrying real audio).

## The fix

Add **`-copyinkf:a`** ("copy initial non-keyframes", audio streams only) to both
`-c copy` audio sites — zero transcode, it only ungates the copy:

- **Recorder** (`recording.rs`) — via a new testable `audio_segmenter_args`
  helper.
- **Export** (`export.rs` `build_codec_args` copy path) — **mandatory**: the
  recorded fMP4's `trun` sample flags faithfully preserve the missing key flag,
  so even a correctly-recorded segment reads back unflagged and a plain
  `-f concat … -c:a copy` would re-drop the audio. The export output is
  non-fragmented mp4, so it re-writes proper key flags and stays remux-safe.

Decode paths (re-encode exports, clip playback/preview/thumbnails) are
unaffected. fMP4 crash-safety flags (correctness #1) are untouched.

## Tests / docs

- New unit tests on both audio arg paths (recorder `audio_segmenter_args`,
  export `build_codec_args`): asserts `-copyinkf:a` on the copy paths, `-an` when
  audio is off, and no copy flag on the re-encode path.
- New **RECORDER-CORRECTNESS** invariant 23: *a declared media track must carry
  decodable packets* (ffprobe's stream listing looks healthy; only a packet
  count reveals the loss), documenting `-copyinkf:a` as load-bearing.

## Gate

On the Linux build host, fresh Postgres: `cargo fmt --all --check` OK, `cargo
clippy --all-targets -D warnings` clean, `cargo test --workspace` green **except**
the pre-existing `reap_invalid_indexes_drops` flake — which this PR doesn't touch
and which is de-flaked here by cherry-picking the same fix as #89 (identical
hunk; whichever of the two merges second, the other's hunk is already present).

## Notes

- **Footage recorded before this has no recoverable audio** — those packets were
  never written. This only fixes capture going forward; deploy sooner = start
  capturing audio sooner.
- After the fix, a camera with mild audio RTP timestamp jitter will emit
  occasional harmless "Non-monotonic DTS" recorder log lines (cosmetic, ≤1.5 ms
  a/v wobble, not footage loss).
- If #89 merges first, the RECORDER-CORRECTNESS numbering (its 23–27 vs this 23)
  needs a trivial renumber on rebase.
