### PR TITLE
HA on-video overlay backend — placement + /ha/states [P0]

### DIFF
--- a/db/migrations/0058_ha_overlay_placement.sql
+++ b/db/migrations/0058_ha_overlay_placement.sql
@@ -1,0 +1,26 @@
+-- HA on-video overlay (desktop first, issue #170): a linked entity may be
+-- pinned to a normalized position on the camera's DISPLAYED VIDEO FRAME so a
+-- badge (door/motion/light...) can sit over the thing it represents. NULL = the
+-- link is not placed (no badge drawn). Coordinates are fractions of the video
+-- frame, not the pane, so a badge stays on the door as the tile aspect changes.
+--
+-- Additive to migration 0048's camera_ha_links; placement is optional and a
+-- link with no placement behaves exactly as before. overlay_size is a scale
+-- multiplier on the base badge size (1.0 = default), mirroring the PTZ panel's
+-- base-size x pane-scale model.
+
+ALTER TABLE camera_ha_links
+    ADD COLUMN IF NOT EXISTS overlay_x    double precision,
+    ADD COLUMN IF NOT EXISTS overlay_y    double precision,
+    ADD COLUMN IF NOT EXISTS overlay_size real;
+
+-- x and y are set together or not at all (a half-placed badge is meaningless),
+-- and both live in [0,1] (fractions of the video frame). size is left
+-- unconstrained beyond NULL-vs-set; the API clamps it to a sane range.
+ALTER TABLE camera_ha_links
+    ADD CONSTRAINT camera_ha_links_overlay_xy_paired
+        CHECK ((overlay_x IS NULL) = (overlay_y IS NULL)),
+    ADD CONSTRAINT camera_ha_links_overlay_range
+        CHECK (overlay_x IS NULL
+               OR (overlay_x >= 0 AND overlay_x <= 1
+                   AND overlay_y >= 0 AND overlay_y <= 1));

--- a/services/api/src/ha.rs
+++ b/services/api/src/ha.rs
@@ -9,9 +9,12 @@
 //! Config + links edits are admin-only; reading a camera's links needs only
 //! access to that camera.
 
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
 use axum::{
     extract::{Path, Query, State},
-    routing::{get, post},
+    routing::{get, post, put},
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
@@ -21,17 +24,30 @@ use uuid::Uuid;
 use crate::{
     auth_mw::{AdminUser, AuthUser},
     error::ApiError,
-    state::AppState,
+    state::{AppState, HaStatesCache},
 };
 use crumb_common::db;
 use crumb_common::types::HaSettings;
+
+/// TTL for the on-demand `GET /ha/states` cache. Clients poll on the live-status
+/// 3s tick, so Crumb→HA is at most one `/api/states` request per this window
+/// while at least one wall with placements is open (0 otherwise).
+const HA_STATES_TTL: Duration = Duration::from_secs(2);
+/// How long a last-known snapshot may keep being served (marked `stale`) after
+/// HA starts failing, before `GET /ha/states` gives up with a 502.
+const HA_STATES_STALE_MAX: Duration = Duration::from_secs(30);
 
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/config/ha", get(get_config).put(put_config))
         .route("/config/ha/test", post(test_config))
         .route("/ha/entities", get(get_entities))
+        .route("/ha/states", get(get_states))
         .route("/cameras/:id/ha/links", get(get_links).put(put_links))
+        .route(
+            "/cameras/:id/ha/links/:link_id/placement",
+            put(put_placement),
+        )
 }
 
 // ─── HTTP: shared client + picker filter ──────────────────────────────────────
@@ -139,6 +155,13 @@ struct HaLinkDto {
     device_class: Option<String>,
     label: Option<String>,
     sort_order: i32,
+    /// On-video overlay placement (issue #170): normalized x/y as a fraction of
+    /// the displayed video frame, or `null` when the link is not placed. Set
+    /// together with `overlay_y`.
+    overlay_x: Option<f64>,
+    overlay_y: Option<f64>,
+    /// Badge scale multiplier (1.0 = default) when placed, else `null`.
+    overlay_size: Option<f32>,
 }
 
 impl From<crumb_common::types::CameraHaLink> for HaLinkDto {
@@ -150,8 +173,47 @@ impl From<crumb_common::types::CameraHaLink> for HaLinkDto {
             device_class: l.device_class,
             label: l.label,
             sort_order: l.sort_order,
+            overlay_x: l.overlay_x,
+            overlay_y: l.overlay_y,
+            overlay_size: l.overlay_size,
         }
     }
+}
+
+/// Body of `PUT /cameras/:id/ha/links/:link_id/placement`. A literal `null`
+/// clears the placement; an object pins the badge at `(x, y)` on the video frame
+/// with an optional size multiplier.
+#[derive(Deserialize)]
+struct PlacementInput {
+    x: f64,
+    y: f64,
+    #[serde(default = "default_overlay_size")]
+    size: f32,
+}
+
+fn default_overlay_size() -> f32 {
+    1.0
+}
+
+/// One entity's current state in the `GET /ha/states` feed.
+#[derive(Serialize)]
+struct HaEntityState {
+    entity_id: String,
+    state: String,
+    /// HA `last_changed` (RFC3339), passed through verbatim for "N ago" display.
+    last_changed: Option<String>,
+}
+
+/// `GET /ha/states` response: the caller-visible entity states plus cache age so
+/// the client can show a "stale" treatment without guessing.
+#[derive(Serialize)]
+struct HaStatesResponse {
+    /// Age of the served snapshot in milliseconds.
+    fetched_at_ms_ago: u64,
+    /// True when HA is currently unreachable and this is a last-known snapshot;
+    /// clients grey the badges and never read a stale value as authoritative.
+    stale: bool,
+    states: Vec<HaEntityState>,
 }
 
 #[derive(Deserialize)]
@@ -276,6 +338,142 @@ async fn put_links(
     Ok(Json(links.into_iter().map(HaLinkDto::from).collect()))
 }
 
+/// `PUT /cameras/:id/ha/links/:link_id/placement` — admin. Pin (or, with a
+/// `null` body, clear) a linked entity's on-video badge. Coordinates are clamped
+/// to the video frame `[0,1]`; size to a sane range. Returns the updated link,
+/// 404 if no such link exists on that camera.
+async fn put_placement(
+    _admin: AdminUser,
+    State(state): State<AppState>,
+    Path((camera_id, link_id)): Path<(Uuid, Uuid)>,
+    Json(body): Json<Option<PlacementInput>>,
+) -> Result<Json<HaLinkDto>, ApiError> {
+    let placement = match body {
+        None => None,
+        Some(p) => {
+            if !p.x.is_finite() || !p.y.is_finite() || !p.size.is_finite() {
+                return Err(ApiError::BadRequest(
+                    "placement x/y/size must be finite numbers".to_owned(),
+                ));
+            }
+            Some((
+                p.x.clamp(0.0, 1.0),
+                p.y.clamp(0.0, 1.0),
+                p.size.clamp(0.1, 8.0),
+            ))
+        }
+    };
+    let link = db::update_ha_link_placement(state.pool(), camera_id, link_id, placement)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or_else(|| ApiError::NotFound("no HA link with that id on this camera".to_owned()))?;
+    Ok(Json(link.into()))
+}
+
+/// `GET /ha/states` — any authenticated user. Current state of every HA entity
+/// linked to a camera the caller can access, from the demand-driven cache. A
+/// viewer sees only entities linked to cameras in their grant. Never fabricates
+/// state: HA unreachable ⇒ last-known snapshot marked `stale`, or a 502 once the
+/// snapshot ages past [`HA_STATES_STALE_MAX`].
+async fn get_states(
+    user: AuthUser,
+    State(state): State<AppState>,
+) -> Result<Json<HaStatesResponse>, ApiError> {
+    let s = effective_settings(&state).await?;
+    if !s.enabled {
+        return Err(ApiError::BadRequest(
+            "Home Assistant is not enabled".to_owned(),
+        ));
+    }
+    let client = ha_client(&s)?;
+
+    // Refresh-or-serve under the single-flight lock: concurrent callers on a
+    // stale cache collapse to one HA request.
+    let (states, age, is_stale) = {
+        let mut guard = state.ha_states_cache().lock().await;
+        let fresh = guard
+            .as_ref()
+            .is_some_and(|c| c.fetched_at.elapsed() < HA_STATES_TTL);
+        if fresh {
+            let c = guard.as_ref().expect("fresh implies a present cache");
+            (Arc::clone(&c.states), c.fetched_at.elapsed(), false)
+        } else {
+            match client.get_states().await {
+                Ok(v) => {
+                    let states = Arc::new(v);
+                    *guard = Some(HaStatesCache {
+                        fetched_at: Instant::now(),
+                        states: Arc::clone(&states),
+                    });
+                    (states, Duration::ZERO, false)
+                }
+                // HA is down: serve last-known while it's recent (clients grey
+                // it); give up once it ages out rather than lie about state.
+                Err(e) => match guard.as_ref() {
+                    Some(c) if c.fetched_at.elapsed() < HA_STATES_STALE_MAX => {
+                        (Arc::clone(&c.states), c.fetched_at.elapsed(), true)
+                    }
+                    _ => {
+                        return Err(ApiError::BadGateway(format!(
+                            "Home Assistant unreachable: {e}"
+                        )))
+                    }
+                },
+            }
+        }
+    };
+
+    // RBAC: project the snapshot down to entities linked to caller-visible
+    // cameras (admins see all). A viewer never learns about entities linked only
+    // to cameras outside their grant.
+    let cam_filter = if user.is_admin() {
+        None
+    } else {
+        Some(user.camera_ids.clone())
+    };
+    let linked = db::list_ha_linked_entities(state.pool(), cam_filter.as_deref())
+        .await
+        .map_err(ApiError::Internal)?;
+    let wanted: std::collections::HashSet<&str> = linked.iter().map(String::as_str).collect();
+
+    Ok(Json(HaStatesResponse {
+        fetched_at_ms_ago: u64::try_from(age.as_millis()).unwrap_or(u64::MAX),
+        stale: is_stale,
+        states: project_states(&states, &wanted),
+    }))
+}
+
+/// Project a raw HA `/api/states` array down to the `wanted` entity ids, keeping
+/// each entity's `state` and `last_changed`. Pure (no HA/DB), so the RBAC
+/// filtering it backs is unit-testable. Entities not in `wanted` are dropped —
+/// the caller passes only the entity ids linked to cameras it may access.
+fn project_states(
+    states: &[serde_json::Value],
+    wanted: &std::collections::HashSet<&str>,
+) -> Vec<HaEntityState> {
+    states
+        .iter()
+        .filter_map(|v| {
+            let eid = v.get("entity_id")?.as_str()?;
+            if !wanted.contains(eid) {
+                return None;
+            }
+            Some(HaEntityState {
+                entity_id: eid.to_owned(),
+                state: v
+                    .get("state")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("")
+                    .to_owned(),
+                last_changed: v
+                    .get("last_changed")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned),
+            })
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -314,5 +512,57 @@ mod tests {
         let controls = entities_from_states(arr, &["light", "switch", "scene"]);
         assert_eq!(controls.len(), 1);
         assert_eq!(controls[0].entity_id, "light.kitchen");
+    }
+
+    #[test]
+    fn project_states_keeps_only_wanted_with_state_and_last_changed() {
+        let states = json!([
+            {"entity_id": "binary_sensor.front_door", "state": "off",
+             "last_changed": "2026-07-14T18:22:04Z"},
+            {"entity_id": "light.kitchen", "state": "on"},
+            {"entity_id": "binary_sensor.garage", "state": "open",
+             "last_changed": "2026-07-14T10:00:00Z"}
+        ]);
+        let arr = states.as_array().unwrap();
+
+        // Caller can see only the front door + kitchen light; garage is linked
+        // to a camera outside their grant and must not leak.
+        let wanted: std::collections::HashSet<&str> = ["binary_sensor.front_door", "light.kitchen"]
+            .into_iter()
+            .collect();
+        let out = project_states(arr, &wanted);
+        let ids: Vec<&str> = out.iter().map(|e| e.entity_id.as_str()).collect();
+        assert_eq!(out.len(), 2);
+        assert!(ids.contains(&"binary_sensor.front_door"));
+        assert!(ids.contains(&"light.kitchen"));
+        assert!(!ids.contains(&"binary_sensor.garage"));
+
+        let door = out
+            .iter()
+            .find(|e| e.entity_id == "binary_sensor.front_door")
+            .unwrap();
+        assert_eq!(door.state, "off");
+        assert_eq!(door.last_changed.as_deref(), Some("2026-07-14T18:22:04Z"));
+        // last_changed is optional and absent here.
+        let light = out.iter().find(|e| e.entity_id == "light.kitchen").unwrap();
+        assert_eq!(light.state, "on");
+        assert_eq!(light.last_changed, None);
+
+        // Empty wanted set ⇒ nothing projected (a viewer with no linked cameras).
+        assert!(project_states(arr, &std::collections::HashSet::new()).is_empty());
+    }
+
+    #[test]
+    fn placement_input_clamps_and_defaults_size() {
+        // Out-of-range coordinates clamp into the video frame; missing size
+        // defaults to 1.0. (Mirrors the clamp the handler applies.)
+        let p: PlacementInput = serde_json::from_value(json!({"x": 1.4, "y": -0.2})).unwrap();
+        assert!((p.x.clamp(0.0, 1.0) - 1.0).abs() < f64::EPSILON);
+        assert!((p.y.clamp(0.0, 1.0) - 0.0).abs() < f64::EPSILON);
+        assert!((p.size - 1.0).abs() < f32::EPSILON);
+
+        // A null body deserializes to None (clears the placement).
+        let cleared: Option<PlacementInput> = serde_json::from_value(json!(null)).unwrap();
+        assert!(cleared.is_none());
     }
 }

--- a/services/api/src/state.rs
+++ b/services/api/src/state.rs
@@ -64,6 +64,20 @@ fn login_backoff_secs(failures: u32) -> Option<u64> {
     Some(secs.min(LOGIN_BACKOFF_CAP_SECS))
 }
 
+/// Cached Home Assistant `/api/states` snapshot backing `GET /ha/states`
+/// (issue #170). There is no standing poller: the handler refreshes on demand
+/// when this is older than the TTL, so a wall with no HA badges (or no client
+/// open) costs HA zero traffic. The `states` are the raw `/api/states` array
+/// (shared behind an `Arc` so a caller clones the handle, not the payload, out
+/// from under the lock); the per-caller RBAC projection happens after.
+#[derive(Clone)]
+pub struct HaStatesCache {
+    /// When this snapshot was fetched from HA (monotonic).
+    pub fetched_at: Instant,
+    /// Raw HA `/api/states` array.
+    pub states: Arc<Vec<serde_json::Value>>,
+}
+
 /// Per-username failed-login state for the brute-force backoff (issue #127).
 #[derive(Clone, Copy)]
 struct FailState {
@@ -169,6 +183,12 @@ struct Inner {
     /// state can never lock a legitimate user out. This is IN ADDITION to the
     /// shared per-IP request bucket, not a replacement.
     login_failures: DashMap<String, FailState>,
+
+    /// Demand-driven cache behind `GET /ha/states` (issue #170). `None` until
+    /// the first request. The `tokio::sync::Mutex` makes a refresh single-flight:
+    /// concurrent callers on a stale cache collapse to one HA `/api/states`
+    /// request (the others wait on the lock, then read the fresh snapshot).
+    ha_states: tokio::sync::Mutex<Option<HaStatesCache>>,
 }
 
 /// Cheaply-cloneable handle to shared API state.
@@ -227,7 +247,16 @@ impl AppState {
             revoked_jtis_loaded_at: AtomicI64::new(0),
             maintenance_until: Arc::new(AtomicI64::new(maintenance_until)),
             login_failures: DashMap::new(),
+            ha_states: tokio::sync::Mutex::new(None),
         }))
+    }
+
+    /// Borrow the demand-driven HA `/api/states` cache (issue #170). The
+    /// `GET /ha/states` handler locks it, refreshes on TTL expiry, and reads the
+    /// snapshot back out; the lock serializes refreshes into a single HA request.
+    #[inline]
+    pub fn ha_states_cache(&self) -> &tokio::sync::Mutex<Option<HaStatesCache>> {
+        &self.0.ha_states
     }
 
     /// Resolve a permission role by id, caching the result. Returns `None` if the

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -1614,6 +1614,9 @@ fn ha_link_from_row(row: &tokio_postgres::Row) -> CameraHaLink {
         device_class: row.get("device_class"),
         label: row.get("label"),
         sort_order: row.get("sort_order"),
+        overlay_x: row.get("overlay_x"),
+        overlay_y: row.get("overlay_y"),
+        overlay_size: row.get("overlay_size"),
     }
 }
 
@@ -1626,7 +1629,8 @@ pub async fn list_camera_ha_links(pool: &Pool, camera_id: Uuid) -> Result<Vec<Ca
     let client = get_conn(pool).await?;
     let rows = client
         .query(
-            "SELECT id, camera_id, entity_id, role, device_class, label, sort_order
+            "SELECT id, camera_id, entity_id, role, device_class, label, sort_order,
+                    overlay_x, overlay_y, overlay_size
              FROM camera_ha_links WHERE camera_id = $1
              ORDER BY sort_order, entity_id",
             &[&camera_id],
@@ -1651,7 +1655,8 @@ pub async fn get_camera_ha_links(
     let client = get_conn(pool).await?;
     let rows = client
         .query(
-            "SELECT id, camera_id, entity_id, role, device_class, label, sort_order
+            "SELECT id, camera_id, entity_id, role, device_class, label, sort_order,
+                    overlay_x, overlay_y, overlay_size
              FROM camera_ha_links WHERE camera_id = $1 AND role = $2
              ORDER BY sort_order, entity_id",
             &[&camera_id, &role],
@@ -1668,6 +1673,11 @@ pub type HaLinkInsert = (String, String, Option<String>, Option<String>, i32);
 /// Replace the full set of a camera's HA links (delete-then-insert in one
 /// transaction) and bump `ha_config.version` so consumers hot-reload.
 ///
+/// On-video overlay placements (migration 0058) are **carried over** by
+/// `(entity_id, role)`: re-saving the link list from the admin console must not
+/// wipe a badge an operator placed. A link that survives the re-save keeps its
+/// placement; a link that is removed loses it (there is nowhere to put it).
+///
 /// # Errors
 ///
 /// Returns an error if the transaction fails.
@@ -1681,6 +1691,31 @@ pub async fn replace_camera_ha_links(
         .transaction()
         .await
         .context("replace_camera_ha_links: begin")?;
+    // Snapshot existing placements before the delete so surviving links keep
+    // their on-video position. Keyed by (entity_id, role) — the table's natural
+    // identity for a link (see the UNIQUE(camera_id, entity_id, role)).
+    type Placement = (Option<f64>, Option<f64>, Option<f32>);
+    let mut placements: std::collections::HashMap<(String, String), Placement> =
+        std::collections::HashMap::new();
+    let old_rows = tx
+        .query(
+            "SELECT entity_id, role, overlay_x, overlay_y, overlay_size
+             FROM camera_ha_links WHERE camera_id = $1",
+            &[&camera_id],
+        )
+        .await
+        .context("replace_camera_ha_links: read placements")?;
+    for row in &old_rows {
+        let key: (String, String) = (row.get("entity_id"), row.get("role"));
+        placements.insert(
+            key,
+            (
+                row.get("overlay_x"),
+                row.get("overlay_y"),
+                row.get("overlay_size"),
+            ),
+        );
+    }
     tx.execute(
         "DELETE FROM camera_ha_links WHERE camera_id = $1",
         &[&camera_id],
@@ -1688,10 +1723,26 @@ pub async fn replace_camera_ha_links(
     .await
     .context("replace_camera_ha_links: delete")?;
     for (entity_id, role, device_class, label, sort_order) in links {
+        let (ox, oy, osize) = placements
+            .get(&(entity_id.clone(), role.clone()))
+            .copied()
+            .unwrap_or((None, None, None));
         tx.execute(
-            "INSERT INTO camera_ha_links (camera_id, entity_id, role, device_class, label, sort_order)
-             VALUES ($1, $2, $3, $4, $5, $6)",
-            &[&camera_id, entity_id, role, device_class, label, sort_order],
+            "INSERT INTO camera_ha_links
+                 (camera_id, entity_id, role, device_class, label, sort_order,
+                  overlay_x, overlay_y, overlay_size)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+            &[
+                &camera_id,
+                entity_id,
+                role,
+                device_class,
+                label,
+                sort_order,
+                &ox,
+                &oy,
+                &osize,
+            ],
         )
         .await
         .context("replace_camera_ha_links: insert")?;
@@ -1706,6 +1757,76 @@ pub async fn replace_camera_ha_links(
         .await
         .context("replace_camera_ha_links: commit")?;
     list_camera_ha_links(pool, camera_id).await
+}
+
+/// Set (or clear) one link's on-video overlay placement (migration 0058).
+///
+/// `placement = Some((x, y, size))` pins the badge; `None` clears it (badge
+/// removed). Scoped to `(link_id, camera_id)` so a caller can't move a link that
+/// belongs to another camera. Returns the updated link, or `None` if no link
+/// with that id exists on that camera (⇒ 404 at the API). Does **not** bump
+/// `ha_config.version`: a placement is a per-camera display tweak, and the
+/// recorder's motion loop (the version's main consumer) does not read overlay
+/// columns.
+///
+/// # Errors
+///
+/// Returns an error if the query fails.
+pub async fn update_ha_link_placement(
+    pool: &Pool,
+    camera_id: Uuid,
+    link_id: Uuid,
+    placement: Option<(f64, f64, f32)>,
+) -> Result<Option<CameraHaLink>> {
+    let (x, y, size) = match placement {
+        Some((x, y, s)) => (Some(x), Some(y), Some(s)),
+        None => (None, None, None),
+    };
+    let client = get_conn(pool).await?;
+    let row = client
+        .query_opt(
+            "UPDATE camera_ha_links
+                SET overlay_x = $3, overlay_y = $4, overlay_size = $5
+              WHERE id = $1 AND camera_id = $2
+          RETURNING id, camera_id, entity_id, role, device_class, label, sort_order,
+                    overlay_x, overlay_y, overlay_size",
+            &[&link_id, &camera_id, &x, &y, &size],
+        )
+        .await
+        .context("update_ha_link_placement")?;
+    Ok(row.as_ref().map(ha_link_from_row))
+}
+
+/// Distinct HA `entity_id`s linked to any of the given cameras (or all cameras
+/// when `camera_ids` is `None`, for an admin). Used by `GET /ha/states` to
+/// project the cached HA state array down to only the entities a caller may see
+/// — a viewer never learns about entities linked to cameras they can't access.
+///
+/// # Errors
+///
+/// Returns an error if the query fails.
+pub async fn list_ha_linked_entities(
+    pool: &Pool,
+    camera_ids: Option<&[Uuid]>,
+) -> Result<Vec<String>> {
+    let client = get_conn(pool).await?;
+    let rows = match camera_ids {
+        None => client
+            .query("SELECT DISTINCT entity_id FROM camera_ha_links", &[])
+            .await
+            .context("list_ha_linked_entities: all")?,
+        Some(ids) => client
+            .query(
+                "SELECT DISTINCT entity_id FROM camera_ha_links WHERE camera_id = ANY($1)",
+                &[&ids],
+            )
+            .await
+            .context("list_ha_linked_entities: scoped")?,
+    };
+    Ok(rows
+        .iter()
+        .map(|r| r.get::<_, String>("entity_id"))
+        .collect())
 }
 
 /// Repair a segment row's `size_bytes` to the actual on-disk byte length.
@@ -9165,6 +9286,10 @@ static MIGRATIONS: &[(&str, &str)] = &[
     (
         "0057_update_available_alert.sql",
         include_str!("../../../db/migrations/0057_update_available_alert.sql"),
+    ),
+    (
+        "0058_ha_overlay_placement.sql",
+        include_str!("../../../db/migrations/0058_ha_overlay_placement.sql"),
     ),
 ];
 

--- a/services/common/src/types.rs
+++ b/services/common/src/types.rs
@@ -208,6 +208,15 @@ pub struct CameraHaLink {
     pub label: Option<String>,
     /// Display order within the camera.
     pub sort_order: i32,
+    /// On-video overlay placement (migration 0058, issue #170): normalized x/y
+    /// as a fraction of the DISPLAYED VIDEO FRAME (not the pane), so a badge
+    /// stays on the physical thing it marks as the tile aspect changes. `None`
+    /// (both null) ⇒ the link is not placed and draws no badge. Set together.
+    pub overlay_x: Option<f64>,
+    pub overlay_y: Option<f64>,
+    /// Scale multiplier on the base badge size (1.0 = default). `None` when not
+    /// placed; the API clamps it to a sane range on write.
+    pub overlay_size: Option<f32>,
 }
 
 // ─── recording_policies ──────────────────────────────────────────────────────


### PR DESCRIPTION
Backend slice of the Home Assistant entity-on-video overlay POC (issue #170). A linked HA entity can be pinned to a normalized position on a camera's displayed video frame, and desktop clients read live entity state from a lean on-demand cache. No client changes here — the desktop overlay layer lands in a follow-up PR.

## What's in it
- **migration 0058** — `overlay_x/y/size` on `camera_ha_links` (fractions of the *video frame*, not the pane; paired + `[0,1]` range CHECKs). Registered in `MIGRATIONS`.
- **placement survives a links re-save** — `replace_camera_ha_links` (the `PUT /cameras/:id/ha/links` DELETE+reinsert) now carries placements over by `(entity_id, role)`. Without this, re-saving the console's link list would silently wipe every placed badge. Removing a link drops its placement (cascade). 
- **`PUT /cameras/:id/ha/links/:link_id/placement`** (admin) — set `{x,y,size}` or `null` to clear; coords clamped to `[0,1]`, size to a sane range; 404 if the link isn't on that camera.
- **`GET /ha/states`** (any authed user) — current state of entities linked to **caller-visible cameras only** (RBAC projection; a viewer never learns about entities on cameras outside their grant). Backed by a **demand-driven single-flight cache**: 2s TTL, concurrent callers collapse to one HA `/api/states` request, stale-with-flag while HA is briefly down, 502 once the snapshot ages out. **No standing poller — zero HA traffic when no wall is watching** (the energy-lean reading). Never fabricates state (carries the recorder-side `edge_on` "unavailable is not off" invariant).

## Secure-by-default / correctness
- New endpoints authenticated; placement is admin-only, states are RBAC-projected per caller.
- HA token stays server-side (states are proxied, same as the existing picker).
- Recorder untouched by behavior — only additive columns its old binary ignores, so a footage-safe api-only deploy is safe (recorder can catch up on the next full deploy with no recording gap).

## Gate
`cargo fmt --all --check` ✓ · `cargo clippy --all-targets -D warnings` ✓ · `cargo test --workspace` ✓ (Postgres; DB suites boot the schema, so 0058 applies clean). New unit tests: RBAC projection, placement clamp/default.

## Install guide
No `.env` / port / service / secret changes — HA config already exists. `docs/AI-INSTALL.md` not triggered.

Part of #170. Desktop overlay layer + shared drag-to-place editor + grouped picker follow in the next PR.