### PR TITLE
ci: build the Android app on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,44 @@ jobs:
         working-directory: apps/desktop/src-tauri
         run: cargo build
 
+  # ── Android client: compile-check the debug build ───────────────────────────
+  # Catches Kotlin/resource/manifest breakage on every PR. Without this the
+  # Android app was only ever built by android-release.yml on a `v*` tag, so a
+  # broken commit surfaced at release time. Debug build only (no signing) —
+  # mirrors android-release.yml's toolchain (JDK 17, SDK via setup-android).
+  android:
+    name: android (debug build)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/android
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('apps/android/**/*.gradle*', 'apps/android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      - name: Assemble debug APK
+        run: |
+          chmod +x ./gradlew
+          ./gradlew :app:assembleDebug --console=plain --stacktrace
+
   # ── Docker images: build + tag (push only if registry configured) ───────────
   images:
     name: build images


### PR DESCRIPTION
Adds an `android (debug build)` job to `ci.yml` so Kotlin/resource/manifest breakage is caught on every PR.

Until now the Android app was only built by `android-release.yml` on a `v*` tag — a broken commit would first surface at release time (this session hit exactly that: the Android audio-toggle change had to be manually compiled on the build host to verify it). GitHub-hosted `ubuntu-latest`, JDK 17 + `setup-android` + Gradle cache (mirrors the release workflow), running `:app:assembleDebug` (no signing needed). This PR's own CI run exercises the new job.