### PR TITLE
feat(android): Live top-bar declutter + snapshot button + system share sheet (Fixes #161 #163 #164)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/clips/ClipsScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/clips/ClipsScreen.kt
@@ -444,10 +444,10 @@ private fun ClipPlayerDialog(
         val bmp = (playerView?.videoSurfaceView as? TextureView)?.takeIf { it.isAvailable }?.bitmap
         if (bmp != null) {
             scope.launch {
-                val path = saveFrameToGallery(context, bmp, clip.cameraName.ifBlank { "clip" })
+                val saved = saveFrameToGallery(context, bmp, clip.cameraName.ifBlank { "clip" })
                 Toast.makeText(
                     context,
-                    if (path != null) "Snapshot saved to $path" else "Snapshot failed",
+                    if (saved != null) "Snapshot saved to ${saved.displayPath}" else "Snapshot failed",
                     Toast.LENGTH_SHORT,
                 ).show()
             }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportScreen.kt
@@ -41,15 +41,16 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -103,13 +104,6 @@ fun ExportScreen(onBack: () -> Unit) {
     )
     val state by vm.state.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
-
-    // Show transient download confirmation in a snackbar.
-    LaunchedEffect(state.downloadMsg) {
-        val msg = state.downloadMsg ?: return@LaunchedEffect
-        snackbarHostState.showSnackbar(msg)
-        vm.clearDownloadMsg()
-    }
 
     Scaffold(
         snackbarHost = {
@@ -203,7 +197,6 @@ fun ExportScreen(onBack: () -> Unit) {
                     polling = state.polling,
                     job = job,
                     jobError = jobError,
-                    onDownloadSaved = vm::onDownloadSaved,
                     snackbarHostState = snackbarHostState,
                 )
             }
@@ -492,7 +485,6 @@ private fun JobStatusSection(
     polling: Boolean,
     job: ExportJob?,
     jobError: String?,
-    onDownloadSaved: (String) -> Unit,
     snackbarHostState: SnackbarHostState,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -556,7 +548,6 @@ private fun JobStatusSection(
                 OutputFileRow(
                     container = container,
                     outputFile = outputFile,
-                    onDownloadSaved = onDownloadSaved,
                     snackbarHostState = snackbarHostState,
                 )
             }
@@ -583,17 +574,17 @@ private fun jobStatusLabel(job: ExportJob?): String = when {
  * They differ in destination (#134):
  * - **Download** streams to the device's **public Downloads** collection via
  *   [saveExportToDownloads] (MediaStore on API 29+, the public Downloads dir on
- *   ≤ 28) so the file is user-findable and not silently purged, then reports the
- *   real saved location via [onDownloadSaved].
+ *   ≤ 28) so the file is user-findable and not silently purged, then shows a
+ *   "Saved to …" confirmation with an actionable **Share** action (#164).
  * - **Share** downloads to app-private cache ([downloadExportFileToCache]) and
  *   hands the receiving app a scoped `content://` [FileProvider] Uri (read-only,
- *   this file only) — a transient copy is the right lifetime for a share.
+ *   this file only) — a transient copy is the right lifetime for a share. The
+ *   Download confirmation's Share action reuses this same stage-then-share path.
  */
 @Composable
 private fun OutputFileRow(
     container: AppContainer,
     outputFile: ExportOutputFile,
-    onDownloadSaved: (String) -> Unit,
     snackbarHostState: SnackbarHostState,
 ) {
     val context = LocalContext.current
@@ -636,12 +627,33 @@ private fun OutputFileRow(
                         if (busy) return@FilledTonalButton
                         busy = true
                         scope.launch {
-                            saveExportToDownloads(context, container, outputFile)
-                                .onSuccess { location -> onDownloadSaved(location) }
+                            val result = saveExportToDownloads(context, container, outputFile)
+                            busy = false
+                            result
+                                .onSuccess { location ->
+                                    // #164: the "Saved to …" confirmation is now
+                                    // actionable — a "Share" action opens the system
+                                    // share sheet. The public-Downloads copy isn't a
+                                    // FileProvider path, so Share re-stages the file in
+                                    // app cache (downloadExportFileToCache) and shares
+                                    // that scoped content:// Uri (the proven path the
+                                    // dedicated Share button already uses).
+                                    val res = snackbarHostState.showSnackbar(
+                                        message = "Saved to $location",
+                                        actionLabel = "Share",
+                                        duration = SnackbarDuration.Long,
+                                    )
+                                    if (res == SnackbarResult.ActionPerformed) {
+                                        downloadExportFileToCache(context, container, outputFile)
+                                            .onSuccess { file -> shareLocalFile(context, file) }
+                                            .onFailure { e ->
+                                                snackbarHostState.showSnackbar("Share failed: ${e.message}")
+                                            }
+                                    }
+                                }
                                 .onFailure { e ->
                                     snackbarHostState.showSnackbar("Download failed: ${e.message}")
                                 }
-                            busy = false
                         }
                     },
                     enabled = !busy,

--- a/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportViewModel.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportViewModel.kt
@@ -33,8 +33,6 @@ import java.time.Instant
  * @property job The most recent [ExportJob] returned by the server (null until created).
  * @property jobError Human-readable error string when the job itself fails.
  * @property polling True while we are actively polling exportStatus.
- * @property downloadMsg Transient confirmation shown after an export file is saved
- *   to the device's public Downloads (reports the real saved location).
  */
 data class ExportUiState(
     val loadingCameras: Boolean = true,
@@ -47,7 +45,6 @@ data class ExportUiState(
     val job: ExportJob? = null,
     val jobError: String? = null,
     val polling: Boolean = false,
-    val downloadMsg: String? = null,
 )
 
 /**
@@ -133,7 +130,7 @@ class ExportViewModel(private val repo: CrumbRepository) : ViewModel() {
 
         viewModelScope.launch {
             // Reset any previous job state before submitting.
-            _state.update { it.copy(job = null, jobError = null, polling = false, downloadMsg = null) }
+            _state.update { it.copy(job = null, jobError = null, polling = false) }
 
             repo.createExport(
                 cameraIds = s.selectedCameraIds.toList(),
@@ -181,25 +178,6 @@ class ExportViewModel(private val repo: CrumbRepository) : ViewModel() {
                         }
                     }
             }
-        }
-    }
-
-    // ─── download / share helpers ───────────────────────────────────────────
-
-    /** Acknowledge the transient download confirmation banner. */
-    fun clearDownloadMsg() {
-        _state.update { it.copy(downloadMsg = null) }
-    }
-
-    /**
-     * Called by the UI after an export file has been written to the device's
-     * public Downloads collection. [location] is the user-visible saved path
-     * (e.g. `Downloads/CrumbVMS/crumb-export-…​.mp4`) so the confirmation reflects
-     * where the file actually landed rather than an app-private cache dir.
-     */
-    fun onDownloadSaved(location: String) {
-        _state.update {
-            it.copy(downloadMsg = "Saved to $location")
         }
     }
 

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddAPhoto
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Fullscreen
 import androidx.compose.material.icons.filled.FullscreenExit
@@ -33,6 +34,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -61,9 +67,19 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import android.graphics.drawable.BitmapDrawable
+import coil.imageLoader
+import coil.request.CachePolicy
+import coil.request.ImageRequest
+import coil.request.SuccessResult
+import video.crumb.app.data.CameraDto
 import video.crumb.app.data.CameraView
+import video.crumb.app.data.MediaUrls
 import video.crumb.app.di.appContainer
 import video.crumb.app.feature.about.AboutDialog
+import video.crumb.app.feature.playback.SavedSnapshot
+import video.crumb.app.feature.playback.saveFrameToGallery
+import video.crumb.app.feature.playback.shareImageUri
 import video.crumb.app.feature.settings.SettingsDialog
 import video.crumb.app.feature.update.UpdateAvailableBanner
 import video.crumb.app.feature.update.UpdateViewModel
@@ -72,7 +88,6 @@ import video.crumb.app.ui.CrumbModeTabs
 import video.crumb.app.ui.GridLayoutToggle
 import video.crumb.app.ui.HintTooltip
 import video.crumb.app.ui.ImmersiveMode
-import video.crumb.app.ui.InlineDivider
 import video.crumb.app.ui.KeepScreenOn
 import video.crumb.app.ui.ViewChipsRow
 import video.crumb.app.ui.WallGridLayout
@@ -140,6 +155,14 @@ fun LiveScreen(
     var showSettings by remember { mutableStateOf(false) }
     var showViewsManager by remember { mutableStateOf(false) }
     var wallFullscreen by remember { mutableStateOf(false) }
+    // Snapshot (#163): when more than one camera is shown, tapping the snapshot
+    // action opens this menu to pick WHICH camera's live frame to grab.
+    var snapshotMenuOpen by remember { mutableStateOf(false) }
+    // Actionable "Snapshot saved to …" / "Saved to …" confirmations (#164 offers a
+    // Share action on them). Activity context (not applicationContext) so the share
+    // chooser launches without needing FLAG_ACTIVITY_NEW_TASK.
+    val snackbarHostState = remember { SnackbarHostState() }
+    val activityContext = LocalContext.current
     // Local saved views (named camera subsets) — phone-only, see SecureStore.
     var views by remember { mutableStateOf(store.cameraViews) }
     var activeViewId by remember { mutableStateOf(store.activeViewId) }
@@ -267,51 +290,53 @@ fun LiveScreen(
     // Low-bw mode: read from the VM state (which is seeded from SecureStore on init).
     val lowBandwidthMode = state.lowBandwidthMode
 
+    // Snapshot (#163): grab a camera's current live frame → device gallery, then a
+    // Share-able confirmation (#164). The wall tiles render on a SurfaceView (no
+    // readable pixel buffer), so rather than a surface grab we fetch the camera's
+    // server still (`/cameras/{id}/frame.jpg`, the same proxied frame the wall's
+    // placeholder/low-bw tiles use) — a full-resolution current frame, decoded via
+    // Coil and saved through the shared [saveFrameToGallery] path.
+    fun takeSnapshot(cam: CameraDto) {
+        viewScope.launch {
+            val saved = captureCameraSnapshot(activityContext, mediaUrls, cam.id, cam.name)
+            if (saved != null) {
+                val res = snackbarHostState.showSnackbar(
+                    message = "Snapshot saved to ${saved.displayPath}",
+                    actionLabel = "Share",
+                    duration = SnackbarDuration.Long,
+                )
+                if (res == SnackbarResult.ActionPerformed) {
+                    shareImageUri(activityContext, saved.shareUri)
+                }
+            } else {
+                snackbarHostState.showSnackbar("Snapshot failed — frame unavailable")
+            }
+        }
+    }
+
     Scaffold(
+        snackbarHost = {
+            SnackbarHost(hostState = snackbarHostState) { data -> Snackbar(snackbarData = data) }
+        },
         topBar = {
             if (!wallFullscreen) {
                 TopAppBar(
                     title = {
-                        // Live | Playback tabs. In LANDSCAPE the saved-view chips ride
-                        // inline to their right (separated by a rule; overflow scrolls
-                        // sideways) to save scarce vertical space; in PORTRAIT they're a
-                        // separate strip below (rendered in the body).
-                        if (isLandscape && views.isNotEmpty()) {
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                modifier = Modifier.fillMaxWidth(),
-                            ) {
-                                CrumbModeTabs(
-                                    selected = CrumbMode.LIVE,
-                                    onLive = {},
-                                    onPlayback = onOpenPlaybackMode,
-                                    onClips = onOpenClips,
-                                    onPlates = onOpenPlates,
-                                    showPlayback = caps.playback || store.isAdmin,
-                                    showClips = caps.clips || store.isAdmin,
-                                    showPlates = store.platesEnabled,
-                                )
-                                InlineDivider()
-                                ViewChipsRow(
-                                    views = views,
-                                    activeViewId = activeViewId,
-                                    onSelect = { setActive(it) },
-                                    modifier = Modifier.weight(1f),
-                                    showAllCamerasView = showAllCamerasView,
-                                )
-                            }
-                        } else {
-                            CrumbModeTabs(
-                                selected = CrumbMode.LIVE,
-                                onLive = {},
-                                onPlayback = onOpenPlaybackMode,
-                                onClips = onOpenClips,
-                                onPlates = onOpenPlates,
-                                showPlayback = caps.playback || store.isAdmin,
-                                showClips = caps.clips || store.isAdmin,
-                                showPlates = store.platesEnabled,
-                            )
-                        }
+                        // Live | Playback | Clips | LPR tabs. The grid/snapshot/
+                        // fullscreen actions used to share this row and squeezed the
+                        // tabs (#161); they now live on the second bar (the view-chips
+                        // row, in the body) so the tabs get the full title width and
+                        // keep their own horizontal scroll.
+                        CrumbModeTabs(
+                            selected = CrumbMode.LIVE,
+                            onLive = {},
+                            onPlayback = onOpenPlaybackMode,
+                            onClips = onOpenClips,
+                            onPlates = onOpenPlates,
+                            showPlayback = caps.playback || store.isAdmin,
+                            showClips = caps.clips || store.isAdmin,
+                            showPlates = store.platesEnabled,
+                        )
                     },
                     colors = TopAppBarDefaults.topAppBarColors(
                         containerColor = NavyDeep,
@@ -319,27 +344,9 @@ fun LiveScreen(
                         actionIconContentColor = MaterialTheme.colorScheme.onSurface,
                     ),
                     actions = {
-                        // Low-bandwidth mode now lives in Settings (overflow → Settings),
-                        // not as an app-bar icon. The auto-fallback banner (below the
-                        // tabs) still offers one-tap restore when it engages on its own.
-
-                        // Grid-density picker (shared control + value with Playback).
-                        GridLayoutToggle(layout, maxCols) { next ->
-                            layout = next
-                            store.liveGridLayout = next.ordinal
-                        }
-
-                        // Export lives under Playback now (not on the Live wall).
-
-                        // Wall fullscreen toggle.
-                        HintTooltip("Fullscreen wall") {
-                            IconButton(onClick = { wallFullscreen = true }) {
-                                Icon(
-                                    imageVector = Icons.Default.Fullscreen,
-                                    contentDescription = "Fullscreen",
-                                )
-                            }
-                        }
+                        // Low-bandwidth mode lives in Settings (overflow → Settings).
+                        // The grid-density, snapshot, and fullscreen actions moved to the
+                        // second bar (#161); only the overflow ⋮ stays in the app bar.
 
                         // Overflow menu (Settings / About / Logout).
                         Box {
@@ -420,18 +427,78 @@ fun LiveScreen(
                     )
                 }
 
-                // Saved-view chips strip (PORTRAIT only; landscape shows them inline in
-                // the title). Hidden in fullscreen kiosk mode. Tap to switch; persists.
-                if (!isLandscape && !wallFullscreen && views.isNotEmpty()) {
-                    ViewChipsRow(
-                        views = views,
-                        activeViewId = activeViewId,
-                        onSelect = { setActive(it) },
+                // ── Second bar (#161): saved-view chips + relocated actions ────────
+                // The grid-density, snapshot (#163), and fullscreen actions were moved
+                // off the top tab row to here so the tabs get more room. The chips take
+                // the remaining width and scroll horizontally (so a growing view list +
+                // the fixed action icons never run out of room); the icons stay pinned
+                // to the end. Hidden in fullscreen kiosk mode.
+                if (!wallFullscreen) {
+                    Row(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 8.dp, vertical = 2.dp),
-                        showAllCamerasView = showAllCamerasView,
-                    )
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        ViewChipsRow(
+                            views = views,
+                            activeViewId = activeViewId,
+                            onSelect = { setActive(it) },
+                            modifier = Modifier.weight(1f),
+                            showAllCamerasView = showAllCamerasView,
+                        )
+
+                        // Grid-density picker (shared control + value with Playback).
+                        GridLayoutToggle(layout, maxCols) { next ->
+                            layout = next
+                            store.liveGridLayout = next.ordinal
+                        }
+
+                        // Take snapshot (#163). One shown camera → grab it directly;
+                        // several → a small menu to pick which camera's frame to grab.
+                        Box {
+                            HintTooltip("Take snapshot") {
+                                IconButton(onClick = {
+                                    when (shownCameras.size) {
+                                        0 -> viewScope.launch {
+                                            snackbarHostState.showSnackbar("No camera to snapshot")
+                                        }
+                                        1 -> takeSnapshot(shownCameras.first())
+                                        else -> snapshotMenuOpen = true
+                                    }
+                                }) {
+                                    Icon(
+                                        imageVector = Icons.Default.AddAPhoto,
+                                        contentDescription = "Take snapshot",
+                                    )
+                                }
+                            }
+                            DropdownMenu(
+                                expanded = snapshotMenuOpen,
+                                onDismissRequest = { snapshotMenuOpen = false },
+                            ) {
+                                shownCameras.forEach { cam ->
+                                    DropdownMenuItem(
+                                        text = { Text(cam.name) },
+                                        onClick = {
+                                            snapshotMenuOpen = false
+                                            takeSnapshot(cam)
+                                        },
+                                    )
+                                }
+                            }
+                        }
+
+                        // Wall fullscreen toggle.
+                        HintTooltip("Fullscreen wall") {
+                            IconButton(onClick = { wallFullscreen = true }) {
+                                Icon(
+                                    imageVector = Icons.Default.Fullscreen,
+                                    contentDescription = "Fullscreen",
+                                )
+                            }
+                        }
+                    }
                 }
 
                 Box(modifier = Modifier.fillMaxSize()) {
@@ -660,6 +727,40 @@ fun LiveScreen(
             onDismiss = { editorTarget = null },
         )
     }
+}
+
+// ─── live snapshot capture ───────────────────────────────────────────────────
+
+/**
+ * Fetch a camera's current server still frame (`GET /cameras/{id}/frame.jpg`,
+ * scoped-token authed via [MediaUrls]) and save it to the device gallery.
+ *
+ * The live wall renders tiles on a Media3 SurfaceView, whose pixel buffer can't
+ * be read back for an on-screen grab, so instead of a surface capture we pull the
+ * same API-proxied still the wall already uses for its placeholder / low-bandwidth
+ * tiles — a full-resolution current frame that works regardless of which go2rtc
+ * owns the camera. Decoded with Coil (hardware bitmaps disabled so it can be
+ * JPEG-compressed) and written through the shared [saveFrameToGallery] path.
+ *
+ * Returns the [SavedSnapshot] (location + share Uri) or null on any failure.
+ */
+private suspend fun captureCameraSnapshot(
+    context: android.content.Context,
+    mediaUrls: MediaUrls,
+    cameraId: String,
+    cameraName: String,
+): SavedSnapshot? {
+    val url = runCatching { mediaUrls.cameraFrameUrl(cameraId) }.getOrNull() ?: return null
+    val req = ImageRequest.Builder(context)
+        .data(url)
+        .memoryCachePolicy(CachePolicy.DISABLED)
+        .diskCachePolicy(CachePolicy.DISABLED)
+        .allowHardware(false)
+        .build()
+    val result = context.imageLoader.execute(req)
+    if (result !is SuccessResult) return null
+    val bmp = (result.drawable as? BitmapDrawable)?.bitmap ?: return null
+    return saveFrameToGallery(context, bmp, cameraName)
 }
 
 // ─── low-bandwidth auto-fallback banner ──────────────────────────────────────

--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
@@ -48,8 +48,10 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -625,10 +627,19 @@ fun PlaybackScreen(
                 } else {
                     full
                 }
-                val path = saveFrameToGallery(context, bmp, state.cameraName ?: cameraId)
-                snackbarHostState.showSnackbar(
-                    if (path != null) "Snapshot saved to $path" else "Snapshot failed",
-                )
+                val saved = saveFrameToGallery(context, bmp, state.cameraName ?: cameraId)
+                if (saved != null) {
+                    val res = snackbarHostState.showSnackbar(
+                        message = "Snapshot saved to ${saved.displayPath}",
+                        actionLabel = "Share",
+                        duration = SnackbarDuration.Long,
+                    )
+                    if (res == SnackbarResult.ActionPerformed) {
+                        shareImageUri(context, saved.shareUri)
+                    }
+                } else {
+                    snackbarHostState.showSnackbar("Snapshot failed")
+                }
             } else {
                 snackbarHostState.showSnackbar("Snapshot unavailable — video not ready")
             }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/Snapshot.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/Snapshot.kt
@@ -4,23 +4,38 @@ package video.crumb.app.feature.playback
 
 import android.content.ContentValues
 import android.content.Context
+import android.content.Intent
 import android.graphics.Bitmap
+import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
+import androidx.core.content.FileProvider
 import java.io.File
 import java.io.FileOutputStream
 
 /**
+ * A saved snapshot: where it landed (human-readable, for the "Snapshot saved to …"
+ * confirmation) plus a scoped `content://` [Uri] that can be handed to the system
+ * share sheet ([shareImageUri]).
+ *
+ * - On API 29+ the [shareUri] is the MediaStore image entry itself (already a
+ *   shareable `content://media/…` Uri — no FileProvider needed).
+ * - On pre-Q it's a [FileProvider] Uri over the app-external Pictures file (the
+ *   provider path is declared in `res/xml/file_paths.xml`).
+ */
+data class SavedSnapshot(val displayPath: String, val shareUri: Uri)
+
+/**
  * Save a captured video frame to the device gallery under Pictures/Crumb/
- * (commercial-VMS-style "Snapshot saved to Pictures/…"). Returns a human-readable
- * location on success, or null on failure.
+ * (commercial-VMS-style "Snapshot saved to Pictures/…"). Returns a [SavedSnapshot]
+ * (location + shareable Uri) on success, or null on failure.
  *
  * - Q+ (API 29+): MediaStore with RELATIVE_PATH — lands in the gallery, no
  *   storage permission required.
  * - Pre-Q: the app's external Pictures dir (no permission; not gallery-indexed).
  */
-fun saveFrameToGallery(context: Context, bitmap: Bitmap, camName: String): String? {
+fun saveFrameToGallery(context: Context, bitmap: Bitmap, camName: String): SavedSnapshot? {
     val safeCam = camName.replace(Regex("[^A-Za-z0-9_-]"), "_").ifBlank { "camera" }
     val stamp = android.text.format.DateFormat.format("yyyyMMdd_HHmmss", System.currentTimeMillis())
     val fileName = "crumb_${safeCam}_$stamp.jpg"
@@ -37,16 +52,41 @@ fun saveFrameToGallery(context: Context, bitmap: Bitmap, camName: String): Strin
             context.contentResolver.openOutputStream(uri)?.use { out ->
                 bitmap.compress(Bitmap.CompressFormat.JPEG, 92, out)
             } ?: return null
-            "Pictures/Crumb/$fileName"
+            // The MediaStore entry is itself a shareable content:// Uri.
+            SavedSnapshot(displayPath = "Pictures/Crumb/$fileName", shareUri = uri)
         } else {
             val dir = File(context.getExternalFilesDir(Environment.DIRECTORY_PICTURES), "Crumb")
             dir.mkdirs()
             val f = File(dir, fileName)
             FileOutputStream(f).use { out -> bitmap.compress(Bitmap.CompressFormat.JPEG, 92, out) }
-            f.absolutePath
+            val shareUri = FileProvider.getUriForFile(
+                context, "${context.packageName}.fileprovider", f,
+            )
+            SavedSnapshot(displayPath = f.absolutePath, shareUri = shareUri)
         }
     } catch (e: Exception) {
         android.util.Log.w("Snapshot", "snapshot save failed", e)
         null
+    }
+}
+
+/**
+ * Open the Android system share sheet for a saved snapshot [uri] (a JPEG image).
+ * The receiving app is granted read access to this one item only
+ * ([Intent.FLAG_GRANT_READ_URI_PERMISSION]); no persistent permission is granted.
+ */
+fun shareImageUri(context: Context, uri: Uri) {
+    try {
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "image/jpeg"
+            putExtra(Intent.EXTRA_STREAM, uri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            putExtra(Intent.EXTRA_SUBJECT, "CrumbVMS Snapshot")
+        }
+        context.startActivity(Intent.createChooser(intent, "Share snapshot"))
+    } catch (e: android.content.ActivityNotFoundException) {
+        android.widget.Toast
+            .makeText(context, "No app available to share", android.widget.Toast.LENGTH_SHORT)
+            .show()
     }
 }

--- a/apps/android/app/src/main/res/xml/file_paths.xml
+++ b/apps/android/app/src/main/res/xml/file_paths.xml
@@ -15,4 +15,11 @@
         scoped content:// Uri (see PlatesPdf.kt). Same posture as the export path.
     -->
     <cache-path name="reports" path="reports/" />
+    <!--
+        Camera snapshots on pre-Q (API < 29): saved to the app-external Pictures
+        dir (getExternalFilesDir(PICTURES)/Crumb) and shared through the
+        FileProvider as a scoped content:// Uri (see Snapshot.kt). On Q+ the
+        MediaStore image entry is shared directly and this path is unused.
+    -->
+    <external-files-path name="snapshots" path="Pictures/" />
 </paths>


### PR DESCRIPTION
Three interlinked Live top-area features, done together as one cohesive change since they all touch the Live screen's top rows.

## #161 — Declutter the Live top bar
The grid-density and fullscreen actions used to share the top tab row with the `Live | Playback | Clips | LPR` tabs, squeezing them. They now move down to the **second bar** (the saved-view chips row); only the overflow `⋮` stays in the app bar.

- Top tab row keeps its horizontal scroll and gains the full title width.
- The second bar renders in **both** orientations now (it replaces the old portrait-only chips strip and the landscape-inline chips). The chips take the remaining width and **scroll horizontally**; the relocated action icons stay pinned to the end, so a growing view list + the icons never collide.

## #163 — "Take snapshot" button
An `AddAPhoto` button joins the relocated icons on the second bar.

**How the frame is captured:** the live wall tiles render on a Media3 **SurfaceView**, which has no readable pixel buffer for an on-screen grab. So rather than a surface capture, the snapshot fetches the camera's **server still frame** (`GET /cameras/{id}/frame.jpg` — the same scoped-token-authed, API-proxied, full-resolution frame the wall already uses for its placeholder / low-bandwidth tiles), decodes it via Coil, and saves through the shared `saveFrameToGallery` path to the device gallery. This works regardless of which go2rtc owns the camera and yields a higher-res frame than the sub-stream a tile shows.

- One shown camera → grabs it directly. Several → a small dropdown to pick which camera. Zero → a "No camera to snapshot" Snackbar.

## #164 — Open the system share sheet after a save
The "Saved to `<location>`" confirmation is now **actionable**.

- After a **snapshot** (Live and Playback) and after an **Export download**, the Snackbar gains a **"Share"** action that opens `Intent.ACTION_SEND` via `Intent.createChooser`, sharing the file as a scoped `content://` URI with `FLAG_GRANT_READ_URI_PERMISSION` (MIME `image/jpeg` for snapshots, `video/*` for exports).
- Snapshots share the **MediaStore image URI** directly on API 29+, or a **FileProvider** URI on pre-Q (new `external-files-path` in `file_paths.xml`).
- Export reuses the **existing** stage-to-cache + FileProvider `shareLocalFile` path (the dedicated Share button already used it).
- `saveFrameToGallery` now returns a `SavedSnapshot` (display path + share URI); the orphaned Export `downloadMsg` VM plumbing is removed.

## Gate
- `:app:compileDebugKotlin` → BUILD SUCCESSFUL
- `:app:assembleDebug` → BUILD SUCCESSFUL

(Only pre-existing warnings — Media3 `UnstableApi` opt-in, AutoMirrored icon deprecations — no new ones.)

## Pending manual verification (on-device)
The share sheet actually opening, and snapshot frame quality/latency, are the reviewer's on-device step.