### PR TITLE
fix(mobile): playback-wall hint wrongly implied you must tap to interact

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackWallScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackWallScreen.kt
@@ -467,12 +467,7 @@ fun PlaybackWallScreen(
                         Text("Latest", fontWeight = FontWeight.Bold, style = MaterialTheme.typography.labelMedium)
                     }
                     Text(
-                        text = if (atLatest) {
-                            "Tap a camera to play its latest footage"
-                        } else {
-                            "Tap a camera to play from " +
-                                Time.dateTime(Instant.ofEpochMilli(cursorMs))
-                        },
+                        text = "Tap a camera for full playback control",
                         style = MaterialTheme.typography.labelSmall,
                         color = TextSecondary,
                         modifier = Modifier.weight(1f).padding(horizontal = 10.dp),

--- a/apps/ios/Crumb/Features/Playback/PlaybackWallView.swift
+++ b/apps/ios/Crumb/Features/Playback/PlaybackWallView.swift
@@ -73,8 +73,7 @@ struct PlaybackWallView: View {
                         .foregroundColor(atLatest ? CrumbColors.tealAccent : .white)
                         .clipShape(Capsule())
                 }
-                Text(atLatest ? "Tap a camera to play its latest footage"
-                              : "Play from \(formatTime(Date(timeIntervalSince1970: Double(cursorMs)/1000), style: .clockLong))")
+                Text("Tap a camera for full playback control")
                     .font(.caption2).foregroundColor(CrumbColors.textSecondary)
                     .lineLimit(1).frame(maxWidth: .infinity, alignment: .leading)
                 Button { showJump = true } label: {


### PR DESCRIPTION
The multi-window playback scrubber already seeks the whole wall to the scrubbed time on its own. The old hint — "Tap a camera to play its latest footage" / "…to play from &lt;time&gt;" — implied nothing happened until you tapped a camera, which is misleading.

Tapping a camera is what opens **full single-camera playback control**, so the hint now says exactly that in both the at-latest and scrubbed states.

Android + iOS parity (same copy on both wall views). Copy-only change.