### PR TITLE
feat(android): fix playback audio (#106) + adaptive mobile quality (phases 0-2)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/data/Models.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/Models.kt
@@ -289,6 +289,12 @@ data class LiveStreamsResponse(
     @SerialName("webrtc_sub_url") val webrtcSubUrl: String? = null,
     @SerialName("rtsp_main_url") val rtspMainUrl: String,
     @SerialName("rtsp_sub_url") val rtspSubUrl: String? = null,
+    /**
+     * On-demand low-res H.264 transcode for cellular "Data saver" fullscreen live.
+     * `null` when the server has the feature disabled or the camera is
+     * Frigate-served. Nullable-with-default so older servers deserialize cleanly.
+     */
+    @SerialName("rtsp_mobile_url") val rtspMobileUrl: String? = null,
 )
 
 // ─── export ──────────────────────────────────────────────────────────────────

--- a/apps/android/app/src/main/java/video/crumb/app/data/SecureStore.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/SecureStore.kt
@@ -115,6 +115,18 @@ class SecureStore(context: Context) {
         set(value) = prefs.edit().putBoolean(KEY_LIVE_AUDIO, value).apply()
 
     /**
+     * Whether the recorded-playback screen plays segment audio. Persisted across
+     * sessions so the user's choice is remembered. Defaults to FALSE — reviewing
+     * footage should stay silent unless the operator explicitly turns audio on,
+     * so scrubbing through recordings never blares unexpected sound. (Older
+     * footage recorded before audio capture landed simply plays silent when the
+     * toggle is on — no crash.)
+     */
+    var playbackAudioOn: Boolean
+        get() = prefs.getBoolean(KEY_PLAYBACK_AUDIO, false)
+        set(value) = prefs.edit().putBoolean(KEY_PLAYBACK_AUDIO, value).apply()
+
+    /**
      * Live wall grid-layout ordinal (GridLayout: 0=single, 1=2x2, 2=list).
      * Persisted so the chosen layout survives navigating in/out of a camera AND
      * app restarts (a plain `remember` was resetting it to 2x2 on every return).
@@ -244,6 +256,7 @@ class SecureStore(context: Context) {
         private const val KEY_USERNAME = "username"
         private const val KEY_LAST_LIVE_CAM = "last_live_cam"
         private const val KEY_LIVE_AUDIO = "live_audio_on"
+        private const val KEY_PLAYBACK_AUDIO = "playback_audio_on"
         private const val KEY_LIVE_LAYOUT = "live_grid_layout"
         private const val KEY_LOW_BW_AUTOFIX = "low_bw_autofix_applied"
         private const val KEY_PTZ_STYLE = "ptz_style"

--- a/apps/android/app/src/main/java/video/crumb/app/data/SecureStore.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/SecureStore.kt
@@ -127,6 +127,18 @@ class SecureStore(context: Context) {
         set(value) = prefs.edit().putBoolean(KEY_PLAYBACK_AUDIO, value).apply()
 
     /**
+     * Recorded-playback quality mode: "auto" (default), "full", or "low".
+     * - "auto": full-res recorded bytes on Wi-Fi/unmetered, the server's on-demand
+     *   640p `low.mp4` transcode on metered/cellular.
+     * - "full": always the recorded main-stream bytes.
+     * - "low": always the low-bitrate transcode ("Data saver").
+     * Persisted across sessions (a device-level preference, so it survives logout).
+     */
+    var playbackQuality: String
+        get() = prefs.getString(KEY_PLAYBACK_QUALITY, "auto") ?: "auto"
+        set(value) = prefs.edit().putString(KEY_PLAYBACK_QUALITY, value).apply()
+
+    /**
      * Live wall grid-layout ordinal (GridLayout: 0=single, 1=2x2, 2=list).
      * Persisted so the chosen layout survives navigating in/out of a camera AND
      * app restarts (a plain `remember` was resetting it to 2x2 on every return).
@@ -257,6 +269,7 @@ class SecureStore(context: Context) {
         private const val KEY_LAST_LIVE_CAM = "last_live_cam"
         private const val KEY_LIVE_AUDIO = "live_audio_on"
         private const val KEY_PLAYBACK_AUDIO = "playback_audio_on"
+        private const val KEY_PLAYBACK_QUALITY = "playback_quality"
         private const val KEY_LIVE_LAYOUT = "live_grid_layout"
         private const val KEY_LOW_BW_AUTOFIX = "low_bw_autofix_applied"
         private const val KEY_PTZ_STYLE = "ptz_style"

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
@@ -141,6 +141,9 @@ fun LiveFullscreenScreen(
     var rtspUrl by remember { mutableStateOf<String?>(null) }
     var mainUrl by remember(currentCameraId) { mutableStateOf<String?>(null) }
     var subUrl by remember(currentCameraId) { mutableStateOf<String?>(null) }
+    // On-demand mobile transcode URL (server may omit it); used as the metered
+    // "data saver" start stream for cameras that have no sub of their own.
+    var mobileUrl by remember(currentCameraId) { mutableStateOf<String?>(null) }
     // True once we've downgraded to the sub stream because the main never played.
     var usingSub by remember(currentCameraId) { mutableStateOf(false) }
     // Drives the subtle "SD" badge: the main (HD) stream was unplayable, on sub now.
@@ -163,6 +166,11 @@ fun LiveFullscreenScreen(
     // fullscreen reconnect loop pauses instead of burning its fast-attempt budget
     // against a link that can't reach the server at all.
     val isOnline by rememberIsOnline()
+
+    // Metered/cellular signal: on a metered link, fullscreen live starts on a
+    // data-saver stream (sub, or the on-demand mobile transcode when there is no
+    // sub) instead of the HD main — the SD badge lets the user tap for HD.
+    val isMetered by rememberIsMetered()
 
     // Bumped to force a fresh `remember(rtspUrl, playerGeneration)` player without
     // touching rtspUrl — tap-to-retry (#2) rebuilds from scratch (fresh backoff
@@ -235,11 +243,22 @@ fun LiveFullscreenScreen(
                 onSuccess = { streams ->
                     mainUrl = streams.rtspMainUrl
                     subUrl = streams.rtspSubUrl
-                    usingSub = false
-                    hdUnavailable = false
-                    // Start on the main (HD) stream; the reconnect logic below falls
-                    // back to the sub stream if the main never reaches a playable frame.
-                    rtspUrl = streams.rtspMainUrl
+                    mobileUrl = streams.rtspMobileUrl
+                    // On a metered link, start on a data-saver stream: the camera's
+                    // sub when it has one, else the server's on-demand mobile
+                    // transcode. Off metered (Wi-Fi/LAN), start on the main (HD)
+                    // stream. Either way the codec-failure fallback + "tap for HD"
+                    // badge below still apply.
+                    val lowFirst = if (isMetered) (streams.rtspSubUrl ?: streams.rtspMobileUrl) else null
+                    if (lowFirst != null) {
+                        usingSub = true
+                        hdUnavailable = true
+                        rtspUrl = lowFirst
+                    } else {
+                        usingSub = false
+                        hdUnavailable = false
+                        rtspUrl = streams.rtspMainUrl
+                    }
                     isResolving = false
                 },
                 onFailure = { cause ->
@@ -565,12 +584,13 @@ fun LiveFullscreenScreen(
             }
         }
 
-        // "SD" badge — the main (HD) stream couldn't play on this device (e.g. an
-        // H265 main the RTSP path can't decode), so we downgraded to the sub stream.
-        // Distinct from the reconnecting/error states. Hidden in PiP (video only).
+        // "SD" badge — running the sub (or mobile) stream rather than HD main,
+        // either because the main couldn't decode on this device (H265-over-RTSP)
+        // or because we're on a metered link (data-saver start). TAPPABLE: forces
+        // the HD (main) stream — the manual HD/SD override. Hidden in PiP.
         if (!inPip && hdUnavailable && !isResolving && !playerError) {
             Text(
-                text = "SD",
+                text = "SD · tap for HD",
                 style = MaterialTheme.typography.labelMedium,
                 color = Color.White,
                 modifier = Modifier
@@ -581,6 +601,14 @@ fun LiveFullscreenScreen(
                         color = Color.Black.copy(alpha = 0.55f),
                         shape = androidx.compose.foundation.shape.RoundedCornerShape(6.dp),
                     )
+                    .clickable {
+                        mainUrl?.let {
+                            usingSub = false
+                            hdUnavailable = false
+                            rtspUrl = it
+                            playerGeneration += 1
+                        }
+                    }
                     .padding(horizontal = 8.dp, vertical = 4.dp),
             )
         }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/NetworkConnectivity.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/NetworkConnectivity.kt
@@ -47,6 +47,78 @@ object NetworkConnectivityObserver {
         return caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
             caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
     }
+
+    /**
+     * Best-effort synchronous "is the active network metered" check — cellular,
+     * a metered Wi-Fi hotspot, or a network the user manually flagged as metered.
+     * Uses [ConnectivityManager.isActiveNetworkMetered], which honours the user's
+     * per-network metered override, and falls back to `false` (assume unmetered,
+     * i.e. never force the low-bitrate path) when connectivity can't be read.
+     * Drives the playback quality selector's **Auto** mode (Auto → Low on metered).
+     */
+    fun isMeteredNow(context: Context): Boolean {
+        val cm = context.getSystemService(ConnectivityManager::class.java) ?: return false
+        return cm.isActiveNetworkMetered
+    }
+}
+
+/**
+ * Remembers a live [State]<Boolean> tracking whether the active network is
+ * metered (see [NetworkConnectivityObserver.isMeteredNow]). Re-samples on every
+ * connectivity change over the same lifecycle-gated callback pattern as
+ * [rememberIsOnline]. Drives the playback quality selector's Auto mode.
+ */
+@Composable
+fun rememberIsMetered(): State<Boolean> {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    var metered by remember { mutableStateOf(NetworkConnectivityObserver.isMeteredNow(context)) }
+
+    DisposableEffect(lifecycleOwner) {
+        val cm = context.getSystemService(ConnectivityManager::class.java)
+        var callback: ConnectivityManager.NetworkCallback? = null
+
+        fun resync() {
+            metered = NetworkConnectivityObserver.isMeteredNow(context)
+        }
+
+        fun register() {
+            if (cm == null || callback != null) return
+            resync()
+            val request = NetworkRequest.Builder()
+                .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                .build()
+            val cb = object : ConnectivityManager.NetworkCallback() {
+                override fun onAvailable(network: Network) = resync()
+                override fun onLost(network: Network) = resync()
+                override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) = resync()
+            }
+            callback = cb
+            cm.registerNetworkCallback(request, cb)
+        }
+
+        fun unregister() {
+            callback?.let { cm?.unregisterNetworkCallback(it) }
+            callback = null
+        }
+
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_START -> register()
+                Lifecycle.Event.ON_STOP -> unregister()
+                else -> Unit
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        register()
+
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            unregister()
+        }
+    }
+
+    return remember { DerivedOnlineState { metered } }
 }
 
 /**

--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
@@ -78,6 +79,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.media3.common.PlaybackException
+import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.SeekParameters
@@ -103,6 +105,7 @@ import video.crumb.app.ui.player.MediaFactory
 import video.crumb.app.ui.player.PlayerSurface
 import video.crumb.app.ui.player.ViewTransform
 import video.crumb.app.ui.player.ZoomableVideoSurface
+import video.crumb.app.feature.live.rememberIsMetered
 import video.crumb.app.ui.theme.NavyDeep
 import video.crumb.app.ui.theme.NavySurface
 import video.crumb.app.ui.theme.TealAccent
@@ -115,8 +118,47 @@ import java.time.Instant
  * Segments are short (~4s), so this needs enough lead time for a resolve
  * round-trip on a slow link, without firing so early it refetches needlessly
  * on every short segment.
+ *
+ * Raised from 2 s to hide one more resolve+fetch round-trip on a slow link (on a
+ * LAN, resolves are instant so this changes nothing). Keep in sync with
+ * [PlaybackViewModel]'s own `PREFETCH_LEAD_MS`.
  */
-private const val PREFETCH_LEAD_MS_SCREEN = 2_000L
+private const val PREFETCH_LEAD_MS_SCREEN = 3_500L
+
+/**
+ * Playback quality selector values, persisted as a string in `SecureStore`.
+ *
+ * - [AUTO] (default): full on Wi-Fi/unmetered, [DATA_SAVER] on metered/cellular.
+ * - [FULL]: always the recorded main-stream bytes (`/segments/{id}`).
+ * - [DATA_SAVER]: always the server's on-demand 640p transcode
+ *   (`/segments/{id}/low.mp4`).
+ */
+object PlaybackQuality {
+    const val AUTO = "auto"
+    const val FULL = "full"
+    const val DATA_SAVER = "low"
+
+    /** Cycle order for the one-tap selector: Auto → Full → Data saver → Auto. */
+    fun next(current: String): String = when (current) {
+        AUTO -> FULL
+        FULL -> DATA_SAVER
+        else -> AUTO
+    }
+
+    /** Short label for the selector's tooltip / hint. */
+    fun label(current: String): String = when (current) {
+        FULL -> "Quality: Full"
+        DATA_SAVER -> "Quality: Data saver"
+        else -> "Quality: Auto"
+    }
+
+    /** Compact badge text for the in-bar chip. */
+    fun short(current: String): String = when (current) {
+        FULL -> "HD"
+        DATA_SAVER -> "SD"
+        else -> "AUTO"
+    }
+}
 
 /**
  * Full-screen single-camera recorded-playback screen.
@@ -233,8 +275,10 @@ fun PlaybackScreen(
     var bookmarkAtMs by remember { mutableLongStateOf(0L) }
 
     // ── ExoPlayer setup ─────────────────────────────────────────────────────────
+    // newPlaybackPlayer declares media audio attributes + audio-focus handling
+    // (#106) and a WAN-tuned buffer, unlike the muted live-wall tiles.
     val player = remember {
-        MediaFactory.newPlayer(context).apply {
+        MediaFactory.newPlaybackPlayer(context).apply {
             setSeekParameters(SeekParameters.EXACT) // frame-accurate stepping
         }
     }
@@ -245,13 +289,46 @@ fun PlaybackScreen(
     // without an audio track just plays silent when this is on — no crash.
     val store = container.store
     var audioOn by remember { mutableStateOf(store.playbackAudioOn) }
-    // Drive the single ExoPlayer's volume from the toggle. ExoPlayer keeps this
-    // volume across setMediaSource / the gapless addMediaSource path, so applying it
-    // to the one player here covers every segment (initial, scrub, motion-jump,
-    // auto-advance) without re-asserting it per segment.
+    // Drive the single ExoPlayer's volume from the toggle whenever it changes.
     LaunchedEffect(player, audioOn) {
         player.volume = if (audioOn) 1f else 0f
     }
+    // Re-assert the intended volume across media transitions (#106). ExoPlayer is
+    // *supposed* to keep player.volume across setMediaSource / gapless
+    // addMediaSource, but on a segment-boundary AudioTrack reconfigure the
+    // framework AudioTrack could be re-created and end up muted independent of the
+    // player-level volume. Re-applying it on every transition / when the renderer
+    // reaches READY / on an audio-session change makes the intended state
+    // authoritative no matter what the sink did underneath.
+    val currentAudioOn by rememberUpdatedState(audioOn)
+    DisposableEffect(player) {
+        val listener = object : Player.Listener {
+            private fun reassert() {
+                player.volume = if (currentAudioOn) 1f else 0f
+            }
+            override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) = reassert()
+            override fun onPlaybackStateChanged(playbackState: Int) {
+                if (playbackState == Player.STATE_READY) reassert()
+            }
+            override fun onAudioSessionIdChanged(audioSessionId: Int) = reassert()
+        }
+        player.addListener(listener)
+        onDispose { player.removeListener(listener) }
+    }
+
+    // ── Playback quality (Auto / Full / Data saver) ─────────────────────────────
+    // Auto (default) = full on unmetered, low on metered/cellular; Full = always
+    // the recorded main-stream bytes; Data saver = always the server's on-demand
+    // 640p `low.mp4` transcode. The chosen "low" decision drives which segment URL
+    // the ViewModel builds (see PlaybackViewModel.setLowQuality).
+    var quality by remember { mutableStateOf(store.playbackQuality) }
+    val isMetered by rememberIsMetered()
+    val useLow = when (quality) {
+        PlaybackQuality.FULL -> false
+        PlaybackQuality.DATA_SAVER -> true
+        else -> isMetered // AUTO
+    }
+    LaunchedEffect(useLow) { vm.setLowQuality(useLow) }
 
     // Frame step (paused): nudge the player by ~one frame within the current
     // segment. We derive the frame interval from the decoded stream's actual frame
@@ -628,6 +705,21 @@ fun PlaybackScreen(
                 // floating overlay that lands over the footage on a letterboxed
                 // pane. Only meaningful once a segment is resolved to hear.
                 actions = {
+                    // Quality selector (Auto / Full / Data saver) — always visible so
+                    // the operator can pick a cellular-friendly stream before playing.
+                    HintTooltip(PlaybackQuality.label(quality)) {
+                        IconButton(
+                            onClick = {
+                                quality = PlaybackQuality.next(quality)
+                                store.playbackQuality = quality
+                            },
+                        ) {
+                            Text(
+                                text = PlaybackQuality.short(quality),
+                                color = if (quality == PlaybackQuality.AUTO) Color.White else TealAccent,
+                            )
+                        }
+                    }
                     if (state.currentSegment != null) {
                         HintTooltip(if (audioOn) "Mute audio" else "Play audio") {
                             IconButton(
@@ -816,6 +908,13 @@ fun PlaybackScreen(
                     } else {
                         null
                     },
+                    // Landscape hosts the quality selector inline too (portrait uses
+                    // the app bar).
+                    quality = quality,
+                    onCycleQuality = {
+                        quality = PlaybackQuality.next(quality)
+                        store.playbackQuality = quality
+                    },
                     // Portrait can't fit every control inline (the snapshot button was
                     // being clipped), so the SECONDARY actions (snapshot, bookmark,
                     // jump-to-time, speed) collapse into a 3-dot overflow menu. In
@@ -912,6 +1011,10 @@ private fun PlaybackControls(
     // lives in the top app bar instead). null hides it.
     audioOn: Boolean = false,
     onToggleAudio: (() -> Unit)? = null,
+    // Quality selector (Auto/Full/Data saver) rides inline on the landscape row
+    // too. null hides it (portrait uses the app bar chip).
+    quality: String = PlaybackQuality.AUTO,
+    onCycleQuality: (() -> Unit)? = null,
 ) {
     // Landscape is vertically cramped, so the transport runs a notch smaller there
     // (this is what "shrinks the play/pause bar"). Portrait keeps its roomier sizes.
@@ -1091,13 +1194,25 @@ private fun PlaybackControls(
 
             // Snapshot + Bookmark share this transport row in landscape (the app bar
             // is hidden there). In portrait they live in the overflow menu above.
-            if (onSnapshot != null || onBookmark != null || onToggleAudio != null) {
+            if (onSnapshot != null || onBookmark != null || onToggleAudio != null || onCycleQuality != null) {
                 Spacer(Modifier.width(6.dp))
                 onSnapshot?.let {
                     SmallControl(Icons.Default.PhotoCamera, "Snapshot", ctlSize, ctlIcon, it)
                 }
                 onBookmark?.let {
                     SmallControl(Icons.Default.BookmarkAdd, "Add bookmark", ctlSize, ctlIcon, it)
+                }
+                // Quality selector (Auto/Full/Data saver) — a compact text chip
+                // matching the portrait app-bar control.
+                onCycleQuality?.let { cycle ->
+                    HintTooltip(PlaybackQuality.label(quality)) {
+                        IconButton(onClick = cycle, modifier = Modifier.size(ctlSize)) {
+                            Text(
+                                text = PlaybackQuality.short(quality),
+                                color = if (quality == PlaybackQuality.AUTO) Color.White else TealAccent,
+                            )
+                        }
+                    }
                 }
                 // Audio on/off — same row as Snapshot/Bookmark in landscape (teal
                 // when on), instead of a float that lands over the video.

--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
@@ -773,27 +773,9 @@ fun PlaybackScreen(
                         }
                     }
                 }
-
-                // Audio on/off toggle — LANDSCAPE ONLY: the top app bar is hidden
-                // then, so float it in the corner. In portrait it lives in the app
-                // bar's actions (above) instead of floating over the footage.
-                if (isLandscape && state.currentSegment != null) {
-                    HintTooltip(if (audioOn) "Mute audio" else "Play audio") {
-                        IconButton(
-                            onClick = {
-                                audioOn = !audioOn
-                                store.playbackAudioOn = audioOn
-                            },
-                            modifier = Modifier.align(Alignment.TopEnd).padding(2.dp),
-                        ) {
-                            Icon(
-                                imageVector = if (audioOn) Icons.Default.VolumeUp else Icons.Default.VolumeOff,
-                                contentDescription = if (audioOn) "Mute audio" else "Play audio",
-                                tint = if (audioOn) TealAccent else Color.White,
-                            )
-                        }
-                    }
-                }
+                // (Audio toggle: portrait → top app bar actions; landscape → inline
+                // on the transport row below, next to Snapshot/Bookmark. It is NOT
+                // floated over the video in either orientation.)
             }
 
             // ── PINNED transport bar (controls + timeline) at the bottom ──────────
@@ -826,6 +808,14 @@ fun PlaybackScreen(
                     onSnapshot = onSnapshot,
                     // null hides the bookmark control (transport uses onBookmark?.let)
                     onBookmark = if (bookmarksEnabled) onBookmark else null,
+                    // Landscape hosts the audio toggle inline on this row (portrait
+                    // uses the app bar). Gate on a resolved segment, same as portrait.
+                    audioOn = audioOn,
+                    onToggleAudio = if (state.currentSegment != null) {
+                        { audioOn = !audioOn; store.playbackAudioOn = audioOn }
+                    } else {
+                        null
+                    },
                     // Portrait can't fit every control inline (the snapshot button was
                     // being clipped), so the SECONDARY actions (snapshot, bookmark,
                     // jump-to-time, speed) collapse into a 3-dot overflow menu. In
@@ -918,6 +908,10 @@ private fun PlaybackControls(
     useOverflowMenu: Boolean = false,
     onSnapshot: (() -> Unit)? = null,
     onBookmark: (() -> Unit)? = null,
+    // Audio toggle rides inline on the landscape transport row (in portrait it
+    // lives in the top app bar instead). null hides it.
+    audioOn: Boolean = false,
+    onToggleAudio: (() -> Unit)? = null,
 ) {
     // Landscape is vertically cramped, so the transport runs a notch smaller there
     // (this is what "shrinks the play/pause bar"). Portrait keeps its roomier sizes.
@@ -1097,13 +1091,27 @@ private fun PlaybackControls(
 
             // Snapshot + Bookmark share this transport row in landscape (the app bar
             // is hidden there). In portrait they live in the overflow menu above.
-            if (onSnapshot != null || onBookmark != null) {
+            if (onSnapshot != null || onBookmark != null || onToggleAudio != null) {
                 Spacer(Modifier.width(6.dp))
                 onSnapshot?.let {
                     SmallControl(Icons.Default.PhotoCamera, "Snapshot", ctlSize, ctlIcon, it)
                 }
                 onBookmark?.let {
                     SmallControl(Icons.Default.BookmarkAdd, "Add bookmark", ctlSize, ctlIcon, it)
+                }
+                // Audio on/off — same row as Snapshot/Bookmark in landscape (teal
+                // when on), instead of a float that lands over the video.
+                onToggleAudio?.let { toggle ->
+                    HintTooltip(if (audioOn) "Mute audio" else "Play audio") {
+                        IconButton(onClick = toggle, modifier = Modifier.size(ctlSize)) {
+                            Icon(
+                                imageVector = if (audioOn) Icons.Default.VolumeUp else Icons.Default.VolumeOff,
+                                contentDescription = if (audioOn) "Mute audio" else "Play audio",
+                                tint = if (audioOn) TealAccent else Color.White,
+                                modifier = Modifier.size(ctlIcon),
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
@@ -623,6 +623,28 @@ fun PlaybackScreen(
                         }
                     }
                 },
+                // Audio on/off toggle lives here (portrait): a primary, always-
+                // visible control docked in the app bar, out of the video — NOT a
+                // floating overlay that lands over the footage on a letterboxed
+                // pane. Only meaningful once a segment is resolved to hear.
+                actions = {
+                    if (state.currentSegment != null) {
+                        HintTooltip(if (audioOn) "Mute audio" else "Play audio") {
+                            IconButton(
+                                onClick = {
+                                    audioOn = !audioOn
+                                    store.playbackAudioOn = audioOn
+                                },
+                            ) {
+                                Icon(
+                                    imageVector = if (audioOn) Icons.Default.VolumeUp else Icons.Default.VolumeOff,
+                                    contentDescription = if (audioOn) "Mute audio" else "Play audio",
+                                    tint = if (audioOn) TealAccent else Color.White,
+                                )
+                            }
+                        }
+                    }
+                },
                 // Snapshot + Bookmark moved OUT of the app bar into the transport's
                 // 3-dot overflow menu (portrait), keeping the bar uncluttered and the
                 // secondary actions grouped where the user controls playback.
@@ -752,11 +774,10 @@ fun PlaybackScreen(
                     }
                 }
 
-                // Audio on/off toggle — floats top-end over the video in BOTH
-                // orientations (same affordance as the fullscreen live view). Only
-                // shown once there's a resolved segment to hear; hidden on the
-                // loading / error / no-footage states where there's nothing playing.
-                if (state.currentSegment != null) {
+                // Audio on/off toggle — LANDSCAPE ONLY: the top app bar is hidden
+                // then, so float it in the corner. In portrait it lives in the app
+                // bar's actions (above) instead of floating over the footage.
+                if (isLandscape && state.currentSegment != null) {
                     HintTooltip(if (audioOn) "Mute audio" else "Play audio") {
                         IconButton(
                             onClick = {

--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.material.icons.filled.NavigateNext
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.VolumeOff
+import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -103,6 +105,7 @@ import video.crumb.app.ui.player.ViewTransform
 import video.crumb.app.ui.player.ZoomableVideoSurface
 import video.crumb.app.ui.theme.NavyDeep
 import video.crumb.app.ui.theme.NavySurface
+import video.crumb.app.ui.theme.TealAccent
 import video.crumb.app.ui.theme.TextSecondary
 import java.time.Instant
 
@@ -234,6 +237,20 @@ fun PlaybackScreen(
         MediaFactory.newPlayer(context).apply {
             setSeekParameters(SeekParameters.EXACT) // frame-accurate stepping
         }
+    }
+
+    // Recorded-playback audio on/off (mirrors the fullscreen live view's toggle).
+    // Seeded from SecureStore (default OFF — reviewing footage is silent until the
+    // operator asks for sound) and persisted on every change. A segment recorded
+    // without an audio track just plays silent when this is on — no crash.
+    val store = container.store
+    var audioOn by remember { mutableStateOf(store.playbackAudioOn) }
+    // Drive the single ExoPlayer's volume from the toggle. ExoPlayer keeps this
+    // volume across setMediaSource / the gapless addMediaSource path, so applying it
+    // to the one player here covers every segment (initial, scrub, motion-jump,
+    // auto-advance) without re-asserting it per segment.
+    LaunchedEffect(player, audioOn) {
+        player.volume = if (audioOn) 1f else 0f
     }
 
     // Frame step (paused): nudge the player by ~one frame within the current
@@ -730,6 +747,28 @@ fun PlaybackScreen(
                                 Icons.AutoMirrored.Filled.ArrowBack,
                                 contentDescription = "Back",
                                 tint = Color.White,
+                            )
+                        }
+                    }
+                }
+
+                // Audio on/off toggle — floats top-end over the video in BOTH
+                // orientations (same affordance as the fullscreen live view). Only
+                // shown once there's a resolved segment to hear; hidden on the
+                // loading / error / no-footage states where there's nothing playing.
+                if (state.currentSegment != null) {
+                    HintTooltip(if (audioOn) "Mute audio" else "Play audio") {
+                        IconButton(
+                            onClick = {
+                                audioOn = !audioOn
+                                store.playbackAudioOn = audioOn
+                            },
+                            modifier = Modifier.align(Alignment.TopEnd).padding(2.dp),
+                        ) {
+                            Icon(
+                                imageVector = if (audioOn) Icons.Default.VolumeUp else Icons.Default.VolumeOff,
+                                contentDescription = if (audioOn) "Mute audio" else "Play audio",
+                                tint = if (audioOn) TealAccent else Color.White,
                             )
                         }
                     }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
@@ -523,6 +523,10 @@ fun PlaybackScreen(
                 }
             }
             override fun onPlayerError(error: PlaybackException) {
+                // If the low-bitrate variant failed (server has no `/low.mp4`, or a
+                // transcode errored), fall back to full BEFORE re-resolving — else
+                // onPlayerError would just refetch the same failing low URL forever.
+                vm.noteLowQualityFailed()
                 vm.onPlayerError()
             }
         }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackViewModel.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackViewModel.kt
@@ -115,9 +115,11 @@ private const val NEXT_SEGMENT_LOOKAHEAD_MS = 1L
  * How close to the end of the current segment (in playhead time) the screen
  * should trigger [PlaybackViewModel.prefetchNextSegment]. Segments are short
  * (~4s), so this needs to be small enough not to fire immediately on entry but
- * comfortably ahead of a resolve round-trip on a slow link.
+ * comfortably ahead of a resolve round-trip on a slow link. Raised from 2 s to
+ * hide one more round-trip on a slow link; keep in sync with the screen's
+ * `PREFETCH_LEAD_MS_SCREEN`.
  */
-private const val PREFETCH_LEAD_MS = 2_000L
+private const val PREFETCH_LEAD_MS = 3_500L
 
 /**
  * Motion histogram resolution over the loaded data window. 1440 buckets across
@@ -421,6 +423,32 @@ class PlaybackViewModel(
      *   retry ONCE at this exact time before falling back to the calm
      *   "no footage" state. Null for every other caller (plain seeks never retry).
      */
+    /**
+     * When true, playback fetches the server's on-demand low-bitrate transcode
+     * (`/segments/{id}/low.mp4`) instead of the recorded main-stream bytes. Driven
+     * by the screen's quality selector (Auto→metered / Full / Data saver).
+     */
+    private var lowQuality = false
+
+    /** Map a resolved segment URL to the active quality variant. */
+    private fun qualityUrl(segmentUrl: String): String =
+        if (lowQuality) "$segmentUrl/low.mp4" else segmentUrl
+
+    /**
+     * Switch the playback quality (full vs. low-bitrate transcode). If it actually
+     * changes, re-resolve the current playhead so the newly-built segment URL
+     * (with/without the `low.mp4` suffix) takes effect immediately, and drop any
+     * prefetched next segment (it was resolved for the old quality).
+     */
+    fun setLowQuality(low: Boolean) {
+        if (low == lowQuality) return
+        lowQuality = low
+        _state.update { it.copy(nextSegment = null, nextSegmentUrl = null) }
+        if (_state.value.currentSegment != null) {
+            seekTo(_state.value.playheadMs)
+        }
+    }
+
     fun seekTo(tsMs: Long, retryAtMs: Long? = null) {
         _state.update { it.copy(playheadMs = tsMs) }
         // Cancel any in-flight resolve so a stale result can't override this seek
@@ -441,7 +469,7 @@ class PlaybackViewModel(
             repo.resolveSegment(cameraId, tsIso).onSuccess { segment ->
                 val startMs = Time.parseToMillis(segment.start)
                 val offsetMs = (tsMs - startMs).coerceAtLeast(0L)
-                val authedUrl = repo.mediaUrls().scopedUrl(cameraId, segment.url)
+                val authedUrl = repo.mediaUrls().scopedUrl(cameraId, qualityUrl(segment.url))
                 _state.update {
                     it.copy(
                         // Belt-and-braces re-assertion (spec 5.): whatever else
@@ -524,7 +552,7 @@ class PlaybackViewModel(
                 // segment this prefetch was FOR while the network call was in
                 // flight, don't attach a stale "next" to the new current segment.
                 if (_state.value.currentSegment?.segmentId != targetSegmentId) return@onSuccess
-                val authedUrl = repo.mediaUrls().scopedUrl(cameraId, next.url)
+                val authedUrl = repo.mediaUrls().scopedUrl(cameraId, qualityUrl(next.url))
                 _state.update { it.copy(nextSegment = next, nextSegmentUrl = authedUrl) }
             }
             // Failures (including 404 at a span boundary edge case) are silently

--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackViewModel.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackViewModel.kt
@@ -430,17 +430,43 @@ class PlaybackViewModel(
      */
     private var lowQuality = false
 
+    /**
+     * Set once a low-bitrate fetch fails (the server doesn't offer `/low.mp4` —
+     * e.g. it predates that endpoint — or a transcode errored). While set, we stop
+     * appending `/low.mp4` and serve the full recorded bytes, so playback never
+     * hard-stalls on a missing/broken low variant. Cleared when the user
+     * explicitly (re-)selects a low quality mode, to give it another chance.
+     */
+    private var lowUnavailable = false
+
     /** Map a resolved segment URL to the active quality variant. */
     private fun qualityUrl(segmentUrl: String): String =
-        if (lowQuality) "$segmentUrl/low.mp4" else segmentUrl
+        if (lowQuality && !lowUnavailable) "$segmentUrl/low.mp4" else segmentUrl
+
+    /**
+     * Note that the low-bitrate variant failed to load, and fall back to full for
+     * the rest of the session. Returns true if this actually changed anything (we
+     * were using low and hadn't already fallen back), so the caller can re-resolve
+     * the current playhead with the full URL instead of refetching the failing one.
+     */
+    fun noteLowQualityFailed(): Boolean {
+        if (lowQuality && !lowUnavailable) {
+            lowUnavailable = true
+            _state.update { it.copy(nextSegment = null, nextSegmentUrl = null) }
+            return true
+        }
+        return false
+    }
 
     /**
      * Switch the playback quality (full vs. low-bitrate transcode). If it actually
      * changes, re-resolve the current playhead so the newly-built segment URL
      * (with/without the `low.mp4` suffix) takes effect immediately, and drop any
-     * prefetched next segment (it was resolved for the old quality).
+     * prefetched next segment (it was resolved for the old quality). Explicitly
+     * asking for low clears a prior "low unavailable" fallback so it's retried.
      */
     fun setLowQuality(low: Boolean) {
+        if (low) lowUnavailable = false
         if (low == lowQuality) return
         lowQuality = low
         _state.update { it.copy(nextSegment = null, nextSegmentUrl = null) }

--- a/apps/android/app/src/main/java/video/crumb/app/ui/player/MediaFactory.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/ui/player/MediaFactory.kt
@@ -3,6 +3,8 @@
 package video.crumb.app.ui.player
 
 import android.content.Context
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultHttpDataSource
@@ -27,6 +29,48 @@ object MediaFactory {
     /** A fresh ExoPlayer. Caller MUST call `release()` when done. */
     fun newPlayer(context: Context): ExoPlayer =
         ExoPlayer.Builder(context).build()
+
+    /**
+     * ExoPlayer for RECORDED PLAYBACK (the timeline scrubber). Differs from the
+     * bare [newPlayer] in two ways that matter for footage review over a WAN:
+     *
+     * 1. **Audio focus + media attributes (#106).** Unlike the deliberately-muted
+     *    live-wall tiles, recorded playback is watched WITH sound on purpose. We
+     *    declare `USAGE_MEDIA` / `CONTENT_TYPE_MOVIE` audio attributes and let
+     *    ExoPlayer manage audio focus (`handleAudioFocus = true`), so the player
+     *    properly acquires the media output path instead of a silent AudioTrack,
+     *    and pauses on headphones-unplug (`handleAudioBecomingNoisy`). The
+     *    per-segment volume the UI sets (mute/unmute toggle) rides on top of this.
+     * 2. **WAN-tuned buffering.** A larger `DefaultLoadControl` window than the
+     *    ExoPlayer default plus a retained back-buffer, so small backward scrubs
+     *    replay from RAM instead of re-fetching, and a jittery cellular link has
+     *    more slack before it rebuffers. (This reduces thrash; it does not change
+     *    the source bitrate — that is what the `low.mp4` quality lever is for.)
+     *
+     * Caller MUST call `release()` when done.
+     */
+    fun newPlaybackPlayer(context: Context): ExoPlayer {
+        val loadControl = DefaultLoadControl.Builder()
+            .setBufferDurationsMs(
+                /* minBufferMs */ 15_000,
+                /* maxBufferMs */ 60_000,
+                /* bufferForPlaybackMs */ 2_500,
+                /* bufferForPlaybackAfterRebufferMs */ 5_000,
+            )
+            // Retain up to 30 s of already-played media so a small backward scrub
+            // replays from memory rather than re-downloading over the slow link.
+            .setBackBuffer(/* backBufferDurationMs */ 30_000, /* retainBackBufferFromKeyframe */ true)
+            .build()
+        val audioAttributes = AudioAttributes.Builder()
+            .setUsage(C.USAGE_MEDIA)
+            .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
+            .build()
+        return ExoPlayer.Builder(context)
+            .setLoadControl(loadControl)
+            .setAudioAttributes(audioAttributes, /* handleAudioFocus = */ true)
+            .setHandleAudioBecomingNoisy(true)
+            .build()
+    }
 
     /**
      * Low-latency ExoPlayer for LIVE RTSP. Thin buffers (start after ~100 ms,


### PR DESCRIPTION
Client side of mobile / poor-connection performance, plus the playback-audio fix. Pairs with #107 (needs #107 deployed for the `low.mp4` / mobile-live URLs to resolve at runtime).

## Fixes #106 — no audio in recorded playback
Recorded playback now uses a dedicated `MediaFactory.newPlaybackPlayer`:
- Declares `USAGE_MEDIA` / `CONTENT_TYPE_MOVIE` audio attributes with **audio-focus handling** — the muted live-wall tiles never request focus, and that was the only functional audio difference between the working live path and silent playback.
- `handleAudioBecomingNoisy(true)`.
- A `Player.Listener` re-asserts the intended volume on `onMediaItemTransition` / `STATE_READY` / `onAudioSessionIdChanged`, so a segment-boundary AudioTrack reconfigure can't leave the sink muted while `player.volume` reads 1.0.
- Removed the temporary `CRUMB_PB_AUDIO` diagnostic log.

⚠️ **Needs on-device verification** — I can't confirm audio actually plays without hardware; the debug APK is installed on the test phone.

## Phase 1 — quality selector
Auto / Full / Data-saver, default **Auto** (compact AUTO/HD/SD chip in the portrait app bar and the landscape transport row), persisted in `SecureStore`. Auto = Full on Wi-Fi, Low on metered/cellular; Data saver = always the server's `/segments/{id}/low.mp4`. Switching quality re-resolves the current playhead.

## Phase 0 — buffering
WAN-tuned playback `LoadControl` (bigger window + 30 s back-buffer so small backward scrubs replay from RAM); `PREFETCH_LEAD` 2 s → 3.5 s.

## Phase 0c / Phase 2 — fullscreen live
On a metered link, fullscreen live starts on the sub stream (or `rtsp_mobile_url` when the camera has no sub) instead of HD main; the "SD · tap for HD" badge forces HD. New `rememberIsMetered()` helper + `rtspMobileUrl` model field.

## Build
`:app:compileDebugKotlin` + `:app:assembleDebug` succeed (only pre-existing warnings). Debug APK built and installed on the test device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
