### PR TITLE
HA entity icons on live video — desktop client [P0]

### DIFF
--- a/apps/desktop-flutter/lib/api/ha_api.dart
+++ b/apps/desktop-flutter/lib/api/ha_api.dart
@@ -1,0 +1,131 @@
+// Home Assistant on-video overlay API calls (issue #170): a camera's linked
+// entities + on-video placement, and the live states feed. Kept as an
+// extension on the shared `CrumbApi` (see crumb_api.dart) rather than editing
+// that file directly — same approach as `status_api.dart`, using the shared
+// process-wide `TimeoutClient` since `CrumbApi`'s own client is private to
+// that file.
+//
+// Route facts (services/api/src/ha.rs):
+//   GET /cameras/{id}/ha/links                      -> HaLinkDto[] (any user
+//                                                       with camera access)
+//   PUT /cameras/{id}/ha/links/{link_id}/placement   body {x,y,size} pins the
+//                                                       badge; a literal JSON
+//                                                       `null` body clears it.
+//                                                       Admin-only server-side
+//                                                       (matches link writes).
+//                                                       Returns the updated
+//                                                       link.
+//   GET /ha/states                                   -> HaStatesResponse (any
+//                                                       authenticated user;
+//                                                       RBAC-projected to the
+//                                                       caller's cameras)
+
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'crumb_api.dart';
+import 'ha_models.dart';
+import 'http_client.dart';
+import 'models.dart';
+
+extension HaApi on CrumbApi {
+  /// GET /cameras/{id}/ha/links — the camera's linked HA entities, including
+  /// on-video placement if any.
+  Future<List<HaLink>> cameraHaLinks(Session s, String cameraId) async {
+    final resp = await sharedHttpClient.get(
+      Uri.parse('${s.base}/cameras/$cameraId/ha/links'),
+      headers: {'authorization': 'Bearer ${s.token}'},
+    );
+    if (resp.statusCode != 200) {
+      throw CrumbApiException(
+        'Failed to load HA links (HTTP ${resp.statusCode}).',
+        statusCode: resp.statusCode,
+      );
+    }
+    final list = jsonDecode(resp.body) as List<dynamic>;
+    return list
+        .map((e) => HaLink.fromJson(e as Map<String, dynamic>))
+        .toList(growable: false);
+  }
+
+  Future<http.Response> _putPlacement(
+    Session s,
+    String cameraId,
+    String linkId,
+    Object? body,
+  ) {
+    return sharedHttpClient.put(
+      Uri.parse('${s.base}/cameras/$cameraId/ha/links/$linkId/placement'),
+      headers: {
+        'authorization': 'Bearer ${s.token}',
+        'content-type': 'application/json',
+      },
+      body: jsonEncode(body),
+    );
+  }
+
+  /// PUT .../placement — pin the badge at `(x, y)` [each 0..1, a fraction of
+  /// the video frame] with a size multiplier (server clamps/validates).
+  /// Returns the updated link.
+  Future<HaLink> saveHaPlacement(
+    Session s,
+    String cameraId,
+    String linkId, {
+    required double x,
+    required double y,
+    double size = 1.0,
+  }) async {
+    final resp = await _putPlacement(s, cameraId, linkId, {
+      'x': x,
+      'y': y,
+      'size': size,
+    });
+    if (resp.statusCode != 200) {
+      throw CrumbApiException(
+        'Failed to save HA badge placement (HTTP ${resp.statusCode}).',
+        statusCode: resp.statusCode,
+      );
+    }
+    return HaLink.fromJson(jsonDecode(resp.body) as Map<String, dynamic>);
+  }
+
+  /// PUT .../placement with a `null` body — clears the badge's placement.
+  /// Returns the updated (now-unplaced) link.
+  Future<HaLink> clearHaPlacement(
+    Session s,
+    String cameraId,
+    String linkId,
+  ) async {
+    final resp = await _putPlacement(s, cameraId, linkId, null);
+    if (resp.statusCode != 200) {
+      throw CrumbApiException(
+        'Failed to clear HA badge placement (HTTP ${resp.statusCode}).',
+        statusCode: resp.statusCode,
+      );
+    }
+    return HaLink.fromJson(jsonDecode(resp.body) as Map<String, dynamic>);
+  }
+
+  /// GET /ha/states — current state of every HA entity linked to a camera
+  /// the caller can access, from the server's demand-driven cache. Throws
+  /// [CrumbApiException] on any non-200 (400 "not enabled", 502 "unreachable"
+  /// past the server's stale window, ...) — callers should treat any failure
+  /// as "keep last-known, mark stale", mirroring
+  /// `LiveStatusController`'s `/events` failure handling.
+  Future<HaStatesSnapshot> haStates(Session s) async {
+    final resp = await sharedHttpClient.get(
+      Uri.parse('${s.base}/ha/states'),
+      headers: {'authorization': 'Bearer ${s.token}'},
+    );
+    if (resp.statusCode != 200) {
+      throw CrumbApiException(
+        'Failed to load HA states (HTTP ${resp.statusCode}).',
+        statusCode: resp.statusCode,
+      );
+    }
+    return HaStatesSnapshot.fromJson(
+      jsonDecode(resp.body) as Map<String, dynamic>,
+    );
+  }
+}

--- a/apps/desktop-flutter/lib/api/ha_models.dart
+++ b/apps/desktop-flutter/lib/api/ha_models.dart
@@ -1,0 +1,130 @@
+// Data shapes for the Home Assistant on-video overlay feature (issue #170).
+// Snake_case JSON -> camelCase Dart, mirroring the server DTOs exactly:
+// `HaLinkDto` / `HaEntityState` / `HaStatesResponse` (services/api/src/ha.rs).
+
+/// A camera's linked HA entity (`GET /cameras/:id/ha/links`), including its
+/// on-video overlay placement, if any. One link -> at most one badge.
+class HaLink {
+  HaLink({
+    required this.id,
+    required this.entityId,
+    required this.role,
+    this.deviceClass,
+    this.label,
+    required this.sortOrder,
+    this.overlayX,
+    this.overlayY,
+    this.overlaySize,
+  });
+
+  final String id; // UUID
+  final String entityId;
+
+  /// `"motion" | "sensor" | "actuator"` (see migration 0048).
+  final String role;
+
+  /// HA `device_class` (`door`, `motion`, ...), binary_sensor links only.
+  final String? deviceClass;
+
+  /// Operator-set display label; falls back to [entityId] when unset (see
+  /// [displayLabel]).
+  final String? label;
+  final int sortOrder;
+
+  /// Normalized fraction (0..1) of the DISPLAYED video frame — top-left
+  /// anchor of the rendered badge. Set together with [overlayY]; null when
+  /// this link is not placed on the video.
+  final double? overlayX;
+  final double? overlayY;
+
+  /// Badge scale multiplier (1.0 = default) when placed, else null.
+  final double? overlaySize;
+
+  bool get hasPlacement => overlayX != null && overlayY != null;
+
+  /// The entity_id's domain prefix (`binary_sensor`, `light`, `switch`,
+  /// `scene`, ...); empty string if [entityId] has no dot.
+  String get domain {
+    final i = entityId.indexOf('.');
+    return i < 0 ? '' : entityId.substring(0, i);
+  }
+
+  /// Display label: the operator's rename if set, else the raw entity_id
+  /// (mirrors the admin console's link-row rendering convention).
+  String get displayLabel =>
+      (label != null && label!.trim().isNotEmpty) ? label! : entityId;
+
+  factory HaLink.fromJson(Map<String, dynamic> j) => HaLink(
+    id: j['id'] as String,
+    entityId: j['entity_id'] as String,
+    role: (j['role'] as String?) ?? 'sensor',
+    deviceClass: j['device_class'] as String?,
+    label: j['label'] as String?,
+    sortOrder: (j['sort_order'] as num?)?.toInt() ?? 0,
+    overlayX: (j['overlay_x'] as num?)?.toDouble(),
+    overlayY: (j['overlay_y'] as num?)?.toDouble(),
+    overlaySize: (j['overlay_size'] as num?)?.toDouble(),
+  );
+}
+
+/// One entity's current reading from `GET /ha/states`.
+class HaEntityState {
+  HaEntityState({required this.state, this.lastChanged});
+
+  /// Raw HA state string (e.g. `"on"`, `"open"`, `"unavailable"`). Never
+  /// reinterpret this as a boolean directly — use `ha_overlay/ha_icons.dart`'s
+  /// `edgeOn`, which mirrors the server's `edge_on` invariant (unavailable/
+  /// unknown are INDETERMINATE, never "off").
+  final String state;
+
+  /// HA `last_changed` (RFC3339), passed through verbatim for "N ago" display.
+  final DateTime? lastChanged;
+
+  factory HaEntityState.fromJson(Map<String, dynamic> j) => HaEntityState(
+    state: (j['state'] as String?) ?? '',
+    lastChanged: DateTime.tryParse((j['last_changed'] as String?) ?? ''),
+  );
+}
+
+/// `GET /ha/states` response: caller-visible entity states + cache age, so
+/// the client can show a "stale" treatment without guessing.
+class HaStatesSnapshot {
+  HaStatesSnapshot({
+    required this.fetchedAtMsAgo,
+    required this.stale,
+    required this.byEntity,
+  });
+
+  /// Age of the served snapshot in milliseconds.
+  final int fetchedAtMsAgo;
+
+  /// True when HA is currently unreachable and this is a last-known
+  /// snapshot; badges must grey out rather than trust it as authoritative.
+  final bool stale;
+
+  final Map<String, HaEntityState> byEntity;
+
+  /// Empty/never-polled snapshot — not stale (no data to distrust yet, but
+  /// callers should treat "no entry" the same as "unknown" either way).
+  static final empty = HaStatesSnapshot(
+    fetchedAtMsAgo: 0,
+    stale: false,
+    byEntity: const {},
+  );
+
+  factory HaStatesSnapshot.fromJson(Map<String, dynamic> j) {
+    final list = (j['states'] as List<dynamic>?) ?? const [];
+    final map = <String, HaEntityState>{};
+    for (final e in list) {
+      final m = e as Map<String, dynamic>;
+      final id = m['entity_id'] as String?;
+      if (id == null) continue;
+      map[id] = HaEntityState.fromJson(m);
+    }
+    return HaStatesSnapshot(
+      fetchedAtMsAgo: (j['fetched_at_ms_ago'] as num?)?.toInt() ?? 0,
+      stale: (j['stale'] as bool?) ?? false,
+      byEntity: map,
+    );
+  }
+}

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_entity_palette.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_entity_palette.dart
@@ -1,0 +1,205 @@
+// The camera's linked-entity picker for the HA overlay editor bar (issue
+// #170 §4.5, POC): a search field + the LINKED entities (already fetched via
+// `HaApi.cameraHaLinks`) grouped by domain — Sensors (`binary_sensor.*`,
+// subtitled with device_class), Lights (`light.*`), Switches (`switch.*`),
+// Scenes (`scene.*`). Each row shows the same icon mapping as the on-video
+// badge (`ha_icons.dart`), the display label (`link.label ?? entity_id`),
+// and a checkmark for links currently placed in the edit session. Tapping
+// ANY row calls [onPick] — the host decides what that means (place at
+// frame-center if new, or just re-select if already placed; see
+// `ha_overlay_controller.dart`'s `pickFromPalette`).
+//
+// This is intentionally the FLAT grouped+search picker (not the HA
+// Area->Device->Entity tree — that needs the HA registry API and is a later
+// phase, see the desktop P0 plan §4.5/§7 Q1).
+
+import 'package:flutter/material.dart';
+
+import '../../api/ha_models.dart';
+import 'ha_icons.dart';
+
+class HaEntityPalette extends StatefulWidget {
+  const HaEntityPalette({
+    super.key,
+    required this.links,
+    required this.placedIds,
+    required this.onPick,
+  });
+
+  /// The camera's full linked-entity set (`GET /cameras/:id/ha/links`).
+  final List<HaLink> links;
+
+  /// Ids of links currently placed in THIS edit session — drives the row
+  /// checkmark. Pass the live set from the host (e.g.
+  /// `HaOverlayController.placedIdsInSession`) so it stays in sync as the
+  /// operator drags/deletes badges.
+  final Set<String> placedIds;
+
+  final void Function(HaLink link) onPick;
+
+  @override
+  State<HaEntityPalette> createState() => _HaEntityPaletteState();
+}
+
+class _HaEntityPaletteState extends State<HaEntityPalette> {
+  final _searchCtrl = TextEditingController();
+  String _query = '';
+
+  @override
+  void dispose() {
+    _searchCtrl.dispose();
+    super.dispose();
+  }
+
+  static const _groupOrder = <String, String>{
+    'binary_sensor': 'Sensors',
+    'light': 'Lights',
+    'switch': 'Switches',
+    'scene': 'Scenes',
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final q = _query.trim().toLowerCase();
+    final groups = <String, List<HaLink>>{};
+    for (final link in widget.links) {
+      if (q.isNotEmpty &&
+          !link.displayLabel.toLowerCase().contains(q) &&
+          !link.entityId.toLowerCase().contains(q)) {
+        continue;
+      }
+      final group = _groupOrder.containsKey(link.domain) ? link.domain : 'other';
+      (groups[group] ??= []).add(link);
+    }
+
+    return SizedBox(
+      width: 320,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            height: 32,
+            child: TextField(
+              controller: _searchCtrl,
+              style: const TextStyle(color: Colors.white, fontSize: 13),
+              decoration: const InputDecoration(
+                isDense: true,
+                prefixIcon: Icon(Icons.search, color: Colors.white38, size: 16),
+                hintText: 'Search linked entities…',
+                hintStyle: TextStyle(color: Colors.white38),
+                border: OutlineInputBorder(),
+                contentPadding: EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+              ),
+              onChanged: (v) => setState(() => _query = v),
+            ),
+          ),
+          const SizedBox(height: 6),
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 220),
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  for (final entry in _orderedGroups(groups))
+                    _group(entry.key, entry.value),
+                  if (groups.isEmpty)
+                    const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 8),
+                      child: Text(
+                        'No linked entities match.',
+                        style: TextStyle(color: Colors.white38, fontSize: 12),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<MapEntry<String, List<HaLink>>> _orderedGroups(
+    Map<String, List<HaLink>> groups,
+  ) {
+    final ordered = <MapEntry<String, List<HaLink>>>[];
+    for (final domain in _groupOrder.keys) {
+      final list = groups[domain];
+      if (list != null && list.isNotEmpty) ordered.add(MapEntry(domain, list));
+    }
+    final other = groups['other'];
+    if (other != null && other.isNotEmpty) ordered.add(MapEntry('other', other));
+    return ordered;
+  }
+
+  Widget _group(String domain, List<HaLink> links) {
+    final title = _groupOrder[domain] ?? 'Other';
+    links.sort(
+      (a, b) => a.displayLabel.toLowerCase().compareTo(b.displayLabel.toLowerCase()),
+    );
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 2),
+            child: Text(
+              title,
+              style: const TextStyle(
+                color: Colors.white54,
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                letterSpacing: 0.4,
+              ),
+            ),
+          ),
+          for (final link in links) _row(link),
+        ],
+      ),
+    );
+  }
+
+  Widget _row(HaLink link) {
+    final placed = widget.placedIds.contains(link.id);
+    final visual = haVisualFor(
+      domain: link.domain,
+      deviceClass: link.deviceClass,
+      state: null,
+      stale: false,
+    );
+    return InkWell(
+      onTap: () => widget.onPick(link),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 2),
+        child: Row(
+          children: [
+            Icon(visual.icon, size: 15, color: visual.color),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    link.displayLabel,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(color: Colors.white, fontSize: 12.5),
+                  ),
+                  if (link.domain == 'binary_sensor' && link.deviceClass != null)
+                    Text(
+                      link.deviceClass!,
+                      style: const TextStyle(color: Colors.white38, fontSize: 10.5),
+                    ),
+                ],
+              ),
+            ),
+            if (placed) const Icon(Icons.check, size: 14, color: Colors.greenAccent),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_icons.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_icons.dart
@@ -1,0 +1,208 @@
+// Icon + state->visual mapping for HA on-video badges (issue #170 §4.6). A
+// Dart mirror of the backend's `edge_on` / `label_for_device_class`
+// (services/common/src/ha.rs) extended for the light/switch/scene DOMAINS
+// (the backend slug only covers binary_sensor device classes — domain-based
+// mapping for controls is new here, client-side only). Curated Material
+// Icons mapping, dependency-free — same ethos as
+// `live_status/detection_icons.dart`.
+//
+// State->visual NEVER treats an indeterminate reading as "off"/"closed": an
+// unknown/unavailable/stale entity renders grey + reduced opacity. This
+// mirrors the backend's `edge_on` invariant (services/common/src/ha.rs) —
+// `unavailable`/`unknown` map to `None`, never `false` — carried into the UI
+// because a badge that looks "closed" on a dead HA connection is the overlay
+// equivalent of the footage-loss bug class (AGENTS.md golden rule 2's
+// spirit, applied to state honesty rather than footage).
+//
+// NOTE for the reviewing human: `sensor_door`, `sensor_window`, `garage`,
+// `sensors_occupied`, `movie_filter`, `lightbulb`, `power`, `power_off` are
+// NOT used anywhere else in this codebase yet (grepped at write time) — this
+// file was written without a local Flutter SDK to verify against
+// `Icons.<name>`, so please double check these compile on `flutter analyze`.
+// `directions_run` and `sensors` ARE already used elsewhere (confirmed safe).
+
+import 'package:flutter/material.dart';
+
+/// A resolved icon + color + optional short label for one badge/card render.
+class HaVisual {
+  const HaVisual(this.icon, this.color, {this.label, this.pulsing = false});
+
+  final IconData icon;
+  final Color color;
+
+  /// Short state label for hosts that want to show text alongside the icon
+  /// (e.g. `ha_state_card.dart`'s state line: "Open"/"Closed"/"On"/"Off").
+  final String? label;
+
+  /// Advisory hint for hosts that want an "active" attention treatment
+  /// (motion/occupancy while active). Not consumed by the POC badge chip;
+  /// kept so a later polish pass has the signal without a model change.
+  final bool pulsing;
+}
+
+const Color _kGrey = Color(0xFF8E8E93);
+const Color _kAmber = Color(0xFFFFB143); // matches the license_plate/detection amber family
+const Color _kNeutral = Color(0xFFB9C2CC); // closed/off but KNOWN — not grey
+const Color _kBlue = Color(0xFF33C3FF); // matches the person-detection blue family
+const Color _kGreen = Color(0xFF2BA84A);
+const Color _kWarmYellow = Color(0xFFFFCC33);
+
+/// HA `state` string -> on/off/indeterminate, mirroring
+/// `services/common/src/ha.rs::edge_on` EXACTLY (including which strings map
+/// to which side) so the client's "is this open/on" reading never disagrees
+/// with what the recorder's motion source already treats as ground truth.
+/// `null` = indeterminate (unavailable/unknown/anything else) — NEVER
+/// treated as off.
+bool? edgeOn(String state) {
+  switch (state.trim().toLowerCase()) {
+    case 'on':
+    case 'open':
+    case 'detected':
+    case 'true':
+    case 'home':
+    case 'motion':
+    case 'occupied':
+      return true;
+    case 'off':
+    case 'closed':
+    case 'clear':
+    case 'false':
+    case 'not_home':
+    case 'no_motion':
+      return false;
+    default:
+      return null;
+  }
+}
+
+/// Device-class -> Crumb label slug, mirroring
+/// `services/common/src/ha.rs::label_for_device_class` exactly.
+String labelForDeviceClass(String? deviceClass) {
+  switch (deviceClass?.trim().toLowerCase()) {
+    case 'motion':
+    case 'moving':
+    case 'vibration':
+      return 'motion';
+    case 'occupancy':
+    case 'presence':
+      return 'occupancy';
+    case 'door':
+    case 'opening':
+      return 'door';
+    case 'window':
+      return 'window';
+    case 'garage_door':
+      return 'garage';
+    default:
+      return 'sensor';
+  }
+}
+
+/// Resolve the icon + color (+ optional label) to render for a linked
+/// entity's current reading.
+///
+/// - `domain` is the entity_id's domain prefix (`light`, `switch`, `scene`,
+///   `binary_sensor`, ...).
+/// - `deviceClass` is the link's HA device_class (binary_sensor links only).
+/// - `state` is the raw HA state string, or `null` when no state is known
+///   yet.
+/// - `stale` forces the indeterminate/grey treatment regardless of `state`
+///   (the HA states feed has gone stale — never trust a possibly-stale
+///   reading as authoritative).
+HaVisual haVisualFor({
+  required String domain,
+  String? deviceClass,
+  required String? state,
+  required bool stale,
+}) {
+  if (domain == 'scene') {
+    // Stateless — a neutral chip regardless of state/staleness.
+    return const HaVisual(Icons.movie_filter, _kNeutral, label: 'Scene');
+  }
+
+  final on = (state == null || stale) ? null : edgeOn(state);
+  if (on == null) {
+    return HaVisual(
+      _iconFor(domain: domain, deviceClass: deviceClass),
+      _kGrey.withValues(alpha: 0.6),
+      label: state ?? 'Unknown',
+    );
+  }
+
+  if (domain == 'light') {
+    return HaVisual(
+      Icons.lightbulb,
+      on ? _kWarmYellow : _kGrey,
+      label: on ? 'On' : 'Off',
+    );
+  }
+  if (domain == 'switch') {
+    return HaVisual(
+      on ? Icons.power : Icons.power_off,
+      on ? _kGreen : _kGrey,
+      label: on ? 'On' : 'Off',
+    );
+  }
+
+  // binary_sensor (or any other domain) — device_class driven.
+  switch (labelForDeviceClass(deviceClass)) {
+    case 'door':
+      return HaVisual(
+        Icons.sensor_door,
+        on ? _kAmber : _kNeutral,
+        label: on ? 'Open' : 'Closed',
+      );
+    case 'window':
+      return HaVisual(
+        Icons.sensor_window,
+        on ? _kAmber : _kNeutral,
+        label: on ? 'Open' : 'Closed',
+      );
+    case 'garage':
+      return HaVisual(
+        Icons.garage,
+        on ? _kAmber : _kNeutral,
+        label: on ? 'Open' : 'Closed',
+      );
+    case 'motion':
+      return HaVisual(
+        Icons.directions_run,
+        on ? _kBlue : _kGrey,
+        label: on ? 'Motion' : 'Clear',
+        pulsing: on,
+      );
+    case 'occupancy':
+      return HaVisual(
+        Icons.person,
+        on ? _kBlue : _kGrey,
+        label: on ? 'Occupied' : 'Clear',
+        pulsing: on,
+      );
+    default:
+      return HaVisual(
+        Icons.sensors,
+        on ? _kBlue : _kGrey,
+        label: on ? 'Active' : 'Clear',
+      );
+  }
+}
+
+IconData _iconFor({required String domain, String? deviceClass}) {
+  if (domain == 'light') return Icons.lightbulb;
+  if (domain == 'switch') return Icons.power;
+  if (domain == 'scene') return Icons.movie_filter;
+  switch (labelForDeviceClass(deviceClass)) {
+    case 'door':
+      return Icons.sensor_door;
+    case 'window':
+      return Icons.sensor_window;
+    case 'garage':
+      return Icons.garage;
+    case 'motion':
+      return Icons.directions_run;
+    case 'occupancy':
+      return Icons.person;
+    default:
+      return Icons.sensors;
+  }
+}

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_controller.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_controller.dart
@@ -1,0 +1,209 @@
+// Thin host adapter wiring the generic drag-to-place overlay editor
+// (`overlay_editor/`) to HA badge placements (issue #170 P0): wraps a
+// camera's PLACED `HaLink`s as `OverlayItem`s (video-frame anchored),
+// persists via the placement PUT/clear, and exposes the camera's full
+// linked-entity set for the palette.
+//
+// Lifecycle (host-loads-first, per `overlay_editor_controller.dart`'s
+// synchronous-edit contract): call [loadLinks] BEFORE maximizing/entering
+// edit mode, THEN [beginEditFromLoadedLinks]. Guard the async gap with
+// [editor]'s `editToken` so a fast camera-switch mid-load can't clobber a
+// newer session:
+//
+//   final ha = HaOverlayController(api: widget.api, session: widget.session);
+//   final token = ha.editor.editToken;
+//   await ha.loadLinks(cam.id);
+//   if (ha.editor.editToken != token) return; // stale — user moved on
+//   _maximize(cam);
+//   ha.beginEditFromLoadedLinks();
+//   // ... later, on Done:
+//   await ha.endEditAndSave();
+
+import '../../api/crumb_api.dart';
+import '../../api/ha_api.dart';
+import '../../api/ha_models.dart';
+import '../../api/models.dart';
+import '../overlay_editor/overlay_editor_controller.dart';
+import '../overlay_editor/overlay_item.dart';
+
+/// [OverlayItem] adapter over a placed [HaLink] — video-frame anchored,
+/// always-square badge, resized via the editor bar's size stepper only (no
+/// on-canvas drag-resize handle; see [resizable]).
+class HaOverlayBadgeItem implements OverlayItem {
+  HaOverlayBadgeItem(this.link, {double? x, double? y})
+    : _x = x ?? link.overlayX ?? 0.46,
+      _y = y ?? link.overlayY ?? 0.46,
+      _scale = (link.overlaySize ?? 1.0).clamp(0.1, 8.0).toDouble();
+
+  final HaLink link;
+
+  double _x;
+  double _y;
+  double _scale;
+
+  @override
+  String get id => link.id;
+
+  @override
+  double get x => _x;
+  @override
+  set x(double v) => _x = v;
+  @override
+  double get y => _y;
+  @override
+  set y(double v) => _y = v;
+
+  @override
+  OverlayAnchor get anchor => OverlayAnchor.videoFrame;
+
+  /// Reference badge size (logical px at pane-scale 1.0) — matches the
+  /// black-scrim chip drawn by `ha_overlay_layer.dart`'s `HaBadgeChip` and
+  /// the ~22px scale of the tile-badge visual language
+  /// (`live_status/live_status_badges.dart`).
+  static const double baseRefPx = 22;
+
+  @override
+  (double w, double h) baseSize() => (baseRefPx * _scale, baseRefPx * _scale);
+
+  @override
+  void setBaseSize(double w, double h) {
+    final v = (w > h ? w : h) / baseRefPx;
+    _scale = v.clamp(0.1, 8.0).toDouble();
+  }
+
+  /// The `overlay_size` multiplier to persist (mirrors the server's clamp,
+  /// services/api/src/ha.rs `put_placement`).
+  double get scale => _scale;
+
+  @override
+  bool get resizable => false;
+}
+
+/// One or more of an edit session's badge placements failed to save. The
+/// session's edit is still ended (items are gone from the editor either
+/// way); the host should surface this so the operator knows to retry.
+class HaOverlaySaveException implements Exception {
+  HaOverlaySaveException(this.failures);
+
+  /// link id -> the error that occurred saving/clearing its placement.
+  final Map<String, Object> failures;
+
+  @override
+  String toString() =>
+      'Failed to save ${failures.length} HA badge placement(s): '
+      '${failures.keys.join(', ')}';
+}
+
+class HaOverlayController {
+  HaOverlayController({required CrumbApi api, required Session session})
+    : _api = api,
+      _session = session,
+      editor = OverlayEditorController();
+
+  final CrumbApi _api;
+  Session _session;
+
+  /// The generic editor session this adapter drives — pass this to
+  /// `OverlayEditorLayer`/`OverlayEditorBar` while editing this camera.
+  final OverlayEditorController editor;
+
+  void updateSession(Session session) => _session = session;
+
+  String? _cameraId;
+
+  /// The camera's full linked-entity set (for the palette), refreshed by
+  /// [loadLinks]. Includes both placed and unplaced links.
+  List<HaLink> links = const [];
+  bool loading = false;
+  Object? loadError;
+
+  /// Fetch the camera's HA links. Call BEFORE [beginEditFromLoadedLinks] —
+  /// see the class doc for the required session-token race guard.
+  Future<List<HaLink>> loadLinks(String cameraId) async {
+    loading = true;
+    loadError = null;
+    try {
+      final loaded = await _api.cameraHaLinks(_session, cameraId);
+      _cameraId = cameraId;
+      links = loaded;
+      return loaded;
+    } catch (e) {
+      loadError = e;
+      rethrow;
+    } finally {
+      loading = false;
+    }
+  }
+
+  /// Begin the shared editor's edit session from the already-loaded [links]
+  /// (call once [loadLinks] has resolved and the caller has verified
+  /// `editor.editToken` is still current). Only PLACED links become overlay
+  /// items; the rest are pick-from-palette candidates.
+  void beginEditFromLoadedLinks() {
+    final items = [
+      for (final link in links)
+        if (link.hasPlacement) HaOverlayBadgeItem(link),
+    ];
+    editor.beginEdit(items, anchor: OverlayAnchor.videoFrame);
+  }
+
+  /// Pick a linked entity from the palette: places it (frame-center default)
+  /// if it isn't already in the session, or just selects it if it is —
+  /// mirrors `PtzPanelController.addButton`'s "add and select" UX.
+  void pickFromPalette(HaLink link) {
+    for (final item in editor.items) {
+      if (item.id == link.id) {
+        editor.selectItem(link.id);
+        return;
+      }
+    }
+    editor.addItem(HaOverlayBadgeItem(link, x: 0.46, y: 0.46));
+  }
+
+  /// Ids of links currently placed in this edit session — drives the
+  /// palette's "placed" checkmark (`HaEntityPalette.placedIds`).
+  Set<String> get placedIdsInSession => {for (final i in editor.items) i.id};
+
+  /// End the edit session and persist: PUT a placement for every item still
+  /// in the session, and CLEAR the placement for every previously-placed
+  /// link no longer present (deleted on-canvas). Best-effort per item — one
+  /// failed request doesn't block the others; throws
+  /// [HaOverlaySaveException] afterward if any failed, so the host can
+  /// surface a retry prompt.
+  Future<void> endEditAndSave() async {
+    final cameraId = _cameraId;
+    final result = editor.endEdit();
+    if (cameraId == null) return; // never loaded — nothing to persist against
+
+    final keepIds = {for (final i in result) i.id};
+    final failures = <String, Object>{};
+
+    for (final item in result) {
+      if (item is! HaOverlayBadgeItem) continue;
+      try {
+        await _api.saveHaPlacement(
+          _session,
+          cameraId,
+          item.id,
+          x: item.x,
+          y: item.y,
+          size: item.scale,
+        );
+      } catch (e) {
+        failures[item.id] = e;
+      }
+    }
+    for (final link in links) {
+      if (link.hasPlacement && !keepIds.contains(link.id)) {
+        try {
+          await _api.clearHaPlacement(_session, cameraId, link.id);
+        } catch (e) {
+          failures[link.id] = e;
+        }
+      }
+    }
+    if (failures.isNotEmpty) throw HaOverlaySaveException(failures);
+  }
+
+  void dispose() => editor.dispose();
+}

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_layer.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_layer.dart
@@ -1,0 +1,239 @@
+// View-mode HA badge layer for a wall tile / maximized pane (issue #170 P0).
+// A thin wrapper over `overlay_editor/overlay_editor_layer.dart` in VIEW
+// mode: given a camera's placed HA links, a live-state lookup, a staleness
+// flag, and the pane's decoded-video pixel size, it renders each placed link
+// as a badge pinned to its normalized position on the DISPLAYED video frame
+// (contain-fit, so it survives per-tile letterboxing differences —
+// `overlay_geometry.dart`'s `fieldRect`), and shows a read-only
+// `HaStateCard` on tap.
+//
+// Purely a display widget: everything comes via the constructor, no
+// controller/global lookups (it builds its own private, ephemeral
+// `OverlayEditorController` purely to satisfy `OverlayEditorLayer`'s
+// generic plumbing — it never enters edit mode), so a tile/pane can drop it
+// in without depending on any edit-session state. The actual placement
+// EDITOR (drag-to-place, "Edit HA overlay…") is wired directly by the host
+// using `overlay_editor/overlay_editor_layer.dart` +
+// `overlay_editor/overlay_editor_bar.dart` + `HaOverlayController.editor` —
+// this file's `haBadgeItemBuilder` is exported so the host's edit-mode UI
+// renders the exact same badge visual language.
+//
+// Usage (wall tile / maximized pane, both already fetch+cache their camera's
+// HA links once per mount — see the desktop P0 plan §4.4):
+//
+//   Positioned.fill(
+//     child: HaOverlayLayer(
+//       links: _haLinks,                        // List<HaLink>, tile-cached
+//       stateFor: widget.liveStatus.haStateFor,  // add to LiveStatusController
+//       stale: widget.liveStatus.haStale,        // add to LiveStatusController
+//       videoW: _videoW, videoH: _videoH,        // null until first frame
+//       hideBadges: _scale > 1.01,               // digital zoom, POC rule §4.2
+//     ),
+//   )
+
+import 'package:flutter/material.dart';
+
+import '../../api/ha_models.dart';
+import '../overlay_editor/overlay_editor_controller.dart';
+import '../overlay_editor/overlay_editor_layer.dart';
+import 'ha_icons.dart';
+import 'ha_overlay_controller.dart' show HaOverlayBadgeItem;
+import 'ha_state_card.dart';
+
+/// Build an `OverlayItemBuilder` bound to a specific state lookup — used
+/// identically by [HaOverlayLayer] (view mode, internally) and by the host's
+/// maximized-pane "Edit HA overlay…" UI
+/// (`OverlayEditorLayer(..., buildItem: haBadgeItemBuilder(stateFor: ...,
+/// stale: ...))`), so both modes render the exact same badge visual
+/// language.
+OverlayItemBuilder haBadgeItemBuilder({
+  required HaEntityState? Function(String entityId) stateFor,
+  required bool stale,
+}) {
+  return (item, {required bool editing, required bool selected}) {
+    final link = (item as HaOverlayBadgeItem).link;
+    final state = stateFor(link.entityId);
+    final visual = haVisualFor(
+      domain: link.domain,
+      deviceClass: link.deviceClass,
+      state: state?.state,
+      stale: stale,
+    );
+    return HaBadgeChip(visual: visual, selected: selected);
+  };
+}
+
+/// The badge chip itself: a circular dark-scrim container with the resolved
+/// icon, matching the tile-badge visual language (black-0.55 rounded scrim,
+/// `live_status/live_status_badges.dart`). Sizes itself to fill whatever
+/// rect the overlay layer gives it (see `overlay_editor_layer.dart`'s
+/// `SizedBox` wrap) and scales the icon/border proportionally, mirroring
+/// `PtzPanelOverlay`'s `_glyphOrLabel` clamp pattern.
+class HaBadgeChip extends StatelessWidget {
+  const HaBadgeChip({super.key, required this.visual, this.selected = false});
+
+  final HaVisual visual;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final side = constraints.biggest.shortestSide;
+        return DecoratedBox(
+          decoration: BoxDecoration(
+            color: Colors.black.withValues(alpha: 0.55),
+            shape: BoxShape.circle,
+            border: Border.all(
+              color: selected ? Colors.white : visual.color.withValues(alpha: 0.85),
+              width: selected ? 2.4 : (side * 0.06).clamp(1.0, 2.5).toDouble(),
+            ),
+          ),
+          child: Center(
+            child: Icon(
+              visual.icon,
+              color: visual.color,
+              size: (side * 0.58).clamp(10.0, 40.0).toDouble(),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class HaOverlayLayer extends StatefulWidget {
+  const HaOverlayLayer({
+    super.key,
+    required this.links,
+    required this.stateFor,
+    this.stale = false,
+    this.videoW,
+    this.videoH,
+    this.hideBadges = false,
+  });
+
+  /// The camera's linked entities (incl. placement) — only the PLACED ones
+  /// render a badge.
+  final List<HaLink> links;
+
+  /// Live-state lookup, e.g. `LiveStatusController.haStateFor` (a method the
+  /// wall_screen wiring adds to that controller — see the desktop P0 plan
+  /// §4.4). Returns null when no state is known yet for that entity.
+  final HaEntityState? Function(String entityId) stateFor;
+
+  /// True when the HA states feed is stale (poll failures) — every badge
+  /// renders the grey/dim "unknown" treatment regardless of its last-known
+  /// state (never shows a possibly-false closed/off — mirrors the backend's
+  /// `edge_on` invariant).
+  final bool stale;
+
+  /// Decoded video pixel size — needed to map a video-frame-fraction
+  /// placement onto the letterboxed video rect. Badges render nothing until
+  /// both are known (a sub-second window right after a stream opens).
+  final int? videoW;
+  final int? videoH;
+
+  /// Digital-zoom gate (POC rule, desktop P0 plan §4.2): badges sit outside
+  /// the pane's zoom `Transform`, so a zoomed pane would misplace them —
+  /// hide entirely while zoomed rather than draw them wrong. Pass
+  /// `_scale > 1.01`.
+  final bool hideBadges;
+
+  @override
+  State<HaOverlayLayer> createState() => _HaOverlayLayerState();
+}
+
+class _HaOverlayLayerState extends State<HaOverlayLayer> {
+  /// Ephemeral controller purely to satisfy `OverlayEditorLayer`'s generic
+  /// plumbing in VIEW mode — never enters edit mode, never leaves this
+  /// widget's private state.
+  final OverlayEditorController _viewController = OverlayEditorController();
+
+  /// Link id of the currently-open state card, if any.
+  String? _openLinkId;
+
+  @override
+  void dispose() {
+    _viewController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.hideBadges || widget.videoW == null || widget.videoH == null) {
+      return const SizedBox.shrink();
+    }
+    final placed = [for (final l in widget.links) if (l.hasPlacement) l];
+    if (placed.isEmpty) return const SizedBox.shrink();
+
+    final items = [for (final l in placed) HaOverlayBadgeItem(l)];
+    final open = _findOpen(placed);
+
+    return Stack(
+      children: [
+        // See overlay_editor_layer.dart's usage contract — it must be given
+        // TIGHT constraints via Positioned.fill, or its inner Stack (which
+        // clips) collapses to zero size under this Stack's default loose
+        // constraints for non-positioned children.
+        Positioned.fill(
+          child: OverlayEditorLayer(
+            controller: _viewController,
+            editing: false,
+            items: items,
+            videoW: widget.videoW,
+            videoH: widget.videoH,
+            buildItem: haBadgeItemBuilder(
+              stateFor: widget.stateFor,
+              stale: widget.stale,
+            ),
+            onTapItem: (item) => setState(
+              () => _openLinkId = _openLinkId == item.id ? null : item.id,
+            ),
+          ),
+        ),
+        if (open != null) ...[
+          // Tap-away scrim: any tap outside the card dismisses it. Sits
+          // ABOVE the badge layer in paint/hit-test order (Stack hit-tests
+          // the topmost child first and stops at the first opaque hit), so
+          // while a card is open, a tap anywhere — including over a
+          // DIFFERENT badge — is swallowed here and just dismisses the
+          // card, rather than reaching the badge underneath (tap the badge
+          // again to open its card). Sits BELOW the card itself, which
+          // swallows its own taps (see `HaStateCard`). While no card is
+          // open this scrim doesn't exist at all, so badge/tile gestures
+          // are unaffected.
+          Positioned.fill(
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () => setState(() => _openLinkId = null),
+              child: const SizedBox.expand(),
+            ),
+          ),
+          Positioned(
+            left: 12,
+            top: 12,
+            child: HaStateCard(
+              entityId: open.entityId,
+              friendlyName: open.displayLabel,
+              domain: open.domain,
+              deviceClass: open.deviceClass,
+              state: widget.stateFor(open.entityId),
+              stale: widget.stale,
+              onDismiss: () => setState(() => _openLinkId = null),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  HaLink? _findOpen(List<HaLink> placed) {
+    final id = _openLinkId;
+    if (id == null) return null;
+    for (final l in placed) {
+      if (l.id == id) return l;
+    }
+    return null;
+  }
+}

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_state_card.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_state_card.dart
@@ -1,0 +1,142 @@
+// Read-only detail card shown when an operator taps a placed HA badge (issue
+// #170 POC — no controls, see the desktop P0 plan §4.6/§1 locked decision
+// #3). Friendly name, current state, a relative "N ago" from `last_changed`,
+// the raw entity_id in mono-dim, and a stale note when applicable.
+//
+// This widget is just the card's CONTENT (plus swallowing taps on itself so
+// a host's tap-away scrim underneath doesn't dismiss when the card itself is
+// tapped) — the caller (`ha_overlay_layer.dart`) owns showing/hiding it and
+// wiring tap-away/Esc dismissal, matching `PtzPanelEditorBar`'s
+// plain-content-widget pattern (no Dialog/route machinery).
+
+import 'package:flutter/material.dart';
+
+import '../../api/ha_models.dart';
+import 'ha_icons.dart';
+
+class HaStateCard extends StatelessWidget {
+  const HaStateCard({
+    super.key,
+    required this.entityId,
+    required this.friendlyName,
+    required this.domain,
+    this.deviceClass,
+    this.state,
+    this.stale = false,
+    this.onDismiss,
+  });
+
+  final String entityId;
+  final String friendlyName;
+  final String domain;
+  final String? deviceClass;
+  final HaEntityState? state;
+  final bool stale;
+  final VoidCallback? onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final visual = haVisualFor(
+      domain: domain,
+      deviceClass: deviceClass,
+      state: state?.state,
+      stale: stale,
+    );
+    return GestureDetector(
+      // Swallow taps on the card so a tap-away scrim behind it (drawn by the
+      // host) doesn't treat "tapping the card" as "tapping away".
+      behavior: HitTestBehavior.opaque,
+      onTap: () {},
+      child: Material(
+        color: Colors.transparent,
+        child: Container(
+          constraints: const BoxConstraints(maxWidth: 260),
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: const Color(0xFF15181D).withValues(alpha: 0.96),
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: Colors.white24),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                children: [
+                  Icon(visual.icon, color: visual.color, size: 18),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      friendlyName,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w600,
+                        fontSize: 13,
+                      ),
+                    ),
+                  ),
+                  if (onDismiss != null)
+                    GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onTap: onDismiss,
+                      child: const Padding(
+                        padding: EdgeInsets.all(2),
+                        child: Icon(Icons.close, color: Colors.white54, size: 16),
+                      ),
+                    ),
+                ],
+              ),
+              const SizedBox(height: 6),
+              Text(
+                visual.label ?? (state?.state ?? 'Unknown'),
+                style: TextStyle(
+                  color: visual.color,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              if (state?.lastChanged != null) ...[
+                const SizedBox(height: 2),
+                Text(
+                  _relativeAgo(state!.lastChanged!),
+                  style: const TextStyle(color: Colors.white54, fontSize: 11),
+                ),
+              ],
+              const SizedBox(height: 6),
+              Text(
+                entityId,
+                style: const TextStyle(
+                  color: Colors.white38,
+                  fontSize: 10.5,
+                  fontFamily: 'monospace',
+                ),
+              ),
+              if (stale) ...[
+                const SizedBox(height: 6),
+                const Text(
+                  '⚠ Stale — Home Assistant connection may be down',
+                  style: TextStyle(
+                    color: Colors.amberAccent,
+                    fontSize: 10.5,
+                    fontStyle: FontStyle.italic,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  static String _relativeAgo(DateTime t) {
+    final d = DateTime.now().difference(t);
+    if (d.inSeconds < 5) return 'just now';
+    if (d.inMinutes < 1) return '${d.inSeconds} s ago';
+    if (d.inHours < 1) return '${d.inMinutes} m ago';
+    if (d.inDays < 1) return '${d.inHours} h ago';
+    return '${d.inDays} d ago';
+  }
+}

--- a/apps/desktop-flutter/lib/ui/live_status/live_status_controller.dart
+++ b/apps/desktop-flutter/lib/ui/live_status/live_status_controller.dart
@@ -25,6 +25,8 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 
 import 'package:crumb_desktop/api/crumb_api.dart';
+import 'package:crumb_desktop/api/ha_api.dart';
+import 'package:crumb_desktop/api/ha_models.dart';
 import 'package:crumb_desktop/api/models.dart';
 import 'package:crumb_desktop/api/status_api.dart';
 import 'package:crumb_desktop/api/status_models.dart';
@@ -87,6 +89,13 @@ class LiveStatusController extends ChangeNotifier {
   /// (still drives recording/motion + config/bookmarks) but skips `/events`.
   List<String> cameraIds = const [];
 
+  /// Whether to also poll `GET /ha/states` this tick (issue #170 P0 plan
+  /// §4.4). The owner sets this to `true` iff at least one visible camera has
+  /// at least one placed HA badge — while `false`, `/ha/states` is NEVER
+  /// fetched at all (the client half of the energy-lean "poll on demand"
+  /// contract; the server side already caches/no-ops when nobody asks).
+  bool wantHaStates = false;
+
   /// Called (debounced) when `/status.config_version` changes after the first
   /// observation — the owner should re-fetch cameras + streams and re-sync
   /// panes. Optional; if unset, config changes are still tracked in
@@ -104,6 +113,17 @@ class LiveStatusController extends ChangeNotifier {
   String? _configVersion; // null = not yet observed
   bool _bookmarksEnabled = true;
   bool _connectionLost = false;
+
+  /// Last-known `/ha/states` snapshot (kept across a failed poll — never
+  /// blank the badges on one bad tick, same rationale as `_byCameraId`).
+  /// Null until the first successful fetch while [wantHaStates] is true.
+  HaStatesSnapshot? _haStates;
+
+  /// Consecutive `/ha/states` fetch failures while [wantHaStates] is true;
+  /// mirrors `_failStreak` but scoped to the HA feed only (an HA outage must
+  /// grey the badges without flipping the whole-wall `connectionLost`
+  /// banner).
+  int _haMissStreak = 0;
 
   /// Latest per-camera status, keyed by camera id. Empty until the first
   /// successful poll.
@@ -126,6 +146,21 @@ class LiveStatusController extends ChangeNotifier {
 
   Set<String> detectionKeysFor(String cameraId) =>
       _detectionKeysByCameraId[cameraId] ?? const {};
+
+  /// Latest known state for `entityId` from the last successful `/ha/states`
+  /// poll, or null when no state is known yet (never polled, or the entity
+  /// isn't in the caller-visible set). A null return is "unknown", NOT
+  /// "off" — callers (e.g. `ha_overlay/ha_icons.dart`'s `haVisualFor`) must
+  /// treat it as indeterminate, matching the backend's `edge_on` invariant.
+  HaEntityState? haStateFor(String entityId) => _haStates?.byEntity[entityId];
+
+  /// True when the HA badges should render the grey/stale treatment: either
+  /// the server's own snapshot is marked stale (HA unreachable past its
+  /// cache TTL) or this poller has missed 2+ consecutive `/ha/states` fetches
+  /// itself. Mirrors `connectionLost`'s "never lie about staleness" rule, but
+  /// scoped to the HA feed so an HA outage doesn't trip the whole-wall
+  /// connection-lost banner.
+  bool get haStale => (_haStates?.stale ?? false) || _haMissStreak >= 2;
 
   void start() {
     _timer?.cancel();
@@ -160,9 +195,10 @@ class LiveStatusController extends ChangeNotifier {
       final now = DateTime.now();
       SystemStatus? status;
       EventsResponse? events;
+      HaStatesSnapshot? haSnapshot;
       Object? statusError;
       try {
-        final results = await Future.wait([
+        final futures = <Future<Object?>>[
           api.getStatus(session),
           api
               .getEvents(
@@ -175,9 +211,23 @@ class LiveStatusController extends ChangeNotifier {
               // existing glyphs — surface as null and keep the last-known set.
               .then<EventsResponse?>((v) => v)
               .catchError((_) => null),
-        ], eagerError: false);
+        ];
+        // Only polled when at least one visible camera has a placed badge —
+        // the energy-lean half of the "poll on demand" contract (issue #170
+        // P0 plan §4.4). Same failure isolation as /events: a bad tick keeps
+        // the last-known snapshot rather than blanking the badges.
+        if (wantHaStates) {
+          futures.add(
+            api
+                .haStates(session)
+                .then<HaStatesSnapshot?>((v) => v)
+                .catchError((_) => null),
+          );
+        }
+        final results = await Future.wait(futures, eagerError: false);
         status = results[0] as SystemStatus;
         events = results[1] as EventsResponse?;
+        if (wantHaStates) haSnapshot = results[2] as HaStatesSnapshot?;
       } catch (e) {
         statusError = e;
       }
@@ -201,6 +251,17 @@ class LiveStatusController extends ChangeNotifier {
         _detectionKeysByCameraId = _activeDetectionKeys(events, now);
       }
       // else: keep the previous _detectionKeysByCameraId as-is.
+
+      if (wantHaStates) {
+        if (haSnapshot != null) {
+          _haStates = haSnapshot;
+          _haMissStreak = 0;
+        } else {
+          // Keep the previous _haStates as-is (last-known); count the miss
+          // toward haStale.
+          _haMissStreak += 1;
+        }
+      }
 
       _failStreak = 0;
       _connectionLost = false;

--- a/apps/desktop-flutter/lib/ui/overlay_editor/overlay_editor_bar.dart
+++ b/apps/desktop-flutter/lib/ui/overlay_editor/overlay_editor_bar.dart
@@ -1,0 +1,156 @@
+// Shared edit-mode bottom bar frame for the drag-to-place overlay editor —
+// lifted from `ptz/ptz_panel_editor_bar.dart`'s Done/Clear/selected-props
+// chrome and generalized: palette content (the PTZ "Add:" row, or the HA
+// linked-entity picker, `ha_overlay/ha_entity_palette.dart`) is injected by
+// the host as a plain widget slot; the Done/Clear buttons are host callbacks
+// too — this bar never calls `OverlayEditorController.endEdit()`/`clearAll()`
+// itself, because the controller never touches storage (see
+// `overlay_editor_controller.dart`'s lifecycle contract) so a host must
+// always be the one that persists on Done.
+//
+// Usage: place along the bottom of the maximized-tile screen that also hosts
+// `OverlayEditorLayer`, while `controller.editMode == true` — same placement
+// rule as `PtzPanelEditorBar`.
+
+import 'package:flutter/material.dart';
+
+import 'overlay_editor_controller.dart';
+import 'overlay_item.dart';
+
+class OverlayEditorBar extends StatelessWidget {
+  const OverlayEditorBar({
+    super.key,
+    required this.controller,
+    required this.paletteSlot,
+    required this.onDone,
+    this.onClear,
+    this.clearLabel = 'Clear all',
+    this.itemLabel,
+  });
+
+  final OverlayEditorController controller;
+
+  /// Host-supplied palette content, laid out before the shared Clear/Done +
+  /// selected-item controls (e.g. an "Add:" button row for PTZ, or
+  /// `HaEntityPalette` for HA badges).
+  final Widget paletteSlot;
+
+  /// Called when the operator taps Done. The host should call
+  /// `controller.endEdit()` itself here and persist the returned items —
+  /// this bar deliberately does not call it directly (storage is entirely
+  /// the host's responsibility).
+  final VoidCallback onDone;
+
+  /// Called when the operator taps [clearLabel] (the button is disabled
+  /// while there are no items). Typically composes `controller.clearAll`
+  /// with whatever the host also needs to do on a full clear (e.g. queue
+  /// every removed placement to be cleared server-side on the next Done).
+  final VoidCallback? onClear;
+
+  final String clearLabel;
+
+  /// Display text for the currently-selected item, shown next to the size
+  /// stepper (e.g. its entity id / display label). Null hides the chip.
+  final String Function(OverlayItem item)? itemLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: controller,
+      builder: (context, _) {
+        final selected = controller.selected;
+        final hasItems = controller.items.isNotEmpty;
+        return Material(
+          color: Colors.black.withValues(alpha: 0.75),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+            child: Wrap(
+              crossAxisAlignment: WrapCrossAlignment.center,
+              spacing: 6,
+              runSpacing: 6,
+              children: [
+                paletteSlot,
+                const SizedBox(width: 12),
+                _EdButton(
+                  label: clearLabel,
+                  danger: true,
+                  onTap: hasItems ? onClear : null,
+                ),
+                _EdButton(label: 'Done', primary: true, onTap: onDone),
+                if (selected != null) ...[
+                  const _EdLabel('Selected:'),
+                  if (itemLabel != null)
+                    Text(
+                      itemLabel!(selected),
+                      style: const TextStyle(color: Colors.white70, fontSize: 12),
+                    ),
+                  _EdButton(
+                    label: '−',
+                    onTap: () => controller.resizeSelected(1 / 1.15),
+                  ),
+                  const _EdLabel('size'),
+                  _EdButton(
+                    label: '+',
+                    onTap: () => controller.resizeSelected(1.15),
+                  ),
+                  _EdButton(
+                    label: 'Delete',
+                    danger: true,
+                    onTap: () => controller.removeItem(selected.id),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _EdLabel extends StatelessWidget {
+  const _EdLabel(this.text);
+  final String text;
+
+  @override
+  Widget build(BuildContext context) =>
+      Text(text, style: const TextStyle(color: Colors.white70, fontSize: 12));
+}
+
+class _EdButton extends StatelessWidget {
+  const _EdButton({
+    required this.label,
+    required this.onTap,
+    this.danger = false,
+    this.primary = false,
+  });
+
+  final String label;
+  final VoidCallback? onTap;
+  final bool danger;
+  final bool primary;
+
+  @override
+  Widget build(BuildContext context) {
+    final bg = primary
+        ? const Color(0xFF2CA3E8)
+        : danger
+        ? const Color(0xFF7A2020)
+        : const Color(0xFF2A2F36);
+    return SizedBox(
+      height: 30,
+      child: TextButton(
+        onPressed: onTap,
+        style: TextButton.styleFrom(
+          backgroundColor: bg,
+          disabledBackgroundColor: bg.withValues(alpha: 0.35),
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(horizontal: 10),
+          minimumSize: Size.zero,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(5)),
+        ),
+        child: Text(label, style: const TextStyle(fontSize: 12)),
+      ),
+    );
+  }
+}

--- a/apps/desktop-flutter/lib/ui/overlay_editor/overlay_editor_controller.dart
+++ b/apps/desktop-flutter/lib/ui/overlay_editor/overlay_editor_controller.dart
@@ -1,0 +1,288 @@
+// Generic drag-to-place overlay editor: selection, drag/resize with
+// alignment-snap guides, and an explicit SYNCHRONOUS edit lifecycle. Lifted
+// from `ptz/ptz_panel_controller.dart` (`ptzSnapLines`/`ptzSnapAxis`,
+// `ptzPanelMoveButton`/`ptzPanelResizeButton` in the old client's app.js) and
+// repaired per the desktop P0 plan (issue #170 §3.2/§3.3): the PTZ
+// controller's `beginEdit`/`endEdit` `await` storage calls BEFORE their only
+// `notifyListeners()`, which produces an interleave-clobber race between two
+// back-to-back edit sessions (D3) and a UI-lag-behind-the-click window (D5).
+//
+// This controller never touches storage: `beginEdit` takes an
+// ALREADY-LOADED item list and fires `notifyListeners()` synchronously;
+// `endEdit` returns the final items synchronously so the HOST persists.
+// Hosts own storage entirely — a client-local store for PTZ panels (future
+// adapter), a server PUT for HA badge placements
+// (`ha_overlay/ha_overlay_controller.dart`).
+//
+// One [OverlayEditorController] is owned by whatever host adapts a specific
+// overlay kind. The host drives [OverlayEditorLayer] (rendering/gestures,
+// `overlay_editor_layer.dart`) and [OverlayEditorBar] (palette/props chrome,
+// `overlay_editor_bar.dart`).
+
+import 'package:flutter/foundation.dart';
+
+import 'overlay_geometry.dart';
+import 'overlay_item.dart';
+
+/// Alignment guide lines (logical px, pane-local) shown while dragging/resizing.
+class OverlaySnapGuides {
+  const OverlaySnapGuides({this.vx = const [], this.hy = const []});
+  final List<double> vx;
+  final List<double> hy;
+  static const none = OverlaySnapGuides();
+}
+
+/// Snap threshold in logical px (`PTZ_SNAP_PX` in the old client /
+/// `kPtzSnapPx`).
+const double kOverlaySnapPx = 7;
+
+class OverlayEditorController extends ChangeNotifier {
+  bool editMode = false;
+  String? selectedId;
+  OverlaySnapGuides snapGuides = OverlaySnapGuides.none;
+
+  List<OverlayItem> _items = const [];
+  OverlayAnchor _anchor = OverlayAnchor.pane;
+  int _editToken = 0;
+
+  /// Bumped on every `beginEdit`/`endEdit`. Hosts that kick off an async load
+  /// BEFORE calling `beginEdit` (the mandated "host-loads-first" order, see
+  /// `ha_overlay/ha_overlay_controller.dart`) should capture this beforehand
+  /// and compare it once the load resolves — if it changed, another edit
+  /// session started or ended in the meantime, and the late `beginEdit`
+  /// call must be skipped (a stale continuation would otherwise clobber
+  /// whatever the user is doing now).
+  int get editToken => _editToken;
+
+  /// Live item list for the current edit session (empty outside edit mode —
+  /// hosts pass their own list to [OverlayEditorLayer] for view mode).
+  List<OverlayItem> get items => _items;
+
+  OverlayAnchor get anchor => _anchor;
+
+  OverlayItem? get selected {
+    final id = selectedId;
+    if (id == null) return null;
+    for (final i in _items) {
+      if (i.id == id) return i;
+    }
+    return null;
+  }
+
+  /// Begin an edit session with `items` the host has ALREADY loaded (and
+  /// `anchor`, since an empty item list still needs a coordinate space for
+  /// snap-line/placement math). No awaits; fires `notifyListeners()`
+  /// synchronously so the editor chrome appears the instant this returns.
+  void beginEdit(List<OverlayItem> items, {required OverlayAnchor anchor}) {
+    _editToken++;
+    editMode = true;
+    _items = List.of(items);
+    _anchor = anchor;
+    selectedId = null;
+    snapGuides = OverlaySnapGuides.none;
+    notifyListeners();
+  }
+
+  /// End the edit session and hand the final item list back to the host,
+  /// which persists it. Synchronous — no fire-and-forget transitions.
+  List<OverlayItem> endEdit() {
+    _editToken++;
+    final result = _items;
+    editMode = false;
+    _items = const [];
+    selectedId = null;
+    snapGuides = OverlaySnapGuides.none;
+    notifyListeners();
+    return result;
+  }
+
+  void selectItem(String? id) {
+    if (selectedId == id) return;
+    selectedId = id;
+    notifyListeners();
+  }
+
+  /// Add a new item to the session (e.g. a palette pick) and select it. Pure
+  /// in-memory — the host persists on `endEdit`.
+  void addItem(OverlayItem item) {
+    _items = [..._items, item];
+    selectedId = item.id;
+    notifyListeners();
+  }
+
+  /// Remove an item from the session (the on-canvas delete handle, or the
+  /// selected-item bar's Delete button). Pure in-memory.
+  void removeItem(String id) {
+    _items = _items.where((i) => i.id != id).toList(growable: false);
+    if (selectedId == id) selectedId = null;
+    notifyListeners();
+  }
+
+  void clearAll() {
+    _items = const [];
+    selectedId = null;
+    notifyListeners();
+  }
+
+  /// Nudge the selected item's size by `factor` (editor bar +/- stepper —
+  /// `ptzPanelResizeSelected` in the old client). Works for every item,
+  /// drag-resizable or not (HA badges use this exclusively).
+  void resizeSelected(double factor) {
+    final item = selected;
+    if (item == null) return;
+    final (bw, bh) = item.baseSize();
+    item.setBaseSize(bw * factor, bh * factor);
+    notifyListeners();
+  }
+
+  // ─── Drag / resize with snapping ────────────────────────────────────────
+
+  OverlayItem? _find(String id) {
+    for (final i in _items) {
+      if (i.id == id) return i;
+    }
+    return null;
+  }
+
+  /// Candidate snap lines from the OTHER items' edges/centres + the anchor
+  /// field's edges/centre, in logical px.
+  OverlaySnapGuides _snapLines(
+    String exceptId,
+    double paneW,
+    double paneH, {
+    int? videoW,
+    int? videoH,
+  }) {
+    final (fx, fy, fw, fh) = OverlayGeometry.fieldRect(
+      _anchor,
+      paneW,
+      paneH,
+      videoW: videoW,
+      videoH: videoH,
+    );
+    final vx = <double>[fx, fx + fw / 2, fx + fw];
+    final hy = <double>[fy, fy + fh / 2, fy + fh];
+    for (final o in _items) {
+      if (o.id == exceptId) continue;
+      final (x, y, w, h) = OverlayGeometry.rectFor(
+        o,
+        paneW,
+        paneH,
+        videoW: videoW,
+        videoH: videoH,
+      );
+      vx.addAll([x, x + w / 2, x + w]);
+      hy.addAll([y, y + h / 2, y + h]);
+    }
+    return OverlaySnapGuides(vx: vx, hy: hy);
+  }
+
+  (double delta, double? guide) _snapAxis(
+    List<double> cands,
+    List<double> lines,
+  ) {
+    double? bestDelta;
+    double? bestGuide;
+    for (final c in cands) {
+      for (final g in lines) {
+        final d = g - c;
+        if (d.abs() <= kOverlaySnapPx &&
+            (bestDelta == null || d.abs() < bestDelta.abs())) {
+          bestDelta = d;
+          bestGuide = g;
+        }
+      }
+    }
+    return (bestDelta ?? 0, bestGuide);
+  }
+
+  /// Nudge `id` by a pointer-movement delta (px, pane-local); snaps the
+  /// resulting edges/centre to alignment guides. Does NOT persist — call on
+  /// every drag-update tick; the host persists once at `endEdit`.
+  void moveItemByDelta(
+    String id,
+    double paneW,
+    double paneH,
+    double dx,
+    double dy, {
+    int? videoW,
+    int? videoH,
+  }) {
+    final item = _find(id);
+    if (item == null) return;
+    final (curX, curY, bw, bh) = OverlayGeometry.rectFor(
+      item,
+      paneW,
+      paneH,
+      videoW: videoW,
+      videoH: videoH,
+    );
+    var px = curX + dx;
+    var py = curY + dy;
+    final lines = _snapLines(id, paneW, paneH, videoW: videoW, videoH: videoH);
+    final sx = _snapAxis([px, px + bw / 2, px + bw], lines.vx);
+    final sy = _snapAxis([py, py + bh / 2, py + bh], lines.hy);
+    px += sx.$1;
+    py += sy.$1;
+    snapGuides = OverlaySnapGuides(
+      vx: sx.$2 != null ? [sx.$2!] : const [],
+      hy: sy.$2 != null ? [sy.$2!] : const [],
+    );
+    final (fx, fy, fw, fh) = OverlayGeometry.fieldRect(
+      _anchor,
+      paneW,
+      paneH,
+      videoW: videoW,
+      videoH: videoH,
+    );
+    item.x = fw <= 0 ? 0 : ((px - fx) / fw).clamp(0, 1).toDouble();
+    item.y = fh <= 0 ? 0 : ((py - fy) / fh).clamp(0, 1).toDouble();
+    notifyListeners();
+  }
+
+  /// Resize `id` by a pointer-movement delta applied to its bottom-right
+  /// edge; snaps to alignment guides. Only meaningful for `item.resizable`
+  /// items — the layer only shows the drag-resize handle for those; a
+  /// non-resizable item's caller shouldn't invoke this (defensive no-op if
+  /// it does).
+  void resizeItemByDelta(
+    String id,
+    double paneW,
+    double paneH,
+    double dx,
+    double dy, {
+    int? videoW,
+    int? videoH,
+  }) {
+    final item = _find(id);
+    if (item == null || !item.resizable) return;
+    final s = OverlayGeometry.paneScale(paneW, paneH);
+    final (left, top, curW, curH) = OverlayGeometry.rectFor(
+      item,
+      paneW,
+      paneH,
+      videoW: videoW,
+      videoH: videoH,
+    );
+    var nw = curW + dx;
+    var nh = curH + dy;
+    final lines = _snapLines(id, paneW, paneH, videoW: videoW, videoH: videoH);
+    final sx = _snapAxis([left + nw], lines.vx);
+    final sy = _snapAxis([top + nh], lines.hy);
+    nw += sx.$1;
+    nh += sy.$1;
+    snapGuides = OverlaySnapGuides(
+      vx: sx.$2 != null ? [sx.$2!] : const [],
+      hy: sy.$2 != null ? [sy.$2!] : const [],
+    );
+    item.setBaseSize(s <= 0 ? nw : nw / s, s <= 0 ? nh : nh / s);
+    notifyListeners();
+  }
+
+  /// End of a drag/resize gesture: clear guides. No persistence — see the
+  /// class doc; the host persists once at `endEdit`.
+  void commitDrag() {
+    snapGuides = OverlaySnapGuides.none;
+    notifyListeners();
+  }
+}

--- a/apps/desktop-flutter/lib/ui/overlay_editor/overlay_editor_layer.dart
+++ b/apps/desktop-flutter/lib/ui/overlay_editor/overlay_editor_layer.dart
@@ -1,0 +1,305 @@
+// The overlay editor's render + gesture layer (edit + view mode) — lifted
+// from `ptz/ptz_panel_overlay.dart`'s Stack/hit-test structure and
+// generalized over any `OverlayItem`. Item VISUALS (body/selection styling)
+// come from a host delegate ([OverlayItemBuilder]); this layer owns only the
+// generic chrome: the opaque per-item hit target (so gaps between items fall
+// through to whatever's underneath — the video pane's own gestures), the
+// delete (x) / resize handles in edit mode, and the snap-guide lines.
+// Handles are suppressed below [kOverlayHandleMinRenderedPx] (repairs the PTZ
+// panel's D6 defect — a small button's handles could cover its whole body,
+// see the desktop P0 plan §3.2) — use the editor bar's size stepper /
+// selected-item Delete button instead at that size.
+//
+// Usage: stack this INSIDE the same-sized `Positioned.fill` video pane that
+// hosts the Video widget, above it in z-order — same placement rule as
+// `PtzPanelOverlay`:
+//
+//   Stack(children: [
+//     Video(controller: videoController),
+//     Positioned.fill(child: OverlayEditorLayer(
+//       controller: controller,
+//       editing: controller.editMode,
+//       buildItem: myBuildItem,
+//       videoW: videoW, videoH: videoH, // only needed for videoFrame items
+//     )),
+//   ])
+
+import 'package:flutter/material.dart';
+
+import 'overlay_editor_controller.dart';
+import 'overlay_geometry.dart';
+import 'overlay_item.dart';
+
+/// Host-supplied item visual: body/selection styling only — NOT the hit
+/// target or edit-mode handles, which this layer draws itself.
+typedef OverlayItemBuilder =
+    Widget Function(
+      OverlayItem item, {
+      required bool editing,
+      required bool selected,
+    });
+
+/// Below this rendered size (logical px, either dimension), the delete/resize
+/// handles are hidden — repairs the PTZ panel's D6 defect where a small
+/// button's own handles could cover most/all of its body. Use the editor
+/// bar's size stepper / selected-item Delete button instead at this size.
+const double kOverlayHandleMinRenderedPx = 24;
+
+class OverlayEditorLayer extends StatelessWidget {
+  const OverlayEditorLayer({
+    super.key,
+    required this.controller,
+    required this.buildItem,
+    this.editing = false,
+    this.items,
+    this.videoW,
+    this.videoH,
+    this.onTapItem,
+    this.emptyEditHint,
+  });
+
+  final OverlayEditorController controller;
+
+  /// Item body/selection visual — see [OverlayItemBuilder].
+  final OverlayItemBuilder buildItem;
+
+  /// True renders the LIVE edit session (`controller.items`, drag/resize,
+  /// handles, snap guides). False renders a read-only view-mode layer from
+  /// [items] (badges/buttons only, tap dispatches [onTapItem]).
+  final bool editing;
+
+  /// View-mode item list — required (and used) when [editing] is false;
+  /// ignored while editing (the controller's own live `items` drives that).
+  final List<OverlayItem>? items;
+
+  /// Decoded video pixel size — needed only for `OverlayAnchor.videoFrame`
+  /// items. Those are skipped entirely (both modes) until both are known,
+  /// rather than falling back to a misplaced full-pane guess.
+  final int? videoW;
+  final int? videoH;
+
+  /// View-mode tap dispatch (e.g. show a state card). Edit-mode taps select
+  /// the item instead and never call this.
+  final void Function(OverlayItem item)? onTapItem;
+
+  /// Edit-mode placeholder text shown centered when there are no items yet
+  /// (e.g. "Add controls from the bar, then drag them where you want"). Null
+  /// shows nothing.
+  final String? emptyEditHint;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: controller,
+      builder: (context, _) {
+        final source = editing ? controller.items : (items ?? const []);
+        final hasVideoDims =
+            videoW != null && videoH != null && videoW! > 0 && videoH! > 0;
+        final visible = [
+          for (final item in source)
+            if (item.anchor != OverlayAnchor.videoFrame || hasVideoDims) item,
+        ];
+        return LayoutBuilder(
+          builder: (context, constraints) {
+            final w = constraints.maxWidth;
+            final h = constraints.maxHeight;
+            if (w <= 0 || h <= 0) return const SizedBox.shrink();
+            return Stack(
+              clipBehavior: Clip.hardEdge,
+              children: [
+                for (final item in visible)
+                  _OverlayItemWidget(
+                    key: ValueKey(item.id),
+                    controller: controller,
+                    item: item,
+                    paneW: w,
+                    paneH: h,
+                    videoW: videoW,
+                    videoH: videoH,
+                    editing: editing,
+                    selected: editing && controller.selectedId == item.id,
+                    buildItem: buildItem,
+                    onTap: onTapItem,
+                  ),
+                if (editing) ..._snapGuideLines(controller.snapGuides, w, h),
+                if (editing && visible.isEmpty && emptyEditHint != null)
+                  Center(child: _hintChip(emptyEditHint!)),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
+  List<Widget> _snapGuideLines(OverlaySnapGuides g, double w, double h) {
+    const color = Color(0x664CC9FF);
+    return [
+      for (final x in g.vx)
+        Positioned(
+          left: x,
+          top: 0,
+          width: 1,
+          height: h,
+          child: Container(color: color),
+        ),
+      for (final y in g.hy)
+        Positioned(
+          left: 0,
+          top: y,
+          width: w,
+          height: 1,
+          child: Container(color: color),
+        ),
+    ];
+  }
+
+  Widget _hintChip(String text) => Container(
+    padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+    decoration: BoxDecoration(
+      color: Colors.black.withValues(alpha: 0.55),
+      borderRadius: BorderRadius.circular(6),
+    ),
+    child: Text(text, style: const TextStyle(color: Colors.white, fontSize: 13)),
+  );
+}
+
+class _OverlayItemWidget extends StatelessWidget {
+  const _OverlayItemWidget({
+    super.key,
+    required this.controller,
+    required this.item,
+    required this.paneW,
+    required this.paneH,
+    required this.videoW,
+    required this.videoH,
+    required this.editing,
+    required this.selected,
+    required this.buildItem,
+    required this.onTap,
+  });
+
+  final OverlayEditorController controller;
+  final OverlayItem item;
+  final double paneW;
+  final double paneH;
+  final int? videoW;
+  final int? videoH;
+  final bool editing;
+  final bool selected;
+  final OverlayItemBuilder buildItem;
+  final void Function(OverlayItem item)? onTap;
+
+  static const double _handle = 16;
+
+  @override
+  Widget build(BuildContext context) {
+    final (x, y, w, h) = OverlayGeometry.rectFor(
+      item,
+      paneW,
+      paneH,
+      videoW: videoW,
+      videoH: videoH,
+    );
+    return Positioned(
+      left: x,
+      top: y,
+      width: w,
+      height: h,
+      child: editing ? _editBody(w, h) : _viewBody(),
+    );
+  }
+
+  // ─── Edit-mode: draggable body + delete/resize handles ─────────────────
+
+  Widget _editBody(double w, double h) {
+    final showHandles =
+        w >= kOverlayHandleMinRenderedPx && h >= kOverlayHandleMinRenderedPx;
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () => controller.selectItem(item.id),
+      onPanStart: (_) => controller.selectItem(item.id),
+      onPanUpdate: (d) => controller.moveItemByDelta(
+        item.id,
+        paneW,
+        paneH,
+        d.delta.dx,
+        d.delta.dy,
+        videoW: videoW,
+        videoH: videoH,
+      ),
+      onPanEnd: (_) => controller.commitDrag(),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          // Explicit SizedBox: a Stack loosens the constraints of a
+          // non-positioned child, so the delegate's returned widget must be
+          // told its exact target size rather than relying on it to
+          // self-size correctly under loose constraints (mirrors
+          // `PtzPanelOverlay`'s `Container(width: w, height: h, ...)`).
+          SizedBox(
+            width: w,
+            height: h,
+            child: buildItem(item, editing: true, selected: selected),
+          ),
+          // Delete (x) handle, top-right.
+          if (showHandles)
+            Positioned(
+              right: 0,
+              top: 0,
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () => controller.removeItem(item.id),
+                child: Container(
+                  width: _handle,
+                  height: _handle,
+                  decoration: const BoxDecoration(color: Color(0xCC2030D0)),
+                  alignment: Alignment.center,
+                  child: const Text(
+                    '×',
+                    style: TextStyle(color: Colors.white, fontSize: 13, height: 1),
+                  ),
+                ),
+              ),
+            ),
+          // Resize handle, bottom-right — only when selected AND the item
+          // opts into drag-resize (`OverlayItem.resizable`).
+          if (showHandles && selected && item.resizable)
+            Positioned(
+              right: 0,
+              bottom: 0,
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onPanUpdate: (d) => controller.resizeItemByDelta(
+                  item.id,
+                  paneW,
+                  paneH,
+                  d.delta.dx,
+                  d.delta.dy,
+                  videoW: videoW,
+                  videoH: videoH,
+                ),
+                onPanEnd: (_) => controller.commitDrag(),
+                child: Container(
+                  width: _handle,
+                  height: _handle,
+                  decoration: const BoxDecoration(color: Color(0xE62CA3E8)),
+                  child: const Icon(Icons.south_east, size: 12, color: Colors.white),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  // ─── View mode: only the item glyph is an opaque hit target ────────────
+
+  Widget _viewBody() {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap == null ? null : () => onTap!(item),
+      child: buildItem(item, editing: false, selected: false),
+    );
+  }
+}

--- a/apps/desktop-flutter/lib/ui/overlay_editor/overlay_geometry.dart
+++ b/apps/desktop-flutter/lib/ui/overlay_editor/overlay_geometry.dart
@@ -1,0 +1,91 @@
+// Pure geometry for the shared drag-to-place overlay editor — lifted from
+// `api/ptz_panel_models.dart`'s `PtzPanelGeometry` (`paneScale`/`rectFor`)
+// plus the contain-fit video-rect math lifted from
+// `ui/wall_screen.dart`'s `_MaximizedPane._normOffset`, so pane-anchored
+// (PTZ) and video-frame-anchored (HA badges) items share ONE pure geometry
+// layer used identically by rendering and hit-testing/drag math (issue #170
+// §3.3/§4.2). No Flutter/widget dependency — safe to unit test directly.
+
+import 'dart:math' as math;
+
+import 'overlay_item.dart';
+
+class OverlayGeometry {
+  const OverlayGeometry._(); // no instances — static namespace only
+
+  /// Reference tile short-side (`PTZ_PANEL_REF` in the old client /
+  /// `PtzPanelGeometry.refShortSide`) at which base item sizes render 1:1.
+  static const double refShortSide = 320;
+
+  /// Rendered items never shrink below this (logical px), so a heavily
+  /// scaled-down item never fully disappears.
+  static const double minRenderedPx = 8;
+
+  /// Whole-cluster scale factor for a `paneW`x`paneH` pane
+  /// (`PtzPanelGeometry.paneScale`).
+  static double paneScale(double paneW, double paneH) {
+    final s = (paneW < paneH ? paneW : paneH) / refShortSide;
+    return s.clamp(0.5, 3.0).toDouble();
+  }
+
+  /// The anchor "field" rect (origin + size, in pane-local px) that an
+  /// item's normalized x/y is a fraction OF.
+  ///
+  /// `OverlayAnchor.pane` -> the whole pane, origin (0,0).
+  ///
+  /// `OverlayAnchor.videoFrame` -> the DISPLAYED (`BoxFit.contain`
+  /// letterboxed) video rect within the pane, computed from the decoded
+  /// video's pixel size (`videoW`/`videoH`) — mirrors
+  /// `_MaximizedPane._normOffset`'s contain-rect math (wall_screen.dart) so
+  /// placement/hit-test agree with what's actually on screen regardless of
+  /// tile aspect ratio. Falls back to the whole pane when the video's pixel
+  /// size isn't known yet — callers should gate rendering on known
+  /// dimensions instead of relying on this fallback (see
+  /// `overlay_editor_layer.dart`, which skips `videoFrame`-anchored items
+  /// entirely until both are known).
+  static (double x, double y, double w, double h) fieldRect(
+    OverlayAnchor anchor,
+    double paneW,
+    double paneH, {
+    int? videoW,
+    int? videoH,
+  }) {
+    if (anchor == OverlayAnchor.pane) return (0, 0, paneW, paneH);
+    final w = videoW, h = videoH;
+    if (w == null || h == null || w <= 0 || h <= 0) {
+      return (0, 0, paneW, paneH);
+    }
+    final s = math.min(paneW / w, paneH / h);
+    final fw = w * s;
+    final fh = h * s;
+    return ((paneW - fw) / 2, (paneH - fh) / 2, fw, fh);
+  }
+
+  /// Rendered pixel rect (x, y, w, h) of `item` within a `paneW`x`paneH`
+  /// pane, honoring its [OverlayItem.anchor] (`ptzPanelBtnRect`/
+  /// `PtzPanelGeometry.rectFor` lifted + anchor-aware). Floors rendered size
+  /// at [minRenderedPx] so a shrunk item never disappears; clamps inside its
+  /// anchor field.
+  static (double x, double y, double w, double h) rectFor(
+    OverlayItem item,
+    double paneW,
+    double paneH, {
+    int? videoW,
+    int? videoH,
+  }) {
+    final (baseW, baseH) = item.baseSize();
+    final s = paneScale(paneW, paneH);
+    final bw = (baseW * s).clamp(minRenderedPx, double.infinity).toDouble();
+    final bh = (baseH * s).clamp(minRenderedPx, double.infinity).toDouble();
+    final (fx, fy, fw, fh) = fieldRect(
+      item.anchor,
+      paneW,
+      paneH,
+      videoW: videoW,
+      videoH: videoH,
+    );
+    final x = (fx + item.x * fw).clamp(fx, fx + fw - bw).toDouble();
+    final y = (fy + item.y * fh).clamp(fy, fy + fh - bh).toDouble();
+    return (x, y, bw, bh);
+  }
+}

--- a/apps/desktop-flutter/lib/ui/overlay_editor/overlay_item.dart
+++ b/apps/desktop-flutter/lib/ui/overlay_editor/overlay_item.dart
@@ -1,0 +1,58 @@
+// Shared "thing placed on a video pane" abstraction used by the generic
+// drag-to-place overlay editor (`overlay_editor_controller.dart` /
+// `overlay_editor_layer.dart`, issue #170 §3.3). One concrete implementation
+// exists today: HA on-video badges (`ha_overlay/ha_overlay_controller.dart`'s
+// `HaOverlayBadgeItem`, video-frame-anchored). A PTZ custom-panel-button
+// adapter (`PtzPanelButton` implementing this) is a later follow-up per the
+// desktop P0 plan §3.3/§5 P1 — NOT part of this change; `PtzPanelButton`
+// (`api/ptz_panel_models.dart`) keeps its own pane-fraction geometry for now.
+
+/// What an item's normalized x/y is a fraction OF.
+enum OverlayAnchor {
+  /// Fraction of the whole rendered pane (the PTZ custom-panel convention).
+  pane,
+
+  /// Fraction of the DISPLAYED (`BoxFit.contain` letterboxed) video frame
+  /// within the pane — stays pinned to the same physical point in frame
+  /// regardless of tile aspect/letterboxing (HA badge placement, issue #170
+  /// §4.2). Requires the decoded video's pixel size to render/hit-test —
+  /// see `overlay_geometry.dart`'s `fieldRect`.
+  videoFrame,
+}
+
+/// One item placed on the overlay. Mutable — the editor controller mutates
+/// `x`/`y`/size in place during a drag/resize, and the host reads the final
+/// state back from `OverlayEditorController.endEdit()`.
+abstract class OverlayItem {
+  /// Stable identity within an edit session (e.g. the HA link's uuid).
+  String get id;
+
+  /// Normalized position (0..1 each), a fraction of [anchor]'s field —
+  /// TOP-LEFT anchor of the rendered rect (matches the PTZ button convention
+  /// this abstraction was lifted from, `ptz_panel_models.dart`).
+  double get x;
+  set x(double v);
+  double get y;
+  set y(double v);
+
+  OverlayAnchor get anchor;
+
+  /// Current BASE (unscaled) size in logical px at pane-scale 1.0 — the
+  /// rendered size is `base * OverlayGeometry.paneScale(...)`, so the item
+  /// reads the same on a small grid tile and a maximized pane (WYSIWYG,
+  /// matches the PTZ panel's rationale).
+  (double w, double h) baseSize();
+
+  /// Apply a new base size — already the result of a drag-resize delta (or
+  /// the editor bar's +/- stepper) divided back to base units.
+  /// Implementations own their own clamping/aspect rules (e.g. a PTZ d-pad
+  /// stays square; an HA badge is always square and stores a scale
+  /// multiplier, not raw px).
+  void setBaseSize(double w, double h);
+
+  /// Whether the on-canvas drag-resize handle appears when this item is
+  /// selected in edit mode. `false` items (HA badges) are still resizable
+  /// via the editor bar's size stepper, which calls [setBaseSize] directly —
+  /// this flag ONLY gates the drag handle, not resizability in general.
+  bool get resizable;
+}

--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -13,6 +13,8 @@ import 'package:media_kit_video/media_kit_video.dart';
 import 'package:flutter/gestures.dart';
 
 import 'package:crumb_desktop/api/crumb_api.dart';
+import 'package:crumb_desktop/api/ha_api.dart';
+import 'package:crumb_desktop/api/ha_models.dart';
 import 'package:crumb_desktop/api/models.dart';
 import 'package:crumb_desktop/api/ptz_panel_store.dart';
 import 'package:crumb_desktop/services/audio_follow_controller.dart';
@@ -22,10 +24,15 @@ import 'package:crumb_desktop/state/client_options.dart';
 import 'package:crumb_desktop/state/hotkey_config.dart';
 import 'package:crumb_desktop/state/keyboard_shortcuts.dart';
 import 'package:crumb_desktop/state/stream_prefs.dart';
+import 'package:crumb_desktop/ui/ha_overlay/ha_entity_palette.dart';
+import 'package:crumb_desktop/ui/ha_overlay/ha_overlay_controller.dart';
+import 'package:crumb_desktop/ui/ha_overlay/ha_overlay_layer.dart';
 import 'package:crumb_desktop/ui/hotkeys/global_hotkeys_listener.dart';
 import 'package:crumb_desktop/ui/live/pane_watchdog.dart';
 import 'package:crumb_desktop/ui/live_status/live_status_badges.dart';
 import 'package:crumb_desktop/ui/live_status/live_status_controller.dart';
+import 'package:crumb_desktop/ui/overlay_editor/overlay_editor_bar.dart';
+import 'package:crumb_desktop/ui/overlay_editor/overlay_editor_layer.dart';
 import 'package:crumb_desktop/ui/ptz/ptz_imaging_controls.dart';
 import 'package:crumb_desktop/ui/ptz/ptz_panel_controller.dart';
 import 'package:crumb_desktop/ui/ptz/ptz_panel_editor_bar.dart';
@@ -172,6 +179,35 @@ class _WallScreenState extends State<WallScreen> {
     store: _ptzPanelStore,
   );
 
+  /// HA on-video badge placements (issue #170 P0) — one adapter shared by
+  /// every maximized pane, mirroring `_ptzPanel`'s shared-controller pattern.
+  /// Only the maximized pane ever enters its edit session (WYSIWYG, same
+  /// rule as the PTZ panel editor); the wall tracks which camera that
+  /// session belongs to itself (`_haEditCameraId`) since the shared editor
+  /// controller is camera-agnostic by design.
+  late final HaOverlayController _haOverlay = HaOverlayController(
+    api: widget.api,
+    session: widget.session,
+  );
+  String? _haEditCameraId;
+
+  /// Per-camera "has ≥1 placed HA badge" flag, reported by each tile/pane as
+  /// it (re)loads its own links (mirrors how each pane self-fetches
+  /// `cameraStreams` — desktop P0 plan §4.4). Drives `_liveStatus.wantHaStates`
+  /// so `/ha/states` is polled only while at least one VISIBLE camera has a
+  /// placement — the client half of the server's demand-driven-cache
+  /// contract (services/api/src/ha.rs `HA_STATES_TTL`).
+  final Set<String> _camerasWithHaPlacements = {};
+
+  /// Fresh per-maximize `GlobalKey` for the maximized pane (mirrors
+  /// `_tileKeyFor`'s per-camera keys, but this pane only ever shows ONE
+  /// camera at a time so a single field — reassigned on every `_maximize` —
+  /// is enough). Lets the wall push a refreshed HA-links list into the pane
+  /// after an edit session saves, the same way it reaches into a tile via
+  /// `_tileKeys`.
+  GlobalKey<_MaximizedPaneState> _maximizedPaneKey =
+      GlobalKey<_MaximizedPaneState>();
+
   List<Camera> get _shown =>
       widget.cameras.where((c) => c.enabled).toList(growable: false);
 
@@ -206,6 +242,7 @@ class _WallScreenState extends State<WallScreen> {
     if (old.session.token != widget.session.token ||
         old.session.base != widget.session.base) {
       _ptzPanel.updateSession(widget.session);
+      _haOverlay.updateSession(widget.session);
       _liveStatus.updateSession(widget.session);
     }
     // A different applied view (or none) → re-parse its special-tile specs.
@@ -235,6 +272,16 @@ class _WallScreenState extends State<WallScreen> {
   void _onConfigChanged() {
     final refresh = widget.onConfigChanged;
     if (refresh != null) unawaited(refresh());
+    // HA links/placements can change server-side independently of the
+    // camera list itself (an admin edits links in the console) — refresh
+    // every currently-mounted tile's cached copy, and the maximized pane's
+    // if one is up, so badges don't go stale without a full wall remount.
+    for (final key in _tileKeys.values) {
+      final state = key.currentState;
+      if (state != null) unawaited(state.reloadHaLinks());
+    }
+    final maxCam = _maximized;
+    if (maxCam != null) unawaited(_refreshHaLinksFor(maxCam.id));
   }
 
   void _onSpecialChanged() {
@@ -321,6 +368,7 @@ class _WallScreenState extends State<WallScreen> {
       );
     }
     _ptzPanel.dispose();
+    _haOverlay.dispose();
     super.dispose();
   }
 
@@ -330,6 +378,10 @@ class _WallScreenState extends State<WallScreen> {
     // edit — the editor chrome must not follow the wrong camera.
     if (_ptzPanel.editMode && _ptzPanel.editCameraId != cam.id) {
       unawaited(_ptzPanel.endEdit());
+    }
+    // Same guard for an in-progress HA-overlay edit session.
+    if (_haOverlay.editor.editMode && _haEditCameraId != cam.id) {
+      unawaited(_endHaOverlayEdit());
     }
     // Load the camera's saved custom PTZ panel (if any) so the maximized
     // pane can render it in view mode.
@@ -342,6 +394,11 @@ class _WallScreenState extends State<WallScreen> {
       // own main-stream player waits ~a GOP for its first keyframe.
       _maximizeWarmCtrl = _tileKeys[cam.id]?.currentState?.warmController;
       _maximized = cam;
+      // Fresh key per maximize — lets the wall reach this pane's State later
+      // (e.g. to push refreshed HA links after an edit saves) while keeping
+      // the exact same "always a clean remount" identity a plain per-camera
+      // ValueKey gave (see the field doc).
+      _maximizedPaneKey = GlobalKey<_MaximizedPaneState>();
     });
   }
 
@@ -349,6 +406,7 @@ class _WallScreenState extends State<WallScreen> {
   void _restore() {
     // Leaving the maximized view mid panel-edit ends (and persists) the edit.
     if (_ptzPanel.editMode) unawaited(_ptzPanel.endEdit());
+    if (_haOverlay.editor.editMode) unawaited(_endHaOverlayEdit());
     widget.audio?.setMaximized(null);
     widget.onMaximizedCameraChanged?.call(null);
     setState(() {
@@ -361,8 +419,106 @@ class _WallScreenState extends State<WallScreen> {
   /// (the panel is composed over the full-pane video, WYSIWYG) and enter the
   /// panel editor.
   void _editPtzPanel(Camera cam) {
+    // Mutually exclusive with an in-progress HA-overlay edit session (only
+    // one editor open on the maximized pane at a time).
+    if (_haOverlay.editor.editMode) unawaited(_endHaOverlayEdit());
     if (_maximized?.id != cam.id) _maximize(cam);
     unawaited(_ptzPanel.beginEdit(cam.id));
+  }
+
+  /// "Edit HA overlay…" from a tile's right-click menu, or the
+  /// maximized-pane pencil affordance: maximize the camera (badges are
+  /// placed WYSIWYG over the full-pane video, same rule as the PTZ panel
+  /// editor) and enter the placement editor.
+  ///
+  /// Host-loads-first (desktop P0 plan §3.3, and
+  /// `HaOverlayController`'s own class doc): loads the camera's links
+  /// BEFORE maximizing/entering edit mode, guarded by `editor.editToken` so
+  /// a fast camera-switch mid-load can't clobber a newer session — this is
+  /// the funnel that avoids the PTZ builder's D3/D4 races by construction.
+  Future<void> _beginHaOverlayEdit(Camera cam) async {
+    // Mutually exclusive with a PTZ-panel edit session.
+    if (_ptzPanel.editMode) unawaited(_ptzPanel.endEdit());
+    // Editing a DIFFERENT camera's HA overlay ends (and persists) that
+    // first — mirrors _maximize's PTZ-panel guard.
+    if (_haOverlay.editor.editMode && _haEditCameraId != cam.id) {
+      await _endHaOverlayEdit();
+    }
+
+    final token = _haOverlay.editor.editToken;
+    List<HaLink> links;
+    try {
+      links = await _haOverlay.loadLinks(cam.id);
+    } catch (_) {
+      return; // best-effort — no edit session if the links fetch failed
+    }
+    if (!mounted || _haOverlay.editor.editToken != token) {
+      return; // stale — another edit session started/ended meanwhile
+    }
+    if (_maximized?.id != cam.id) _maximize(cam);
+    _haOverlay.beginEditFromLoadedLinks();
+    _haEditCameraId = cam.id;
+    // Keep this camera's own tile cache in step immediately (the tile
+    // right-click menu's gate and the palette's "placed" checkmarks both
+    // read live link data) rather than waiting for Done.
+    _tileKeys[cam.id]?.currentState?.setHaLinks(links);
+  }
+
+  /// End the current HA-overlay edit session (Done / Esc / a forced
+  /// transition from `_maximize`/`_restore`/`_editPtzPanel`) and persist:
+  /// `HaOverlayController.endEditAndSave` PUTs/clears each placement
+  /// server-side. Best-effort — a failed save still closes the session (the
+  /// controller never touches storage either way, so there's nothing to roll
+  /// back); refreshes the affected camera's cached links afterward so its
+  /// tile/pane badge layer reflects what was actually saved.
+  Future<void> _endHaOverlayEdit() async {
+    if (!_haOverlay.editor.editMode) return;
+    final cam = _haEditCameraId;
+    _haEditCameraId = null;
+    try {
+      await _haOverlay.endEditAndSave();
+    } catch (_) {
+      // HaOverlaySaveException: one or more placements didn't save. The POC
+      // has no toast/snackbar surface in this file (matches its existing
+      // silent-best-effort style for PTZ dispatch calls) — a future pass can
+      // add a retry prompt.
+    }
+    if (cam != null) unawaited(_refreshHaLinksFor(cam));
+  }
+
+  /// Re-fetch `cameraId`'s HA links and push them into whichever mounted
+  /// surfaces are showing that camera (its wall tile, and the maximized pane
+  /// if it's the one showing it) — mirrors `_tileKeys`' per-camera
+  /// GlobalKey access pattern. Called after an HA-overlay edit session saves
+  /// (the server-side placement PUT/clear happens without any of the normal
+  /// stream/config-reload signals firing) and from the config-changed
+  /// reload path.
+  Future<void> _refreshHaLinksFor(String cameraId) async {
+    try {
+      final links = await widget.api.cameraHaLinks(widget.session, cameraId);
+      if (!mounted) return;
+      _tileKeys[cameraId]?.currentState?.setHaLinks(links);
+      if (_maximized?.id == cameraId) {
+        _maximizedPaneKey.currentState?.setHaLinks(links);
+      }
+    } catch (_) {
+      // best-effort — a stale cache just means one tile's badges lag until
+      // its next natural reload.
+    }
+  }
+
+  /// Reported by every tile/pane as it (re)loads its own HA links — recomputes
+  /// `_liveStatus.wantHaStates` so `/ha/states` is polled only while at least
+  /// one VISIBLE camera has a placed badge (desktop P0 plan §4.4's
+  /// energy-lean "poll on demand" contract, client half).
+  void _onHaLinksLoaded(String cameraId, List<HaLink> links) {
+    final hasPlacement = links.any((l) => l.hasPlacement);
+    final changed = hasPlacement
+        ? _camerasWithHaPlacements.add(cameraId)
+        : _camerasWithHaPlacements.remove(cameraId);
+    if (changed) {
+      _liveStatus.wantHaStates = _camerasWithHaPlacements.isNotEmpty;
+    }
   }
 
   @override
@@ -409,7 +565,7 @@ class _WallScreenState extends State<WallScreen> {
           // Maximized single-camera view (main stream + zoom/pan), on top.
           if (_maximized != null)
             _MaximizedPane(
-              key: ValueKey('max-${_maximized!.id}'),
+              key: _maximizedPaneKey,
               api: widget.api,
               session: widget.session,
               camera: _maximized!,
@@ -424,6 +580,10 @@ class _WallScreenState extends State<WallScreen> {
               ptzWheelCorner:
                   widget.clientOptions?.ptzWheelCorner ??
                   PtzWheelCorner.bottomLeft,
+              haOverlay: _haOverlay,
+              onEditHaOverlay: () => unawaited(_beginHaOverlayEdit(_maximized!)),
+              onHaOverlayDone: () => unawaited(_endHaOverlayEdit()),
+              onHaLinksLoaded: _onHaLinksLoaded,
               onClose: _restore,
             ),
         ],
@@ -449,12 +609,16 @@ class _WallScreenState extends State<WallScreen> {
         }
       },
       // Esc leaves panel-edit mode first (persisting the layout); the next
-      // Esc restores the wall — same layered-Esc model as fullscreen.
+      // Esc restores the wall — same layered-Esc model as fullscreen. The
+      // HA-overlay editor is another such layer (mutually exclusive with the
+      // PTZ one, so at most one of these two branches is ever live).
       onEscape: _maximized == null
           ? null
           : () {
               if (_ptzPanel.editMode) {
                 unawaited(_ptzPanel.endEdit());
+              } else if (_haOverlay.editor.editMode) {
+                unawaited(_endHaOverlayEdit());
               } else {
                 _restore();
               }
@@ -558,6 +722,9 @@ class _WallScreenState extends State<WallScreen> {
                       _maximize(cam);
                     },
                     onEditPtzPanel: () => _editPtzPanel(cam),
+                    onEditHaOverlay: () =>
+                        unawaited(_beginHaOverlayEdit(cam)),
+                    onHaLinksLoaded: _onHaLinksLoaded,
                   );
           }
           children.add(
@@ -623,6 +790,9 @@ class _WallScreenState extends State<WallScreen> {
                 fit: BoxFit.contain,
                 onTap: () => _maximize(cam),
                 onEditPtzPanel: () => _editPtzPanel(cam),
+                onEditHaOverlay: () =>
+                    unawaited(_beginHaOverlayEdit(cam)),
+                onHaLinksLoaded: _onHaLinksLoaded,
               ),
             ),
           );
@@ -695,6 +865,8 @@ class _WallTile extends StatefulWidget {
     this.fit = BoxFit.cover,
     this.zoomToMain = false,
     this.onEditPtzPanel,
+    this.onEditHaOverlay,
+    this.onHaLinksLoaded,
   });
 
   final CrumbApi api;
@@ -709,6 +881,16 @@ class _WallTile extends StatefulWidget {
   /// "Edit PTZ panel…" from the right-click menu (PTZ cameras only): the wall
   /// maximizes this camera and opens the custom-panel editor over it.
   final VoidCallback? onEditPtzPanel;
+
+  /// "Edit HA overlay…" from the right-click menu (any camera with ≥1 HA
+  /// link, not gated on PTZ): the wall maximizes this camera and opens the
+  /// drag-to-place badge editor over it (issue #170 P0).
+  final VoidCallback? onEditHaOverlay;
+
+  /// Reported every time this tile (re)loads its own HA links, so the wall
+  /// can track which visible cameras have a placed badge and drive
+  /// `LiveStatusController.wantHaStates` (desktop P0 plan §4.4).
+  final void Function(String cameraId, List<HaLink> links)? onHaLinksLoaded;
 
   /// When true, digitally zooming this tile past 100% temporarily loads its
   /// main stream (reverting to sub at 100%). From the "Zoom switches to main
@@ -741,6 +923,19 @@ class _WallTileState extends State<_WallTile> {
   /// menu can gate the Data-saver option on `rtspMobile` availability, and the
   /// tile badge can show which tier is actually playing.
   StreamUrls? _streams;
+
+  /// This camera's HA links (issue #170 P0), fetched once at mount like
+  /// [_streams] — see [_loadHaLinks]. Only the PLACED ones (`hasPlacement`)
+  /// render a badge; the full set gates the right-click menu's "Edit HA
+  /// overlay…" item.
+  List<HaLink> _haLinks = const [];
+
+  /// Decoded video pixel size — needed to map an HA badge's video-frame
+  /// fraction onto the letterboxed video rect (mirrors `_MaximizedPaneState`'s
+  /// `_videoW`/`_videoH`). Retained across frames; badges render nothing
+  /// until both are known.
+  int? _videoW;
+  int? _videoH;
 
   /// The quality tier this pane is currently resolved to play (mirrors the URL
   /// [StreamPrefsStore.liveStreamUrl] picked), for the tile's "SD" badge. Null
@@ -819,6 +1014,7 @@ class _WallTileState extends State<_WallTile> {
   void initState() {
     super.initState();
     _load();
+    unawaited(_loadHaLinks());
   }
 
   Future<void> _load() async {
@@ -875,9 +1071,13 @@ class _WallTileState extends State<_WallTile> {
         }
       }
       player.stream.width.listen((w) {
+        if (w != null && w > 0) _videoW = w;
         if (w != null && w > 0 && mounted) {
           _onFirstFrame(player, controller);
         }
+      });
+      player.stream.height.listen((h) {
+        if (h != null && h > 0) _videoH = h;
       });
       await player.open(Media(url));
       if (!mounted) {
@@ -1014,6 +1214,41 @@ class _WallTileState extends State<_WallTile> {
   /// blanking the pane for that wait was the 1–2 s black flash.
   Future<void> _reloadStream() => _load();
 
+  /// Fetch this camera's HA links, exactly like [_load]'s `cameraStreams`
+  /// self-fetch (issue #170 P0 plan §4.4). Best-effort: a failed fetch just
+  /// means no HA badges/menu item this tile, same tolerance as a failed
+  /// stream load being surfaced via [_error] rather than crashing the tile.
+  Future<void> _loadHaLinks() async {
+    try {
+      final links = await widget.api.cameraHaLinks(
+        widget.session,
+        widget.camera.id,
+      );
+      if (!mounted) return;
+      _applyHaLinks(links);
+    } catch (_) {
+      // best-effort — see doc above
+    }
+  }
+
+  /// Re-fetch this tile's HA links from the server — called by the wall on
+  /// the config-changed reload path (an admin's link/placement edit in the
+  /// console) so a mounted tile's badges don't go stale without a full
+  /// remount.
+  Future<void> reloadHaLinks() => _loadHaLinks();
+
+  /// External push of already-fetched links — used by the wall right after
+  /// an HA-overlay edit session opens/saves on the MAXIMIZED pane (a
+  /// different State than this tile), so this tile's own cached copy (and
+  /// its right-click menu / badge layer) doesn't wait for its next natural
+  /// reload to reflect what just changed.
+  void setHaLinks(List<HaLink> links) => _applyHaLinks(links);
+
+  void _applyHaLinks(List<HaLink> links) {
+    if (mounted) setState(() => _haLinks = links);
+    widget.onHaLinksLoaded?.call(widget.camera.id, links);
+  }
+
   /// Right-click menu: per-camera PTZ-controls toggle + stream main/sub
   /// override (overriding the global "wall uses sub" setting).
   Future<void> _showTileMenu(Offset globalPos) async {
@@ -1047,6 +1282,18 @@ class _WallTileState extends State<_WallTile> {
               value: 'ptz-panel',
               child: Text('Edit PTZ panel…'),
             ),
+          const PopupMenuDivider(),
+        ],
+        // HA on-video badges (issue #170 P0) — deliberately OUTSIDE the
+        // `camera.ptz` block above: HA badges must work on non-PTZ cameras
+        // too. Gated on the camera actually having linked entities (not on
+        // any of them being PLACED yet — the editor's palette is where an
+        // operator places the first one).
+        if (_haLinks.isNotEmpty && widget.onEditHaOverlay != null) ...[
+          const PopupMenuItem(
+            value: 'ha-overlay',
+            child: Text('Edit HA overlay…'),
+          ),
           const PopupMenuDivider(),
         ],
         CheckedPopupMenuItem(
@@ -1085,6 +1332,8 @@ class _WallTileState extends State<_WallTile> {
         setState(() {}); // no reload needed — only affects maximized PTZ UI
       case 'ptz-panel':
         widget.onEditPtzPanel?.call();
+      case 'ha-overlay':
+        widget.onEditHaOverlay?.call();
       case 'main':
         prefs?.setOverride(widget.camera.id, StreamQuality.main);
         await _reloadStream();
@@ -1105,6 +1354,10 @@ class _WallTileState extends State<_WallTile> {
     _watchdog?.dispose();
     SnapshotRegistry.instance.unregister(_paneId);
     widget.audio?.unregisterPane(_paneId);
+    // Report "no links" so the wall drops this camera from its
+    // has-a-placement set (_camerasWithHaPlacements) — otherwise a removed
+    // tile's last-known placement would keep /ha/states polling forever.
+    widget.onHaLinksLoaded?.call(widget.camera.id, const []);
     // Detach the (potentially seconds-long) libmpv teardown from the teardown
     // path so restore/close doesn't freeze the UI (#105). Null first.
     final pending = _pending;
@@ -1234,6 +1487,28 @@ class _WallTileState extends State<_WallTile> {
                           ),
                   ),
 
+                // HA on-video badges (issue #170 P0), view mode only — this
+                // tile never enters the edit session (WYSIWYG, maximized-pane
+                // only, same rule as the PTZ panel editor). Non-interactive
+                // except the badge glyphs themselves, so tile select /
+                // double-click-maximize / right-click / wheel-zoom above keep
+                // working through the gaps. Only built when there's at least
+                // one placed badge, so non-HA tiles are untouched.
+                if (_haLinks.any((l) => l.hasPlacement))
+                  Positioned.fill(
+                    child: ListenableBuilder(
+                      listenable: widget.liveStatus,
+                      builder: (context, _) => HaOverlayLayer(
+                        links: _haLinks,
+                        stateFor: widget.liveStatus.haStateFor,
+                        stale: widget.liveStatus.haStale,
+                        videoW: _videoW,
+                        videoH: _videoH,
+                        hideBadges: _scale > 1.01,
+                      ),
+                    ),
+                  ),
+
                 // Floating overlays: only when the header strip is OFF (in
                 // header-bar mode the name + indicators live in the strip).
                 if (!widget.showInfoBar) ...[
@@ -1347,6 +1622,10 @@ class _MaximizedPane extends StatefulWidget {
     this.ptzClickMode = PtzClickMode.center,
     this.ptzStyle = PtzStyle.edges,
     this.ptzWheelCorner = PtzWheelCorner.bottomLeft,
+    this.haOverlay,
+    this.onEditHaOverlay,
+    this.onHaOverlayDone,
+    this.onHaLinksLoaded,
   });
 
   final CrumbApi api;
@@ -1379,6 +1658,28 @@ class _MaximizedPane extends StatefulWidget {
   /// box (Options → "PTZ style"), plus which corner the wheel box pins to.
   final PtzStyle ptzStyle;
   final PtzWheelCorner ptzWheelCorner;
+
+  /// HA on-video badge placements (issue #170 P0) — shared, owned by the
+  /// wall (mirrors [ptzPanel]). Non-null enables the "Edit HA overlay…"
+  /// pencil affordance and the drag-to-place editor session; null (e.g. a
+  /// host that hasn't wired it) just means view-mode badges never render.
+  final HaOverlayController? haOverlay;
+
+  /// The maximized-pane pencil affordance next to the name pill: maximizes
+  /// (already maximized here) and begins the HA-overlay edit session for
+  /// this camera. Gated by the caller on this camera having ≥1 HA link.
+  final VoidCallback? onEditHaOverlay;
+
+  /// The HA-overlay editor bar's Done button: the wall ends + persists the
+  /// edit session (`HaOverlayController.endEditAndSave`) and refreshes the
+  /// affected tile/pane caches. Kept as a callback (rather than this pane
+  /// calling `haOverlay!.endEditAndSave()` itself) because the cross-tile
+  /// refresh needs the wall's `_tileKeys`/`_maximizedPaneKey`.
+  final VoidCallback? onHaOverlayDone;
+
+  /// Reported every time this pane (re)loads its own HA links — see
+  /// `_WallTile.onHaLinksLoaded`'s doc; same contract.
+  final void Function(String cameraId, List<HaLink> links)? onHaLinksLoaded;
 
   @override
   State<_MaximizedPane> createState() => _MaximizedPaneState();
@@ -1433,6 +1734,34 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
     }
   }
 
+  /// This camera's HA links (issue #170 P0), fetched once at mount like the
+  /// tile's own copy — see [_loadHaLinks]. Independent of `_haLinks` on any
+  /// `_WallTileState` for the same camera (each pane self-caches, mirroring
+  /// `cameraStreams`); [setHaLinks] lets the wall push a refresh into
+  /// whichever one is showing.
+  List<HaLink> _haLinks = const [];
+
+  /// Mirror of `widget.haOverlay!.editor.editMode` for THIS pane (analogous
+  /// to `_panelEditing` above) — kept as a field updated by a
+  /// change-comparing listener so the pane only rebuilds its editor chrome
+  /// on an actual mode transition, not on every drag/selection tick
+  /// (`OverlayEditorLayer`/`OverlayEditorBar` have their own
+  /// `AnimatedBuilder` for that).
+  bool _haEditing = false;
+
+  void _onHaOverlayChanged() {
+    if (!mounted) return;
+    final editing = widget.haOverlay?.editor.editMode ?? false;
+    if (editing == _haEditing) return;
+    final wasEditing = _haEditing;
+    setState(() => _haEditing = editing);
+    if (wasEditing && !editing) {
+      // Edit session just ended (Done/Esc) — placements may have changed;
+      // refresh this pane's own view-mode link cache.
+      unawaited(_loadHaLinks());
+    }
+  }
+
   @override
   void initState() {
     super.initState();
@@ -1440,7 +1769,41 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
     final rec = widget.ptzPanel?.activePanelFor(widget.camera.id);
     _panelActive = rec != null;
     _panelEditing = rec?.$2 ?? false;
+    widget.haOverlay?.editor.addListener(_onHaOverlayChanged);
+    _haEditing = widget.haOverlay?.editor.editMode ?? false;
     _load();
+    unawaited(_loadHaLinks());
+  }
+
+  /// Fetch this camera's HA links, exactly like [_load]'s `cameraStreams`
+  /// self-fetch (issue #170 P0 plan §4.4). Best-effort — see
+  /// `_WallTileState._loadHaLinks`'s identical doc.
+  Future<void> _loadHaLinks() async {
+    try {
+      final links = await widget.api.cameraHaLinks(
+        widget.session,
+        widget.camera.id,
+      );
+      if (!mounted) return;
+      _applyHaLinks(links);
+    } catch (_) {
+      // best-effort — see doc above
+    }
+  }
+
+  /// Re-fetch from the config-changed reload path — see
+  /// `_WallTileState.reloadHaLinks`'s identical doc.
+  Future<void> reloadHaLinks() => _loadHaLinks();
+
+  /// External push of already-fetched links — see
+  /// `_WallTileState.setHaLinks`'s identical doc (here: pushed right after
+  /// `_beginHaOverlayEdit` loads them, so the pencil-affordance gate and any
+  /// view-mode badges reflect the just-loaded set immediately).
+  void setHaLinks(List<HaLink> links) => _applyHaLinks(links);
+
+  void _applyHaLinks(List<HaLink> links) {
+    if (mounted) setState(() => _haLinks = links);
+    widget.onHaLinksLoaded?.call(widget.camera.id, links);
   }
 
   Future<void> _load() async {
@@ -1595,9 +1958,13 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
   bool get _ptzCenter =>
       _ptzEnabled &&
       !_panelEditing &&
+      !_haEditing &&
       widget.ptzClickMode == PtzClickMode.center;
   bool get _ptzPan =>
-      _ptzEnabled && !_panelEditing && widget.ptzClickMode == PtzClickMode.pan;
+      _ptzEnabled &&
+      !_panelEditing &&
+      !_haEditing &&
+      widget.ptzClickMode == PtzClickMode.pan;
 
   // ── PTZ optical zoom via the mouse wheel ────────────────────────────────
   // The wheel is discrete but ONVIF zoom is continuous (move → stop), so each
@@ -1719,6 +2086,11 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
   void dispose() {
     _watchdog?.dispose();
     widget.ptzPanel?.removeListener(_onPtzPanelChanged);
+    widget.haOverlay?.editor.removeListener(_onHaOverlayChanged);
+    // Mirrors `_WallTileState.dispose`'s report — drops this camera from the
+    // wall's has-a-placement set so a closed maximized pane can't keep
+    // /ha/states polling forever.
+    widget.onHaLinksLoaded?.call(widget.camera.id, const []);
     SnapshotRegistry.instance.unregister('maximized');
     widget.audio?.unregisterPane('max:${widget.camera.id}');
     // Guaranteed stop: if any PTZ motion could still be in flight (an active
@@ -1800,10 +2172,10 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
                           onPointerCancel: (_) => _ptzStopSteer(),
                           onPointerSignal: (e) {
                             if (e is PointerScrollEvent) {
-                              // Panel editor open: the wheel must not move
-                              // the camera (or scale the video under the
-                              // fixed-position editor overlay).
-                              if (_panelEditing) return;
+                              // Panel/HA-overlay editor open: the wheel must
+                              // not move the camera (or scale the video
+                              // under the fixed-position editor overlay).
+                              if (_panelEditing || _haEditing) return;
                               if (_ptzEnabled) {
                                 // PTZ camera → drive OPTICAL zoom, not digital.
                                 _ptzWheelZoom(e.scrollDelta.dy);
@@ -1860,6 +2232,40 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
                     child: PtzPanelOverlay(
                       controller: widget.ptzPanel!,
                       cameraId: widget.camera.id,
+                    ),
+                  ),
+
+                // HA on-video badges (issue #170 P0): a per-camera set of
+                // drag-placed entity badges, camera-pinned like PTZ panels
+                // but persisted server-side. Edit mode swaps in the shared
+                // drag-to-place editor layer instead of the read-only view
+                // layer — never both at once (same `_scale > 1.01` hide-on-
+                // digital-zoom POC rule as the wall tile's copy).
+                if (widget.haOverlay != null && _haEditing)
+                  Positioned.fill(
+                    child: OverlayEditorLayer(
+                      controller: widget.haOverlay!.editor,
+                      editing: true,
+                      videoW: _videoW,
+                      videoH: _videoH,
+                      buildItem: haBadgeItemBuilder(
+                        stateFor: widget.liveStatus.haStateFor,
+                        stale: widget.liveStatus.haStale,
+                      ),
+                    ),
+                  )
+                else if (_haLinks.any((l) => l.hasPlacement))
+                  Positioned.fill(
+                    child: ListenableBuilder(
+                      listenable: widget.liveStatus,
+                      builder: (context, _) => HaOverlayLayer(
+                        links: _haLinks,
+                        stateFor: widget.liveStatus.haStateFor,
+                        stale: widget.liveStatus.haStale,
+                        videoW: _videoW,
+                        videoH: _videoH,
+                        hideBadges: _scale > 1.01,
+                      ),
                     ),
                   ),
 
@@ -1921,6 +2327,27 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
                           ],
                         ),
                       ),
+                      // "Edit HA overlay…" pencil (issue #170 P0): a second,
+                      // always-visible entry point alongside the tile
+                      // right-click menu — gated on this camera actually
+                      // having HA links, and hidden while either editor is
+                      // already open (mutual exclusion, no re-entry).
+                      if (widget.onEditHaOverlay != null &&
+                          _haLinks.isNotEmpty &&
+                          !_haEditing &&
+                          !_panelEditing) ...[
+                        const SizedBox(width: 8),
+                        Material(
+                          color: Colors.black.withValues(alpha: 0.55),
+                          shape: const CircleBorder(),
+                          child: IconButton(
+                            tooltip: 'Edit HA overlay…',
+                            icon: const Icon(Icons.edit_outlined, size: 18),
+                            color: Colors.white,
+                            onPressed: widget.onEditHaOverlay,
+                          ),
+                        ),
+                      ],
                     ],
                   ),
                 ),
@@ -1998,6 +2425,37 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
                     child: PtzPanelEditorBar(controller: widget.ptzPanel!),
                   ),
                 ],
+
+                // HA-overlay editor bar (issue #170 P0): the palette (this
+                // camera's linked entities, grouped+searched) + Done/Clear +
+                // selected-badge size stepper. Mutually exclusive with the
+                // PTZ chrome above by construction (`_haEditing`/
+                // `_panelEditing` can't both be true — see the wall's
+                // `_beginHaOverlayEdit`/`_editPtzPanel` guards).
+                if (widget.haOverlay != null && _haEditing)
+                  Positioned(
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    child: OverlayEditorBar(
+                      controller: widget.haOverlay!.editor,
+                      paletteSlot: AnimatedBuilder(
+                        // Independent rebuild on every editor tick (drag/
+                        // add/remove), so the palette's "placed" checkmarks
+                        // stay live without the whole pane rebuilding.
+                        animation: widget.haOverlay!.editor,
+                        builder: (context, _) => HaEntityPalette(
+                          links: widget.haOverlay!.links,
+                          placedIds: widget.haOverlay!.placedIdsInSession,
+                          onPick: widget.haOverlay!.pickFromPalette,
+                        ),
+                      ),
+                      itemLabel: (item) =>
+                          (item as HaOverlayBadgeItem).link.displayLabel,
+                      onClear: widget.haOverlay!.editor.clearAll,
+                      onDone: () => widget.onHaOverlayDone?.call(),
+                    ),
+                  ),
               ],
             );
           },


### PR DESCRIPTION
Desktop half of the HA on-video overlay POC (issue #170), on top of the backend in #171 (merged + deployed). Drag an HA-linked entity's icon onto a camera's live video; it shows live state and stays pinned to the video frame.

## What's in it
- **Shared drag-to-place overlay editor** (`lib/ui/overlay_editor/`) — generic geometry/snap/drag lifted from the PTZ panel, with a **synchronous, host-loads-first edit lifecycle** that eliminates the PTZ builder's `beginEdit`/`endEdit` race class by construction. Built so the PTZ panel can adopt it in P1 (the "PTZ builder can't customize" repair).
- **HA overlay widgets** (`lib/ui/ha_overlay/`) — `HaOverlayLayer` (view-mode badges on grid tiles + maximized pane), grouped+search entity palette, `device_class`→icon/state mapping (**unknown/stale ⇒ grey, never rendered as off/closed** — mirrors the server `edge_on` invariant), read-only tap card with relative last-changed.
- **API mirror** — `lib/api/ha_{api,models}.dart`: `/cameras/:id/ha/links` (+ placement PUT), `/ha/states`.
- **`live_status_controller`** — fetches `/ha/states` on the existing 3s tick **only when a visible camera has a placement** (client half of the energy-lean contract); `haStateFor`/`haStale` accessors, last-known-on-miss, stale after 2 misses.
- **`wall_screen`** — view-mode badges (hidden while digitally zoomed), **"Edit HA overlay…"** entry that works on non-PTZ cameras too, maximized-pane edit session mutually exclusive with PTZ, video-dimension retention.

## Anchoring
Badges are stored as fractions of the **displayed video frame** (not the pane), so a badge stays on the physical door as the tile aspect changes — the deliberate divergence from PTZ's pane-fraction anchoring.

## Gate
`flutter analyze lib` clean (only the pre-existing ~64 info baseline), `flutter build windows --release` green. Installed + smoke-run on the maintainer's workstation against prod (renders, connects, no regressions to the live wall / PTZ).

## Not in scope (later phases)
Control (service calls) + RBAC, full HA Area→Device→Entity tree picker, WebSocket push, Android/web port, the PTZ-panel port onto the shared editor (P1). A few narrow edge cases flagged in-code for the record (dispose-time in-flight edit is dropped; rapid two-camera edit trigger).

Part of #170. Depends on the deployed backend (#171).