### PR TITLE
fix(recorder): always re-encode audio to gap-filled 48 kHz AAC (Fixes #106)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,54 @@ revisit.
 
 ---
 
+## 2026-07-13, Recorded audio: ALWAYS re-encode to gap-filled 48 kHz AAC (supersedes the 2026-07-12 copy-when-safe split)
+
+**Context.** The 2026-07-12 decision recorded audio with a per-camera split:
+copy bit-exact when the source rate is "client-safe" (≤ 48 kHz), transcode only
+the rates Android/web reject (> 48 kHz). Its premise was that a ≤ 48 kHz rate is
+safe to copy. On-device diagnostics (Media3 1.4.1, SM-S921U) proved that **false**:
+recorded playback was silent on Android for a **48 kHz** camera on the copy path.
+
+**Root cause (measured).** A bit-exact `-c:a copy` preserves the camera's audio
+*timeline* verbatim, and cheap camera audio clocks drift ~1 %: the container
+timestamps promise more time than the AAC frames deliver (measured ~32 ms
+phantom gap per 4 s segment; 61 of 62 frames non-uniform). ExoPlayer's
+`DefaultAudioSink` enforces sample-continuous audio — once accumulated drift
+crosses ~200 ms it throws `UnexpectedDiscontinuityException` and, because the
+audio renderer is the player's master clock, the position lurches, segments
+"end" early, and the whole player wedges (silent audio, stalled video). libmpv
+(desktop) and the RTSP live path don't slave to strict sample continuity, which
+is why only Android fMP4 playback broke.
+
+**Decision.** The recorder ALWAYS re-encodes audio (when `record_audio`):
+`-af aresample=async=1:first_pts=0 -c:a aac -ar 48000`. Video stays a bit-exact
+`-c copy`.
+
+**Alternatives considered.**
+
+| Option | Verdict |
+|---|---|
+| **Always re-encode + `aresample=async`** | **Chosen.** `aresample=async=1` resamples onto a strictly continuous lattice, filling genuine gaps with silence (preserving A/V alignment). Measured 0/192 discontinuous frames after (vs 61/62 before). |
+| Keep the copy-when-safe split | Rejected: its premise is empirically false; timeline continuity — not sample rate — is what matters, and only re-encode guarantees it. |
+| Plain re-encode (`-c:a aac` without `aresample`) | Rejected: still inherits the input's jittery frame PTS (measured 75/187 discontinuous) — this is why SD/low.mp4 still threw the occasional discontinuity. `aresample=async` is the load-bearing part. |
+| Client-side (tolerate the discontinuity in a custom `AudioSink`) | Rejected/tested: making the sink swallow the discontinuity turned it into a silent continuous clock lurch that dragged **video** down too. No correct client-only fix exists (the audio renderer is the master clock). |
+| Per-client serve variant (video-copy + audio-reencode on demand) | Rejected: ships a workaround for defective recorded *data*; bad cache economics (full-segment-sized entries); export/iOS/web still inherit the broken timeline. Fix the data at the source instead. |
+
+**Trades accepted.** A mono/stereo AAC encode is < 1 % of a core per camera
+(negligible; the CPU-saving that motivated the copy path is not worth silent
+audio). `-copyinkf:a` is dropped (it only mattered for the `-c copy` keyframe
+gate — RECORDER-CORRECTNESS #23). Existing footage recorded on the copy path
+(only ~1–2 days, since #103) is **not** retroactively fixed, but it already
+plays with audio via Data-saver's on-demand re-encode (`/segments/{id}/low.mp4`).
+
+**Revisit triggers.** If the `aac` encoder ever becomes a measurable CPU problem
+on a large deployment, revisit selective copy — but only for sources *proven*
+sample-continuous, not merely ≤ 48 kHz. If a future ExoPlayer/Media3 gains a
+"trust sample count over container PTS" mode for progressive sources, the copy
+path could return.
+
+---
+
 ## 2026-07-13, Mobile performance: on-demand per-segment low-bitrate transcode (not continuous stream / ABR), Auto default
 
 **Context.** Recorded playback and fullscreen live were unusable over poor

--- a/docs/RECORDER-CORRECTNESS.md
+++ b/docs/RECORDER-CORRECTNESS.md
@@ -124,36 +124,40 @@ recorder, and later the API) must satisfy these *by construction*.
 
 ## declared tracks must carry decodable packets, on every client (audio-integrity)
 23. **A recorded segment MUST contain decodable media PACKETS for every track it
-    declares — and those packets must be decodable by EVERY client, not just
-    desktop.** The recorder picks the audio args per camera from the probed source
-    sample rate (`audio_segmenter_args` / `audio_needs_transcode` /
-    `probe_audio_sample_rate`; docs/DECISIONS.md 2026-07-12): **≤ 48 kHz → bit-exact
-    copy** (`-c:a copy -copyinkf:a`); **> 48 kHz, or an unknown/failed probe →
-    transcode to 48 kHz AAC** (`-c:a aac -ar 48000`). This guards two failure modes:
-    - **Cross-client playability (the transcode case).** Some cameras stream AAC at
-      rates that Android's hardware/`c2` decoders reject outright (a real device
-      logs `MediaCodecInfo: NoSupport [sampleRate.support, 64000] [c2.android.aac
-      .decoder]` and plays SILENT). A bit-exact copy plays on desktop's software
-      ffmpeg decoder but not on Android/web, so any rate > 48 kHz is transcoded down
-      to a universally-decodable 48 kHz.
-    - **Empty-track copy gate (the copy case still needs `-copyinkf:a`).** Under
-      `-c copy`, ffmpeg's CLI silently discards every packet on a stream until the
-      first keyframe-flagged one, and the RTP-AAC (MPEG4-GENERIC) depacketizer never
-      key-flags audio — so a plain copy yields a declared-but-EMPTY aac track (the
-      moov lists it from the SDP; zero samples), silent with no warning at any
-      normal log level. The copy path therefore keeps `-copyinkf:a`; the transcode
-      path re-encodes from decoded PCM and has no keyframe gate.
+    declares — and those packets must be decodable AND sample-continuous on EVERY
+    client, not just desktop.** The recorder ALWAYS re-encodes audio (when
+    `record_audio`): `-af aresample=async=1:first_pts=0 -c:a aac -ar 48000`
+    (`audio_segmenter_args`; docs/DECISIONS.md 2026-07-13, superseding the
+    2026-07-12 copy-when-safe split). This guards two failure modes that a
+    bit-exact `-c:a copy` could not:
+    - **Sample-continuity (the reason for the 2026-07-13 change).** A copy
+      preserves the camera's audio *timeline* verbatim; cheap camera audio clocks
+      drift ~1 %, so the container timestamps promise more time than the AAC frames
+      deliver (~32 ms/segment). ExoPlayer's `DefaultAudioSink` requires
+      sample-continuous audio and, once accumulated drift crosses ~200 ms, throws
+      `UnexpectedDiscontinuityException`; since the audio renderer is the master
+      clock the position lurches and playback wedges (silent audio, stalled video)
+      — a 48 kHz copy plays silent on Android. `aresample=async=1` resamples onto a
+      strictly continuous lattice (fills genuine gaps with silence, preserving A/V
+      alignment): measured 0/192 discontinuous frames after vs 61/62 before. A
+      plain re-encode WITHOUT `aresample` still left 75/187 (it inherits the jittery
+      input frame PTS), so `aresample=async` is load-bearing, not decorative.
+    - **Cross-client playability.** Re-encoding to a universal 48 kHz AAC also
+      covers cameras whose native rate (64/88.2/96 kHz) Android's hardware/`c2`
+      decoders reject outright (`MediaCodecInfo: NoSupport [sampleRate.support,
+      64000]` → silent). One re-encode fixes both.
 
-    Video always stays a bit-exact copy (the audio args override only audio; they do
-    NOT touch the fMP4 crash-safety flags, item 1). **The export path is separate:**
-    `services/api/src/export.rs`'s `-c:a copy` still emits `-copyinkf:a` against
-    the keyframe gate (the recorded fMP4's `trun` faithfully preserves the missing
-    key flag), and it does **not yet** normalize the sample rate — an exported
-    clip can still carry a rate a phone won't decode until export is normalized
-    too (a known follow-up). Detector: `audio_needs_transcode` is unit-tested (≤ 48 kHz
-    → copy, > 48 kHz / unknown → transcode) and `audio_segmenter_args` for both
-    branches; any integration check should assert `nb_read_packets > 0` on the audio
-    stream, not merely that the stream exists.
+    No `-copyinkf:a` any more: it only mattered for the `-c copy` keyframe gate
+    (RTP-AAC is never key-flagged → a bare copy declared a zero-packet track). The
+    re-encode decodes from PCM, so there is no keyframe gate. Video always stays a
+    bit-exact copy (the audio args override only audio; they do NOT touch the fMP4
+    crash-safety flags, item 1). **The export path is separate:**
+    `services/api/src/export.rs` still `-c:a copy`s — now against a *clean*
+    re-encoded source for new footage (so exports of new footage inherit the good
+    timeline for free); normalizing export itself remains a follow-up for
+    copy-path-era footage. Detector: `audio_segmenter_args` is unit-tested (always
+    AAC/48 k/`aresample` when recording, `-an` otherwise); any integration check
+    should assert both `nb_read_packets > 0` AND uniform audio packet deltas.
 
 ## free-space floor (ENOSPC safety valve)
 24. **The floor keys off free space AVAILABLE to the recorder, and its response

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -4620,25 +4620,14 @@ function renderCamInfoTab(c) {
    an "Identify" (ONVIF probe) action and a "Contribute this camera" flow that
    opens a pre-filled GitHub issue in the operator's own browser. */
 /* ── Audio-transcoding notice (per camera) ──
-   Shows a warning when the recorder is re-encoding this camera's audio to 48 kHz
-   because its source rate is one Android/web decoders can't play (> 48 kHz), with
-   a hint to set the camera's own audio to <=48 kHz to record bit-exact. Reads the
-   recorder-published per-camera audio status from GET /config/decode-status. */
+   Obsolete: recorded audio is now ALWAYS normalized to gap-filled 48 kHz AAC at
+   record time (docs/DECISIONS.md 2026-07-13), because a bit-exact copy of the
+   camera's drifting audio clock plays silent on Android. There is no longer a
+   per-camera copy-vs-transcode decision for the operator to act on, so this shows
+   nothing. Kept as a no-op so the #ce-audio-status slot + call site stay stable
+   (the /config/decode-status audio fields remain available for future use). */
 async function loadCameraAudioStatus(id) {
-  const el = $('ce-audio-status'); if (!el) return;
-  el.innerHTML = '';
-  try {
-    const r = await api('/config/decode-status');
-    const cam = (r.cameras || []).find(c => c.camera_id === id);
-    if (!cam || !cam.audio_transcoding) return; // copied (or unknown) — nothing to warn about
-    const khz = cam.audio_sample_rate ? Math.round(cam.audio_sample_rate / 1000) : null;
-    el.innerHTML = `<div class="card-hint" style="margin:0 0 10px 0;border-left:3px solid var(--warn);padding:6px 0 6px 10px">
-      <b style="color:var(--warn)">Audio is being re-encoded to 48&nbsp;kHz.</b>
-      This camera streams ${khz ? esc(khz + ' kHz') : 'a sample rate'} audio, which phones and browsers
-      can't decode, so Crumb transcodes it so recorded audio plays on every client (desktop copies it fine).
-      To record it <b>bit-exact</b> (no re-encode, no CPU), set this camera's own audio sample rate to
-      <b>&le;&nbsp;48&nbsp;kHz</b> (48&nbsp;kHz is ideal) in its web UI, then it will be copied automatically.</div>`;
-  } catch (e) { /* status unavailable (recorder not reporting yet) — no notice */ }
+  const el = $('ce-audio-status'); if (el) el.innerHTML = '';
 }
 
 async function loadCameraCompat(id) {

--- a/services/recorder/src/recording.rs
+++ b/services/recorder/src/recording.rs
@@ -425,50 +425,52 @@ pub async fn run(
 /// error/stall restart of the ffmpeg child instead of being silently reset
 /// (which used to discard the remainder of the event).
 /// The audio ffmpeg args for the `-c copy` (video) segmenter, given the camera's
-/// `record_audio` policy and whether the source audio needs transcoding.
+/// `record_audio` policy.
 ///
 /// - `record_audio == false` → `-an` (drop the audio output stream).
-/// - `transcode == true` → **re-encode to 48 kHz AAC** (`-c:a aac -ar 48000`).
-/// - otherwise → **bit-exact copy** (`-c:a copy -copyinkf:a`), zero re-encode.
+/// - otherwise → **re-encode to a gap-filled, sample-continuous 48 kHz AAC**
+///   (`-af aresample=async=1:first_pts=0 -c:a aac -ar 48000`).
 ///
-/// The copy-vs-transcode split (docs/DECISIONS.md 2026-07-12): most cameras
-/// already stream a client-safe rate (≤ 48 kHz standard AAC), and those are
-/// copied — zero CPU, bit-exact. Only cameras whose audio is a rate Android's
-/// hardware/`c2` AAC decoders reject (64/88.2/96 kHz — a real device logs
-/// `MediaCodecInfo: NoSupport [sampleRate.support, 64000]` and plays silent) are
-/// transcoded down to 48 kHz so recorded audio plays on EVERY client, not just
-/// desktop's software decoder. See [`audio_needs_transcode`] /
-/// [`probe_audio_sample_rate`].
+/// Why ALWAYS re-encode (docs/DECISIONS.md 2026-07-13, superseding the
+/// 2026-07-12 "copy when the rate is client-safe" split): a bit-exact `-c:a copy`
+/// preserves the camera's audio *timeline* verbatim, and cheap camera audio
+/// clocks drift ~1 % — the container timestamps promise more time than the AAC
+/// frames deliver (measured ~32 ms phantom gap per 4 s segment). ExoPlayer's
+/// `DefaultAudioSink` requires sample-continuous audio: once the accumulated
+/// drift crosses ~200 ms it throws `UnexpectedDiscontinuityException`, and
+/// because the audio renderer is the player's master clock the position lurches,
+/// segments "end" early, and playback wedges (silent audio, stalled video). The
+/// premise that "≤ 48 kHz ⇒ client-safe to copy" is empirically false — 48 kHz
+/// copies were silent on Android. `aresample=async=1` resamples onto a strictly
+/// continuous lattice (fills genuine gaps with silence, preserving A/V
+/// alignment), so the recorded track has ZERO discontinuities on every client
+/// (verified: 61/62 discontinuous frames on the copy path → 0/192 after; a plain
+/// re-encode WITHOUT `aresample` still left 75, because it inherits the input's
+/// jittery frame PTS). `first_pts=0` anchors the audio start.
 ///
-/// The copy path keeps `-copyinkf:a` ("copy initial non-keyframes"): under
-/// `-c copy` ffmpeg drops every packet until a keyframe-flagged one, and RTP-AAC
-/// (MPEG4-GENERIC) audio is never key-flagged, so without it the segment would
-/// declare an aac track (from the SDP) with ZERO packets — silent footage, no
-/// warning (RECORDER-CORRECTNESS #23). The transcode path re-encodes from decoded
-/// PCM, so it has no keyframe gate and needs no such flag.
-///
-/// All of these come AFTER `-c copy`, so they override ONLY the audio (video
-/// stays a bit-exact copy).
-fn audio_segmenter_args(record_audio: bool, transcode: bool) -> &'static [&'static str] {
+/// No `-copyinkf:a` here: that flag existed only for the `-c copy` path (RTP-AAC
+/// is never key-flagged, so a bare copy declared a zero-packet track —
+/// RECORDER-CORRECTNESS #23). Re-encoding decodes from PCM, so there is no
+/// keyframe gate. These args come AFTER `-c copy`, overriding ONLY the audio;
+/// video stays a bit-exact copy.
+fn audio_segmenter_args(record_audio: bool) -> &'static [&'static str] {
     if !record_audio {
         &["-an"]
-    } else if transcode {
-        &["-c:a", "aac", "-ar", "48000"]
     } else {
-        &["-c:a", "copy", "-copyinkf:a"]
+        &[
+            "-af",
+            "aresample=async=1:first_pts=0",
+            "-c:a",
+            "aac",
+            "-ar",
+            "48000",
+        ]
     }
 }
 
-/// AAC sample rates above 48 kHz (64 / 88.2 / 96 kHz) are the ones Android/web
-/// hardware decoders reject; every standard rate at or below 48 kHz is decodable
-/// on every client and can be bit-exact copied. An UNKNOWN rate (probe failed,
-/// go2rtc not ready yet) ⇒ transcode — the always-safe default.
-fn audio_needs_transcode(sample_rate: Option<u32>) -> bool {
-    sample_rate.is_none_or(|hz| hz > 48_000)
-}
-
 /// Best-effort probe of the first audio stream's sample rate (Hz) at `url`, for
-/// the copy-vs-transcode decision. Returns `None` on ANY failure — no audio
+/// the admin console's per-camera audio status. Returns `None` on ANY failure —
+/// no audio
 /// stream, `ffprobe` missing, a timeout, or go2rtc not serving yet — so the
 /// caller safely falls back to transcode. Bounded timeout so a slow/unready
 /// source never stalls the start of recording (the recorder records from the
@@ -847,48 +849,37 @@ async fn run_ffmpeg_loop(
         .args(["-tag:v", "hvc1"]);
 
     // Audio handling (see [`audio_segmenter_args`]).  These come AFTER `-c copy`
-    // so they override ONLY the audio (video stays a bit-exact copy). When
-    // recording audio, probe the source sample rate first: already-client-safe
-    // rates (≤ 48 kHz) are bit-exact COPIED (zero re-encode); only the rates
-    // Android/web decoders reject (> 48 kHz) are transcoded down to 48 kHz. A
-    // failed/timed-out probe (e.g. go2rtc not serving yet) falls back to the
-    // safe transcode. The recorder records from the go2rtc restream, so this
-    // probe is a local consumer, not an extra camera connection.
-    let (audio_sample_rate, audio_transcode) = if camera.policy.record_audio {
+    // so they override ONLY the audio (video stays a bit-exact copy). Audio is
+    // ALWAYS re-encoded to a gap-filled, sample-continuous 48 kHz AAC now (a bare
+    // `-c copy` burns the camera's drifting audio clock into the file and Android
+    // playback goes silent — see the fn doc). We still probe the SOURCE rate,
+    // purely so the admin console can show it; the probe is a local consumer of
+    // the go2rtc restream, not an extra camera connection.
+    let audio_sample_rate = if camera.policy.record_audio {
         let sample_rate = probe_audio_sample_rate(&rtsp_url).await;
-        let transcode = audio_needs_transcode(sample_rate);
         info!(
             camera_id = %camera.id,
             audio_sample_rate = ?sample_rate,
-            transcode,
-            "audio: {}",
-            if transcode {
-                "transcoding to 48 kHz AAC (source rate not client-safe or unknown)"
-            } else {
-                "bit-exact copy (source rate already client-safe)"
-            }
+            "audio: re-encoding to gap-filled 48 kHz AAC (sample-continuous for all clients)"
         );
-        (sample_rate, transcode)
+        sample_rate
     } else {
-        (None, false)
+        None
     };
-    // Publish the per-camera audio status so the admin console can flag which
-    // cameras are being re-encoded (and hint the operator to set the camera to
-    // ≤ 48 kHz). Best-effort — a DB hiccup must never stop recording.
+    // Publish the per-camera audio status for the admin console. `transcoding` is
+    // now simply "are we recording audio" (we always re-encode). Best-effort — a
+    // DB hiccup must never stop recording.
     if let Err(e) = crumb_common::db::upsert_camera_audio_status(
         pool,
         camera.id,
         audio_sample_rate.and_then(|r| i32::try_from(r).ok()),
-        audio_transcode,
+        camera.policy.record_audio,
     )
     .await
     {
         warn!(camera_id = %camera.id, error = %e, "upsert_camera_audio_status failed (audio badge may be stale)");
     }
-    ffmpeg_cmd.args(audio_segmenter_args(
-        camera.policy.record_audio,
-        audio_transcode,
-    ));
+    ffmpeg_cmd.args(audio_segmenter_args(camera.policy.record_audio));
 
     ffmpeg_cmd
         // Segmenter muxer
@@ -3182,75 +3173,43 @@ mod tests {
     // ── audio segmenter args (declared-track-must-carry-packets invariant) ──────
 
     #[test]
-    fn audio_needs_transcode_only_above_48k() {
-        // Already-client-safe rates (≤ 48 kHz) are copied; only the rates Android
-        // /web decoders reject (64/88.2/96 kHz) are transcoded. An unknown rate
-        // (probe failed / go2rtc not ready) defaults to transcode — always safe.
-        assert!(!audio_needs_transcode(Some(48_000)));
-        assert!(!audio_needs_transcode(Some(44_100)));
-        assert!(!audio_needs_transcode(Some(16_000)));
-        assert!(!audio_needs_transcode(Some(8_000)));
-        assert!(audio_needs_transcode(Some(64_000)));
-        assert!(audio_needs_transcode(Some(88_200)));
-        assert!(audio_needs_transcode(Some(96_000)));
+    fn audio_args_always_reencode_to_gapfilled_48k_aac() {
+        // Audio is ALWAYS re-encoded now: a bit-exact copy preserves the camera's
+        // drifting audio timeline and Android playback goes silent
+        // (UnexpectedDiscontinuityException). aresample=async=1 makes it
+        // sample-continuous; -c:a aac -ar 48000 normalizes the codec/rate.
+        let args = audio_segmenter_args(true);
         assert!(
-            audio_needs_transcode(None),
-            "an unknown source rate must default to transcode (safe)"
-        );
-    }
-
-    #[test]
-    fn audio_args_copy_when_source_rate_is_client_safe() {
-        // transcode=false ⇒ bit-exact copy, and it MUST keep -copyinkf:a so the
-        // RTP-AAC keyframe gate doesn't drop the whole (declared) audio track.
-        let args = audio_segmenter_args(true, false);
-        assert!(
-            args.contains(&"-c:a") && args.contains(&"copy"),
-            "client-safe audio must be copied; got {args:?}"
-        );
-        assert!(
-            args.contains(&"-copyinkf:a"),
-            "the copy path must keep -copyinkf:a (empty-track guard); got {args:?}"
-        );
-        assert!(
-            !args.contains(&"aac"),
-            "the copy path must not re-encode; got {args:?}"
-        );
-    }
-
-    #[test]
-    fn audio_args_transcode_to_48k_when_unsafe_or_unknown() {
-        // transcode=true ⇒ re-encode to 48 kHz AAC (no keyframe gate to work
-        // around, so no -copyinkf:a).
-        let args = audio_segmenter_args(true, true);
-        assert!(
-            args.contains(&"-c:a") && args.contains(&"aac"),
+            args.windows(2).any(|w| w == ["-c:a", "aac"]),
             "must encode AAC; got {args:?}"
         );
         assert!(
-            args.contains(&"-ar") && args.contains(&"48000"),
-            "must resample to 48 kHz; got {args:?}"
+            args.windows(2).any(|w| w == ["-ar", "48000"]),
+            "must normalize to 48 kHz; got {args:?}"
+        );
+        assert!(
+            args.windows(2)
+                .any(|w| w == ["-af", "aresample=async=1:first_pts=0"]),
+            "must gap-fill onto a continuous lattice (aresample=async); got {args:?}"
         );
         assert!(
             !args.contains(&"copy") && !args.contains(&"-copyinkf:a"),
-            "the transcode path must not copy; got {args:?}"
+            "the re-encode path must not copy (no keyframe gate); got {args:?}"
         );
     }
 
     #[test]
     fn audio_args_disable_audio_when_not_recording_audio() {
-        // record_audio=false ⇒ -an regardless of the transcode flag.
-        for transcode in [false, true] {
-            let args = audio_segmenter_args(false, transcode);
-            assert!(
-                args.contains(&"-an"),
-                "record_audio=false must pass -an (transcode={transcode}); got {args:?}"
-            );
-            assert!(
-                !args.contains(&"aac") && !args.contains(&"copy"),
-                "record_audio=false has no audio (transcode={transcode}); got {args:?}"
-            );
-        }
+        // record_audio=false ⇒ -an, no audio output at all.
+        let args = audio_segmenter_args(false);
+        assert!(
+            args.contains(&"-an"),
+            "record_audio=false must pass -an; got {args:?}"
+        );
+        assert!(
+            !args.contains(&"aac") && !args.contains(&"copy"),
+            "record_audio=false has no audio; got {args:?}"
+        );
     }
 
     // ── classify_failure (cold-start fast retry) ────────────────────────────────


### PR DESCRIPTION
Fixes #106 — recorded playback was silent on Android.

## Root cause (measured, not guessed)
A bit-exact `-c:a copy` burns the camera's audio **timeline** into the segment verbatim, and cheap camera audio clocks drift ~1%: the container timestamps promise more time than the AAC frames deliver (**~32 ms phantom gap per 4 s segment; 61/62 frames non-uniform** on a real segment). ExoPlayer's `DefaultAudioSink` requires sample-continuous audio and, once accumulated drift crosses ~200 ms, throws `UnexpectedDiscontinuityException`; because the audio renderer is the player's **master clock**, the position lurches, segments end early, and the whole player wedges (silent audio + stalled video). libmpv (desktop) and RTSP live don't slave to strict sample continuity — which is exactly why only Android fMP4 playback broke. The 2026-07-12 premise that "≤ 48 kHz is client-safe to copy" is **empirically false**: a 48 kHz copy plays silent on Android.

On-device confirmation via a diagnostics panel: audio track selected+supported, `c2.android.aac.decoder` inits, then `audioSinkError UnexpectedDiscontinuityException` (Δ = 200 ms threshold + 1 AAC frame — the signature of accumulated drift, not a structural gap).

## Fix
Always re-encode audio: `-af aresample=async=1:first_pts=0 -c:a aac -ar 48000`. `aresample=async=1` resamples onto a strictly continuous lattice (fills genuine gaps with silence, preserving A/V alignment). Video stays a bit-exact `-c copy`.

Proven before writing code (ffprobe on a real segment):

| approach | discontinuous audio frames |
|---|---|
| raw copy (today) | **61 / 62** |
| plain re-encode | **75 / 187** (inherits input jitter) |
| **aresample=async + aac** | **0 / 192** |

## Scope / cost
- Audio only — **video untouched** (bit-exact copy). AAC encode is < 1% of a core/camera.
- Fixes **new** footage; copy-path footage (~1–2 days, since #103) still plays via Data-saver's on-demand re-encode.
- Drops `-copyinkf:a` (only mattered for the copy keyframe gate). Removed the now-obsolete admin "audio is being transcoded, set to 48 kHz" warning. Exports of new footage inherit the clean audio for free.

## Docs / tests
DECISIONS 2026-07-13 (supersedes 2026-07-12 copy-when-safe, with revisit triggers); RECORDER-CORRECTNESS #23 rewritten; `audio_segmenter_args` tests rewritten. Gate green on the Linux build host (fmt, clippy, workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
