### PR TITLE
feat(android): audio on/off toggle in recorded playback

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/data/SecureStore.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/SecureStore.kt
@@ -115,6 +115,18 @@ class SecureStore(context: Context) {
         set(value) = prefs.edit().putBoolean(KEY_LIVE_AUDIO, value).apply()
 
     /**
+     * Whether the recorded-playback screen plays segment audio. Persisted across
+     * sessions so the user's choice is remembered. Defaults to FALSE — reviewing
+     * footage should stay silent unless the operator explicitly turns audio on,
+     * so scrubbing through recordings never blares unexpected sound. (Older
+     * footage recorded before audio capture landed simply plays silent when the
+     * toggle is on — no crash.)
+     */
+    var playbackAudioOn: Boolean
+        get() = prefs.getBoolean(KEY_PLAYBACK_AUDIO, false)
+        set(value) = prefs.edit().putBoolean(KEY_PLAYBACK_AUDIO, value).apply()
+
+    /**
      * Live wall grid-layout ordinal (GridLayout: 0=single, 1=2x2, 2=list).
      * Persisted so the chosen layout survives navigating in/out of a camera AND
      * app restarts (a plain `remember` was resetting it to 2x2 on every return).
@@ -244,6 +256,7 @@ class SecureStore(context: Context) {
         private const val KEY_USERNAME = "username"
         private const val KEY_LAST_LIVE_CAM = "last_live_cam"
         private const val KEY_LIVE_AUDIO = "live_audio_on"
+        private const val KEY_PLAYBACK_AUDIO = "playback_audio_on"
         private const val KEY_LIVE_LAYOUT = "live_grid_layout"
         private const val KEY_LOW_BW_AUTOFIX = "low_bw_autofix_applied"
         private const val KEY_PTZ_STYLE = "ptz_style"

--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
@@ -773,27 +773,9 @@ fun PlaybackScreen(
                         }
                     }
                 }
-
-                // Audio on/off toggle — LANDSCAPE ONLY: the top app bar is hidden
-                // then, so float it in the corner. In portrait it lives in the app
-                // bar's actions (above) instead of floating over the footage.
-                if (isLandscape && state.currentSegment != null) {
-                    HintTooltip(if (audioOn) "Mute audio" else "Play audio") {
-                        IconButton(
-                            onClick = {
-                                audioOn = !audioOn
-                                store.playbackAudioOn = audioOn
-                            },
-                            modifier = Modifier.align(Alignment.TopEnd).padding(2.dp),
-                        ) {
-                            Icon(
-                                imageVector = if (audioOn) Icons.Default.VolumeUp else Icons.Default.VolumeOff,
-                                contentDescription = if (audioOn) "Mute audio" else "Play audio",
-                                tint = if (audioOn) TealAccent else Color.White,
-                            )
-                        }
-                    }
-                }
+                // (Audio toggle: portrait → top app bar actions; landscape → inline
+                // on the transport row below, next to Snapshot/Bookmark. It is NOT
+                // floated over the video in either orientation.)
             }
 
             // ── PINNED transport bar (controls + timeline) at the bottom ──────────
@@ -826,6 +808,14 @@ fun PlaybackScreen(
                     onSnapshot = onSnapshot,
                     // null hides the bookmark control (transport uses onBookmark?.let)
                     onBookmark = if (bookmarksEnabled) onBookmark else null,
+                    // Landscape hosts the audio toggle inline on this row (portrait
+                    // uses the app bar). Gate on a resolved segment, same as portrait.
+                    audioOn = audioOn,
+                    onToggleAudio = if (state.currentSegment != null) {
+                        { audioOn = !audioOn; store.playbackAudioOn = audioOn }
+                    } else {
+                        null
+                    },
                     // Portrait can't fit every control inline (the snapshot button was
                     // being clipped), so the SECONDARY actions (snapshot, bookmark,
                     // jump-to-time, speed) collapse into a 3-dot overflow menu. In
@@ -918,6 +908,10 @@ private fun PlaybackControls(
     useOverflowMenu: Boolean = false,
     onSnapshot: (() -> Unit)? = null,
     onBookmark: (() -> Unit)? = null,
+    // Audio toggle rides inline on the landscape transport row (in portrait it
+    // lives in the top app bar instead). null hides it.
+    audioOn: Boolean = false,
+    onToggleAudio: (() -> Unit)? = null,
 ) {
     // Landscape is vertically cramped, so the transport runs a notch smaller there
     // (this is what "shrinks the play/pause bar"). Portrait keeps its roomier sizes.
@@ -1097,13 +1091,27 @@ private fun PlaybackControls(
 
             // Snapshot + Bookmark share this transport row in landscape (the app bar
             // is hidden there). In portrait they live in the overflow menu above.
-            if (onSnapshot != null || onBookmark != null) {
+            if (onSnapshot != null || onBookmark != null || onToggleAudio != null) {
                 Spacer(Modifier.width(6.dp))
                 onSnapshot?.let {
                     SmallControl(Icons.Default.PhotoCamera, "Snapshot", ctlSize, ctlIcon, it)
                 }
                 onBookmark?.let {
                     SmallControl(Icons.Default.BookmarkAdd, "Add bookmark", ctlSize, ctlIcon, it)
+                }
+                // Audio on/off — same row as Snapshot/Bookmark in landscape (teal
+                // when on), instead of a float that lands over the video.
+                onToggleAudio?.let { toggle ->
+                    HintTooltip(if (audioOn) "Mute audio" else "Play audio") {
+                        IconButton(onClick = toggle, modifier = Modifier.size(ctlSize)) {
+                            Icon(
+                                imageVector = if (audioOn) Icons.Default.VolumeUp else Icons.Default.VolumeOff,
+                                contentDescription = if (audioOn) "Mute audio" else "Play audio",
+                                tint = if (audioOn) TealAccent else Color.White,
+                                modifier = Modifier.size(ctlIcon),
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
@@ -623,6 +623,28 @@ fun PlaybackScreen(
                         }
                     }
                 },
+                // Audio on/off toggle lives here (portrait): a primary, always-
+                // visible control docked in the app bar, out of the video — NOT a
+                // floating overlay that lands over the footage on a letterboxed
+                // pane. Only meaningful once a segment is resolved to hear.
+                actions = {
+                    if (state.currentSegment != null) {
+                        HintTooltip(if (audioOn) "Mute audio" else "Play audio") {
+                            IconButton(
+                                onClick = {
+                                    audioOn = !audioOn
+                                    store.playbackAudioOn = audioOn
+                                },
+                            ) {
+                                Icon(
+                                    imageVector = if (audioOn) Icons.Default.VolumeUp else Icons.Default.VolumeOff,
+                                    contentDescription = if (audioOn) "Mute audio" else "Play audio",
+                                    tint = if (audioOn) TealAccent else Color.White,
+                                )
+                            }
+                        }
+                    }
+                },
                 // Snapshot + Bookmark moved OUT of the app bar into the transport's
                 // 3-dot overflow menu (portrait), keeping the bar uncluttered and the
                 // secondary actions grouped where the user controls playback.
@@ -752,11 +774,10 @@ fun PlaybackScreen(
                     }
                 }
 
-                // Audio on/off toggle — floats top-end over the video in BOTH
-                // orientations (same affordance as the fullscreen live view). Only
-                // shown once there's a resolved segment to hear; hidden on the
-                // loading / error / no-footage states where there's nothing playing.
-                if (state.currentSegment != null) {
+                // Audio on/off toggle — LANDSCAPE ONLY: the top app bar is hidden
+                // then, so float it in the corner. In portrait it lives in the app
+                // bar's actions (above) instead of floating over the footage.
+                if (isLandscape && state.currentSegment != null) {
                     HintTooltip(if (audioOn) "Mute audio" else "Play audio") {
                         IconButton(
                             onClick = {

--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.material.icons.filled.NavigateNext
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.VolumeOff
+import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -103,6 +105,7 @@ import video.crumb.app.ui.player.ViewTransform
 import video.crumb.app.ui.player.ZoomableVideoSurface
 import video.crumb.app.ui.theme.NavyDeep
 import video.crumb.app.ui.theme.NavySurface
+import video.crumb.app.ui.theme.TealAccent
 import video.crumb.app.ui.theme.TextSecondary
 import java.time.Instant
 
@@ -234,6 +237,20 @@ fun PlaybackScreen(
         MediaFactory.newPlayer(context).apply {
             setSeekParameters(SeekParameters.EXACT) // frame-accurate stepping
         }
+    }
+
+    // Recorded-playback audio on/off (mirrors the fullscreen live view's toggle).
+    // Seeded from SecureStore (default OFF — reviewing footage is silent until the
+    // operator asks for sound) and persisted on every change. A segment recorded
+    // without an audio track just plays silent when this is on — no crash.
+    val store = container.store
+    var audioOn by remember { mutableStateOf(store.playbackAudioOn) }
+    // Drive the single ExoPlayer's volume from the toggle. ExoPlayer keeps this
+    // volume across setMediaSource / the gapless addMediaSource path, so applying it
+    // to the one player here covers every segment (initial, scrub, motion-jump,
+    // auto-advance) without re-asserting it per segment.
+    LaunchedEffect(player, audioOn) {
+        player.volume = if (audioOn) 1f else 0f
     }
 
     // Frame step (paused): nudge the player by ~one frame within the current
@@ -730,6 +747,28 @@ fun PlaybackScreen(
                                 Icons.AutoMirrored.Filled.ArrowBack,
                                 contentDescription = "Back",
                                 tint = Color.White,
+                            )
+                        }
+                    }
+                }
+
+                // Audio on/off toggle — floats top-end over the video in BOTH
+                // orientations (same affordance as the fullscreen live view). Only
+                // shown once there's a resolved segment to hear; hidden on the
+                // loading / error / no-footage states where there's nothing playing.
+                if (state.currentSegment != null) {
+                    HintTooltip(if (audioOn) "Mute audio" else "Play audio") {
+                        IconButton(
+                            onClick = {
+                                audioOn = !audioOn
+                                store.playbackAudioOn = audioOn
+                            },
+                            modifier = Modifier.align(Alignment.TopEnd).padding(2.dp),
+                        ) {
+                            Icon(
+                                imageVector = if (audioOn) Icons.Default.VolumeUp else Icons.Default.VolumeOff,
+                                contentDescription = if (audioOn) "Mute audio" else "Play audio",
+                                tint = if (audioOn) TealAccent else Color.White,
                             )
                         }
                     }


### PR DESCRIPTION
Adds a playback audio enable/disable toggle to the Android client, mirroring the fullscreen live view's affordance.

- **SecureStore**: new persisted `playbackAudioOn` (key `playback_audio_on`, default **off** — reviewing footage stays silent until asked).
- **PlaybackScreen**: a TopEnd `VolumeUp`/`VolumeOff` `IconButton` (teal when on), shown once a segment is resolved, driving the single ExoPlayer's `volume` via a `LaunchedEffect` (covers initial/scrub/motion-jump/auto-advance). A segment with no audio track just plays silent when on — no crash.
- **PlaybackWallScreen** untouched (it renders static JPEG stills, no ExoPlayer).

**Verified:** `./gradlew :app:compileDebugKotlin` on the Android build host — BUILD SUCCESSFUL (only pre-existing deprecation warnings).

Needs a human visual check: toggle appears/positions correctly in portrait + landscape, mutes/unmutes in real time on a segment with audio, and the choice persists across navigation + restart.