### PR TITLE
feat(rbac): bookmark "view all, manage own" role tier

### DIFF
--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -8407,9 +8407,10 @@ function roleCapUI(pfx, caps) {
     <div style="margin-top:10px">
       <label class="field-label" style="margin-top:0">Bookmarks</label>
       <select id="${pfx}-cap-bookmarks" style="max-width:280px">
-        <option value="none"  ${bk==='none' ?'selected':''}>None, no bookmark access</option>
-        <option value="own"   ${bk==='own'  ?'selected':''}>Own, create &amp; view their own bookmarks</option>
-        <option value="all"   ${bk==='all'  ?'selected':''}>All, view and manage all users' bookmarks</option>
+        <option value="none"    ${bk==='none'    ?'selected':''}>None, no bookmark access</option>
+        <option value="own"     ${bk==='own'     ?'selected':''}>Own, create &amp; view their own bookmarks</option>
+        <option value="viewall" ${bk==='viewall' ?'selected':''}>View all, manage own, see everyone's, edit/delete only their own</option>
+        <option value="all"     ${bk==='all'     ?'selected':''}>All, view and manage everyone's bookmarks</option>
       </select>
     </div>
   </div>`;

--- a/services/api/src/bookmarks.rs
+++ b/services/api/src/bookmarks.rs
@@ -20,8 +20,11 @@
 //! * [`BookmarkScope::None`] — viewer has no bookmark access; all routes return 403.
 //! * [`BookmarkScope::Own`]  — viewer sees / modifies only their OWN bookmarks, and
 //!   only for cameras they can access.
-//! * [`BookmarkScope::All`]  — viewer (or admin) may see all bookmarks for cameras
-//!   they can access.
+//! * [`BookmarkScope::ViewAll`] — viewer SEES all bookmarks for cameras they can
+//!   access and may create, but may edit/delete only their OWN (read-all,
+//!   manage-own).
+//! * [`BookmarkScope::All`]  — viewer (or admin) may see AND manage (edit/delete)
+//!   all bookmarks for cameras they can access.
 //!
 //! Admins always resolve to `All` (via [`AuthUser::bookmarks_scope`]).
 
@@ -93,9 +96,11 @@ pub struct UpdateBookmarkRequest {
 /// * `BookmarkScope::Own`   → bookmarks created by this user for cameras they
 ///   can access (newest first). When `?camera_id=` is given, asserts camera
 ///   access and returns that camera's bookmarks owned by this user (newest first).
-/// * `BookmarkScope::All`   → all bookmarks for cameras the user can access
-///   (newest first). When `?camera_id=` is given, asserts camera access and
-///   returns that camera's bookmarks (oldest first, for timeline marker order).
+/// * `BookmarkScope::ViewAll` / `BookmarkScope::All` → all bookmarks for cameras
+///   the user can access (newest first). When `?camera_id=` is given, asserts
+///   camera access and returns that camera's bookmarks (oldest first, for
+///   timeline marker order). `ViewAll` differs from `All` only at edit/delete
+///   time (see [`check_bookmark_access`]), not in what it can see.
 async fn list_bookmarks(
     user: AuthUser,
     State(state): State<AppState>,
@@ -133,7 +138,7 @@ async fn list_bookmarks(
             }
         }
 
-        BookmarkScope::All => {
+        BookmarkScope::ViewAll | BookmarkScope::All => {
             if let Some(cam) = q.camera_id {
                 user.assert_camera_access(cam)?;
                 let list = db::list_bookmarks_for_camera(state.pool(), cam)
@@ -215,8 +220,8 @@ async fn create_bookmark(
 
 /// `PATCH /bookmarks/:id` — edit a bookmark's note.
 ///
-/// Enforces bookmark scope: `None` → 403; `Own` → must be creator; `All` →
-/// any accessible camera.
+/// Enforces bookmark scope: `None` → 403; `Own`/`ViewAll` → must be creator;
+/// `All` → any accessible camera.
 async fn update_bookmark(
     user: AuthUser,
     State(state): State<AppState>,
@@ -239,8 +244,8 @@ async fn update_bookmark(
 
 /// `DELETE /bookmarks/:id` — remove a bookmark.
 ///
-/// Enforces bookmark scope: `None` → 403; `Own` → must be creator; `All` →
-/// any accessible camera.
+/// Enforces bookmark scope: `None` → 403; `Own`/`ViewAll` → must be creator;
+/// `All` → any accessible camera.
 async fn delete_bookmark(
     user: AuthUser,
     State(state): State<AppState>,
@@ -265,7 +270,10 @@ async fn delete_bookmark(
 /// 1. `BookmarkScope::None` → 403 immediately.
 /// 2. Loads `(camera_id, created_by)` from the DB — 404 if the row is missing.
 /// 3. Asserts camera access (viewer can only touch bookmarks for their cameras).
-/// 4. For `BookmarkScope::Own`: additionally requires the caller is the creator.
+/// 4. For `BookmarkScope::Own` and `BookmarkScope::ViewAll`: additionally
+///    requires the caller is the creator (both are manage-own tiers — `ViewAll`
+///    can *see* everyone's but only *modify* its own). Only `All` may edit/delete
+///    another user's bookmark.
 async fn check_bookmark_access(user: &AuthUser, pool: &Pool, id: Uuid) -> Result<(), ApiError> {
     if matches!(user.bookmarks_scope(), BookmarkScope::None) {
         return Err(ApiError::Forbidden(
@@ -280,7 +288,10 @@ async fn check_bookmark_access(user: &AuthUser, pool: &Pool, id: Uuid) -> Result
 
     user.assert_camera_access(camera_id)?;
 
-    if matches!(user.bookmarks_scope(), BookmarkScope::Own) {
+    if matches!(
+        user.bookmarks_scope(),
+        BookmarkScope::Own | BookmarkScope::ViewAll
+    ) {
         let is_owner = created_by.is_some_and(|u| u == user.user_id);
         if !is_owner {
             return Err(ApiError::Forbidden(

--- a/services/api/tests/auth_rbac.rs
+++ b/services/api/tests/auth_rbac.rs
@@ -1477,3 +1477,92 @@ async fn scrub_preview_get_put_roundtrip_and_clamps() {
     assert_eq!(after_clamp["cache_ttl_seconds"]["source"], "env");
     assert_eq!(after_clamp["cache_ttl_seconds"]["value"], default_ttl);
 }
+
+// ─── bookmark scope: the read-all / manage-own tier (BookmarkScope::ViewAll) ──
+
+/// A `ViewAll` viewer SEES every bookmark on cameras it can access (like `All`)
+/// but may edit/delete only its OWN — the "view all, manage own" tier. Proven
+/// end-to-end: it lists another user's bookmark, is refused 403 on PATCH/DELETE
+/// of that bookmark, and can PATCH/DELETE one it created itself.
+#[tokio::test]
+async fn bookmark_viewall_sees_all_but_manages_only_own() {
+    use crumb_common::types::BookmarkScope;
+
+    let app = TestApp::new().await;
+    let cam = seed_camera(app.pool()).await;
+
+    // Owner (any bookmark-capable scope) + the ViewAll viewer, both scoped to
+    // the same camera so cross-visibility is about bookmark scope, not camera
+    // scope.
+    let owner = seed_viewer_with_bookmark_scope(app.pool(), &[cam], BookmarkScope::Own).await;
+    let viewer = seed_viewer_with_bookmark_scope(app.pool(), &[cam], BookmarkScope::ViewAll).await;
+    let owner_token = login(&app, &owner.username, &owner.password).await;
+    let viewer_token = login(&app, &viewer.username, &viewer.password).await;
+
+    // Each user creates a bookmark on the shared camera.
+    let mk = |token: &str| {
+        post_auth_json(
+            "/bookmarks",
+            token,
+            &serde_json::json!({ "camera_id": cam, "ts": "2026-06-21T17:03:52Z" }),
+        )
+    };
+    let resp = app.send(mk(&owner_token)).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let owners_bookmark = body_json(resp).await["id"].as_str().unwrap().to_owned();
+
+    let resp = app.send(mk(&viewer_token)).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let viewers_bookmark = body_json(resp).await["id"].as_str().unwrap().to_owned();
+
+    // ViewAll SEES both (the owner's and its own).
+    let resp = app
+        .send(get_auth(
+            &format!("/bookmarks?camera_id={cam}"),
+            &viewer_token,
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let ids: Vec<String> = body_json(resp)
+        .await
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|b| b["id"].as_str().unwrap().to_owned())
+        .collect();
+    assert!(
+        ids.contains(&owners_bookmark) && ids.contains(&viewers_bookmark),
+        "ViewAll must see every bookmark on the camera, got {ids:?}"
+    );
+
+    let patch = |id: &str, token: &str| {
+        axum::http::Request::builder()
+            .method("PATCH")
+            .uri(format!("/bookmarks/{id}"))
+            .header("authorization", format!("Bearer {token}"))
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(r#"{"description":"edited"}"#))
+            .unwrap()
+    };
+    let delete = |id: &str, token: &str| {
+        axum::http::Request::builder()
+            .method("DELETE")
+            .uri(format!("/bookmarks/{id}"))
+            .header("authorization", format!("Bearer {token}"))
+            .body(axum::body::Body::empty())
+            .unwrap()
+    };
+
+    // Managing the OWNER's bookmark is refused — ViewAll is read-all, not
+    // manage-all.
+    let resp = app.send(patch(&owners_bookmark, &viewer_token)).await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let resp = app.send(delete(&owners_bookmark, &viewer_token)).await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    // Managing its OWN bookmark works.
+    let resp = app.send(patch(&viewers_bookmark, &viewer_token)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let resp = app.send(delete(&viewers_bookmark, &viewer_token)).await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+}

--- a/services/api/tests/support/mod.rs
+++ b/services/api/tests/support/mod.rs
@@ -237,6 +237,16 @@ pub async fn test_state() -> AppState {
             db::ensure_named_policies_and_groups(&pool)
                 .await
                 .expect("ensure_named_policies_and_groups");
+            // Mirror the api's startup: `run_migrations` alone leaves the
+            // bookmarks table at its 0001 shape (`note`, no
+            // description/created_by/protect_*) because 0010's CREATE-IF-NOT-
+            // EXISTS is a no-op over the already-created table. Production
+            // reconciles this at boot via ensure_bookmarks_table() (main.rs);
+            // without it here, bookmark inserts fail (missing columns), which is
+            // why the bookmark endpoints previously had no test coverage.
+            db::ensure_bookmarks_table(&pool)
+                .await
+                .expect("ensure_bookmarks_table");
             seed_default_policy_if_absent(&pool).await;
             *done = true;
         }
@@ -440,6 +450,29 @@ pub async fn seed_viewer_user(pool: &Pool, role_id: Uuid) -> SeededUser {
 pub async fn seed_viewer(pool: &Pool, camera_ids: &[Uuid]) -> SeededUser {
     let role_id = seed_viewer_role(pool, camera_ids).await;
     seed_viewer_user(pool, role_id).await
+}
+
+/// Seed a viewer role with a specific [`BookmarkScope`] (camera-scoped to
+/// `camera_ids`, every other capability on) plus a user assigned to it. Backs
+/// the bookmark-scope enforcement tests.
+pub async fn seed_viewer_with_bookmark_scope(
+    pool: &Pool,
+    camera_ids: &[Uuid],
+    scope: crumb_common::types::BookmarkScope,
+) -> SeededUser {
+    let name = unique("role");
+    let caps = Capabilities {
+        export: true,
+        playback: true,
+        clips: true,
+        ptz: true,
+        bookmarks: scope,
+        manage_views: true,
+    };
+    let role = db::create_role(pool, &name, &caps, camera_ids)
+        .await
+        .expect("create_role (viewer bookmark-scope)");
+    seed_viewer_user(pool, role.id).await
 }
 
 /// Hash a password the same way `auth.rs::hash_password` does (Argon2id,

--- a/services/common/src/types.rs
+++ b/services/common/src/types.rs
@@ -918,7 +918,10 @@ pub enum BookmarkScope {
     None,
     /// See/manage only bookmarks the user created (on the role's cameras).
     Own,
-    /// See all bookmarks on the role's cameras (and create).
+    /// See ALL bookmarks on the role's cameras (and create), but edit/delete
+    /// only one's OWN — a read-all, manage-own tier. Serialized as `"viewall"`.
+    ViewAll,
+    /// See and manage (edit/delete) ALL bookmarks on the role's cameras.
     All,
 }
 


### PR DESCRIPTION
## What
Adds `BookmarkScope::ViewAll` between `Own` and `All`: a role can **see every** bookmark on its accessible cameras (and create), but **edit/delete only its own**. Fills the gap between "only my own" and "manage everyone's" — a role with full visibility of the team's saved moments but no authority to alter/remove them.

## Changes
- **`types.rs`** — new `ViewAll` variant (serde `"viewall"`). Additive/backward-compatible: unknown/missing → `None`; existing `"all"` roles unchanged.
- **`bookmarks.rs`** — `list_bookmarks` treats `ViewAll` like `All` (see all); `check_bookmark_access` (PATCH/DELETE) requires ownership for `Own` **and** `ViewAll`, so only `All` may touch another user's bookmark. Docs updated.
- **`admin.html`** — 4th option in the role editor's Bookmarks selector ("View all, manage own"); "All" label sharpened to "view and manage everyone's".

## Tests
The bookmark endpoints had **zero** coverage. Added `bookmark_viewall_sees_all_but_manages_only_own` (lists another user's bookmark ✓, 403 on PATCH/DELETE of it ✓, manages its own ✓).

Writing it surfaced that the test harness ran `run_migrations` but not the api's boot-time `ensure_bookmarks_table()` — so the test DB kept `0001`'s `note`-only bookmarks table (`0010`'s `CREATE IF NOT EXISTS` is a no-op) and every bookmark insert 500'd. That's why these endpoints were untested. The harness now calls `ensure_bookmarks_table()`, mirroring production boot.

## Client note (deferred)
Clients still show manage controls and rely on the server's 403 for `ViewAll` users editing others' bookmarks (safe, deny-by-default). Hiding those controls client-side for non-own bookmarks is deferred UX polish.

## Verification (a Linux build host)
- `auth_rbac` **163/163**.
- `cargo fmt --all --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)