### PR TITLE
chore: rename the 'Plates' tab to 'LPR' across all clients

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/ui/ModeTabs.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/ui/ModeTabs.kt
@@ -76,7 +76,7 @@ fun CrumbModeTabs(
             ModeTab("Clips", selected == CrumbMode.CLIPS, Color(0xFFB07CD8), onClips)
         }
         if (showPlates) {
-            ModeTab("Plates", selected == CrumbMode.PLATES, TimelineColors.eventPlate, onPlates)
+            ModeTab("LPR", selected == CrumbMode.PLATES, TimelineColors.eventPlate, onPlates)
         }
     }
 }

--- a/apps/desktop-flutter/lib/main.dart
+++ b/apps/desktop-flutter/lib/main.dart
@@ -744,7 +744,7 @@ class _MainShellState extends State<MainShell> with WindowListener {
     (_liveIndex, Icons.grid_view, 'Live', Color(0xFFE8A33D)), // amber
     (_playbackIndex, Icons.play_circle_outline, 'Playback', Color(0xFF38BDD6)), // cyan
     (_clipsIndex, Icons.movie_outlined, 'Clips', Color(0xFFB57BEF)), // violet
-    (_platesIndex, Icons.directions_car_outlined, 'Plates', Color(0xFFE05A8A)), // pink
+    (_platesIndex, Icons.directions_car_outlined, 'LPR', Color(0xFFE05A8A)), // pink
     (_exportIndex, Icons.download_outlined, 'Export', Color(0xFF57C888)), // green
   ];
 

--- a/docs/AI-INSTALL.md
+++ b/docs/AI-INSTALL.md
@@ -322,14 +322,14 @@ If the user runs their cameras through Frigate with Frigate's native LPR enabled
 plate reads arrive on the event stream Crumb already ingests — flip
 **License-plate recognition** on there (and set a **retention** window; older
 plate reads are pruned automatically) to start capturing them into the
-searchable **Plates** tab. No new services or env keys; it reuses the Frigate
+searchable **LPR** tab. No new services or env keys; it reuses the Frigate
 integration. A plate database is privacy-sensitive, so it stays opt-in, and
 viewing it needs the **View license plates** role capability (Settings → Users &
 Security). Plate-read retention is independent of footage/storage retention.
 REST-driven install: `PUT /config/lpr {"enabled":true,"retention_days":90}`.
 
 To be **alerted** when a specific plate is seen, add it to the **watchlist** in
-the **Plates** tab (or `POST /lpr/watchlist {"plate":"7ABC123","label":"…"}`,
+the **LPR** tab (or `POST /lpr/watchlist {"plate":"7ABC123","label":"…"}`,
 admin-only). A watchlisted plate raises a **License-plate watchlist hit** alert
 routed over the same notification channels as every other alert — enable/tune it
 under Settings → Notifications → System alerts. No extra services or env keys.

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -3921,7 +3921,7 @@ function renderTree() {
     item("select('detection-root')",     icon('integration',17), 'Detection &amp; clips', detActive, null) +
     // Plates: only when LPR capture is enabled (privacy-sensitive, off by default).
     ((LPR_CONFIG && LPR_CONFIG.enabled)
-      ? item("select('plates-root')", icon('cam_lpr',17), 'Plates', selKind==='plates-root', null)
+      ? item("select('plates-root')", icon('cam_lpr',17), 'LPR', selKind==='plates-root', null)
       : '') +
     item("select('notifications-root')",  icon('bell',17),        'Notifications',        notActive, null) +
     `<div class="rail-eyebrow">Administer</div>` +
@@ -8690,7 +8690,7 @@ const SYS_ALERT_META = {
   frigate_disconnected: { title: 'Frigate / MQTT disconnected',       desc: 'The Frigate detection integration has lost its MQTT connection.', unit: 'secs' },
   stream_no_segments:   { title: 'Camera records nothing',            desc: 'A camera keeps connecting but never produces a recordable segment before the stall watchdog reconnects it, so no footage is saved. Usually a long/adaptive keyframe interval (smart codec, e.g. Hikvision/Dahua H.264+/H.265+) or very low fps, exceeding the segment-receipt timeout. Fix the camera’s I-frame interval / disable the smart codec, or raise SEGMENT_RECEIPT_TIMEOUT_SECS.', unit: null },
   storage_unwritable:   { title: 'Storage not writable',              desc: 'The recorder cannot create a camera’s media directory under the storage root (permission denied) — footage is NOT being saved. Usually the host media dir is root-owned while the recorder runs as non-root uid 1001; fix the media dir ownership/permissions.', unit: null },
-  plate_watchlist_hit:  { title: 'License-plate watchlist hit',        desc: 'A watchlisted license plate was seen on a camera (managed in Plates → Watchlist).', unit: null },
+  plate_watchlist_hit:  { title: 'License-plate watchlist hit',        desc: 'A watchlisted license plate was seen on a camera (managed in LPR → Watchlist).', unit: null },
   update_available:     { title: 'Crumb update available',             desc: 'A newer Crumb release is available on GitHub. Off by default and only fires when the update-available check is also enabled (Settings → Updates) — notify-only, no download or install. Fires once per new version.', unit: null },
 };
 
@@ -8733,7 +8733,7 @@ function renderPlates() {
       <div class="rp-head-left">
         <span class="rp-head-icon">${icon('cam_lpr',22)}</span>
         <div class="rp-head-titles">
-          <div class="rp-head-title">Plates</div>
+          <div class="rp-head-title">LPR</div>
           <div class="rp-head-sub">Recognised license-plate reads, most recent first</div>
         </div>
       </div>


### PR DESCRIPTION
Renames the user-facing **Plates** tab/label to **LPR** on every client. Display-only — all internal identifiers stay (`plates` route/id, `view_plates` capability, `/plates` + `/lpr` API paths, `PLATES`/`CrumbMode.PLATES` enums, `plates-root` nav id, DB tables).

- **Desktop** (`main.dart`): main nav tab → LPR.
- **Android** (`ModeTabs.kt`): mode tab → LPR.
- **Admin console** (`admin.html`): left-nav item + panel header → LPR; watchlist-hit alert description now reads "managed in **LPR → Watchlist**".
- **Install guide** (`AI-INSTALL.md`): the two "Plates tab" references → "LPR tab" (golden rule 5 — keep the runbook matching the UI).

Left intentionally unchanged: iOS (no Plates tab), the admin hint "**Plates** on this list…" (literal license plates, not the tab), and the architectural references in `docs/DECISIONS.md` / `docs/COMPONENT-MAP.md`.

**Gate:** admin inline `node --check` OK; desktop `flutter analyze lib/main.dart` clean; Android change is a string literal.