### PR TITLE
feat(android): watchlist entry edit + fuzzy-match live preview (Fixes #139 #140)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/data/Models.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/Models.kt
@@ -636,11 +636,19 @@ data class ViewDto(
 )
 
 /** `POST /views` body. Cameras are encoded as bare-string slots `{"0": id, …}` so
- *  the `{slotIndex: cameraId}` contract shared with web/desktop stays clean. */
+ *  the `{slotIndex: cameraId}` contract shared with web/desktop stays clean.
+ *
+ *  [layout] deliberately has NO Kotlin default: kotlinx.serialization runs with
+ *  `encodeDefaults = false` (see [video.crumb.app.data.Network]), so any property
+ *  left at its declared default is dropped from the wire body. A `layout = "auto"`
+ *  default made `layout` vanish from `POST /views`, and the server's own
+ *  `CreateViewRequest.layout` has no serde default (it is required), so it rejected
+ *  the body with HTTP 422 — breaking every view save/reorder (#159). Keeping the
+ *  field default-less forces it onto the wire; callers pass "auto" explicitly. */
 @Serializable
 data class CreateViewRequest(
     val name: String,
-    val layout: String = "auto",
+    val layout: String,
     val slots: JsonObject,
 )
 

--- a/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesPdf.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesPdf.kt
@@ -556,18 +556,22 @@ fun matchWatchlistBolo(
     return best
 }
 
-/** Uppercase ASCII-alphanumeric normalization — identical to the server's `normalize_plate`. */
-private fun normalizePlate(s: String): String =
+/** Uppercase ASCII-alphanumeric normalization — identical to the server's `normalize_plate`.
+ *  `internal` so the watchlist fuzziness preview ([acceptedMisreadExamples]) reuses the
+ *  exact same normalization the server matcher uses, keeping the preview truthful. */
+internal fun normalizePlate(s: String): String =
     buildString {
         for (c in s) if (c in '0'..'9' || c in 'a'..'z' || c in 'A'..'Z') append(c.uppercaseChar())
     }
 
-/** Edit budget `floor(fuzz.clamp(0,0.5) · len(reference))` — matches the server. */
-private fun allowedEdits(reference: String, fuzz: Float): Int =
+/** Edit budget `floor(fuzz.clamp(0,0.5) · len(reference))` — matches the server
+ *  (`allowed_edits` in `services/common/src/db.rs`). [reference] must already be
+ *  normalized. `internal` so the fuzziness-preview slider shares this exact rule. */
+internal fun allowedEdits(reference: String, fuzz: Float): Int =
     (fuzz.coerceIn(0f, 0.5f) * reference.length).toInt()
 
 /** Classic two-row Levenshtein edit distance (plates are short). */
-private fun levenshtein(a: String, b: String): Int {
+internal fun levenshtein(a: String, b: String): Int {
     if (a.isEmpty()) return b.length
     if (b.isEmpty()) return a.length
     var prev = IntArray(b.length + 1) { it }
@@ -581,6 +585,67 @@ private fun levenshtein(a: String, b: String): Int {
         val tmp = prev; prev = curr; curr = tmp
     }
     return prev[b.length]
+}
+
+// ─── fuzzy-match preview model (mirrors the desktop + admin console) ──────────
+//
+// The watchlist match tolerance is *character edit distance* — a read matches an
+// entry when `levenshtein(normalize(read), normalize(entry)) <= allowedEdits`. To
+// make the admin fuzziness slider mean something concrete, the preview generates a
+// few plausible OCR misreads of the plate being typed that the CURRENT tolerance
+// would still accept — each verified by the very same edit-distance rule the
+// server uses, so the preview never over-promises. Ported verbatim from the
+// desktop Dart (`plates_screen.dart`) and the admin console JS (`admin.html`).
+
+/** Common ALPR character confusions (the pairs Frigate's OCR most often swaps). */
+internal val OCR_CONFUSIONS: Map<Char, Char> = mapOf(
+    '0' to 'O', 'O' to '0', '1' to 'I', 'I' to '1', 'L' to '1', '2' to 'Z', 'Z' to '2',
+    '5' to 'S', 'S' to '5', '8' to 'B', 'B' to '8', '6' to 'G', 'G' to '6', '4' to 'A',
+    'A' to '4', 'D' to '0', 'Q' to 'O', '7' to 'T',
+)
+
+/**
+ * A few realistic misreads of [plate] that the server WOULD accept at the given
+ * [allowed] tolerance — one/two OCR-confusion substitutions, each verified by the
+ * same edit-distance rule the server uses. Returns an empty list when tolerance is
+ * 0 (exact only) or the plate normalizes to empty. Mirrors the desktop's
+ * `_acceptedMisreadExamples`.
+ */
+internal fun acceptedMisreadExamples(plate: String, allowed: Int): List<String> {
+    val norm = normalizePlate(plate)
+    if (norm.isEmpty() || allowed <= 0) return emptyList()
+    val out = mutableListOf<String>()
+    // Distance-1 variants first: swap one confusable character.
+    var i = 0
+    while (i < norm.length && out.size < 4) {
+        val rep = OCR_CONFUSIONS[norm[i]]
+        if (rep != null) {
+            val cand = norm.substring(0, i) + rep + norm.substring(i + 1)
+            if (cand != norm && cand !in out && levenshtein(cand, norm) <= allowed) out.add(cand)
+        }
+        i++
+    }
+    // If two edits are allowed, add a couple of double-swaps to show the range.
+    if (allowed >= 2) {
+        i = 0
+        while (i < norm.length && out.size < 4) {
+            val r1 = OCR_CONFUSIONS[norm[i]]
+            if (r1 != null) {
+                var j = i + 1
+                while (j < norm.length && out.size < 4) {
+                    val r2 = OCR_CONFUSIONS[norm[j]]
+                    if (r2 != null) {
+                        val cand = norm.substring(0, i) + r1 +
+                            norm.substring(i + 1, j) + r2 + norm.substring(j + 1)
+                        if (cand != norm && cand !in out && levenshtein(cand, norm) <= allowed) out.add(cand)
+                    }
+                    j++
+                }
+            }
+            i++
+        }
+    }
+    return out
 }
 
 // ─── share ──────────────────────────────────────────────────────────────────

--- a/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesScreen.kt
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+@file:OptIn(
+    androidx.compose.material3.ExperimentalMaterial3Api::class,
+    androidx.compose.foundation.layout.ExperimentalLayoutApi::class,
+)
 
 package video.crumb.app.feature.plates
 
@@ -11,6 +14,7 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -36,6 +40,7 @@ import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.CreditCard
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Event
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
@@ -85,7 +90,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -1113,6 +1122,9 @@ private fun WatchlistDialog(
     var notify by remember { mutableStateOf(true) }
     // "watch" (alert on a sighting) vs "ignore" (suppress matching reads).
     var kind by remember { mutableStateOf(WATCHLIST_KIND_WATCH) }
+    // The entry an admin tapped to edit (kind/label/notify), or null. Opens a
+    // small chooser layered over this dialog; saving upserts via [onAdd] (#139).
+    var editingEntry by remember { mutableStateOf<PlateWatchlistEntry?>(null) }
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text("Plate watchlist") },
@@ -1122,6 +1134,7 @@ private fun WatchlistDialog(
                 if (isAdmin && state.lprConfig != null) {
                     FuzzinessSlider(
                         fuzz = state.lprConfig.watchlistFuzz,
+                        plate = plate,
                         onFuzzChange = onFuzzChange,
                     )
                     HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
@@ -1234,6 +1247,7 @@ private fun WatchlistDialog(
                                 WatchlistRow(
                                     entry = entry,
                                     isAdmin = isAdmin,
+                                    onEdit = { editingEntry = entry },
                                     onRemove = { onRemove(entry.id) },
                                 )
                             }
@@ -1243,6 +1257,106 @@ private fun WatchlistDialog(
         },
         confirmButton = { TextButton(onClick = onDismiss) { Text("Done") } },
     )
+
+    // Layered edit chooser for an existing entry (admin tap on a row / its edit
+    // icon). Saving upserts through the same [onAdd] path, keyed on the normalized
+    // plate server-side, so it replaces the entry rather than duplicating it (#139).
+    editingEntry?.let { entry ->
+        EditWatchlistEntryDialog(
+            entry = entry,
+            onSave = { newLabel, newNotify, newKind ->
+                onAdd(entry.plate, newLabel, newNotify, newKind)
+                editingEntry = null
+            },
+            onDismiss = { editingEntry = null },
+        )
+    }
+}
+
+/**
+ * Edit an existing watchlist entry (#139): change its kind (watch/ignore), label,
+ * and notify flag. The plate itself is the entry's normalized key and is shown
+ * read-only; saving re-POSTs to `/lpr/watchlist`, which upserts on that key, so an
+ * edit replaces the entry in place. Mirrors the desktop client's shared
+ * Watch/Ignore chooser (`showWatchlistDialog` in `plates_screen.dart`).
+ */
+@Composable
+private fun EditWatchlistEntryDialog(
+    entry: PlateWatchlistEntry,
+    onSave: (label: String, notify: Boolean, kind: String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var label by remember { mutableStateOf(entry.label ?: "") }
+    var notify by remember { mutableStateOf(entry.notify) }
+    var kind by remember {
+        mutableStateOf(if (entry.isIgnore) WATCHLIST_KIND_IGNORE else WATCHLIST_KIND_WATCH)
+    }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Edit watchlist entry") },
+        text = {
+            Column {
+                Text(
+                    text = entry.plate.ifEmpty { "—" },
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = FontFamily.Monospace,
+                    style = MaterialTheme.typography.titleLarge,
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    FilterChip(
+                        selected = kind == WATCHLIST_KIND_WATCH,
+                        onClick = { kind = WATCHLIST_KIND_WATCH },
+                        leadingIcon = { Icon(Icons.Filled.Star, contentDescription = null, modifier = Modifier.size(16.dp)) },
+                        label = { Text("Watch") },
+                    )
+                    FilterChip(
+                        selected = kind == WATCHLIST_KIND_IGNORE,
+                        onClick = { kind = WATCHLIST_KIND_IGNORE },
+                        leadingIcon = { Icon(Icons.Filled.Block, contentDescription = null, modifier = Modifier.size(16.dp)) },
+                        label = { Text("Ignore") },
+                    )
+                }
+                TextField(
+                    value = label,
+                    onValueChange = { label = it },
+                    placeholder = { Text("Label (optional)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                )
+                // "Notify on sighting" only applies to Watch entries.
+                if (kind == WATCHLIST_KIND_WATCH) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            "Notify on sighting",
+                            color = MaterialTheme.colorScheme.onSurface,
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        Spacer(Modifier.weight(1f))
+                        Switch(checked = notify, onCheckedChange = { notify = it })
+                    }
+                } else {
+                    Text(
+                        "Ignored plates are dropped on capture — never stored or alerted.",
+                        color = TextSecondary,
+                        style = MaterialTheme.typography.labelSmall,
+                        modifier = Modifier.padding(top = 6.dp),
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onSave(label, notify, kind) }) { Text("Save") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
 }
 
 /**
@@ -1250,14 +1364,31 @@ private fun WatchlistDialog(
  * `watchlist_fuzz` config value to a 0–50% control; commits on release via
  * [onFuzzChange] (a `PUT /config/lpr` that preserves enabled + retention). Seeds
  * its position from [fuzz] but tracks the drag locally so the thumb is smooth.
+ *
+ * As the slider moves (or the [plate] in the add field changes) it previews, live,
+ * a few OCR misreads the current tolerance would still accept — computed by the
+ * exact same normalize + Levenshtein + `floor(fuzz·len)` rule the server matches
+ * on ([acceptedMisreadExamples]), so the preview is truthful. Matches the desktop
+ * client and the admin console. When the add field is empty it illustrates on a
+ * sample plate and invites the operator to type one to preview theirs (#140).
  */
 @Composable
 private fun FuzzinessSlider(
     fuzz: Float,
+    plate: String,
     onFuzzChange: (Float) -> Unit,
 ) {
     // Local drag position, re-seeded whenever the persisted config value changes.
     var pos by remember(fuzz) { mutableFloatStateOf(fuzz.coerceIn(0f, 0.5f)) }
+    val accent = TealAccent
+    val faint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+
+    val typed = normalizePlate(plate)
+    val usingSample = typed.isEmpty()
+    val basis = if (usingSample) "7ABC123" else typed
+    val allowed = allowedEdits(basis, pos)
+    val examples = acceptedMisreadExamples(basis, allowed)
+
     Column(Modifier.fillMaxWidth()) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
@@ -1267,9 +1398,14 @@ private fun FuzzinessSlider(
             )
             Spacer(Modifier.weight(1f))
             Text(
-                "${(pos * 100).roundToInt()}%",
-                color = TextSecondary,
+                if (allowed == 0) {
+                    "Exact"
+                } else {
+                    "${(pos * 100).roundToInt()}% · up to $allowed char${if (allowed == 1) "" else "s"}"
+                },
+                color = if (allowed == 0) TextSecondary else accent,
                 style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.SemiBold,
             )
         }
         Slider(
@@ -1278,10 +1414,64 @@ private fun FuzzinessSlider(
             valueRange = 0f..0.5f,
             onValueChangeFinished = { onFuzzChange(pos) },
         )
+        if (allowed == 0) {
+            Text(
+                "Exact match only. A single misread character will not match.",
+                color = TextSecondary,
+                style = MaterialTheme.typography.labelSmall,
+            )
+        } else {
+            Text(
+                if (usingSample) {
+                    "Tolerates up to $allowed misread character${if (allowed == 1) "" else "s"}. " +
+                        "Example on a sample plate — type a plate above to preview yours:"
+                } else {
+                    "Tolerates up to $allowed misread character${if (allowed == 1) "" else "s"} on this plate. " +
+                        "Would still match:"
+                },
+                color = TextSecondary,
+                style = MaterialTheme.typography.labelSmall,
+            )
+            if (examples.isNotEmpty()) {
+                FlowRow(
+                    modifier = Modifier.fillMaxWidth().padding(top = 6.dp),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    examples.forEach { MisreadChip(basis = basis, candidate = it, accent = accent, base = faint) }
+                }
+            }
+        }
+    }
+}
+
+/** A pill showing an accepted misread [candidate], with the character(s) that
+ *  differ from [basis] highlighted in the [accent] colour (the rest in [base]). */
+@Composable
+private fun MisreadChip(basis: String, candidate: String, accent: Color, base: Color) {
+    val text = buildAnnotatedString {
+        for (i in candidate.indices) {
+            val changed = i >= basis.length || candidate[i] != basis[i]
+            withStyle(
+                SpanStyle(
+                    color = if (changed) accent else base,
+                    fontWeight = if (changed) FontWeight.ExtraBold else FontWeight.Medium,
+                ),
+            ) {
+                append(candidate[i])
+            }
+        }
+    }
+    Box(
+        modifier = Modifier
+            .background(MaterialTheme.colorScheme.surface, RoundedCornerShape(4.dp))
+            .border(1.dp, MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(4.dp))
+            .padding(horizontal = 7.dp, vertical = 3.dp),
+    ) {
         Text(
-            "0% matches plates exactly; higher tolerates OCR misreads.",
-            color = TextSecondary,
-            style = MaterialTheme.typography.labelSmall,
+            text = text,
+            fontFamily = FontFamily.Monospace,
+            style = MaterialTheme.typography.labelMedium,
         )
     }
 }
@@ -1290,10 +1480,16 @@ private fun FuzzinessSlider(
 private fun WatchlistRow(
     entry: PlateWatchlistEntry,
     isAdmin: Boolean,
+    onEdit: () -> Unit,
     onRemove: () -> Unit,
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            // Admins can tap the row to edit it (parity with the desktop client);
+            // viewers see it read-only.
+            .then(if (isAdmin) Modifier.clickable(onClick = onEdit) else Modifier)
+            .padding(vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
@@ -1347,6 +1543,13 @@ private fun WatchlistRow(
             )
         }
         if (isAdmin) {
+            IconButton(onClick = onEdit) {
+                Icon(
+                    Icons.Filled.Edit,
+                    contentDescription = "Edit watchlist entry",
+                    tint = TextSecondary,
+                )
+            }
             IconButton(onClick = onRemove) {
                 Icon(
                     Icons.Filled.Delete,

--- a/apps/android/app/src/test/java/video/crumb/app/data/CreateViewRequestSerializationTest.kt
+++ b/apps/android/app/src/test/java/video/crumb/app/data/CreateViewRequestSerializationTest.kt
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.data
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression guard for #159 ("Couldn't save view: Server error (422)").
+ *
+ * Retrofit serializes request bodies with `encodeDefaults = false` (see
+ * [video.crumb.app.data.Network]). With that setting, a property left at its
+ * declared Kotlin default is dropped from the wire JSON. [CreateViewRequest.layout]
+ * previously carried a `= "auto"` default, so it never reached the server — whose
+ * own `CreateViewRequest.layout` is a required field (no serde default) — and the
+ * body was rejected with HTTP 422. Removing the Kotlin default forces `layout`
+ * onto the wire; this test fails if it ever creeps back.
+ */
+class CreateViewRequestSerializationTest {
+
+    // Mirror the production encoder's relevant setting exactly.
+    private val json = Json { encodeDefaults = false; explicitNulls = false }
+
+    @Test
+    fun `POST views body always includes layout`() {
+        val body = CameraView(id = "", name = "Perimeter", cameraIds = listOf("cam-a", "cam-b"))
+            .toCreateRequest()
+        val encoded = json.encodeToString(CreateViewRequest.serializer(), body)
+
+        assertTrue(
+            "layout must be present on the wire — the server requires it (#159): $encoded",
+            encoded.contains("\"layout\""),
+        )
+        assertTrue("name must be present: $encoded", encoded.contains("\"name\""))
+        assertTrue("slots must be present: $encoded", encoded.contains("\"slots\""))
+    }
+}


### PR DESCRIPTION
Three Android LPR/watchlist items. Two are watchlist features that ship together; the third is a distinct view-save bug diagnosed to an Android-vs-server contract mismatch and fixed at the root cause (its own commit).

## #139 — edit an existing watch/ignore entry
The Android watchlist previously only supported add/remove. Now an admin can tap a watchlist row (or its new edit icon) to open a chooser that changes the entry's kind (watch/ignore), label, and notify flag, saving through the existing upsert (`POST /lpr/watchlist` keys on the normalized plate, so it replaces the entry in place). Mirrors the desktop client's shared Watch/Ignore chooser.

## #140 — fuzzy-match live preview (desktop/admin parity)
The admin fuzziness slider now previews, live, a few OCR misreads the current tolerance would still accept for the plate being typed (a sample plate when the add field is empty), with the changed characters highlighted, updating as the slider moves or the plate text changes. Ported verbatim from the desktop Dart and the admin console: the OCR-confusion map plus an accepted-misread generator, each candidate verified by the exact same normalize + Levenshtein + `floor(fuzz*len)` rule the server matches on. It reuses the server-parity helpers already present in `PlatesPdf.kt`, so the preview matches the server and never over-promises.

## #159 — "Couldn't save view: Server error (422)" (BUG, separate commit)
**Root cause:** Retrofit serializes request bodies with `encodeDefaults = false`, which drops any property left at its declared Kotlin default. Android's `CreateViewRequest.layout` carried a `= "auto"` default, so `layout` was omitted from the `POST /views` body. The server's `CreateViewRequest.layout` is a required field (no serde default), so it rejected the body with 422. The desktop client always sends `layout` explicitly, which is why desktop save/reorder worked.

**Diff of the wire body (edit/reorder → delete + create):**
- Android sent: `{"name":"…","slots":{…}}` (no `layout`)
- Server requires: `name`, `layout`, `slots` — missing `layout` → 422

**Fix (Android, root cause):** drop the Kotlin default from `CreateViewRequest.layout` so kotlinx.serialization always emits it (callers already pass `"auto"`). Added a JVM unit test that serializes the body and asserts `layout` is present, guarding the regression.

Fixes #139
Fixes #140
Fixes #159

## Verification
- `:app:compileDebugKotlin` — BUILD SUCCESSFUL
- `:app:assembleDebug` — BUILD SUCCESSFUL
- `:app:testDebugUnitTest` (CreateViewRequestSerializationTest) — BUILD SUCCESSFUL

On-device behavior (tap-to-edit, live preview chips, view save/reorder against a live server) is the maintainer's step.