### PR TITLE
feat(api): on-demand low-bitrate playback + go2rtc mobile live transcode (mobile perf phases 1-2)

### DIFF
--- a/docs/COMPONENT-MAP.md
+++ b/docs/COMPONENT-MAP.md
@@ -75,7 +75,7 @@ All paths below are repo-relative and verified to exist as of 2026-07-06.
 
 | Surface | Path(s) | Notes |
 |---|---|---|
-| Engineering docs | `docs/` (notably `DECISIONS.md`, `RECORDER-CORRECTNESS.md`, `ROADMAP.md`, `MOTION-RECORDING.md`, `MOTION-DETECTION-DESIGN.md`, `MOTION-ADAPTIVE-THRESHOLD.md`, plus design docs) | `DECISIONS.md` is governed by golden rule 7 |
+| Engineering docs | `docs/` (notably `DECISIONS.md`, `RECORDER-CORRECTNESS.md`, `ROADMAP.md`, `MOTION-RECORDING.md`, `MOTION-DETECTION-DESIGN.md`, `MOTION-ADAPTIVE-THRESHOLD.md`, `MOBILE-PERFORMANCE.md`, plus design docs) | `DECISIONS.md` is governed by golden rule 7 |
 | User docs | `docs/AI-INSTALL.md`, `docs/CLIENTS.md` (client install and connect), `docs/RESPONSIBLE-USE.md`, `docs/ALPHA-TESTER-TERMS.md`, `docs/BACKUP.md`, `docs/TLS.md`, `docs/OPS-BACKUP-RECOVERY.md` | These are the seed content for the public docs site |
 | Public docs site | `docs-site/` (Docusaurus), published at `docs.crumbvms.com`; the docs-site build model is recorded in `docs/DECISIONS.md` | Live. It is a propagation surface in every user-facing change below: update the matching `docs-site/docs/` page in the same change |
 | Camera compatibility DB | `data/camera-compatibility.json` (source of truth, schema in `data/README.md`) → `scripts/gen-camera-compat.mjs` (zero-dep) → `docs-site/docs/cameras/compatibility.md` (generated, gitignored). Wired into `docs.yml` and `docs-site/Dockerfile` | PR-curated, no telemetry. Same JSON is the intended input to the future in-app "identify camera + known quirks" hint (`serde_json`); see `docs/DECISIONS.md` 2026-07-10 |

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,61 @@ revisit.
 
 ---
 
+## 2026-07-13, Mobile performance: on-demand per-segment low-bitrate transcode (not continuous stream / ABR), Auto default
+
+**Context.** Recorded playback and fullscreen live were unusable over poor
+cellular: `GET /segments/{id}` served the full main-stream bytes (multi-Mbps
+H.265) with no downscale option anywhere, and fullscreen live started on HD main.
+The 2026-07-07 scrub-preview decision listed "WAN/remote scrubbing becomes a
+first-class target" as an explicit revisit trigger — that trigger fired.
+
+**Decision.** Add an on-demand, cached, operator-side low-bitrate variant, and an
+Auto/Full/Data-saver client selector defaulting to **Auto**:
+
+- **Playback:** `GET /segments/{id}/low.mp4` transcodes one segment to
+  640p/15fps/CRF28 H.264 (+ AAC mono), produced on first request and cached
+  (`{export_dir}/segcache`, LRU, ETag'd). A near-copy of the `clips.rs`
+  preview machinery — same semaphore, same read-only media mount, same
+  path-traversal guard, same auth (`?token=`). The recorder is never touched.
+- **Live:** the reconcile loop registers a per-camera `<name>_mobile` go2rtc
+  ffmpeg transcode of the sub (or main) stream; go2rtc pulls it only while a
+  consumer is attached (zero idle cost). Gated by `MOBILE_STREAM_ENABLED`.
+- **Client (Android):** Auto = Full on unmetered, Low on metered; the on-demand
+  transcode therefore runs ONLY when a client actually asks for Low.
+
+Full write-up: `docs/MOBILE-PERFORMANCE.md`.
+
+**Alternatives considered.**
+
+| # | Option | Verdict |
+|---|--------|---------|
+| 1 | **Per-segment `q=low` variant** | **Chosen.** One-line client URL change; cacheable/idempotent per segment (repeat scrubs hit cache); reuses clip machinery wholesale; failure isolation per 4 s unit. |
+| 2 | Continuous time-range transcode (`/play/.../low.mp4?start=`) | Rejected for v1: replaces the whole segment/prefetch/seek client model with a long-lived stream a seek must restart, holds a semaphore permit for the whole session, output not reusable across scrubs. Kept as the v2 shape (it also removes any residual segment-boundary audio seam). |
+| 3 | HLS/DASH ABR ladder | Rejected: ≥2 encode ladders (double CPU) + playlist generation + a client player-mode change, overkill for a single-operator VMS; a manual/auto two-level selector matches the commercial-app UX at a fraction of the complexity. |
+| 4 | Pre-transcode everything at record time | Rejected outright: permanent CPU+storage for footage mostly never watched, and it touches the sacred write path. On-demand + cache is strictly better. |
+| 5 | Cloud/third-party transcode or relay | Out of scope — violates the ratified direction (footage never leaves operator hardware). |
+
+**Trades knowingly accepted.**
+
+- One ffmpeg spawn per 4 s segment on a cache miss (mitigated by cache + the
+  N-deep prefetch; `-preset ultrafast` at 640p is many-× realtime).
+- The `<name>_mobile` live transcode runs beside the recorder (go2rtc is embedded
+  in the recorder container). On-demand and bounded to one process per active
+  mobile viewer, disable-able via `MOBILE_STREAM_ENABLED=false`.
+- Default-on mobile stream doubles the go2rtc stream table; inert until consumed.
+
+**Revisit triggers.**
+
+- Measured per-segment spawn overhead dominates on real hosts → switch playback
+  to option 2 (continuous-range transcode), which also subsumes any audio seam.
+- Multi-user remote viewing becomes common → reconsider option 3 (real ABR).
+- ROADMAP dual-stream recording ships → "Low" should prefer a *recorded* sub
+  segment over an on-the-fly transcode; design the selector so they compose.
+- Recorder-host CPU contention reports → make the live mobile transcode default
+  off, or move go2rtc to a separate restreamer host.
+
+---
+
 ## 2026-07-12, Recorded audio: copy when client-safe, transcode only the rates Android rejects
 
 **Context.** The Android client played recorded footage silent while desktop

--- a/docs/MOBILE-PERFORMANCE.md
+++ b/docs/MOBILE-PERFORMANCE.md
@@ -1,0 +1,127 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+
+# Mobile / poor-connection performance
+
+Playing recorded footage and fullscreen live over a **poor cellular link** used
+to be near-unusable: every play attempt stalled, every scrub restarted a large
+download. This doc records why, and the on-demand, operator-hardware-only design
+that fixes it — plus what is shipped vs. deferred.
+
+Footage never leaves the operator's server: every quality variant here is just a
+smaller representation of the same footage, produced by the operator's own
+hardware and served over the same authenticated channel. No cloud, no telemetry,
+no third party (per `AGENTS.md`).
+
+## Root cause
+
+- **Recorded playback always fetched the full main-stream bytes.** The recorder
+  records one stream per camera with `-c copy` (default `main`, typically 2K/4K
+  H.265 at multi-Mbps), and `GET /segments/{id}` serves that file byte-for-byte.
+  There was **no downscale option anywhere on the playback path**. A 4 s segment
+  is ~2–4 MB; poor cellular sustains a fraction of that bitrate, so playback can
+  never keep up.
+- **Fullscreen live always started on the HD main stream** (sub only on an H.265
+  *codec* failure, not on bandwidth), so it was a slideshow on cellular.
+- Only the live **grid** used the sub stream, and nothing measured link quality
+  on the playback path.
+
+The commercial-VMS answer is a per-connection "mobile server" transcode. Crumb's
+equivalent is below.
+
+## Design: on-demand, cached, operator-side
+
+### Phase 1 — low-bitrate recorded playback (shipped)
+
+`GET /segments/{id}/low.mp4` (module `services/api/src/segment_low.rs`) returns a
+transcoded **640p / 15 fps / CRF 28 H.264** variant (with AAC mono audio) of one
+recorded segment, produced **only when a client requests it** and then cached.
+
+- Reuses the proven clip-preview machinery: `libx264 -preset ultrafast`, cached
+  under `{export_dir}/segcache`, LRU-pruned to `SEGMENT_LOW_CACHE_MAX_BYTES`,
+  ETag'd and immutable (a segment's bytes never change), concurrency-bounded by
+  the shared `clip_gen_semaphore`.
+- **Auth is identical to `/segments/{id}`**: `require_playback()` +
+  `assert_camera_access()` + the scoped per-camera `?token=` media claim. The
+  same path-traversal guard (`playback::guard_path_traversal`) runs before any
+  file I/O. The API mounts media **read-only**; this writes only to its own
+  cache. **The recorder is never touched — zero recording-correctness risk.**
+- **Bonus:** transcoding to H.264 640p also sidesteps H.265 decode weakness on
+  older Android devices — Data-saver doubles as a compatibility mode.
+
+Client (Android): a playback quality selector **Auto / Full / Data saver**
+(default **Auto**), persisted in `SecureStore`. Auto = Full on Wi-Fi/unmetered,
+Low on metered/cellular; Data saver = always `low.mp4`; Full = always the
+recorded bytes. When "low" is active the client appends `/low.mp4` to the segment
+URL; switching quality re-resolves the current playhead.
+
+Why per-segment (vs. a continuous time-range transcode or HLS ABR): it slots
+into the existing resolve→segment client model with a one-line URL change, is
+cacheable/idempotent per segment (repeat scrubs hit the cache), and reuses the
+clip machinery wholesale. A continuous-range transcode was considered (it also
+smooths audio across boundaries) but rejected for v1 because it replaces the
+client's whole segment/prefetch/seek model with a long-lived per-session stream
+that a seek must restart; keep it as the v2 shape if per-segment spawn overhead
+disappoints. Full ABR was rejected as overkill for a single-operator VMS. See
+`docs/DECISIONS.md` (2026-07-13, mobile performance).
+
+### Phase 2 — on-demand mobile live transcode (shipped)
+
+The API reconcile loop registers a per-camera **`<name>_mobile`** go2rtc stream
+(`services/api/src/go2rtc.rs`) whose source is an ffmpeg transcode
+(`ffmpeg:<input>#video=h264#width=MOBILE_STREAM_WIDTH`) of the camera's **sub**
+stream (or **main** when there is no sub), referenced by go2rtc stream name so it
+shares that stream's single producer. go2rtc only spawns the transcode ffmpeg
+**while a consumer is connected**, so an idle mobile stream costs nothing.
+
+Exposed to clients as `rtsp_mobile_url`. Gated by `MOBILE_STREAM_ENABLED`
+(default on). Removed with the camera.
+
+> **Operator note (recorder-host CPU).** go2rtc is embedded in the **recorder**
+> container, so when a mobile client connects, the transcode ffmpeg runs beside
+> the recorder. It is on-demand (zero idle cost) and bounded to one process per
+> active mobile viewer, but on a CPU-starved host you can disable it with
+> `MOBILE_STREAM_ENABLED=false` — clients then fall back to the sub stream.
+
+Client (Android): on a **metered** link, fullscreen live starts on the sub
+stream (or `rtsp_mobile_url` when the camera has no sub) instead of HD main; the
+"SD · tap for HD" badge forces HD.
+
+### Phase 0 — client buffering quick wins (shipped, Android)
+
+- A dedicated WAN-tuned playback `LoadControl` (larger buffer window + a 30 s
+  retained back-buffer, so small backward scrubs replay from RAM instead of
+  re-downloading), in `MediaFactory.newPlaybackPlayer`.
+- Playback prefetch lead raised 2 s → 3.5 s to hide one resolve round-trip.
+- Fullscreen live sub-stream-first on metered + a tappable HD/SD override.
+
+The same `newPlaybackPlayer` also fixes the **no-audio-in-playback** bug (#106):
+it declares `USAGE_MEDIA` audio attributes with audio-focus handling (the muted
+live tiles never requested focus) and re-asserts the intended volume across media
+transitions.
+
+## New env knobs (API), all optional with sane defaults
+
+| Key | Default | Meaning |
+|---|---|---|
+| `SEGMENT_LOW_CACHE_MAX_BYTES` | `2 GiB` | Byte budget for the `low.mp4` cache (`{export_dir}/segcache`), LRU-pruned. |
+| `MOBILE_STREAM_ENABLED` | `true` | Register the on-demand `<name>_mobile` go2rtc transcode. `false` → clients fall back to the sub stream on metered live. |
+| `MOBILE_STREAM_WIDTH` | `640` | Target width (px) of the mobile transcode; height derived to preserve aspect. |
+
+## Success criteria (to validate on device)
+
+On a throttled ~1 Mbps / 150 ms RTT link: pressing play reaches steady playback
+in < 3 s and sustains ≥ 95 % of wall-clock time playing; a scrub release shows
+moving video in < 3 s; server CPU for one remote viewer < 1 core at 640p
+ultrafast.
+
+## Deferred / future
+
+- **Continuous-range playback transcode** as a v2 shape if per-segment spawn
+  overhead measures badly (also removes any residual segment-boundary audio
+  seam). See the DECISIONS entry's revisit triggers.
+- Extend the `low.mp4` quality lever to the desktop/web clients (they get it
+  nearly free).
+- Interaction with ROADMAP dual-stream recording: when a *recorded* low-res
+  track exists, "Low" should prefer it over an on-the-fly transcode.
+- On-device verification of the #106 audio fix and the throttled-link success
+  criteria above.

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -163,6 +163,28 @@ pub struct ApiConfig {
     /// the cache unbounded within a day. Default: `10 GiB`.
     pub clip_cache_max_bytes: u64,
 
+    /// `SEGMENT_LOW_CACHE_MAX_BYTES` -- soft byte budget for the on-demand
+    /// low-bitrate playback cache (`{export_dir}/segcache`), the transcoded
+    /// 640p/15fps variants served by `GET /segments/{id}/low.mp4` for mobile /
+    /// poor-connection playback. Oldest-by-mtime files are pruned past this after
+    /// each generation. Scrubbing produces many more artifacts than clip
+    /// browsing, so this gets its own knob (separate from `CLIP_CACHE_MAX_BYTES`).
+    /// Default: `2 GiB`.
+    pub segment_low_cache_max_bytes: u64,
+
+    /// `MOBILE_STREAM_ENABLED` -- register a per-camera `<name>_mobile` go2rtc
+    /// stream: an on-demand H.264 transcode of the camera's sub stream (or main,
+    /// when there is no sub), capped to [`Self::mobile_stream_width`]. Exposed to
+    /// clients as `rtsp_mobile_url` for a fullscreen-live "Data saver" mode on
+    /// cellular. go2rtc pulls the source only while a consumer is connected, so
+    /// the idle cost is zero; when a viewer connects, the transcode ffmpeg runs
+    /// inside the recorder container (where go2rtc is embedded). Default: `true`.
+    pub mobile_stream_enabled: bool,
+
+    /// `MOBILE_STREAM_WIDTH` -- target width (px) of the `<name>_mobile`
+    /// transcode; height is derived to preserve aspect. Default: `640`.
+    pub mobile_stream_width: u32,
+
     /// `THUMB_EXTRACT_MAX_CONCURRENCY` -- max concurrent on-demand thumbnail
     /// ffmpeg extractions (the filmstrip scrubber). Each cache miss spawns one
     /// single-frame ffmpeg; a fast multi-camera scrub would otherwise spawn a
@@ -373,6 +395,12 @@ impl ApiConfig {
             export_max_concurrent: parse_env("EXPORT_MAX_CONCURRENT", 2usize)?.max(1),
             clip_gen_max_concurrency: parse_env("CLIP_GEN_MAX_CONCURRENCY", 4usize)?.max(1),
             clip_cache_max_bytes: parse_env("CLIP_CACHE_MAX_BYTES", 10_737_418_240_u64)?,
+            segment_low_cache_max_bytes: parse_env(
+                "SEGMENT_LOW_CACHE_MAX_BYTES",
+                2_147_483_648_u64,
+            )?,
+            mobile_stream_enabled: parse_env("MOBILE_STREAM_ENABLED", true)?,
+            mobile_stream_width: parse_env("MOBILE_STREAM_WIDTH", 640_u32)?.max(160),
             thumb_extract_max_concurrency: parse_env(
                 "THUMB_EXTRACT_MAX_CONCURRENCY",
                 default_thumb_concurrency(),

--- a/services/api/src/dto.rs
+++ b/services/api/src/dto.rs
@@ -1216,6 +1216,13 @@ pub struct LiveStreamsResponse {
     pub rtsp_main_url: String,
     /// RTSP URL for the sub stream (same credential note as `rtsp_main_url`).
     pub rtsp_sub_url: Option<String>,
+    /// RTSP URL for the on-demand mobile transcode (`<name>_mobile`) — a low-res
+    /// H.264 variant produced by go2rtc only while a consumer is connected, for a
+    /// cellular "Data saver" fullscreen-live mode. `None` when the feature is
+    /// disabled (`MOBILE_STREAM_ENABLED=false`) or the camera is Frigate-served
+    /// (its go2rtc is a separate BYO instance Crumb does not manage). Same
+    /// embedded-credential + sensitivity note as `rtsp_main_url`.
+    pub rtsp_mobile_url: Option<String>,
 }
 
 // ─── export ───────────────────────────────────────────────────────────────────

--- a/services/api/src/go2rtc.rs
+++ b/services/api/src/go2rtc.rs
@@ -90,7 +90,11 @@ fn mobile_name(go2rtc_name: &str) -> String {
 /// go2rtc only launches the ffmpeg process while a consumer is attached, so an
 /// idle mobile stream costs nothing. Pure + unit-tested.
 fn mobile_src(input_stream: &str, width: u32) -> String {
-    format!("ffmpeg:{input_stream}#video=h264#width={width}")
+    // `#audio=aac` transcodes audio too (go2rtc drops audio with `-an` when no
+    // `#audio` is given). This matters for the no-sub case, where the mobile
+    // stream sources the MAIN stream whose audio the viewer expects; AAC is safer
+    // than a copy (which could pass through G.711 an RTSP client can't decode).
+    format!("ffmpeg:{input_stream}#video=h264#width={width}#audio=aac")
 }
 
 /// PUT a stream into go2rtc (idempotent — sets/replaces the stream by name).
@@ -478,6 +482,12 @@ pub async fn reconnect(state: &AppState, go2rtc_name: &str) -> Result<()> {
     if let Err(e) = delete_stream(&c, api_base, &sub_name(go2rtc_name), auth).await {
         tracing::warn!(go2rtc_name, error = %format!("{e:#}"), "reconnect: DELETE sub stream failed (ignoring)");
     }
+    // Drop the mobile transcode too, so a source-URL change re-derives it fresh
+    // (its input stream name is unchanged, but symmetry with reconcile's PUT-all
+    // keeps the managed set consistent). Best-effort.
+    if let Err(e) = delete_stream(&c, api_base, &mobile_name(go2rtc_name), auth).await {
+        tracing::warn!(go2rtc_name, error = %format!("{e:#}"), "reconnect: DELETE mobile stream failed (ignoring)");
+    }
     // Brief pause so go2rtc drops the producer before we re-PUT.
     tokio::time::sleep(Duration::from_millis(200)).await;
     // Re-PUT all managed streams (the updated source_url is now in the DB).
@@ -713,11 +723,11 @@ mod tests {
         // References an existing stream by name (shares its producer) and caps width.
         assert_eq!(
             mobile_src("driveway_sub", 640),
-            "ffmpeg:driveway_sub#video=h264#width=640"
+            "ffmpeg:driveway_sub#video=h264#width=640#audio=aac"
         );
         assert_eq!(
             mobile_src("driveway", 480),
-            "ffmpeg:driveway#video=h264#width=480"
+            "ffmpeg:driveway#video=h264#width=480#audio=aac"
         );
     }
 

--- a/services/api/src/go2rtc.rs
+++ b/services/api/src/go2rtc.rs
@@ -76,6 +76,23 @@ fn sub_name(go2rtc_name: &str) -> String {
     format!("{go2rtc_name}_sub")
 }
 
+/// The go2rtc stream name for a camera's on-demand MOBILE transcode.
+fn mobile_name(go2rtc_name: &str) -> String {
+    format!("{go2rtc_name}_mobile")
+}
+
+/// Build the go2rtc source for a camera's `<name>_mobile` transcode. It reads
+/// `input_stream` (an EXISTING go2rtc stream — the camera's sub when present,
+/// else main) and re-encodes to H.264 capped at `width` px (height derived to
+/// preserve aspect). Referencing the stream by NAME (go2rtc's documented
+/// restream-and-transcode form, `ffmpeg:<stream>#video=h264`) shares that
+/// stream's single producer, so the transcode adds no extra camera session — and
+/// go2rtc only launches the ffmpeg process while a consumer is attached, so an
+/// idle mobile stream costs nothing. Pure + unit-tested.
+fn mobile_src(input_stream: &str, width: u32) -> String {
+    format!("ffmpeg:{input_stream}#video=h264#width={width}")
+}
+
 /// PUT a stream into go2rtc (idempotent — sets/replaces the stream by name).
 ///
 /// NOTE: go2rtc REGISTERS the stream even when it answers `400` (its immediate
@@ -311,16 +328,25 @@ pub async fn reconcile(state: &AppState) -> Result<()> {
         .await
         .unwrap_or_default();
 
-    // Every name WE manage (main + sub) — for the PATCH alias-collision guard.
+    let mobile_enabled = state.config().mobile_stream_enabled;
+    let mobile_width = state.config().mobile_stream_width;
+
+    // Every name WE manage (main + sub + mobile) — for the PATCH alias-collision
+    // guard. (The mobile source is `ffmpeg:…`, never `rtsp://`, so it can't
+    // itself alias-collide, but keeping the full managed set is correct.)
     let managed: HashSet<String> = streams
         .iter()
         .flat_map(|s| {
-            let mut names = vec![s.go2rtc_name.clone()];
-            if s.source_sub_url
+            let has_sub = s
+                .source_sub_url
                 .as_deref()
-                .is_some_and(|u| !u.trim().is_empty())
-            {
+                .is_some_and(|u| !u.trim().is_empty());
+            let mut names = vec![s.go2rtc_name.clone()];
+            if has_sub {
                 names.push(sub_name(&s.go2rtc_name));
+            }
+            if mobile_enabled {
+                names.push(mobile_name(&s.go2rtc_name));
             }
             names
         })
@@ -337,12 +363,35 @@ pub async fn reconcile(state: &AppState) -> Result<()> {
             auth,
         )
         .await;
-        if let Some(sub) = s.source_sub_url.as_deref().filter(|u| !u.trim().is_empty()) {
+        let has_sub = s
+            .source_sub_url
+            .as_deref()
+            .is_some_and(|u| !u.trim().is_empty());
+        if has_sub {
             apply_stream(
                 &c,
                 api_base,
                 &sub_name(&s.go2rtc_name),
-                sub,
+                s.source_sub_url.as_deref().unwrap_or_default(),
+                &existing,
+                &managed,
+                auth,
+            )
+            .await;
+        }
+        // On-demand mobile transcode: source the SUB stream when the camera has
+        // one (already low-res), else the MAIN stream. go2rtc pulls it lazily.
+        if mobile_enabled {
+            let input = if has_sub {
+                sub_name(&s.go2rtc_name)
+            } else {
+                s.go2rtc_name.clone()
+            };
+            apply_stream(
+                &c,
+                api_base,
+                &mobile_name(&s.go2rtc_name),
+                &mobile_src(&input, mobile_width),
                 &existing,
                 &managed,
                 auth,
@@ -393,6 +442,9 @@ pub async fn remove(state: &AppState, go2rtc_name: &str) -> Result<()> {
     let c = client()?;
     delete_stream(&c, api_base, go2rtc_name, auth).await?;
     delete_stream(&c, api_base, &sub_name(go2rtc_name), auth).await?;
+    // Best-effort: drop the mobile transcode too (a no-op if it was never
+    // registered — go2rtc DELETE tolerates a missing name).
+    let _ = delete_stream(&c, api_base, &mobile_name(go2rtc_name), auth).await;
     Ok(())
 }
 
@@ -651,6 +703,38 @@ mod tests {
 
     fn names(list: &[&str]) -> HashSet<String> {
         list.iter().copied().map(String::from).collect()
+    }
+
+    // ── mobile transcode stream (Phase 2) ───────────────────────────────────
+
+    #[test]
+    fn mobile_name_and_src_shapes() {
+        assert_eq!(mobile_name("driveway"), "driveway_mobile");
+        // References an existing stream by name (shares its producer) and caps width.
+        assert_eq!(
+            mobile_src("driveway_sub", 640),
+            "ffmpeg:driveway_sub#video=h264#width=640"
+        );
+        assert_eq!(
+            mobile_src("driveway", 480),
+            "ffmpeg:driveway#video=h264#width=480"
+        );
+    }
+
+    #[test]
+    fn mobile_src_is_never_an_rtsp_alias_collision() {
+        // The mobile source is an `ffmpeg:` string, not `rtsp://`, so the PATCH
+        // alias-collision guard never fires for it — it PATCHes in place like any
+        // other existing managed stream.
+        let managed = names(&["driveway", "driveway_sub", "driveway_mobile"]);
+        assert!(!is_patch_alias_collision(
+            &mobile_src("driveway_sub", 640),
+            &managed
+        ));
+        assert_eq!(
+            choose_verb(true, &mobile_src("driveway_sub", 640), &managed),
+            StreamVerb::Patch
+        );
     }
 
     // ── choose_verb (create-vs-patch fan-out fix) ───────────────────────────

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -100,6 +100,7 @@ mod ptz;
 mod rate_limit;
 mod roles;
 mod scrub_settings;
+mod segment_low;
 mod state;
 mod stats;
 mod status;
@@ -493,6 +494,7 @@ async fn main() -> anyhow::Result<()> {
 
     let media_routes = Router::new()
         .merge(playback::routes())
+        .merge(segment_low::routes())
         .merge(export::routes())
         .merge(filmstrip::routes())
         // On-demand DB-vs-disk size verification: a filesystem walk that can run

--- a/services/api/src/playback.rs
+++ b/services/api/src/playback.rs
@@ -671,12 +671,27 @@ async fn live_streams(
         None
     };
 
+    // On-demand mobile transcode (`<name>_mobile`) — a relative go2rtc stream
+    // name Crumb registers in the reconcile loop, so it resolves off the CRUMB
+    // RTSP base (with embedded creds), never Frigate's. Exposed only for
+    // Crumb-owned cameras when the feature is enabled; go2rtc spawns the
+    // transcode ffmpeg lazily on first consumer connect (idle cost zero).
+    let rtsp_mobile_url = (state.config().mobile_stream_enabled && cam.served_by != "frigate")
+        .then(|| {
+            format!(
+                "{}/{}_mobile",
+                crumb_rtsp_authed.trim_end_matches('/'),
+                cam.go2rtc_name
+            )
+        });
+
     Ok(Json(LiveStreamsResponse {
         camera_id,
         webrtc_main_url,
         webrtc_sub_url,
         rtsp_main_url,
         rtsp_sub_url,
+        rtsp_mobile_url,
     }))
 }
 
@@ -730,6 +745,9 @@ fn parse_uuid_csv(csv: &str) -> Result<Vec<Uuid>, ApiError> {
 ///
 /// Returns the canonicalised path on success.
 ///
+/// `pub(crate)` so the low-bitrate segment transcoder (`segment_low`) reuses the
+/// exact same guard rather than duplicating this security-critical check.
+///
 /// # Errors
 ///
 /// * `ApiError::Internal` — if the storage root path cannot be canonicalised
@@ -737,7 +755,7 @@ fn parse_uuid_csv(csv: &str) -> Result<Vec<Uuid>, ApiError> {
 /// * `ApiError::NotFound` — if the file does not exist on disk.
 /// * `ApiError::BadRequest` (400) — if the resolved path escapes the root; also
 ///   emits a `tracing::warn!` so the attempt is visible in the operator logs.
-fn guard_path_traversal(
+pub(crate) fn guard_path_traversal(
     storage_root: &Path,
     absolute: &Path,
     segment_id: Uuid,

--- a/services/api/src/playback.rs
+++ b/services/api/src/playback.rs
@@ -673,10 +673,21 @@ async fn live_streams(
 
     // On-demand mobile transcode (`<name>_mobile`) — a relative go2rtc stream
     // name Crumb registers in the reconcile loop, so it resolves off the CRUMB
-    // RTSP base (with embedded creds), never Frigate's. Exposed only for
-    // Crumb-owned cameras when the feature is enabled; go2rtc spawns the
-    // transcode ffmpeg lazily on first consumer connect (idle cost zero).
-    let rtsp_mobile_url = (state.config().mobile_stream_enabled && cam.served_by != "frigate")
+    // RTSP base (with embedded creds), never Frigate's. Exposed only when reconcile
+    // would ACTUALLY register the stream: the feature is on, the camera is
+    // Crumb-owned, AND it has a `source_url` (the exact predicate
+    // `db::list_camera_streams` filters on). A legacy `served_by='crumb'` row with
+    // an absolute `main_url` but empty `source_url` gets no `_mobile` stream, so we
+    // must not advertise a URL that resolves to nothing (else fullscreen live would
+    // burn its reconnect budget on a dead stream). go2rtc spawns the transcode
+    // ffmpeg lazily on first consumer connect (idle cost zero).
+    let has_source = cam
+        .source_url
+        .as_deref()
+        .is_some_and(|s| !s.trim().is_empty());
+    let rtsp_mobile_url = (state.config().mobile_stream_enabled
+        && cam.served_by != "frigate"
+        && has_source)
         .then(|| {
             format!(
                 "{}/{}_mobile",

--- a/services/api/src/segment_low.rs
+++ b/services/api/src/segment_low.rs
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! On-demand low-bitrate playback variant: `GET /segments/{id}/low.mp4`.
+//!
+//! Recorded segments are served byte-for-byte by [`crate::playback::serve_segment`]
+//! — the camera's native main stream, typically multi-megabit H.265. That is
+//! instant on a LAN but unplayable over a poor cellular link, where the sustained
+//! throughput can be a tenth of the segment bitrate. This module adds a **quality
+//! lever** to the same segment: a transcoded 640p / ~15 fps / CRF 28 H.264
+//! variant (≈300–600 kbps) produced **only when a client requests it** and then
+//! cached, so a good connection pays nothing (the client just keeps using
+//! `/segments/{id}`) and a bad one gets a stream it can actually keep up with.
+//!
+//! It is a deliberate near-copy of the clip-preview machinery in
+//! [`crate::clips`] (on-demand `libx264` transcode, cached under `export_dir`,
+//! LRU-pruned, concurrency-bounded by the shared `clip_gen_semaphore`, `ETag`'d),
+//! reusing the same proven properties:
+//!
+//! * **Secure by default.** Same auth as `/segments/{id}`: `require_playback()` +
+//!   `assert_camera_access()` + the scoped per-camera `?token=` media claim (the
+//!   [`AuthUser`] extractor accepts it), so it serves directly as a `<video>` /
+//!   `ExoPlayer` source. The same path-traversal guard
+//!   ([`crate::playback::guard_path_traversal`]) runs before any file I/O.
+//! * **Read-only footage.** The API mounts media read-only; this reads the
+//!   segment file and writes ONLY to its own cache under `export_dir`. The
+//!   recorder is never touched — zero recording-correctness risk.
+//! * **Content-addressed cache.** A segment's bytes never change once written
+//!   (retention only ever deletes the whole segment, which 404s here), so the
+//!   low variant is immutable and cached hard by segment id — repeat scrubs over
+//!   the same footage hit the cache.
+
+use std::path::{Path as FsPath, PathBuf};
+
+use axum::{
+    body::Body,
+    extract::{Path, Request, State},
+    http::{header, HeaderMap, StatusCode},
+    response::Response,
+    routing::get,
+    Router,
+};
+use tokio::process::Command;
+use tower::ServiceExt as _;
+use tower_http::services::ServeFile;
+use uuid::Uuid;
+
+use crumb_common::db;
+
+use crate::{auth_mw::AuthUser, error::ApiError, playback::guard_path_traversal, state::AppState};
+
+/// Same ffmpeg the clip machinery uses (bundled jellyfin-ffmpeg in the API image).
+const FFMPEG_BIN: &str = "/usr/local/bin/ffmpeg";
+
+/// Long, immutable cache lifetime (30 days) — a segment's footage never changes.
+const CACHE_MAX_AGE_SECS: u64 = 30 * 24 * 60 * 60;
+
+/// Mount `GET /segments/{id}/low.mp4`. Lives in `media_routes` (no 30 s JSON
+/// timeout; `AuthUser` accepts `?token=`), a sibling of the raw
+/// `/segments/{id}` route which stays byte-transparent.
+pub fn routes() -> Router<AppState> {
+    Router::new().route("/segments/:segment_id/low.mp4", get(get_segment_low))
+}
+
+/// `GET /segments/{segment_id}/low.mp4` — generate (once, cached) + serve a
+/// low-bitrate H.264 variant of one recorded segment, with HTTP range support.
+///
+/// # Errors
+///
+/// * `400` — path traversal detected (also emits `WARN`), matching `serve_segment`.
+/// * `403` — caller cannot access the camera that owns this segment.
+/// * `404` — segment row not found, or the file is missing on disk.
+/// * `500` — storage row missing / transcode failed.
+async fn get_segment_low(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(segment_id): Path<Uuid>,
+    req: Request,
+) -> Result<Response, ApiError> {
+    // ── capability + scope (identical to serve_segment) ───────────────────────
+    user.require_playback()?;
+    let seg = db::get_segment(state.pool(), segment_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or_else(|| ApiError::NotFound(format!("segment {segment_id} not found")))?;
+    user.assert_camera_access(seg.camera_id)?;
+
+    // ── content-addressed cache short-circuit ─────────────────────────────────
+    let etag = seg_low_etag(segment_id);
+    if let Some(resp) = not_modified_if_match(req.headers(), &etag) {
+        return Ok(resp);
+    }
+
+    // ── resolve + guard the source segment path (same rules as serve_segment) ─
+    let storage = db::get_storage(state.pool(), seg.storage_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or_else(|| {
+            ApiError::Internal(anyhow::anyhow!(
+                "segment {segment_id} storage row missing (storage_id={}); refusing to guess a mount",
+                seg.storage_id
+            ))
+        })?;
+    let storage_root = PathBuf::from(storage.path);
+    let absolute = storage_root.join(&seg.path);
+    let src = guard_path_traversal(&storage_root, &absolute, segment_id)?;
+
+    // ── generate once, then serve the cached faststart MP4 via ServeFile ──────
+    let cache_dir = PathBuf::from(&state.config().export_dir).join("segcache");
+    tokio::fs::create_dir_all(&cache_dir).await.ok();
+    let out = cache_dir.join(format!("{segment_id}.low.mp4"));
+    if tokio::fs::metadata(&out).await.is_err() {
+        generate_low_file(&state, &src, &out).await?;
+        prune_cache(&cache_dir, state.config().segment_low_cache_max_bytes).await;
+    }
+
+    let resp = ServeFile::new(&out)
+        .oneshot(req)
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("ServeFile: {e}")))?;
+    let (parts, body) = resp.into_parts();
+    let mut resp = Response::from_parts(parts, Body::new(body));
+    add_cache_headers(&mut resp, &etag);
+    Ok(resp)
+}
+
+/// Transcode one segment file to a **faststart** low-bitrate H.264 MP4 at `out`,
+/// waiting for completion. Writes to a unique temp file then atomically renames,
+/// so a crashed/concurrent run never leaves a half file for `ServeFile`. Holds
+/// the shared `clip_gen_semaphore` (same bound as clip previews) for the transcode.
+///
+/// Ladder: `libx264 -preset ultrafast -vf scale=640:-2 -r 15 -crf 28`, matching
+/// the proven clip-preview downscale, but KEEPING audio (AAC mono ~40 kbps) —
+/// the recorded segment already carries 48 kHz AAC (recorder normalizes it), so
+/// the mobile viewer showing someone footage still hears it. Re-encoding audio
+/// (rather than `-c copy`) yields a clean, continuous AAC track within the
+/// segment. Cameras with no audio track simply produce no audio (aac is a no-op).
+async fn generate_low_file(state: &AppState, src: &FsPath, out: &FsPath) -> Result<(), ApiError> {
+    let _permit = state
+        .clip_gen_semaphore()
+        .acquire_owned()
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("clip-gen semaphore closed: {e}")))?;
+    // Another request may have produced it while we waited for the permit.
+    if tokio::fs::metadata(out).await.is_ok() {
+        return Ok(());
+    }
+    let tmp = out.with_file_name(format!("{}.partial.mp4", Uuid::new_v4()));
+    let args = low_transcode_args(&src.to_string_lossy(), &tmp.to_string_lossy());
+    let status = Command::new(FFMPEG_BIN)
+        .args(&args)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .await;
+    match status {
+        Ok(s) if s.success() => tokio::fs::rename(&tmp, out)
+            .await
+            .map_err(|e| ApiError::Internal(anyhow::anyhow!("cache low.mp4 rename: {e}"))),
+        other => {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            Err(ApiError::Internal(anyhow::anyhow!(
+                "ffmpeg low transcode failed: {other:?}"
+            )))
+        }
+    }
+}
+
+/// Build the ffmpeg argv for the low-bitrate transcode of a single input file to
+/// `out` (a faststart MP4). Pure + unit-tested so the ladder can't silently drift.
+fn low_transcode_args(input: &str, out: &str) -> Vec<String> {
+    [
+        "-y",
+        "-i",
+        input,
+        "-c:v",
+        "libx264",
+        "-preset",
+        "ultrafast",
+        "-vf",
+        "scale=640:-2",
+        "-r",
+        "15",
+        "-crf",
+        "28",
+        // Keep audio, but small: AAC mono ~40 kbps. If the source has no audio
+        // track ffmpeg just emits none.
+        "-c:a",
+        "aac",
+        "-ac",
+        "1",
+        "-b:a",
+        "40k",
+        "-movflags",
+        "+faststart",
+        out,
+    ]
+    .into_iter()
+    .map(str::to_owned)
+    .collect()
+}
+
+/// Keep the low-variant cache under `max_bytes` by deleting the oldest
+/// `*.low.mp4` (by mtime) until it fits. Best-effort — mirrors
+/// `clips::prune_clip_cache`. Extension-filtered so it can only ever remove files
+/// this module produced.
+async fn prune_cache(dir: &FsPath, max_bytes: u64) {
+    let Ok(mut rd) = tokio::fs::read_dir(dir).await else {
+        return;
+    };
+    let mut files: Vec<(std::time::SystemTime, u64, PathBuf)> = Vec::new();
+    let mut total: u64 = 0;
+    while let Ok(Some(ent)) = rd.next_entry().await {
+        let p = ent.path();
+        if !p.to_string_lossy().ends_with(".low.mp4") {
+            continue;
+        }
+        let Ok(md) = ent.metadata().await else {
+            continue;
+        };
+        total += md.len();
+        files.push((md.modified().unwrap_or(std::time::UNIX_EPOCH), md.len(), p));
+    }
+    if total <= max_bytes {
+        return;
+    }
+    files.sort_by_key(|(m, _, _)| *m); // oldest first
+    for (_, len, p) in files {
+        if total <= max_bytes {
+            break;
+        }
+        if tokio::fs::remove_file(&p).await.is_ok() {
+            total = total.saturating_sub(len);
+        }
+    }
+}
+
+/// A strong-ish `ETag` for a segment's low variant — content-addressed by the
+/// (immutable) segment id, so repeat requests revalidate with a tiny 304.
+fn seg_low_etag(segment_id: Uuid) -> String {
+    format!("\"{segment_id}-low\"")
+}
+
+/// `Cache-Control` for the immutable low variant.
+fn cache_control() -> String {
+    format!("public, max-age={CACHE_MAX_AGE_SECS}, immutable")
+}
+
+/// Stamp `Cache-Control` (immutable) + `ETag` onto an already-built response.
+fn add_cache_headers(resp: &mut Response, etag: &str) {
+    let h = resp.headers_mut();
+    if let Ok(v) = cache_control().parse() {
+        h.insert(header::CACHE_CONTROL, v);
+    }
+    if let Ok(v) = etag.parse() {
+        h.insert(header::ETAG, v);
+    }
+}
+
+/// If the request's `If-None-Match` matches `etag`, return a bare 304 (with cache
+/// headers re-stated). Mirrors `clips::not_modified_if_match`.
+fn not_modified_if_match(headers: &HeaderMap, etag: &str) -> Option<Response> {
+    let inm = headers.get(header::IF_NONE_MATCH)?.to_str().ok()?;
+    let hit = inm == "*"
+        || inm
+            .split(',')
+            .map(str::trim)
+            .any(|t| t == etag || t.trim_start_matches("W/") == etag);
+    if !hit {
+        return None;
+    }
+    Some(
+        Response::builder()
+            .status(StatusCode::NOT_MODIFIED)
+            .header(header::ETAG, etag)
+            .header(header::CACHE_CONTROL, cache_control())
+            .body(Body::empty())
+            .expect("static 304 response builds"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transcode_args_are_the_low_ladder() {
+        let a = low_transcode_args("/data/live/cam/seg.mp4", "/tmp/x.partial.mp4");
+        // Downscale + fps cap + CRF ladder (matches clip previews) …
+        assert!(a.windows(2).any(|w| w == ["-vf", "scale=640:-2"]));
+        assert!(a.windows(2).any(|w| w == ["-r", "15"]));
+        assert!(a.windows(2).any(|w| w == ["-crf", "28"]));
+        assert!(a.windows(2).any(|w| w == ["-preset", "ultrafast"]));
+        assert!(a.windows(2).any(|w| w == ["-c:v", "libx264"]));
+        // … but unlike clip previews, KEEP audio (mobile viewers showing footage).
+        assert!(a.windows(2).any(|w| w == ["-c:a", "aac"]));
+        assert!(!a.iter().any(|s| s == "-an"));
+        // Seekable output for ServeFile Range support.
+        assert!(a.windows(2).any(|w| w == ["-movflags", "+faststart"]));
+        // Input then output ordering.
+        let ii = a.iter().position(|s| s == "-i").unwrap();
+        assert_eq!(a[ii + 1], "/data/live/cam/seg.mp4");
+        assert_eq!(a.last().unwrap(), "/tmp/x.partial.mp4");
+    }
+
+    #[test]
+    fn etag_is_stable_and_low_scoped() {
+        let id = Uuid::new_v4();
+        assert_eq!(seg_low_etag(id), seg_low_etag(id));
+        let e = seg_low_etag(id);
+        assert!(e.starts_with('"') && e.ends_with('"'));
+        assert!(e.contains("-low"));
+    }
+
+    #[test]
+    fn cache_control_is_immutable_and_long() {
+        let cc = cache_control();
+        assert!(cc.contains("public"));
+        assert!(cc.contains("immutable"));
+        assert!(cc.contains(&format!("max-age={CACHE_MAX_AGE_SECS}")));
+    }
+
+    #[test]
+    fn if_none_match_hits_and_misses() {
+        use axum::http::HeaderValue;
+        let id = Uuid::new_v4();
+        let etag = seg_low_etag(id);
+
+        let mut h = HeaderMap::new();
+        h.insert(header::IF_NONE_MATCH, HeaderValue::from_str(&etag).unwrap());
+        let r = not_modified_if_match(&h, &etag).expect("exact match → 304");
+        assert_eq!(r.status(), StatusCode::NOT_MODIFIED);
+        assert!(r.headers().get(header::ETAG).is_some());
+        assert!(r.headers().get(header::CACHE_CONTROL).is_some());
+
+        // Wildcard + weak-validator list membership.
+        let mut h = HeaderMap::new();
+        h.insert(header::IF_NONE_MATCH, HeaderValue::from_static("*"));
+        assert!(not_modified_if_match(&h, &etag).is_some());
+        let mut h = HeaderMap::new();
+        h.insert(
+            header::IF_NONE_MATCH,
+            HeaderValue::from_str(&format!("\"other\", W/{etag}")).unwrap(),
+        );
+        assert!(not_modified_if_match(&h, &etag).is_some());
+
+        // Miss + absent.
+        let mut h = HeaderMap::new();
+        h.insert(header::IF_NONE_MATCH, HeaderValue::from_static("\"nope\""));
+        assert!(not_modified_if_match(&h, &etag).is_none());
+        assert!(not_modified_if_match(&HeaderMap::new(), &etag).is_none());
+    }
+}

--- a/services/api/tests/auth_rbac.rs
+++ b/services/api/tests/auth_rbac.rs
@@ -790,6 +790,45 @@ async fn query_param_media_token_is_scope_checked_and_full_jwt_is_rejected() {
     );
 }
 
+#[tokio::test]
+async fn low_mp4_variant_enforces_camera_scope_like_segments() {
+    // The on-demand low-bitrate variant `/segments/{id}/low.mp4` is a NEW
+    // authenticated media endpoint (golden rule 1) and must enforce exactly the
+    // same camera scoping as its byte-transparent sibling `/segments/{id}`. We
+    // assert the auth FENCE only (403 cross-camera, 401 full-JWT) — both are
+    // decided before any transcode, so this test needs no ffmpeg.
+    let fx = build_rbac_fixture().await;
+    let pool = fx.app.pool().clone();
+    let storage_id = seed_storage(&pool, fx.storage_root.path().to_str().unwrap()).await;
+    let seg_b = seed_segment_with_file(&pool, fx.cam_b, storage_id, fx.storage_root.path()).await;
+
+    // A media token scoped to cam_a must NOT unlock cam_b's low variant.
+    let media_a = mint_media_token(&fx.app, &fx.viewer_token, fx.cam_a).await;
+    let other = fx
+        .app
+        .send(get(&format!("/segments/{seg_b}/low.mp4?token={media_a}")))
+        .await;
+    assert_eq!(
+        other.status(),
+        StatusCode::FORBIDDEN,
+        "low.mp4 must enforce the same per-camera scoping as /segments/{{id}}"
+    );
+
+    // A full login JWT via ?token= must be rejected on this fail-closed media route.
+    let full_jwt = fx
+        .app
+        .send(get(&format!(
+            "/segments/{seg_b}/low.mp4?token={}",
+            fx.viewer_token
+        )))
+        .await;
+    assert_eq!(
+        full_jwt.status(),
+        StatusCode::UNAUTHORIZED,
+        "a full login JWT via ?token= must be rejected on the low.mp4 media route"
+    );
+}
+
 // The camera snapshot route is now FAIL-CLOSED (audit 2026-07-05 #2): the web
 // console (admin.html) mints a scoped media token like every other client, so a
 // full login JWT via ?token= is rejected here — while a scoped media token still
@@ -1234,6 +1273,7 @@ async fn no_protected_route_is_reachable_without_credentials() {
         (Method::GET, "/play/aligned".into()),
         (Method::GET, format!("/play/{u}")),
         (Method::GET, format!("/segments/{u}")),
+        (Method::GET, format!("/segments/{u}/low.mp4")),
         (Method::GET, format!("/cameras/{u}/streams")),
         (Method::GET, format!("/cameras/{u}/motion-grid")),
         (Method::GET, format!("/live/{u}/stream.mp4")),

--- a/services/api/tests/support/mod.rs
+++ b/services/api/tests/support/mod.rs
@@ -81,6 +81,8 @@ pub mod ptz;
 pub mod roles;
 #[path = "../../src/scrub_settings.rs"]
 pub mod scrub_settings;
+#[path = "../../src/segment_low.rs"]
+pub mod segment_low;
 #[path = "../../src/state.rs"]
 pub mod state;
 #[path = "../../src/stream_test.rs"]
@@ -351,6 +353,7 @@ pub fn test_router() -> Router<AppState> {
         .merge(auth::media_token_routes())
         .nest("/config", config_routes::routes())
         .merge(playback::routes())
+        .merge(segment_low::routes())
         .merge(export::routes())
         .merge(filmstrip::routes())
         .merge(events::json_routes())


### PR DESCRIPTION
Server side of mobile / poor-connection performance (phases 1 & 2). Pairs with the Android client PR.

## Phase 1 — on-demand low-bitrate playback
`GET /segments/{id}/low.mp4` (new module `services/api/src/segment_low.rs`) serves a 640p/15fps/CRF28 H.264 variant (+ AAC mono) of a recorded segment, produced only on request and cached (`{export_dir}/segcache`, LRU-pruned to `SEGMENT_LOW_CACHE_MAX_BYTES`, ETag'd/immutable), concurrency-bounded by the shared `clip_gen_semaphore`. Auth is identical to `/segments/{id}` (`require_playback` + `assert_camera_access` + scoped `?token=`), and the same `playback::guard_path_traversal` runs before any file I/O. The API's media mount is read-only; this writes only to its own cache. **The recorder is never touched.**

## Phase 2 — on-demand mobile live transcode
The reconcile loop registers a per-camera `<name>_mobile` go2rtc stream (`ffmpeg:<sub-or-main>#video=h264#width=MOBILE_STREAM_WIDTH`), referenced by go2rtc stream name so it shares the producer; go2rtc spawns the ffmpeg only while a consumer is connected (zero idle cost). Exposed as `rtsp_mobile_url`; gated by `MOBILE_STREAM_ENABLED` (default on); removed with the camera.
> Operator note: this transcode runs beside the recorder (go2rtc is embedded there). On-demand and bounded per active viewer; `MOBILE_STREAM_ENABLED=false` disables it.

## New env knobs (optional, sane defaults)
`SEGMENT_LOW_CACHE_MAX_BYTES` (2 GiB), `MOBILE_STREAM_ENABLED` (true), `MOBILE_STREAM_WIDTH` (640).

## Docs
`docs/MOBILE-PERFORMANCE.md` (design), `docs/DECISIONS.md` (2026-07-13 entry — per-segment chosen over continuous-stream/ABR, revisit triggers), `docs/COMPONENT-MAP.md`.

## Gate
fmt + clippy (`-D warnings`) clean; `cargo test --workspace` = 248 passed / 0 failed incl. new `segment_low` (4) and go2rtc mobile (2) tests, run on a Linux host with a throwaway Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
