### PR TITLE
LPR crops in-app, update alerts, Frigate 0.18 fix, non-blocking teardown, scrubber highlight

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlateBbox.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlateBbox.kt
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.feature.plates
+
+import android.graphics.Bitmap
+import android.graphics.Rect
+import coil.size.Size
+import coil.transform.Transformation
+import kotlin.math.roundToInt
+
+/**
+ * Shared license-plate bounding-box geometry + a Coil crop transformation.
+ *
+ * A [PlateRead.bbox] is the plate's location within its sibling detection-event
+ * snapshot, as normalized `[x, y, w, h]` fractions (0..1) of the image's
+ * width/height. Both the on-screen Plates thumbnails ([PlateCropTransformation],
+ * applied via Coil) and the single-plate PDF report (`PlatesPdf.kt`'s
+ * `cropToBbox`) resolve that box to pixels through [bboxToRect] so the math lives
+ * in exactly one place.
+ */
+
+/**
+ * Resolve a normalized `[x, y, w, h]` (0..1) [bbox] to a pixel [Rect] within a
+ * [width]×[height] image. Coordinates are clamped into the image so a slightly
+ * out-of-range box never throws; returns null when [bbox] is absent/malformed or
+ * the dimensions are non-positive (the caller then falls back to the full image).
+ */
+fun bboxToRect(bbox: List<Double>?, width: Int, height: Int): Rect? {
+    if (bbox == null || bbox.size < 4 || width <= 0 || height <= 0) return null
+    val left = (bbox[0] * width).roundToInt().coerceIn(0, width - 1)
+    val top = (bbox[1] * height).roundToInt().coerceIn(0, height - 1)
+    val cw = (bbox[2] * width).roundToInt().coerceIn(1, width - left)
+    val ch = (bbox[3] * height).roundToInt().coerceIn(1, height - top)
+    return Rect(left, top, left + cw, top + ch)
+}
+
+/**
+ * Coil [Transformation] that crops a loaded snapshot to a plate [bbox]
+ * (normalized `[x, y, w, h]`), so the plate fills the thumbnail without a second
+ * network round-trip — the snapshot the card already loads is reused.
+ *
+ * Memory-safe by construction: Coil applies the request's target size *before*
+ * transformations, so [transform] runs on the already-downsampled decode (peak
+ * memory is that bounded bitmap) and the returned crop is smaller still. When the
+ * box can't be resolved it returns the input unchanged, matching the report's
+ * "fall back to the full snapshot" behavior.
+ */
+class PlateCropTransformation(private val bbox: List<Double>) : Transformation {
+    override val cacheKey: String = "plate-crop:${bbox.joinToString(",")}"
+
+    override suspend fun transform(input: Bitmap, size: Size): Bitmap {
+        val rect = bboxToRect(bbox, input.width, input.height) ?: return input
+        // Whole-image box → skip the copy (and Coil's input recycling of it).
+        if (rect.left == 0 && rect.top == 0 &&
+            rect.width() == input.width && rect.height() == input.height
+        ) {
+            return input
+        }
+        return Bitmap.createBitmap(input, rect.left, rect.top, rect.width(), rect.height())
+    }
+}

--- a/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesPdf.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesPdf.kt
@@ -244,20 +244,14 @@ private suspend fun fetchSnapshotBitmap(
 
 /**
  * Crop [src] to the normalized `[x, y, w, h]` (0..1 fractions of width/height)
- * [bbox]. Returns null when bbox is absent/malformed or the crop can't be made,
- * so the caller falls back to the full snapshot. Coordinates are clamped into the
- * bitmap so a slightly out-of-range box never throws.
+ * [bbox], reusing the shared [bboxToRect] geometry (same math the on-screen
+ * thumbnails crop with). Returns null when bbox is absent/malformed or the crop
+ * can't be made, so the caller falls back to the full snapshot.
  */
 private fun cropToBbox(src: Bitmap, bbox: List<Double>?): Bitmap? {
-    if (bbox == null || bbox.size < 4) return null
+    val rect = bboxToRect(bbox, src.width, src.height) ?: return null
     return runCatching {
-        val w = src.width
-        val h = src.height
-        val left = (bbox[0] * w).roundToInt().coerceIn(0, w - 1)
-        val top = (bbox[1] * h).roundToInt().coerceIn(0, h - 1)
-        val cw = (bbox[2] * w).roundToInt().coerceIn(1, w - left)
-        val ch = (bbox[3] * h).roundToInt().coerceIn(1, h - top)
-        Bitmap.createBitmap(src, left, top, cw, ch)
+        Bitmap.createBitmap(src, rect.left, rect.top, rect.width(), rect.height())
     }.getOrNull()
 }
 

--- a/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesScreen.kt
@@ -94,6 +94,7 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import coil.compose.AsyncImage
 import coil.imageLoader
+import coil.request.ImageRequest
 import kotlinx.coroutines.launch
 import androidx.compose.ui.layout.ContentScale
 import video.crumb.app.data.CameraDto
@@ -333,6 +334,7 @@ fun PlatesScreen(
     if (reportRead != null) {
         PlateReportDialog(
             read = reportRead,
+            mediaUrls = mediaUrls,
             generating = generatingReport,
             onDownload = { caseText, zoneId, includeDossier ->
                 if (generatingReport) return@PlateReportDialog
@@ -973,11 +975,43 @@ private fun PlateRow(
     }
 }
 
-/** The read's snapshot: fetched from the sibling detection event's snapshot
- *  proxy (scoped-token authed via [MediaUrls.eventSnapshotUrl]). Reads with no
- *  linked event have no authed image source, so they show a placeholder. */
+/** Larger decode ceiling (px) for the report-dialog plate preview, so the crop of
+ *  a small plate region stays crisp. Only one such image is alive at a time (it's
+ *  a modal dialog), so this stays well within the P2 bitmap budget; the list/grid
+ *  thumbnails intentionally omit it and decode at their small display size. */
+private const val PLATE_DETAIL_DECODE_PX = 1024
+
+/** Convenience wrapper: the read's snapshot, cropped to the plate box. */
 @Composable
 private fun PlateThumb(read: PlateRead, mediaUrls: MediaUrls, modifier: Modifier = Modifier) {
+    PlateSnapshotImage(read = read, mediaUrls = mediaUrls, modifier = modifier)
+}
+
+/**
+ * The read's snapshot: fetched from the sibling detection event's snapshot proxy
+ * (scoped-token authed via [MediaUrls.eventSnapshotUrl]). Reads with no linked
+ * event have no authed image source, so they show a placeholder.
+ *
+ * When [crop] is set and the read carries a [PlateRead.bbox], the plate region is
+ * cropped **client-side** out of the already-loaded snapshot via
+ * [PlateCropTransformation] (no extra network round-trip) and shown letterboxed
+ * (`ContentScale.Fit`) so no plate characters are clipped. When the bbox is null
+ * (older reads / no box) it falls back to the full snapshot, cropped to fill
+ * (`ContentScale.Crop`) exactly as before.
+ *
+ * Memory: with [decodePx] null the snapshot decodes at the composable's display
+ * size (the small thumbnails), and the crop runs on that bounded bitmap. The
+ * report-dialog preview passes a bounded [decodePx] for a crisper crop.
+ */
+@Composable
+private fun PlateSnapshotImage(
+    read: PlateRead,
+    mediaUrls: MediaUrls,
+    modifier: Modifier = Modifier,
+    crop: Boolean = true,
+    decodePx: Int? = null,
+) {
+    val context = LocalContext.current
     var thumbUrl by remember(read.id) { mutableStateOf<String?>(null) }
     val eventId = read.eventId
     LaunchedEffect(read.id) {
@@ -992,11 +1026,29 @@ private fun PlateThumb(read: PlateRead, mediaUrls: MediaUrls, modifier: Modifier
             .background(Color.Black, RoundedCornerShape(6.dp)),
         contentAlignment = Alignment.Center,
     ) {
-        if (thumbUrl != null) {
+        val url = thumbUrl
+        if (url != null) {
+            val bbox = read.bbox?.takeIf { it.size >= 4 }
+            val cropping = crop && bbox != null
+            // A plain URL is enough unless we need a crop transform or a decode
+            // ceiling; only then build an ImageRequest.
+            val model: Any = if (cropping || decodePx != null) {
+                ImageRequest.Builder(context)
+                    .data(url)
+                    .apply {
+                        decodePx?.let { size(it) }
+                        if (crop) bbox?.let { transformations(PlateCropTransformation(it)) }
+                    }
+                    .build()
+            } else {
+                url
+            }
             AsyncImage(
-                model = thumbUrl,
+                model = model,
                 contentDescription = null,
-                contentScale = ContentScale.Crop,
+                // Fit for a plate crop (never clip characters); Crop to fill the box
+                // for the full-snapshot fallback.
+                contentScale = if (cropping) ContentScale.Fit else ContentScale.Crop,
                 modifier = Modifier.fillMaxSize(),
             )
         } else {
@@ -1341,6 +1393,7 @@ private val REPORT_COMMON_ZONES: List<String> = listOf(
 @Composable
 private fun PlateReportDialog(
     read: PlateRead,
+    mediaUrls: MediaUrls,
     generating: Boolean,
     onDownload: (caseText: String, zoneId: java.time.ZoneId, includeDossier: Boolean) -> Unit,
     onDismiss: () -> Unit,
@@ -1358,12 +1411,26 @@ private fun PlateReportDialog(
         title = { Text("Plate report") },
         text = {
             Column {
+                // Prominent plate crop (the same client-side bbox crop the report's
+                // "PLATE (zoomed)" image uses), with a bounded decode so a small
+                // plate region stays crisp; falls back to the full snapshot when the
+                // read has no bbox.
+                PlateSnapshotImage(
+                    read = read,
+                    mediaUrls = mediaUrls,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(120.dp),
+                    crop = true,
+                    decodePx = PLATE_DETAIL_DECODE_PX,
+                )
                 Text(
                     text = read.plate.ifEmpty { "—" },
                     color = MaterialTheme.colorScheme.onSurface,
                     fontWeight = FontWeight.Bold,
                     fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
                     style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier.padding(top = 8.dp),
                 )
                 TextField(
                     value = caseText,

--- a/apps/desktop-flutter/lib/ui/motion_timeline/motion_timeline_view.dart
+++ b/apps/desktop-flutter/lib/ui/motion_timeline/motion_timeline_view.dart
@@ -718,6 +718,10 @@ class _TimelinePainter extends CustomPainter {
           motionBottom, prominent: true);
       _drawMotionStarts(canvas, selCamId!, msToX, motionTop);
     }
+    // Highlight the span of any detection event the playhead is currently
+    // inside — drawn under the glyphs so the marker stays crisp on top.
+    _drawActiveEventSpans(
+        canvas, msToX, selCamId, motionTop, motionBottom, size.width);
     _drawDetectionGlyphs(canvas, msToX, selCamId, motionBottom);
 
     // ── recording-coverage line (bottom): where footage exists ──────────────
@@ -865,6 +869,56 @@ class _TimelinePainter extends CustomPainter {
         ..lineTo(x, top + s)
         ..close();
       canvas.drawPath(path, paint);
+    }
+  }
+
+  /// Highlight the time span of any detection event whose `[ts, endTs]`
+  /// currently contains the playhead: a faint band in the event's OWN legend
+  /// colour (the same `detectionIconFor(...).color` the glyph uses) across the
+  /// motion area, with thin colour edges at the start/end. This answers "the
+  /// playhead is inside this event" at a glance, tied to the legend colours so
+  /// it reads consistently and doesn't introduce a new palette.
+  ///
+  /// Only detection events get a span band: motion is shown as the continuous
+  /// intensity ribbon and carries no discrete `[start, end]` in this data
+  /// model, whereas a detection event has an explicit `endTs`. Events with no
+  /// `endTs` (instantaneous / still-open) are skipped — there's no span to draw.
+  void _drawActiveEventSpans(
+    Canvas canvas,
+    double Function(int) msToX,
+    String? selCamId,
+    double top,
+    double bottom,
+    double width,
+  ) {
+    if (motion.detections.isEmpty) return;
+    final phMs = timeline.playhead.millisecondsSinceEpoch;
+    final winStart = timeline.windowStart.millisecondsSinceEpoch;
+    final winEnd = timeline.windowEnd.millisecondsSinceEpoch;
+    for (final ev in motion.detections) {
+      final endTs = ev.endTs;
+      if (endTs == null) continue;
+      final startMs = ev.ts.millisecondsSinceEpoch;
+      final endMs = endTs.millisecondsSinceEpoch;
+      if (endMs <= startMs) continue;
+      // Only the event(s) whose span contains the playhead.
+      if (phMs < startMs || phMs > endMs) continue;
+      // Skip a span entirely off-screen (playhead can be off-window mid-drag).
+      if (endMs < winStart || startMs > winEnd) continue;
+      final spec = detectionIconFor(ev.iconKey);
+      final prominent = ev.cameraId == selCamId;
+      final x1 = msToX(startMs).clamp(0.0, width);
+      final x2 = msToX(endMs).clamp(0.0, width);
+      if (x2 - x1 < 0.5) continue;
+      canvas.drawRect(
+        Rect.fromLTRB(x1, top, x2, bottom),
+        Paint()..color = spec.color.withValues(alpha: prominent ? 0.16 : 0.09),
+      );
+      final edge = Paint()
+        ..color = spec.color.withValues(alpha: prominent ? 0.7 : 0.4)
+        ..strokeWidth = 1;
+      canvas.drawLine(Offset(x1, top), Offset(x1, bottom), edge);
+      canvas.drawLine(Offset(x2, top), Offset(x2, bottom), edge);
     }
   }
 

--- a/apps/desktop-flutter/lib/ui/plates/plate_crop.dart
+++ b/apps/desktop-flutter/lib/ui/plates/plate_crop.dart
@@ -1,0 +1,90 @@
+// Shared license-plate crop helper: crop a detection snapshot down to the
+// plate's normalized bbox, off the UI isolate, with a small result cache.
+//
+// Used by the PDF report (plate_report_dialog.dart) and the Plates UI
+// gallery/detail crop (plates_screen.dart) so all three share ONE crop
+// implementation + cache rather than each re-deriving (and re-decoding) the
+// same plate region.
+
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import 'package:image/image.dart' as img;
+
+/// Crop [fullBytes] to the normalized `[x, y, w, h]` [bbox] (fractions 0..1 of
+/// the snapshot). Returns re-encoded JPEG bytes, or null if the image can't be
+/// decoded (callers then fall back to the full frame).
+///
+/// The decode/crop/encode (all `package:image`, which is isolate-safe) runs on
+/// a background isolate via [Isolate.run] so a full-frame JPEG doesn't freeze
+/// the UI isolate. The closure captures only sendable data (the byte list + the
+/// bbox doubles) and calls a top-level function.
+Future<Uint8List?> cropPlateToBbox(Uint8List fullBytes, List<double> bbox) {
+  return Isolate.run(() => cropPlateToBboxSync(fullBytes, bbox));
+}
+
+/// The synchronous crop, safe to run inside a background isolate. The rect is
+/// clamped into the image so an out-of-range or degenerate box still yields a
+/// crop.
+Uint8List? cropPlateToBboxSync(Uint8List fullBytes, List<double> bbox) {
+  final decoded = img.decodeImage(fullBytes);
+  if (decoded == null) return null;
+  final w = decoded.width;
+  final h = decoded.height;
+  final cx = (bbox[0] * w).round().clamp(0, w - 1);
+  final cy = (bbox[1] * h).round().clamp(0, h - 1);
+  final cw = (bbox[2] * w).round().clamp(1, w - cx);
+  final ch = (bbox[3] * h).round().clamp(1, h - cy);
+  final cropped = img.copyCrop(decoded, x: cx, y: cy, width: cw, height: ch);
+  return img.encodeJpg(cropped, quality: 90);
+}
+
+// ─── result cache ──────────────────────────────────────────────────────────
+
+/// Small process-wide cache of computed plate crops, keyed by a caller-supplied
+/// string (a read id). Crops are the plate region only (small), so a modest
+/// entry-count LRU is plenty; the point is to keep the decode/crop off the
+/// widget rebuild path so a crop is computed once, not on every rebuild.
+final Map<String, Uint8List> _plateCropCache = {};
+final List<String> _plateCropOrder = []; // oldest first
+const _plateCropCacheMax = 256;
+
+/// Sentinel cached against a key when a crop was attempted but failed (bad
+/// bytes / undecodable), so a doomed decode isn't retried on every rebuild.
+/// Distinct from "not computed yet" (absent from the map).
+final Uint8List _cropFailed = Uint8List(0);
+
+/// Return the cached crop for [key], or compute it once from [fullBytes]+[bbox]
+/// (off the UI isolate) and cache the result. Returns null when the crop failed
+/// (the caller falls back to the full frame). Never does any network I/O.
+Future<Uint8List?> cachedPlateCrop(
+  String key,
+  Uint8List fullBytes,
+  List<double> bbox,
+) async {
+  final hit = _plateCropCache[key];
+  if (hit != null) return identical(hit, _cropFailed) ? null : hit;
+  final cropped = await cropPlateToBbox(fullBytes, bbox);
+  _cachePut(key, cropped ?? _cropFailed);
+  return cropped;
+}
+
+/// Read a previously computed crop synchronously, without computing one.
+/// Returns null when absent or when a prior attempt failed.
+Uint8List? peekPlateCrop(String key) {
+  final hit = _plateCropCache[key];
+  if (hit == null || identical(hit, _cropFailed)) return null;
+  return hit;
+}
+
+void _cachePut(String key, Uint8List bytes) {
+  if (_plateCropCache.containsKey(key)) {
+    _plateCropOrder.remove(key);
+  }
+  _plateCropCache[key] = bytes;
+  _plateCropOrder.add(key);
+  while (_plateCropOrder.length > _plateCropCacheMax) {
+    final evicted = _plateCropOrder.removeAt(0);
+    _plateCropCache.remove(evicted);
+  }
+}

--- a/apps/desktop-flutter/lib/ui/plates/plate_report_dialog.dart
+++ b/apps/desktop-flutter/lib/ui/plates/plate_report_dialog.dart
@@ -9,15 +9,14 @@
 // [fetchSnapshot] callback wired to its existing bounded-concurrency snapshot
 // helper + cache, so this reuses the same fetch path the thumbnails do.
 
-import 'dart:isolate';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
-import 'package:image/image.dart' as img;
 
 import 'package:crumb_desktop/api/crumb_api.dart';
 import 'package:crumb_desktop/api/models.dart';
 import 'package:crumb_desktop/api/plates_api.dart';
+import 'package:crumb_desktop/ui/plates/plate_crop.dart';
 import 'package:crumb_desktop/ui/plates/plate_pdf_report.dart';
 
 /// How many other sightings to embed in the dossier's thumbnail strip.
@@ -112,7 +111,7 @@ class _PlateReportDialogState extends State<_PlateReportDialog> {
       Uint8List? plateCrop;
       var cropIsFallback = true;
       if (fullSnapshot != null && read.bbox != null) {
-        final cropped = await _cropToBbox(fullSnapshot, read.bbox!);
+        final cropped = await cropPlateToBbox(fullSnapshot, read.bbox!);
         if (cropped != null) {
           plateCrop = cropped;
           cropIsFallback = false;
@@ -289,34 +288,8 @@ class _PlateReportDialogState extends State<_PlateReportDialog> {
 
 // ─── helpers ─────────────────────────────────────────────────────────────
 
-/// Crop [fullBytes] to the normalized `[x, y, w, h]` [bbox] (fractions 0..1 of
-/// the snapshot). Returns re-encoded JPEG bytes, or null if the image can't be
-/// decoded (the caller then falls back to the full frame).
-///
-/// The decode/crop/encode (all `package:image`, which is isolate-safe) runs on
-/// a background isolate via [Isolate.run] so a full-frame JPEG doesn't freeze
-/// the UI isolate while the report builds. The closure captures only sendable
-/// data (the byte list + the bbox doubles) and calls a top-level function; the
-/// `pdf`/`printing` share step stays on the main isolate (see [_generate]).
-Future<Uint8List?> _cropToBbox(Uint8List fullBytes, List<double> bbox) {
-  return Isolate.run(() => _cropToBboxSync(fullBytes, bbox));
-}
-
-/// The synchronous crop, run inside the background isolate. The rect is clamped
-/// into the image so an out-of-range or degenerate box still yields a crop.
-Uint8List? _cropToBboxSync(Uint8List fullBytes, List<double> bbox) {
-  final decoded = img.decodeImage(fullBytes);
-  if (decoded == null) return null;
-  final w = decoded.width;
-  final h = decoded.height;
-  final cx = (bbox[0] * w).round().clamp(0, w - 1);
-  final cy = (bbox[1] * h).round().clamp(0, h - 1);
-  final cw = (bbox[2] * w).round().clamp(1, w - cx);
-  final ch = (bbox[3] * h).round().clamp(1, h - cy);
-  final cropped =
-      img.copyCrop(decoded, x: cx, y: cy, width: cw, height: ch);
-  return img.encodeJpg(cropped, quality: 90);
-}
+// The plate crop (bbox → cropped JPEG) lives in plate_crop.dart, shared with
+// the Plates gallery/detail crop so all three paths use one implementation.
 
 /// The device-local zone plus UTC and whole-hour offsets. Crumb ships no IANA
 /// tz database, so a fixed-offset picker is the honest, dependency-free option

--- a/apps/desktop-flutter/lib/ui/plates/plates_screen.dart
+++ b/apps/desktop-flutter/lib/ui/plates/plates_screen.dart
@@ -31,6 +31,7 @@ import 'package:crumb_desktop/api/crumb_api.dart';
 import 'package:crumb_desktop/api/http_client.dart';
 import 'package:crumb_desktop/api/models.dart';
 import 'package:crumb_desktop/api/plates_api.dart';
+import 'package:crumb_desktop/ui/plates/plate_crop.dart';
 import 'package:crumb_desktop/ui/plates/plate_report_dialog.dart';
 import 'package:crumb_desktop/ui/plates/plates_prefs.dart';
 
@@ -982,6 +983,7 @@ class _PlateThumb extends StatefulWidget {
     this.height = 56,
     this.radius = 6,
     this.iconSize = 22,
+    this.cropToBbox = false,
   });
 
   final PlateRead read;
@@ -993,12 +995,19 @@ class _PlateThumb extends StatefulWidget {
   final double radius;
   final double iconSize;
 
+  /// When true and the read has a `bbox`, show the plate region cropped from
+  /// the fetched snapshot (client-side, off the UI isolate, cached) instead of
+  /// the full frame. Falls back to the full frame when bbox is null / crop
+  /// fails. Used by the gallery card; the list/timeline thumbs stay full-frame.
+  final bool cropToBbox;
+
   @override
   State<_PlateThumb> createState() => _PlateThumbState();
 }
 
 class _PlateThumbState extends State<_PlateThumb> {
   Uint8List? _bytes;
+  Uint8List? _crop; // plate-region crop (only when widget.cropToBbox)
   bool _requested = false;
   bool _disposed = false;
 
@@ -1020,6 +1029,7 @@ class _PlateThumbState extends State<_PlateThumb> {
     final cached = _snapshotCache[eventId];
     if (cached != null) {
       _bytes = cached;
+      _maybeCrop(cached); // may set _crop synchronously from the crop cache
       return;
     }
     if (_requested) return;
@@ -1034,6 +1044,28 @@ class _PlateThumbState extends State<_PlateThumb> {
     final bytes = await _fetchSnapshotBytes(widget.session, eventId);
     if (_disposed || bytes == null) return;
     if (mounted) setState(() => _bytes = bytes);
+    _maybeCrop(bytes);
+  }
+
+  /// Derive the plate-region crop from [bytes] (no network) when this thumb is
+  /// a cropping one and the read has a bbox. Uses the shared crop cache: a hit
+  /// is applied synchronously; a miss computes off the UI isolate and then
+  /// setState-s. Keyed by read id (bbox belongs to the read).
+  void _maybeCrop(Uint8List bytes) {
+    if (!widget.cropToBbox || _disposed) return;
+    final bbox = widget.read.bbox;
+    if (bbox == null || bbox.length < 4) return;
+    final key = widget.read.id;
+    final existing = peekPlateCrop(key);
+    if (existing != null) {
+      _crop = existing;
+      return;
+    }
+    unawaited(() async {
+      final crop = await cachedPlateCrop(key, bytes, bbox);
+      if (_disposed || crop == null) return;
+      if (mounted) setState(() => _crop = crop);
+    }());
   }
 
   @override
@@ -1047,15 +1079,19 @@ class _PlateThumbState extends State<_PlateThumb> {
     final dpr = MediaQuery.devicePixelRatioOf(context);
     final logicalW = widget.width.isFinite ? widget.width : 320.0;
     final cacheW = (logicalW * dpr).round().clamp(1, 1024);
+    // Prefer the plate crop when we have one. A crop is wide/short, so it reads
+    // best letterboxed (contain) rather than cover-cropped again by the tile.
+    final displayBytes = _crop ?? _bytes;
+    final isCrop = _crop != null;
     return ClipRRect(
       borderRadius: BorderRadius.circular(widget.radius),
       child: SizedBox(
         width: widget.width,
         height: widget.height,
-        child: _bytes != null
+        child: displayBytes != null
             ? Image.memory(
-                _bytes!,
-                fit: BoxFit.cover,
+                displayBytes,
+                fit: isCrop ? BoxFit.contain : BoxFit.cover,
                 gaplessPlayback: true,
                 cacheWidth: cacheW,
               )
@@ -1209,6 +1245,9 @@ class _PlateGalleryCard extends StatelessWidget {
                 height: double.infinity,
                 radius: 0,
                 iconSize: 34,
+                // Gallery cards feature the plate itself: show the bbox crop
+                // (falls back to the full frame when there's no bbox).
+                cropToBbox: true,
               ),
             ),
             Padding(
@@ -1787,6 +1826,9 @@ class _PlateClipPlayerState extends State<_PlateClipPlayer> {
                 ],
               ),
             ),
+            // Prominent plate crop (bbox region of the already-fetched
+            // snapshot), when we have one — renders nothing otherwise.
+            _PlateDetailCrop(read: read),
             // Video pane.
             Expanded(
               child: Center(
@@ -1806,6 +1848,84 @@ class _PlateClipPlayerState extends State<_PlateClipPlayer> {
             ),
             const SizedBox(height: 16),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The prominent plate crop shown in the detail pop-up: the plate region
+/// cropped from the snapshot bytes already fetched for this read's tile (read
+/// straight from the shared snapshot cache — no network). The crop itself is
+/// computed off the UI isolate and cached (see plate_crop.dart). Renders
+/// nothing when there's no cached snapshot or no bbox, so the pop-up simply
+/// shows the clip in that case.
+class _PlateDetailCrop extends StatefulWidget {
+  const _PlateDetailCrop({required this.read});
+
+  final PlateRead read;
+
+  @override
+  State<_PlateDetailCrop> createState() => _PlateDetailCropState();
+}
+
+class _PlateDetailCropState extends State<_PlateDetailCrop> {
+  Uint8List? _crop;
+  bool _disposed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _compute();
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    super.dispose();
+  }
+
+  void _compute() {
+    final read = widget.read;
+    final bbox = read.bbox;
+    final eventId = read.eventId;
+    if (bbox == null || bbox.length < 4 || eventId == null || eventId.isEmpty) {
+      return;
+    }
+    // Cache-only: use the snapshot fetched for the tile. Never fetch here.
+    final bytes = _snapshotCache[eventId];
+    if (bytes == null) return;
+    final existing = peekPlateCrop(read.id);
+    if (existing != null) {
+      _crop = existing;
+      return;
+    }
+    unawaited(() async {
+      final crop = await cachedPlateCrop(read.id, bytes, bbox);
+      if (_disposed || crop == null) return;
+      if (mounted) setState(() => _crop = crop);
+    }());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final crop = _crop;
+    if (crop == null) return const SizedBox.shrink();
+    return Container(
+      margin: const EdgeInsets.only(top: 2, bottom: 6),
+      padding: const EdgeInsets.all(4),
+      decoration: BoxDecoration(
+        color: Colors.black,
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: Colors.white24),
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(4),
+        child: Image.memory(
+          crop,
+          height: 76,
+          fit: BoxFit.contain,
+          gaplessPlayback: true,
         ),
       ),
     );

--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -37,6 +37,25 @@ import 'package:crumb_desktop/ui/special_tiles/special_tile_controller.dart';
 import 'package:crumb_desktop/ui/special_tiles/special_tile_spec.dart';
 import 'package:crumb_desktop/ui/special_tiles/special_tile_widgets.dart';
 
+/// Tear down an mpv-backed [Player] without blocking the caller.
+///
+/// media_kit/libmpv `Player.dispose()` can block the calling isolate for
+/// seconds while the native mpv handle winds down. Calling it synchronously
+/// from a widget `dispose()` on the maximize / restore / close path freezes the
+/// UI (~10s stall, #105). Scheduling it in a fresh microtask/event lets widget
+/// teardown and navigation complete first, so the frame that removes the pane
+/// paints immediately and the native teardown runs afterwards.
+///
+/// Callers MUST null their player field before calling this so nothing else
+/// touches the handle that is being disposed. Only the Player teardown is
+/// detached — the stall-watchdog is still disposed synchronously by the caller.
+///
+/// NOTE: needs on-hardware confirmation that the maximize/restore/close freeze
+/// is actually gone (can only be observed against real libmpv on Windows).
+void _disposePlayerDetached(Player? p) {
+  if (p != null) unawaited(Future(() => p.dispose()));
+}
+
 class WallScreen extends StatefulWidget {
   const WallScreen({
     super.key,
@@ -1023,8 +1042,14 @@ class _WallTileState extends State<_WallTile> {
     _watchdog?.dispose();
     SnapshotRegistry.instance.unregister(_paneId);
     widget.audio?.unregisterPane(_paneId);
-    _pending?.dispose();
-    _player?.dispose();
+    // Detach the (potentially seconds-long) libmpv teardown from the teardown
+    // path so restore/close doesn't freeze the UI (#105). Null first.
+    final pending = _pending;
+    final player = _player;
+    _pending = null;
+    _player = null;
+    _disposePlayerDetached(pending);
+    _disposePlayerDetached(player);
     super.dispose();
   }
 
@@ -1642,7 +1667,11 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
       _ptzSteering = false;
       widget.api.ptzStop(widget.session, widget.camera.id).catchError((_) {});
     }
-    _player?.dispose();
+    // Detach the (potentially seconds-long) libmpv teardown from the restore /
+    // double-click-restore path so the UI doesn't freeze (#105). Null first.
+    final player = _player;
+    _player = null;
+    _disposePlayerDetached(player);
     super.dispose();
   }
 

--- a/db/migrations/0057_update_available_alert.sql
+++ b/db/migrations/0057_update_available_alert.sql
@@ -1,0 +1,34 @@
+-- 0057_update_available_alert.sql
+--
+-- Registers `update_available` as a system/health alert event_key in
+-- `system_alert_rules` (seeded by 0032_system_alerts.sql), so the API's
+-- update-notifier (services/api/src/updates.rs `run_update_notifier`) can route
+-- a "a newer Crumb release is available" signal through the SAME notification
+-- channels (Discord/Slack/Pushover/Telegram/ntfy/webhook) as the health and
+-- plate alerts, instead of the event being dropped by the notification engine's
+-- "unknown event_key -> skip" guard (services/api/src/notifications.rs
+-- `dispatch_system_events_tick`).
+--
+-- OFF BY DEFAULT (`enabled = false`), deliberately unlike every other seeded
+-- system-alert row (which default `true`). This mirrors the update-available
+-- check's own opt-in / off-by-default posture (docs/DECISIONS.md
+-- "Update-available check", D3: a fresh install makes ZERO requests to GitHub
+-- until the operator opts in). Turning update notifications into a channel page
+-- would otherwise be a phone-home behavior a privacy-conscious install has to
+-- notice and turn off; instead it is a value-add the operator turns on. Note
+-- the double gate: the notifier only emits this event when the update check
+-- itself is enabled (server_settings.update_check_enabled / UPDATE_CHECK_ENABLED)
+-- AND this rule is on.
+--
+-- Advisory, not urgent: `bypass_quiet_hours = false` (a new release at 3am is
+-- not worth waking anyone). No threshold (the notifier's own per-version latch
+-- is the edge-trigger). Long cooldown (6h) as a spam backstop behind that latch;
+-- real releases are days/weeks apart so it never collapses two distinct
+-- versions.
+--
+-- Idempotent (ON CONFLICT DO NOTHING), matching every other migration here —
+-- never clobbers an admin's saved preference on re-apply.
+
+INSERT INTO system_alert_rules (event_key, enabled, threshold_secs, threshold_fraction, bypass_quiet_hours, cooldown_secs) VALUES
+    ('update_available', false, NULL, NULL, false, 21600)
+ON CONFLICT (event_key) DO NOTHING;

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -8691,6 +8691,7 @@ const SYS_ALERT_META = {
   stream_no_segments:   { title: 'Camera records nothing',            desc: 'A camera keeps connecting but never produces a recordable segment before the stall watchdog reconnects it, so no footage is saved. Usually a long/adaptive keyframe interval (smart codec, e.g. Hikvision/Dahua H.264+/H.265+) or very low fps, exceeding the segment-receipt timeout. Fix the camera’s I-frame interval / disable the smart codec, or raise SEGMENT_RECEIPT_TIMEOUT_SECS.', unit: null },
   storage_unwritable:   { title: 'Storage not writable',              desc: 'The recorder cannot create a camera’s media directory under the storage root (permission denied) — footage is NOT being saved. Usually the host media dir is root-owned while the recorder runs as non-root uid 1001; fix the media dir ownership/permissions.', unit: null },
   plate_watchlist_hit:  { title: 'License-plate watchlist hit',        desc: 'A watchlisted license plate was seen on a camera (managed in Plates → Watchlist).', unit: null },
+  update_available:     { title: 'Crumb update available',             desc: 'A newer Crumb release is available on GitHub. Off by default and only fires when the update-available check is also enabled (Settings → Updates) — notify-only, no download or install. Fires once per new version.', unit: null },
 };
 
 /* Per-kind connection-field descriptors. */

--- a/services/api/src/detection/frigate.rs
+++ b/services/api/src/detection/frigate.rs
@@ -495,7 +495,11 @@ struct FrigateEventState {
     // tolerantly as raw JSON so a missing/odd-shaped attribute never fails the
     // whole-envelope parse (which would silently drop the detection) — same
     // tolerance discipline as `de_sub_label`. See `plate_box_from_attributes`.
-    #[serde(default, deserialize_with = "de_attributes")]
+    // `alias = "attributes"` (issue #142): the MQTT state object uses
+    // `current_attributes`, but Frigate's HTTP `/api/events` `data` object names
+    // the same list `attributes` — accept either so a shape difference between
+    // the two ingest paths can't silently drop the plate crop box.
+    #[serde(default, alias = "attributes", deserialize_with = "de_attributes")]
     current_attributes: Vec<serde_json::Value>,
 }
 
@@ -592,43 +596,70 @@ fn plate_box_from_attributes(attrs: &[serde_json::Value]) -> Option<[f32; 4]> {
 ///
 /// Frigate reports the `license_plate` attribute box as **normalized
 /// `[x, y, w, h]`** (top-left + size, each coord in `0..=1`), verified against a
-/// live `/api/events` payload — e.g. `[0.7646, 0.5611, 0.0536, 0.0556]`. And
-/// snapshots are full-frame (`snapshots.crop=false`), so these fractions map
-/// straight onto the snapshot the report crops. So the common path is a direct
-/// clamp-and-passthrough — no frame dimensions needed.
+/// live `/api/events` payload — e.g. `[0.7646, 0.5611, 0.0536, 0.0556]` and,
+/// on 0.18, `[0.7973958, 0.7870370, 0.0635416, 0.0796296]`. Snapshots are
+/// full-frame (`snapshots.crop=false`), so these fractions map straight onto the
+/// snapshot the report crops — the common path needs no frame dimensions.
 ///
-/// * Normalized `[x, y, w, h]` (all coords in `0..=1`): clamp the origin into the
-///   frame and the size so the box stays inside it. The primary/observed case.
-/// * Pixel `[x, y, w, h]` (any coord > 1) WITH frame dimensions: divide by the
-///   frame size. (Not exercised today — the ingest paths pass `None` — but kept
-///   so a future caller that has the detect resolution can hand it in.)
-/// * Pixel coords with no frame dimensions: `None` — we don't invent a scale.
+/// This is **defensive** parsing (issue #142): 0.18 was verified to use the
+/// same shape as before, but a future Frigate must not be able to silently
+/// break crops, so three plausible shapes are tolerated in a fixed precedence.
+///
+/// # Precedence (first match wins)
+///
+/// 1. **Normalized `[x, y, w, h]`** — all coords in `0..=1`, `w>0 && h>0`, and
+///    the box FITS as origin+size (`x+w <= 1 && y+h <= 1`). Returned as-is. This
+///    is the primary/observed Frigate shape and always wins when it applies, so
+///    a real (small) plate box is never re-interpreted as anything else.
+/// 2. **Normalized corners `[x1, y1, x2, y2]`** — all coords in `0..=1`,
+///    `x2>x1 && y2>y1`, reached only when the values do NOT already validate as
+///    a fitting `xywh` (rule 1). Converted to `[x1, y1, x2-x1, y2-y1]`. Since a
+///    real plate's `w`/`h` are small, an `xywh` plate has `x2<x1` (its `w` slot
+///    is smaller than its `x` slot) and can never satisfy the corners test —
+///    the disambiguation is robust for real plates.
+/// 3. **Clamped normalized `[x, y, w, h]`** — an in-unit box that overflows the
+///    frame and is not valid corners: clamp the size so it stays inside
+///    (best-effort for slightly-out-of-range data).
+/// 4. **Pixel `[x, y, w, h]`** (any coord `>1`) WITH frame dimensions: divide by
+///    the frame size. Not exercised today (the ingest paths pass `None`), kept
+///    so a future caller that has the detect resolution can hand it in.
+/// 5. Pixel coords with no frame dimensions: `None` — we don't invent a scale.
 ///
 /// Returns `None` for a `None` input or a degenerate (zero-area) box.
 fn normalize_plate_box(raw: Option<[f32; 4]>, frame: Option<(f32, f32)>) -> Option<[f32; 4]> {
-    let [x, y, w, h] = raw?;
+    let [a, b, c, d] = raw?;
     let in_unit = |v: f32| (0.0..=1.0).contains(&v);
 
-    // Normalized [x, y, w, h] — the shape Frigate actually sends. Clamp inside.
-    if in_unit(x) && in_unit(y) && in_unit(w) && in_unit(h) {
-        let cx = x.clamp(0.0, 1.0);
-        let cy = y.clamp(0.0, 1.0);
-        let cw = w.clamp(0.0, 1.0 - cx);
-        let ch = h.clamp(0.0, 1.0 - cy);
-        return (cw > 0.0 && ch > 0.0).then_some([cx, cy, cw, ch]);
+    if in_unit(a) && in_unit(b) && in_unit(c) && in_unit(d) {
+        // Rule 1 — clean, fitting [x, y, w, h] (the shape Frigate sends). Wins
+        // whenever it applies, so a real plate box is never read as corners.
+        if c > 0.0 && d > 0.0 && a + c <= 1.0 && b + d <= 1.0 {
+            return Some([a, b, c, d]);
+        }
+        // Rule 2 — normalized corners [x1, y1, x2, y2], only when NOT a fitting
+        // xywh above. All in-unit with x2>x1 && y2>y1 ⇒ the derived w/h are >0
+        // and the box is inside the frame by construction.
+        if c > a && d > b {
+            return Some([a, b, c - a, d - b]);
+        }
+        // Rule 3 — in-unit xywh that overflows the frame: clamp the size inside.
+        let cw = c.clamp(0.0, 1.0 - a);
+        let ch = d.clamp(0.0, 1.0 - b);
+        return (cw > 0.0 && ch > 0.0).then_some([a, b, cw, ch]);
     }
 
-    // Pixel [x, y, w, h]: only normalizable with frame dimensions.
+    // Rule 4 — pixel [x, y, w, h]: only normalizable with frame dimensions.
     if let Some((fw, fh)) = frame {
         if fw > 0.0 && fh > 0.0 {
-            let nx = (x / fw).clamp(0.0, 1.0);
-            let ny = (y / fh).clamp(0.0, 1.0);
-            let nw = (w / fw).clamp(0.0, 1.0 - nx);
-            let nh = (h / fh).clamp(0.0, 1.0 - ny);
+            let nx = (a / fw).clamp(0.0, 1.0);
+            let ny = (b / fh).clamp(0.0, 1.0);
+            let nw = (c / fw).clamp(0.0, 1.0 - nx);
+            let nh = (d / fh).clamp(0.0, 1.0 - ny);
             return (nw > 0.0 && nh > 0.0).then_some([nx, ny, nw, nh]);
         }
     }
 
+    // Rule 5 — pixel coords, no frame dims: don't guess a scale.
     None
 }
 
@@ -784,10 +815,13 @@ struct FrigateApiEventData {
     #[serde(default, deserialize_with = "de_plate_scored")]
     recognized_license_plate: Option<(String, Option<f32>)>,
     recognized_license_plate_score: Option<f32>,
-    // Plate crop box, mirroring the MQTT `current_attributes`. Tolerant/default
-    // so it's harmless if this backfill payload omits it or names it differently
-    // (yields no box → None). See `plate_box_from_attributes`.
-    #[serde(default, deserialize_with = "de_attributes")]
+    // Plate crop box. Frigate's HTTP `/api/events` `data` object names this list
+    // `attributes` (verified on 0.18: `data.attributes[].box`), whereas the MQTT
+    // state object uses `current_attributes` — accept BOTH via `alias` (issue
+    // #142) so the HTTP backfill actually captures the plate crop box instead of
+    // silently yielding None. Tolerant/default so an odd/absent shape is
+    // harmless. See `plate_box_from_attributes`.
+    #[serde(default, alias = "attributes", deserialize_with = "de_attributes")]
     current_attributes: Vec<serde_json::Value>,
 }
 
@@ -1387,6 +1421,166 @@ mod tests {
         assert_eq!(normalize_plate_box(Some([0.5, 0.5, 0.0, 0.1]), None), None);
         assert_eq!(normalize_plate_box(Some([0.5, 0.5, 0.1, 0.0]), None), None);
         assert_eq!(normalize_plate_box(None, Some((1000.0, 500.0))), None);
+    }
+
+    #[test]
+    fn normalize_plate_box_prefers_xywh_over_corners_for_the_real_018_shape() {
+        // The captured Frigate 0.18 attribute box is normalized [x, y, w, h]
+        // with a small w/h. It FITS as origin+size, so rule 1 (xywh) wins and it
+        // passes through unchanged — it must NOT be re-read as corners (as
+        // corners its x2=0.0635 < x1=0.7974, so the corners test can't even
+        // match — the disambiguation is robust for a real plate).
+        let got = normalize_plate_box(
+            Some([0.797_395_8, 0.787_037, 0.063_541_6, 0.079_629_6]),
+            None,
+        )
+        .expect("0.18 xywh box normalizes");
+        assert!((got[0] - 0.797_395_8).abs() < 1e-5, "x passthrough");
+        assert!((got[1] - 0.787_037).abs() < 1e-5, "y passthrough");
+        assert!(
+            (got[2] - 0.063_541_6).abs() < 1e-5,
+            "w passthrough (not x2-x1)"
+        );
+        assert!(
+            (got[3] - 0.079_629_6).abs() < 1e-5,
+            "h passthrough (not y2-y1)"
+        );
+    }
+
+    #[test]
+    fn normalize_plate_box_accepts_normalized_corners() {
+        // Corners [x1, y1, x2, y2] with x2>x1 && y2>y1 that do NOT fit as xywh
+        // (x+w = 0.10+0.95 = 1.05 > 1, so rule 1 can't claim it) → converted to
+        // [x1, y1, x2-x1, y2-y1].
+        let got = normalize_plate_box(Some([0.10, 0.20, 0.95, 0.98]), None)
+            .expect("corners box normalizes");
+        assert!((got[0] - 0.10).abs() < 1e-6, "x1");
+        assert!((got[1] - 0.20).abs() < 1e-6, "y1");
+        assert!((got[2] - 0.85).abs() < 1e-6, "w = x2 - x1");
+        assert!((got[3] - 0.78).abs() < 1e-6, "h = y2 - y1");
+    }
+
+    #[test]
+    fn normalize_plate_box_corners_stay_inside_frame() {
+        // A corners box near the far edge that does NOT fit as xywh
+        // (0.15 + 0.9 > 1) is read as corners → w/h keep it inside the frame by
+        // construction (x1+w = x2 <= 1, y1+h = y2 <= 1).
+        let got =
+            normalize_plate_box(Some([0.15, 0.10, 0.90, 0.95]), None).expect("edge corners box");
+        assert!((got[0] - 0.15).abs() < 1e-6, "x1");
+        assert!((got[1] - 0.10).abs() < 1e-6, "y1");
+        assert!((got[2] - 0.75).abs() < 1e-6, "w = x2 - x1, inside frame");
+        assert!((got[3] - 0.85).abs() < 1e-6, "h = y2 - y1, inside frame");
+        assert!(got[0] + got[2] <= 1.0 + 1e-6, "x1 + w <= 1");
+        assert!(got[1] + got[3] <= 1.0 + 1e-6, "y1 + h <= 1");
+    }
+
+    #[test]
+    fn frigate_018_http_event_extracts_plate_and_box() {
+        // The real Frigate 0.18 HTTP `/api/events` shape the maintainer captured:
+        // plate + scores + the `license_plate` attribute box all live under
+        // `data`, and the attribute list is named `attributes` (NOT
+        // `current_attributes`). Deserialize it and assert both the plate string
+        // and the normalized [x, y, w, h] crop box are extracted.
+        let body = serde_json::json!({
+            "id": "1700000000.123-abcd",
+            "camera": "driveway",
+            "label": "car",
+            "start_time": 1_700_000_000.0f64,
+            "end_time": 1_700_000_020.0f64,
+            "has_snapshot": true,
+            "false_positive": null,
+            "zones": ["driveway"],
+            "data": {
+                "score": 0.9,
+                "top_score": 0.95,
+                "recognized_license_plate": ["23134X1", 0.994f64],
+                "box": [0.79, 0.78, 0.86, 0.87],
+                "region": [0.7, 0.7, 0.95, 0.95],
+                "attributes": [
+                    {"label": "license_plate",
+                     "box": [0.797_395_8, 0.787_037, 0.063_541_6, 0.079_629_6],
+                     "score": 0.8}
+                ]
+            }
+        });
+        let ev: FrigateApiEvent =
+            serde_json::from_value(body).expect("0.18 HTTP event deserializes");
+        let data = ev.data.expect("data present");
+
+        // Plate string extracted from `data.recognized_license_plate` (HTTP).
+        let (plate, score) = data
+            .recognized_license_plate
+            .clone()
+            .expect("plate present under data");
+        assert_eq!(plate, "23134X1");
+        assert!((score.expect("plate score") - 0.994).abs() < 1e-3);
+
+        // Attribute box captured (via the `attributes` alias) and normalized.
+        let bbox = normalize_plate_box(plate_box_from_attributes(&data.current_attributes), None)
+            .expect("plate crop box extracted from data.attributes");
+        assert!((bbox[0] - 0.797_395_8).abs() < 1e-5);
+        assert!((bbox[1] - 0.787_037).abs() < 1e-5);
+        assert!((bbox[2] - 0.063_541_6).abs() < 1e-5);
+        assert!((bbox[3] - 0.079_629_6).abs() < 1e-5);
+    }
+
+    #[test]
+    fn frigate_mqtt_event_extracts_plate_under_after() {
+        // Sibling to the HTTP test: the MQTT envelope carries the plate on
+        // `after.recognized_license_plate` (a [plate, score] array) and the box
+        // on `after.current_attributes`. Confirms the plate is read from `after`
+        // (not `data`) on the MQTT path.
+        let cam_id = Uuid::new_v4();
+        let payload = serde_json::json!({
+            "type": "end",
+            "before": null,
+            "after": {
+                "id": "abc123", "camera": "driveway", "label": "car",
+                "sub_label": null,
+                "recognized_license_plate": ["23134X1", 0.994f64],
+                "score": 0.9, "top_score": 0.95,
+                "start_time": 1_000_000.0f64, "end_time": 1_000_020.0f64,
+                "current_zones": ["driveway"], "false_positive": false, "has_snapshot": true,
+                "current_attributes": [
+                    {"label": "license_plate",
+                     "box": [0.797_395_8, 0.787_037, 0.063_541_6, 0.079_629_6],
+                     "score": 0.8}
+                ]
+            }
+        });
+        let mut map = HashMap::new();
+        map.insert("driveway".to_owned(), cam_id);
+        let bytes = bytes::Bytes::from(payload.to_string());
+        let ev = process_mqtt_payload(&bytes, &map, 0.3).unwrap().unwrap();
+        assert_eq!(ev.recognized_plate.as_deref(), Some("23134X1"));
+        assert!((ev.plate_confidence.expect("confidence") - 0.994).abs() < 1e-3);
+        let bbox = ev.plate_box.expect("plate_box captured on MQTT path");
+        assert!((bbox[0] - 0.797_395_8).abs() < 1e-5);
+        assert!((bbox[2] - 0.063_541_6).abs() < 1e-5);
+    }
+
+    #[test]
+    fn frigate_http_event_accepts_current_attributes_alias() {
+        // Defensive: if a Frigate build ever names the HTTP `data` list
+        // `current_attributes` (the MQTT name) instead of `attributes`, the
+        // alias still captures the box — neither name silently drops the crop.
+        let body = serde_json::json!({
+            "id": "x", "camera": "driveway", "label": "car",
+            "start_time": 1.0f64, "has_snapshot": true,
+            "data": {
+                "score": 0.9,
+                "current_attributes": [
+                    {"label": "license_plate", "box": [0.4, 0.5, 0.2, 0.15], "score": 0.8}
+                ]
+            }
+        });
+        let ev: FrigateApiEvent = serde_json::from_value(body).expect("deserializes");
+        let data = ev.data.expect("data present");
+        let bbox = normalize_plate_box(plate_box_from_attributes(&data.current_attributes), None)
+            .expect("box via current_attributes alias");
+        assert!((bbox[0] - 0.4).abs() < 1e-6);
+        assert!((bbox[2] - 0.2).abs() < 1e-6);
     }
 
     #[test]

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -631,6 +631,22 @@ async fn main() -> anyhow::Result<()> {
         info!("notification engine started");
     }
 
+    // ── 6c-2. update-available notifier (issue #35) ───────────────────────────
+    //
+    // Edge-triggered "a newer Crumb release is available" → `system_events`,
+    // fanned out over the same channels as health/plate alerts. Doubly opt-in
+    // and off by default: it makes ZERO GitHub requests unless the update-check
+    // is enabled AND the `update_available` system-alert rule is on, preserving
+    // the no-phone-home posture (docs/DECISIONS.md "Update-available check").
+    {
+        let update_pool = state.pool().clone();
+        let update_cfg = cfg.clone();
+        tokio::spawn(async move {
+            updates::run_update_notifier(update_pool, update_cfg).await;
+        });
+        info!("update-available notifier started");
+    }
+
     // ── 6d. system/health watchdogs (P0-HEALTH-NOTIFY) ────────────────────────
     //
     // Always on (no env var gate, unlike the legacy ALERT_WEBHOOK_URL path) —

--- a/services/api/src/notifications.rs
+++ b/services/api/src/notifications.rs
@@ -2042,6 +2042,7 @@ fn system_alert_title(event_key: &str) -> &str {
         "stream_no_segments" => "Camera records nothing (no segments — check keyframe interval)",
         "storage_unwritable" => "Recorder can't write to storage — footage NOT being saved",
         "plate_watchlist_hit" => "License-plate watchlist hit",
+        "update_available" => "Crumb update available",
         other => other,
     }
 }

--- a/services/api/src/updates.rs
+++ b/services/api/src/updates.rs
@@ -341,6 +341,175 @@ async fn get_release_info(force: bool) -> Option<CachedRelease> {
     guard.data.clone()
 }
 
+// ─── background update-available notifier (issue #35) ──────────────────────────
+
+/// System-event key emitted when a newer release is detected. Seeded OFF by
+/// default into `system_alert_rules` by migration
+/// `0057_update_available_alert.sql`, and dispatched over the configured
+/// notification channels by `notifications.rs`.
+const UPDATE_AVAILABLE_EVENT_KEY: &str = "update_available";
+
+/// How often the notifier re-evaluates. Aligned with the 6h cache TTL: a poll
+/// that finds the cache stale triggers exactly one `GitHub` fetch, so this
+/// cadence bounds `GitHub` contact to ~once per 6h (well inside the 60/h/IP
+/// unauthenticated limit) while still surfacing a new release within a few hours
+/// of it landing.
+const UPDATE_NOTIFY_POLL_SECS: u64 = 6 * 60 * 60;
+
+/// Edge-trigger decision for the update-available notifier. Kept pure (no DB, no
+/// network) so the once-per-version de-dupe is exhaustively unit-testable.
+#[derive(Debug, PartialEq, Eq)]
+enum UpdateNotifyDecision {
+    /// A newer version is available that has NOT already been notified — emit an
+    /// `update_available` system event for it, then latch this version.
+    Notify(String),
+    /// Server is up to date (or the local build is newer than latest): clear the
+    /// latch so the NEXT distinct release re-fires.
+    ClearLatch,
+    /// No actionable change — already notified this version, or no parseable
+    /// signal (unreachable `GitHub` / unparseable dev build). Latch untouched.
+    Skip,
+}
+
+/// Decide whether to emit an update-available notification this tick.
+///
+/// * `update_available` — the [`is_update_available`] result: `Some(true)`
+///   newer, `Some(false)` up to date, `None` no signal.
+/// * `latest_version` — the version tag `GitHub` reported (if any).
+/// * `last_notified` — the version this task last emitted an event for (the
+///   in-memory latch), or `None` if it has not emitted for the current streak.
+///
+/// De-dupe rules: a given version fires at most once (latched); a return to
+/// up-to-date clears the latch so a later release fires again; an
+/// unparseable/absent signal is a no-op that specifically does NOT clear a valid
+/// latch (a transient `GitHub` outage must not cause a re-fire when it recovers).
+fn update_notify_decision(
+    update_available: Option<bool>,
+    latest_version: Option<&str>,
+    last_notified: Option<&str>,
+) -> UpdateNotifyDecision {
+    match (update_available, latest_version) {
+        (Some(true), Some(latest)) => {
+            if last_notified == Some(latest) {
+                UpdateNotifyDecision::Skip
+            } else {
+                UpdateNotifyDecision::Notify(latest.to_owned())
+            }
+        }
+        // Up to date (or local build newer than latest) — reset the latch.
+        (Some(false), _) => UpdateNotifyDecision::ClearLatch,
+        // No signal (GitHub unreachable, or an unparseable local version).
+        _ => UpdateNotifyDecision::Skip,
+    }
+}
+
+/// Background task (issue #35): periodically checks whether a newer release is
+/// available and, on the edge where one first appears, fires an
+/// `update_available` system event that the notification engine
+/// (`notifications.rs`) fans out over the configured channels.
+///
+/// Opt-in on BOTH gates, honoring Crumb's no-phone-home posture:
+/// 1. the update-available check must be enabled
+///    (`server_settings.update_check_enabled` / `UPDATE_CHECK_ENABLED`, off by
+///    default per D3) — while off this task makes ZERO `GitHub` requests; and
+/// 2. the `update_available` system-alert rule must be enabled (off by default,
+///    migration 0057) — while off the task neither fetches nor latches.
+///
+/// De-dupe is a per-version in-memory latch (see [`update_notify_decision`]): a
+/// given version emits one event and only a later distinct release re-fires.
+/// The latch resets on process restart — at worst one repeat event for a
+/// still-available version after a restart, itself bounded by the rule's 6h
+/// cooldown in the engine.
+pub async fn run_update_notifier(pool: Pool, cfg: ApiConfig) {
+    let server_version = VERSION.trim().to_owned();
+    let mut last_notified: Option<String> = None;
+
+    let poll_interval = std::time::Duration::from_secs(UPDATE_NOTIFY_POLL_SECS);
+    let mut ticker = tokio::time::interval(poll_interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    tracing::info!(
+        poll_secs = UPDATE_NOTIFY_POLL_SECS,
+        "update-available notifier started"
+    );
+
+    loop {
+        ticker.tick().await;
+
+        // ── Gate 1: update-available check enabled? (else zero GitHub contact —
+        //    the no-phone-home invariant.) ────────────────────────────────────
+        match resolve_enabled(&pool, &cfg).await {
+            Ok(true) => {}
+            Ok(false) => {
+                // Off — reset so re-enabling re-notifies for the current release.
+                last_notified = None;
+                continue;
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "update notifier: resolve_enabled failed; skipping tick");
+                continue;
+            }
+        }
+
+        // ── Gate 2: the `update_available` system-alert rule must be on (else
+        //    nothing would dispatch — don't fetch or latch). ──────────────────
+        match crumb_common::db::get_system_alert_rule(&pool, UPDATE_AVAILABLE_EVENT_KEY).await {
+            Ok(Some(rule)) if rule.enabled => {}
+            Ok(_) => {
+                last_notified = None; // rule off/missing — re-enabling re-notifies
+                continue;
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "update notifier: get_system_alert_rule failed; skipping tick");
+                continue;
+            }
+        }
+
+        // ── Both gates open: consult the shared, cached release info. A `None`
+        //    here is "no signal" (GitHub unreachable / no data yet) — leave the
+        //    latch untouched. ─────────────────────────────────────────────────
+        let Some(release) = get_release_info(false).await else {
+            continue;
+        };
+        let available = is_update_available(&server_version, &release.latest_version);
+
+        match update_notify_decision(
+            available,
+            Some(&release.latest_version),
+            last_notified.as_deref(),
+        ) {
+            UpdateNotifyDecision::Notify(version) => {
+                let detail = format!(
+                    "Crumb {version} is available (this server runs {server_version}). \
+                     Release notes: {}",
+                    release.notes_url
+                );
+                match crumb_common::db::insert_system_event(
+                    &pool,
+                    UPDATE_AVAILABLE_EVENT_KEY,
+                    None,
+                    Some(&detail),
+                )
+                .await
+                {
+                    Ok(_) => {
+                        tracing::info!(
+                            version = %version,
+                            "update notifier: newer release detected — system event emitted"
+                        );
+                        last_notified = Some(version);
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "update notifier: insert_system_event(update_available) failed");
+                    }
+                }
+            }
+            UpdateNotifyDecision::ClearLatch => last_notified = None,
+            UpdateNotifyDecision::Skip => {}
+        }
+    }
+}
+
 // ─── tests ──────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -573,5 +742,62 @@ mod tests {
         assert_eq!(resp.latest_version.as_deref(), Some("0.0.2"));
         assert_eq!(resp.server_update_available, Some(true));
         assert_eq!(resp.checked_at, Some(checked));
+    }
+
+    // ── update-available notifier: edge-trigger + per-version de-dupe (#35) ──
+
+    #[test]
+    fn notify_fires_once_when_a_newer_version_first_appears() {
+        // First sighting of a newer version, nothing latched yet → Notify.
+        assert_eq!(
+            update_notify_decision(Some(true), Some("0.0.2"), None),
+            UpdateNotifyDecision::Notify("0.0.2".to_owned())
+        );
+    }
+
+    #[test]
+    fn notify_deduped_for_the_same_version_already_notified() {
+        // Same newer version, already latched → Skip (no re-fire every poll).
+        assert_eq!(
+            update_notify_decision(Some(true), Some("0.0.2"), Some("0.0.2")),
+            UpdateNotifyDecision::Skip
+        );
+    }
+
+    #[test]
+    fn notify_refires_for_a_different_newer_version() {
+        // A DISTINCT later release supersedes the latched one → Notify again.
+        assert_eq!(
+            update_notify_decision(Some(true), Some("0.0.3"), Some("0.0.2")),
+            UpdateNotifyDecision::Notify("0.0.3".to_owned())
+        );
+    }
+
+    #[test]
+    fn up_to_date_clears_the_latch_so_a_future_release_refires() {
+        // Server caught up (or is newer) → clear latch; then the next newer
+        // release fires as a fresh edge.
+        assert_eq!(
+            update_notify_decision(Some(false), Some("0.0.2"), Some("0.0.2")),
+            UpdateNotifyDecision::ClearLatch
+        );
+        assert_eq!(
+            update_notify_decision(Some(true), Some("0.0.3"), None),
+            UpdateNotifyDecision::Notify("0.0.3".to_owned())
+        );
+    }
+
+    #[test]
+    fn no_signal_never_clears_a_valid_latch() {
+        // A transient GitHub outage / unparseable local version = None: a no-op
+        // that must NOT clear the latch (else recovery would spuriously re-fire).
+        assert_eq!(
+            update_notify_decision(None, None, Some("0.0.2")),
+            UpdateNotifyDecision::Skip
+        );
+        assert_eq!(
+            update_notify_decision(None, Some("0.0.2"), Some("0.0.2")),
+            UpdateNotifyDecision::Skip
+        );
     }
 }

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -9162,6 +9162,10 @@ static MIGRATIONS: &[(&str, &str)] = &[
             "../../../db/migrations/0056_stream_no_segments_storage_unwritable_alerts.sql"
         ),
     ),
+    (
+        "0057_update_available_alert.sql",
+        include_str!("../../../db/migrations/0057_update_available_alert.sql"),
+    ),
 ];
 
 /// The actual migration-application body, run while [`run_migrations`] holds


### PR DESCRIPTION
Closes #35, #57, #105, #142, #149 (and #56 verified/closed).

## What
- **#149 — plate crops in the app UI.** The crop was only in the PDF report; now it renders in the Plates gallery + detail (desktop) and list/gallery/detail (Android), cropped client-side from the already-fetched snapshot, falling back to the full frame when a read has no `bbox`.
- **#35 — update-available alerts.** A new `update_available` system alert fires through the configured notification channels when a newer release is detected. Migration `0057` (registered), edge-triggered + de-duped per version, **double opt-in** (update-check enabled AND the rule enabled), seeded **OFF by default** to keep the no-phone-home posture.
- **#142 — Frigate 0.18.** Caught a real regression: 0.18 HTTP backfill names the attribute list `data.attributes` (not `current_attributes`), so the plate box was being dropped on that path — a `serde(alias)` fixes it. Plus xywh/corner/pixel box-parse precedence and real-0.18 fixtures so a future bump cannot silently break crops again.
- **#105 — non-blocking teardown.** libmpv `Player.dispose()` is now detached off the UI thread, killing the ~10s freeze on maximize/restore/close. *(Needs on-hardware confirmation the freeze is gone.)*
- **#57 — scrubber highlight.** The active detection events time span is highlighted in its legend colour on the timeline.
- **#56 — closed:** verified the glyphs use the same epoch-ms mapping as the playhead (no real offset).

## Verification
`cargo fmt --all --check` ✓ · `clippy --all-targets -D warnings` ✓ · `cargo test --workspace` ✓ (incl. new update-notify + 0.18 fixture tests) · `flutter analyze` ✓ (baseline) · `:app:compileDebugKotlin` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)