### PR TITLE
fix(web): prefill contribute-camera issue title from make/model (Fixes #60)

### DIFF
--- a/services/api/src/camera_compat.rs
+++ b/services/api/src/camera_compat.rs
@@ -252,6 +252,22 @@ pub fn contribute_url(make: Option<&str>, model: Option<&str>, firmware: Option<
     if let Some(v) = firmware.filter(|s| !s.is_empty()) {
         url.push_str(&format!("&firmware={}", enc(v)));
     }
+    // Prefill the issue TITLE too (#60). The camera-report form's template sets a
+    // placeholder `title:`, so without an explicit &title the opened issue keeps
+    // "[camera] <Make> <Model>" verbatim. Build it from whatever identity we have,
+    // matching that template's title shape.
+    let title = match (
+        make.filter(|s| !s.is_empty()),
+        model.filter(|s| !s.is_empty()),
+    ) {
+        (Some(mk), Some(md)) => Some(format!("[camera] {mk} {md}")),
+        (Some(mk), None) => Some(format!("[camera] {mk}")),
+        (None, Some(md)) => Some(format!("[camera] {md}")),
+        (None, None) => None,
+    };
+    if let Some(t) = title {
+        url.push_str(&format!("&title={}", enc(&t)));
+    }
     url
 }
 
@@ -484,5 +500,20 @@ mod tests {
         assert!(u.contains("make=Uniview"));
         assert!(u.contains("model=IPC6322SR-X22P-D"));
         assert!(!u.contains("firmware="));
+        // #60: the title is prefilled (URL-encoded) from make + model, so the
+        // opened issue isn't left on the template placeholder.
+        assert!(
+            u.contains("&title=%5Bcamera%5D%20Uniview%20IPC6322SR-X22P-D"),
+            "expected an encoded [camera] make model title, got: {u}"
+        );
+    }
+
+    /// With no make/model there's nothing to build a meaningful title from, so
+    /// no `&title=` is appended (the form falls back to its own placeholder).
+    #[test]
+    fn contribute_url_omits_title_when_unidentified() {
+        let u = contribute_url(None, None, Some("1.2.3"));
+        assert!(!u.contains("&title="));
+        assert!(u.contains("firmware=1.2.3"));
     }
 }


### PR DESCRIPTION
## Bug
The admin console's **Contribute this camera** flow prefills the make/model/firmware form *fields* but the opened GitHub issue's **title** stays the template placeholder `[camera] <Make> <Model>` — `contribute_url()` never passed a `&title=`.

## Fix
Append a URL-encoded `&title=` built from the identified make/model (matching the template's title shape) when present; omit it when the camera is unidentified so the form keeps its own placeholder. Only the already-whitelisted, non-sensitive make/model go into the title — still no IPs, credentials, stream URLs, or operator camera names.

## Tests
- `contribute_url_encodes_and_omits_empties` now asserts the encoded `&title=%5Bcamera%5D%20Uniview%20…`.
- `contribute_url_omits_title_when_unidentified` — no `&title=` with no make/model.

Verified on a Linux build host: tests pass, `cargo fmt`/`clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)