### PR TITLE
feat(desktop): Data-saver low-bitrate live-stream tier (Main/Sub/Data-saver) (Fixes #160)

### DIFF
--- a/apps/desktop-flutter/lib/api/models.dart
+++ b/apps/desktop-flutter/lib/api/models.dart
@@ -34,14 +34,21 @@ class Camera {
 /// are go2rtc restreams and may embed `user:pass@` credentials — treat as
 /// sensitive, never log them.
 class StreamUrls {
-  StreamUrls({this.rtspMain, this.rtspSub});
+  StreamUrls({this.rtspMain, this.rtspSub, this.rtspMobile});
 
   final String? rtspMain;
   final String? rtspSub;
 
+  /// The on-demand low-bitrate `<name>_mobile` go2rtc transcode (the
+  /// "Data saver" tier). Nullable — absent when the server has mobile streams
+  /// disabled or the camera is Frigate-served. Callers must fall back
+  /// (sub → main) when this is null so a pane never goes black.
+  final String? rtspMobile;
+
   factory StreamUrls.fromJson(Map<String, dynamic> j) => StreamUrls(
     rtspMain: j['rtsp_main_url'] as String?,
     rtspSub: j['rtsp_sub_url'] as String?,
+    rtspMobile: j['rtsp_mobile_url'] as String?,
   );
 
   /// Wall default: prefer the lighter sub stream, fall back to main. (Maximize

--- a/apps/desktop-flutter/lib/state/client_options.dart
+++ b/apps/desktop-flutter/lib/state/client_options.dart
@@ -12,7 +12,7 @@
 // consolidation. Two fields already have a home and are intentionally NOT
 // duplicated here — read/write them through their existing owners:
 ///
-///  * `liveWallSub`     -> `StreamPrefsStore.wallUsesSub` (lib/state/stream_prefs.dart)
+///  * `liveWallSub`     -> `StreamPrefsStore.wallDefaultQuality` (lib/state/stream_prefs.dart)
 ///  * `launchFullscreen` -> `LaunchFullscreenPrefs` (lib/ui/fullscreen/launch_fullscreen_prefs.dart)
 //
 // Everything else the old Options dialog exposed lives here: showInfoBar,

--- a/apps/desktop-flutter/lib/state/stream_prefs.dart
+++ b/apps/desktop-flutter/lib/state/stream_prefs.dart
@@ -15,10 +15,45 @@ import 'dart:convert';
 import 'package:crumb_desktop/api/models.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-enum StreamQuality { main, sub }
+/// Live-stream quality tier for a pane. `main` = full-res, `sub` = the
+/// low-bandwidth sub stream, `dataSaver` = the on-demand low-bitrate
+/// `<name>_mobile` go2rtc transcode ([StreamUrls.rtspMobile]).
+enum StreamQuality { main, sub, dataSaver }
+
+/// Wire form persisted to SharedPreferences / the overrides blob. `dataSaver`
+/// serializes as `'mobile'` (it plays the `_mobile` stream). Kept as a plain
+/// switch (not a const map) to sidestep Dart const-map pitfalls.
+String _qualityToWire(StreamQuality q) {
+  switch (q) {
+    case StreamQuality.main:
+      return 'main';
+    case StreamQuality.sub:
+      return 'sub';
+    case StreamQuality.dataSaver:
+      return 'mobile';
+  }
+}
+
+/// Parse a persisted quality tier; unknown/legacy values return null so the
+/// caller can fall back (to main, the safe full-quality default).
+StreamQuality? _qualityFromWire(String? s) {
+  switch (s) {
+    case 'main':
+      return StreamQuality.main;
+    case 'sub':
+      return StreamQuality.sub;
+    case 'mobile':
+      return StreamQuality.dataSaver;
+    default:
+      return null;
+  }
+}
 
 const String _kStreamPrefKey = 'crumb_stream_pref';
+// Legacy bool key ("wall uses sub") — read once on load and migrated into the
+// string quality key below, then never written again.
 const String _kWallDefaultSubKey = 'crumb_live_wall_sub';
+const String _kWallDefaultQualityKey = 'crumb_live_wall_quality';
 const String _kPtzDisabledKey = 'crumb_ptz_disabled';
 
 /// Holds per-camera stream-quality overrides and the wall-wide default
@@ -29,13 +64,13 @@ const String _kPtzDisabledKey = 'crumb_ptz_disabled';
 class StreamPrefsStore {
   StreamPrefsStore._(
     this._prefs,
-    this._wallDefaultSub,
+    this._wallDefault,
     this._overrides,
     this._ptzDisabled,
   );
 
   final SharedPreferences? _prefs;
-  bool _wallDefaultSub;
+  StreamQuality _wallDefault;
   final Map<String, StreamQuality> _overrides;
 
   /// Camera ids the operator has hidden PTZ controls for (per-camera, client
@@ -54,18 +89,27 @@ class StreamPrefsStore {
     } catch (_) {
       prefs = null; // package not wired up yet — fall back to in-memory only
     }
-    final wallSub = prefs?.getBool(_kWallDefaultSubKey) ?? true;
+    // Wall default: prefer the new string quality key; else migrate the legacy
+    // bool key ("wall uses sub": true→sub) so existing installs keep their
+    // choice; else the historical default (sub, bandwidth-friendly).
+    StreamQuality wallDefault;
+    final rawQ = prefs?.getString(_kWallDefaultQualityKey);
+    if (rawQ != null) {
+      wallDefault = _qualityFromWire(rawQ) ?? StreamQuality.sub;
+    } else {
+      final legacySub = prefs?.getBool(_kWallDefaultSubKey);
+      wallDefault = (legacySub ?? true)
+          ? StreamQuality.sub
+          : StreamQuality.main;
+    }
     final overrides = <String, StreamQuality>{};
     final raw = prefs?.getString(_kStreamPrefKey);
     if (raw != null) {
       try {
         final j = jsonDecode(raw) as Map<String, dynamic>;
         for (final entry in j.entries) {
-          if (entry.value == 'sub') {
-            overrides[entry.key] = StreamQuality.sub;
-          } else if (entry.value == 'main') {
-            overrides[entry.key] = StreamQuality.main;
-          }
+          final q = _qualityFromWire(entry.value as String?);
+          if (q != null) overrides[entry.key] = q;
         }
       } catch (_) {
         /* corrupt/legacy value — start clean */
@@ -74,20 +118,21 @@ class StreamPrefsStore {
     final ptzDisabled = <String>{};
     final rawPtz = prefs?.getStringList(_kPtzDisabledKey);
     if (rawPtz != null) ptzDisabled.addAll(rawPtz);
-    return StreamPrefsStore._(prefs, wallSub, overrides, ptzDisabled);
+    return StreamPrefsStore._(prefs, wallDefault, overrides, ptzDisabled);
   }
 
-  /// The DEFAULT wall stream when a camera has no explicit override — sub
-  /// when "wall uses sub" is on (bandwidth-friendly default), else main.
-  StreamQuality get wallDefault =>
-      _wallDefaultSub ? StreamQuality.sub : StreamQuality.main;
+  /// The DEFAULT stream tier for a camera with no explicit override.
+  StreamQuality get wallDefault => _wallDefault;
 
-  set wallUsesSub(bool v) {
-    _wallDefaultSub = v;
-    unawaited(_prefs?.setBool(_kWallDefaultSubKey, v));
+  /// The wall-wide default tier (Main / Sub / Data saver). Persisted as a
+  /// string under [_kWallDefaultQualityKey]; the legacy bool key is left in
+  /// place but never written again.
+  StreamQuality get wallDefaultQuality => _wallDefault;
+
+  set wallDefaultQuality(StreamQuality q) {
+    _wallDefault = q;
+    unawaited(_prefs?.setString(_kWallDefaultQualityKey, _qualityToWire(q)));
   }
-
-  bool get wallUsesSub => _wallDefaultSub;
 
   /// The EFFECTIVE wall stream for a camera: explicit override, else the
   /// wall default. (app.js `getStreamPref`.)
@@ -133,31 +178,79 @@ class StreamPrefsStore {
   Future<void> _persistOverrides() async {
     if (_prefs == null) return;
     final j = {
-      for (final e in _overrides.entries)
-        e.key: e.value == StreamQuality.sub ? 'sub' : 'main',
+      for (final e in _overrides.entries) e.key: _qualityToWire(e.value),
     };
     await _prefs.setString(_kStreamPrefKey, jsonEncode(j));
   }
 
-  /// The URL to actually play for a camera pane. `isMaximized` forces MAIN
+  /// The quality tier a pane will ACTUALLY play, given which URLs the server
+  /// returned — the effective choice, downgraded when its preferred stream is
+  /// missing (Data saver → sub → main; sub → main). `isMaximized` forces MAIN
   /// (full quality) unless this camera's main is known-dead this session, in
-  /// which case it falls back to sub rather than showing black.
-  /// (app.js `liveStreamUrl`.)
-  String? liveStreamUrl(
+  /// which case it downgrades to sub. [liveStreamUrl] is defined in terms of
+  /// this, so the tile badge never disagrees with the pixels on screen.
+  StreamQuality resolvedQuality(
     String cameraId,
     StreamUrls streams, {
     required bool isMaximized,
     bool maximizeUsesMain = true,
   }) {
     if (isMaximized && maximizeUsesMain) {
-      if (mainUnavailable.contains(cameraId)) {
-        return streams.rtspSub ?? streams.rtspMain;
+      if (mainUnavailable.contains(cameraId) && streams.rtspSub != null) {
+        return StreamQuality.sub;
       }
-      return streams.rtspMain ?? streams.rtspSub;
+      return streams.rtspMain != null
+          ? StreamQuality.main
+          : (streams.rtspSub != null ? StreamQuality.sub : StreamQuality.main);
     }
-    return effectiveFor(cameraId) == StreamQuality.sub
-        ? (streams.rtspSub ?? streams.rtspMain)
-        : (streams.rtspMain ?? streams.rtspSub);
+    switch (effectiveFor(cameraId)) {
+      case StreamQuality.dataSaver:
+        if (streams.rtspMobile != null) return StreamQuality.dataSaver;
+        if (streams.rtspSub != null) return StreamQuality.sub;
+        return StreamQuality.main;
+      case StreamQuality.sub:
+        return streams.rtspSub != null ? StreamQuality.sub : StreamQuality.main;
+      case StreamQuality.main:
+        return streams.rtspMain != null
+            ? StreamQuality.main
+            : (streams.rtspSub != null
+                  ? StreamQuality.sub
+                  : StreamQuality.main);
+    }
+  }
+
+  /// The URL for a given resolved tier, with a final safety fallback so a pane
+  /// never gets a null URL when any stream exists.
+  String? _urlForQuality(StreamQuality q, StreamUrls streams) {
+    switch (q) {
+      case StreamQuality.dataSaver:
+        return streams.rtspMobile ?? streams.rtspSub ?? streams.rtspMain;
+      case StreamQuality.sub:
+        return streams.rtspSub ?? streams.rtspMain ?? streams.rtspMobile;
+      case StreamQuality.main:
+        return streams.rtspMain ?? streams.rtspSub ?? streams.rtspMobile;
+    }
+  }
+
+  /// The URL to actually play for a camera pane. `isMaximized` forces MAIN
+  /// (full quality) unless this camera's main is known-dead this session, in
+  /// which case it falls back to sub rather than showing black. Data saver
+  /// falls back to sub → main when [StreamUrls.rtspMobile] is null (a
+  /// Frigate-served camera, or mobile streams disabled server-side).
+  /// (app.js `liveStreamUrl`, extended for the Data-saver tier.)
+  String? liveStreamUrl(
+    String cameraId,
+    StreamUrls streams, {
+    required bool isMaximized,
+    bool maximizeUsesMain = true,
+  }) {
+    final q = resolvedQuality(
+      cameraId,
+      streams,
+      isMaximized: isMaximized,
+      maximizeUsesMain: maximizeUsesMain,
+    );
+    return _urlForQuality(q, streams);
   }
 
   /// Record that maximizing this camera's main stream produced no frame, so

--- a/apps/desktop-flutter/lib/ui/client_options/client_options_screen.dart
+++ b/apps/desktop-flutter/lib/ui/client_options/client_options_screen.dart
@@ -11,8 +11,9 @@
 //     ptzStyle, ptzWheelCorner),
 //   * the already-ported [LaunchFullscreenOption] widget
 //     (lib/ui/fullscreen/launch_fullscreen_option.dart), and
-//   * the already-ported [StreamPrefsStore.wallUsesSub]
-//     (lib/state/stream_prefs.dart) for "wall tiles use sub streams".
+//   * the already-ported [StreamPrefsStore.wallDefaultQuality]
+//     (lib/state/stream_prefs.dart) for the default live-wall stream tier
+//     (Main / Sub / Data saver).
 //
 // NOTE (integration): give the caller access to the SAME `StreamPrefsStore`
 // instance the live wall uses (so toggling "wall uses sub streams" here takes
@@ -75,10 +76,11 @@ class _ClientOptionsScreenState extends State<ClientOptionsScreen> {
       setState(() => _o.zoomSwitchesToMain = v);
   void _setOpenClipsInHd(bool v) => setState(() => _o.openClipsInHd = v);
 
-  bool get _wallUsesSub => widget.streamPrefs?.wallUsesSub ?? true;
-  void _setWallUsesSub(bool v) {
+  StreamQuality get _wallDefaultQuality =>
+      widget.streamPrefs?.wallDefaultQuality ?? StreamQuality.sub;
+  void _setWallDefaultQuality(StreamQuality q) {
     setState(() {
-      if (widget.streamPrefs != null) widget.streamPrefs!.wallUsesSub = v;
+      widget.streamPrefs?.wallDefaultQuality = q;
     });
   }
 
@@ -161,13 +163,56 @@ class _ClientOptionsScreenState extends State<ClientOptionsScreen> {
             title: 'Show "All Cameras" quick view',
             subtitle: 'Auto-build a grid of every camera as a selectable view.',
           ),
-          _switchRow(
-            value: _wallUsesSub,
-            onChanged: widget.streamPrefs == null ? null : _setWallUsesSub,
-            title: 'Wall tiles use sub streams',
-            subtitle: widget.streamPrefs == null
-                ? 'Unavailable — no stream preference store wired up for this screen.'
-                : 'Lower-bandwidth stream for the grid; maximizing a tile can still switch to main below.',
+          const Padding(
+            padding: EdgeInsets.fromLTRB(16, 6, 16, 2),
+            child: Text(
+              'Default live-wall stream quality',
+              style: TextStyle(fontSize: 13, fontWeight: FontWeight.w500),
+            ),
+          ),
+          if (widget.streamPrefs == null)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 6),
+              child: Text(
+                'Unavailable — no stream preference store wired up for this screen.',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          RadioListTile<StreamQuality>(
+            value: StreamQuality.main,
+            groupValue: _wallDefaultQuality,
+            onChanged: widget.streamPrefs == null
+                ? null
+                : (v) => _setWallDefaultQuality(v!),
+            title: const Text('Main (full quality)'),
+            subtitle: const Text('Highest bandwidth.'),
+            dense: true,
+          ),
+          RadioListTile<StreamQuality>(
+            value: StreamQuality.sub,
+            groupValue: _wallDefaultQuality,
+            onChanged: widget.streamPrefs == null
+                ? null
+                : (v) => _setWallDefaultQuality(v!),
+            title: const Text('Sub (lower bandwidth)'),
+            subtitle: const Text("Camera's built-in low-res stream."),
+            dense: true,
+          ),
+          RadioListTile<StreamQuality>(
+            value: StreamQuality.dataSaver,
+            groupValue: _wallDefaultQuality,
+            onChanged: widget.streamPrefs == null
+                ? null
+                : (v) => _setWallDefaultQuality(v!),
+            title: const Text('Data saver (low-res transcode)'),
+            subtitle: const Text(
+              'On-demand low-bitrate stream; falls back to sub when a '
+              'camera has none.',
+            ),
+            dense: true,
           ),
           if (widget.streamPrefs != null)
             Padding(

--- a/apps/desktop-flutter/lib/ui/live_status/live_status_badges.dart
+++ b/apps/desktop-flutter/lib/ui/live_status/live_status_badges.dart
@@ -77,11 +77,16 @@ class TileInfoBar extends StatelessWidget {
     required this.recording,
     required this.recentMotion,
     required this.detectionKeys,
+    this.dataSaver = false,
     this.height = 18,
   });
 
   /// Camera display name.
   final String name;
+
+  /// The pane is playing the Data-saver (low-res `_mobile` transcode) tier —
+  /// show a small "SD" chip so the active stream tier is visible on the strip.
+  final bool dataSaver;
 
   /// First frame decoded and no error — drives the green "live" dot. When
   /// false (and not [hasError]) the dot is amber ("connecting").
@@ -131,6 +136,28 @@ class TileInfoBar extends StatelessWidget {
               ),
             ),
           ),
+          // Data-saver ("SD") chip, just after the name — marks the tile as on
+          // the low-res transcode tier.
+          if (dataSaver) ...[
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
+              decoration: BoxDecoration(
+                color: Colors.amber.shade600.withValues(alpha: 0.9),
+                borderRadius: BorderRadius.circular(3),
+              ),
+              child: const Text(
+                'SD',
+                style: TextStyle(
+                  color: Colors.black,
+                  fontSize: 8.5,
+                  fontWeight: FontWeight.w800,
+                  height: 1.0,
+                  letterSpacing: 0.5,
+                ),
+              ),
+            ),
+            const SizedBox(width: 5),
+          ],
           // Indicators (right-aligned): specific detection glyphs take
           // precedence over the generic motion runner, then the REC dot —
           // same precedence as LiveStatusBadgeRow.

--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -633,6 +633,37 @@ class _WallScreenState extends State<WallScreen> {
   }
 }
 
+/// Compact "SD" chip marking a pane that is playing the Data-saver (low-res
+/// `_mobile` transcode) tier — so it's visible at a glance which tiles are on
+/// the bandwidth-saving stream. Amber (the app's "warn" accent) on black text.
+class _SdBadge extends StatelessWidget {
+  const _SdBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: 'Data saver (low-res)',
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+        decoration: BoxDecoration(
+          color: Colors.amber.shade600.withValues(alpha: 0.9),
+          borderRadius: BorderRadius.circular(4),
+        ),
+        child: const Text(
+          'SD',
+          style: TextStyle(
+            color: Colors.black,
+            fontSize: 9,
+            fontWeight: FontWeight.w800,
+            height: 1.0,
+            letterSpacing: 0.5,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 /// Placeholder for a view slot with no camera assigned.
 class _EmptySlot extends StatelessWidget {
   const _EmptySlot();
@@ -705,6 +736,24 @@ class _WallTileState extends State<_WallTile> {
 
   String? _error;
   bool _firstFrame = false;
+
+  /// The last-fetched stream URLs for this camera. Retained so the per-tile
+  /// menu can gate the Data-saver option on `rtspMobile` availability, and the
+  /// tile badge can show which tier is actually playing.
+  StreamUrls? _streams;
+
+  /// The quality tier this pane is currently resolved to play (mirrors the URL
+  /// [StreamPrefsStore.liveStreamUrl] picked), for the tile's "SD" badge. Null
+  /// until the first stream fetch completes.
+  StreamQuality? get _activeQuality {
+    final s = _streams;
+    if (s == null) return null;
+    return widget.streamPrefs?.resolvedQuality(
+      widget.camera.id,
+      s,
+      isMaximized: _zoomedToMain,
+    );
+  }
 
   /// Per-pane stall watchdog: polls the ACTIVE player's frame/position
   /// progress and, on a confirmed freeze (camera reboot, go2rtc restart, PoE
@@ -783,8 +832,9 @@ class _WallTileState extends State<_WallTile> {
         widget.session,
         widget.camera.id,
       );
-      // Per-camera main/sub override (right-click menu) wins over the wall
-      // default; falls back to the plain wall preference if no prefs store.
+      _streams = streams; // gate the Data-saver menu item + drive the SD badge
+      // Per-camera main/sub/data-saver override (right-click menu) wins over
+      // the wall default; falls back to the plain wall preference if no store.
       final url =
           widget.streamPrefs?.liveStreamUrl(
             widget.camera.id,
@@ -918,6 +968,7 @@ class _WallTileState extends State<_WallTile> {
         widget.session,
         widget.camera.id,
       );
+      _streams = streams;
       final url =
           widget.streamPrefs?.liveStreamUrl(
             widget.camera.id,
@@ -1008,6 +1059,15 @@ class _WallTileState extends State<_WallTile> {
           checked: eff == StreamQuality.sub,
           child: const Text('Sub stream'),
         ),
+        // Data-saver (low-res `_mobile` transcode). Greyed out when this camera
+        // has no mobile URL (Frigate-served, or mobile streams disabled
+        // server-side) so it can never be picked into a dead/black pane.
+        CheckedPopupMenuItem(
+          value: 'data-saver',
+          checked: eff == StreamQuality.dataSaver,
+          enabled: _streams?.rtspMobile != null,
+          child: const Text('Data saver (low-res)'),
+        ),
         if (prefs?.hasOverride(widget.camera.id) ?? false)
           const PopupMenuItem(
             value: 'reset',
@@ -1030,6 +1090,9 @@ class _WallTileState extends State<_WallTile> {
         await _reloadStream();
       case 'sub':
         prefs?.setOverride(widget.camera.id, StreamQuality.sub);
+        await _reloadStream();
+      case 'data-saver':
+        prefs?.setOverride(widget.camera.id, StreamQuality.dataSaver);
         await _reloadStream();
       case 'reset':
         prefs?.setOverride(widget.camera.id, null);
@@ -1109,6 +1172,7 @@ class _WallTileState extends State<_WallTile> {
           recording: status?.recording ?? false,
           recentMotion: status?.recentMotion ?? false,
           detectionKeys: widget.liveStatus.detectionKeysFor(widget.camera.id),
+          dataSaver: _activeQuality == StreamQuality.dataSaver,
         );
       },
     );
@@ -1236,6 +1300,10 @@ class _WallTileState extends State<_WallTile> {
                               fontSize: 12,
                             ),
                           ),
+                          if (_activeQuality == StreamQuality.dataSaver) ...[
+                            const SizedBox(width: 6),
+                            const _SdBadge(),
+                          ],
                           if (_reconnecting) ...[
                             const SizedBox(width: 6),
                             const Text(


### PR DESCRIPTION
## Summary

Adds a third live-stream quality tier to the **desktop Flutter client** — **Data saver** — alongside the existing **Main** and **Sub**. Data saver plays the server's on-demand low-bitrate `<name>_mobile` go2rtc transcode. **Client-only change**: the server already exposes `rtsp_mobile_url` and spins the `_mobile` stream up on demand; nothing in go2rtc/reconcile/recorder is touched.

## What changed

- **`api/models.dart`** — `StreamUrls` now parses `rtsp_mobile_url` into `rtspMobile` (nullable; absent for Frigate-served cameras or when mobile streams are disabled server-side).
- **`state/stream_prefs.dart`** — `StreamQuality` gains `dataSaver`.
  - Per-camera overrides round-trip `mobile` ↔ `dataSaver` (back-compat: unknown/missing → main).
  - The wall default now holds a `StreamQuality` (Main/Sub/Data saver) via a clean `wallDefaultQuality` getter/setter, persisted as a string under a new key. The legacy `crumb_live_wall_sub` bool is migrated on load (`true` → sub) and never written again.
  - New `resolvedQuality()` computes the tier a pane will actually play and is the single source both `liveStreamUrl()` and the tile badge use — so the badge never disagrees with the pixels. Data saver **gracefully falls back sub → main** when `rtspMobile` is null, so a pane is never black. Maximize still forces Main exactly as before.
- **`ui/wall_screen.dart`** — the per-tile right-click menu gains a "Data saver (low-res)" checked item, **greyed out when the camera has no mobile URL**. Panes on the data-saver tier show a small amber **"SD"** badge (both the tile info bar and the floating name label).
- **`ui/client_options/client_options_screen.dart`** — the wall-default control changes from a bool switch to a 3-way **Main / Sub / Data saver** selector bound to `wallDefaultQuality`, matching the screen's existing radio-row idiom.
- **`ui/live_status/live_status_badges.dart`** — `TileInfoBar` gains an optional `dataSaver` flag that renders the "SD" chip.

## Null `rtspMobile` handling

Frigate-served cameras (and installs with mobile streams disabled) return a null mobile URL. In that case: the menu item is disabled so the tier can't be selected into a dead pane, and if a wall default of Data saver lands on such a camera, `resolvedQuality`/`liveStreamUrl` fall back sub → main. No black panes.

## Gate

- `flutter analyze lib\ui lib\state lib\api` — no new errors or warnings. Remaining items are all pre-existing `info`-level lints (initializing-formals, RadioListTile deprecation infos that already exist for this screen's PTZ radios, the known `unnecessary_import`).
- `flutter build windows --release` — succeeds (`Built ...crumb_desktop.exe`).

## Pending (not verifiable here)

On-hardware confirmation that the `_mobile` transcode actually plays in a pane is the maintainer's step.