### PR TITLE
test(api): make server_settings singleton tests hermetic (Fixes #88)

### DIFF
--- a/services/api/tests/auth_rbac.rs
+++ b/services/api/tests/auth_rbac.rs
@@ -1289,7 +1289,14 @@ async fn no_protected_route_is_reachable_without_credentials() {
 /// not merely the client-side checkbox.
 #[tokio::test]
 async fn beta_terms_acceptance_recorded_and_surfaced() {
+    // This test asserts the fresh-install state of the process-wide
+    // `server_settings` singleton (beta_terms_accepted=false) and then mutates
+    // it. Serialize + reset so a concurrent settings test — or residue from a
+    // prior `cargo test` run against a reused Postgres — can't flip that shared
+    // row mid-assert (#88).
+    let _settings_guard = SERVER_SETTINGS_LOCK.lock().await;
     let app = TestApp::new().await;
+    reset_server_settings(app.pool()).await;
     let admin = seed_admin(app.pool()).await;
     let token = login(&app, &admin.username, &admin.password).await;
 
@@ -1405,7 +1412,14 @@ async fn scrub_preview_requires_admin() {
 /// assertion of this row in one sequential test avoids that race entirely.
 #[tokio::test]
 async fn scrub_preview_get_put_roundtrip_and_clamps() {
+    // Asserts every scrub knob falls back to its env default (`source: "env"`)
+    // on a fresh DB, then mutates them. Serialize + reset the shared
+    // `server_settings` singleton so a concurrent settings test — or leftover
+    // state from a prior `cargo test` run against a reused Postgres — can't make
+    // a knob read `source: "db"` before this test writes it (#88).
+    let _settings_guard = SERVER_SETTINGS_LOCK.lock().await;
     let app = TestApp::new().await;
+    reset_server_settings(app.pool()).await;
     let admin = seed_admin(app.pool()).await;
     let token = login(&app, &admin.username, &admin.password).await;
 

--- a/services/api/tests/support/mod.rs
+++ b/services/api/tests/support/mod.rs
@@ -196,6 +196,17 @@ fn ensure_env() {
 // waits and reuses the result.
 static MIGRATE_ONCE: tokio::sync::Mutex<bool> = tokio::sync::Mutex::const_new(false);
 
+/// Serializes the tests that assert on / mutate the process-wide
+/// `server_settings` singleton row (beta-terms acceptance, scrub-preview
+/// tunables). That row is ONE global row shared by every test against the
+/// single shared test database, so a "fresh install ⇒ default" assertion in one
+/// test can otherwise observe a value written by a concurrent test — or one left
+/// behind by a prior `cargo test` run against a reused throwaway Postgres. Tests
+/// that touch it take this lock and call [`reset_server_settings`] first, giving
+/// each an exclusive, pristine view. (Same cross-runtime `const_new` Mutex idiom
+/// as `MIGRATE_ONCE`; a `Mutex<()>` used purely as a critical-section guard.)
+pub static SERVER_SETTINGS_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 /// Build a fresh [`AppState`] wired to the shared test Postgres, running
 /// migrations exactly once per process (idempotent + tracked via
 /// `schema_migrations`, so this is also safe if called from multiple test
@@ -292,6 +303,29 @@ async fn seed_default_policy_if_absent(pool: &Pool) {
         )
         .await
         .expect("seed default recording_policies row");
+}
+
+/// Reset the `server_settings` singleton back to its pristine, first-boot state
+/// for the columns the settings tests assert on: no beta-terms acceptance, and
+/// no scrub-preview overrides (so every knob falls back to its env default,
+/// `source: "env"`). Call while holding [`SERVER_SETTINGS_LOCK`]. The `UPDATE`
+/// is no-op-safe — the singleton row is seeded by migration 0012, but even zero
+/// matched rows simply does nothing.
+pub async fn reset_server_settings(pool: &Pool) {
+    let client = pool.get().await.expect("pool.get (reset_server_settings)");
+    client
+        .execute(
+            "UPDATE server_settings SET \
+                 beta_terms_accepted_at      = NULL, \
+                 thumb_pregen_enabled        = NULL, \
+                 thumb_pregen_lookback_hours = NULL, \
+                 thumb_pregen_scan_secs      = NULL, \
+                 thumb_cache_max_bytes       = NULL, \
+                 thumb_cache_ttl_seconds     = NULL",
+            &[],
+        )
+        .await
+        .expect("reset server_settings to pristine");
 }
 
 /// Build the subset router this suite exercises: `/auth`, `/config` (admin


### PR DESCRIPTION
## What
The `beta_terms_acceptance_recorded_and_surfaced` and `scrub_preview_get_put_roundtrip_and_clamps` integration tests assert the **fresh-install** state of the process-wide `server_settings` singleton row, then mutate it. The whole `auth_rbac` suite shares one test database, so that single global row is visible to every test — a value written by a concurrent settings test, or left behind by a prior `cargo test` run against a reused throwaway Postgres, could flip the row mid-assert. Green on CI (fresh Postgres service each run); flaky on high-core local runs against a reused DB. This is the real root cause of #88 (not the reap-index flake, which #93 fixed).

## Fix
- `SERVER_SETTINGS_LOCK` — a process-wide `tokio::sync::Mutex<()>` (same cross-runtime `const_new` idiom already used for `MIGRATE_ONCE`) serializing every test that touches the singleton.
- `reset_server_settings()` — returns the singleton's relevant columns (`beta_terms_accepted_at`, the five `thumb_*` scrub knobs) to their pristine NULL/first-boot state.
- The two stateful tests take the lock and reset before asserting → exclusive, deterministic view. The `…_requires_admin` companions only check 403/401 and are untouched.

No production code, migrations, or schema changed — test harness only.

## Verification (a Linux build host, reused Postgres)
- `auth_rbac` **162/162** on two back-to-back runs, the second reusing the first's dirty DB.
- `cargo fmt --all --check` clean, `cargo clippy -p crumb-api --tests -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)