### PR TITLE
LPR client polish: sharp crops, image option, simplified report

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/data/SecureStore.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/SecureStore.kt
@@ -223,12 +223,12 @@ class SecureStore(context: Context) {
         set(value) = safeWrite { it.putString(KEY_PLAYBACK_QUALITY, value) }
 
     /**
-     * LPR thumbnail image mode: "plate" (default) crops the thumbnail to the
-     * license plate; "vehicle" shows the full detection snapshot (the whole car).
+     * LPR thumbnail image mode: "vehicle" (default) shows the full detection
+     * snapshot (the whole car); "plate" crops the thumbnail to the license plate.
      * A device-level display preference, persisted across sessions.
      */
     var lprImageMode: String
-        get() = safeRead("plate") { it.getString(KEY_LPR_IMAGE_MODE, "plate") ?: "plate" }
+        get() = safeRead("vehicle") { it.getString(KEY_LPR_IMAGE_MODE, "vehicle") ?: "vehicle" }
         set(value) = safeWrite { it.putString(KEY_LPR_IMAGE_MODE, value) }
 
     /**

--- a/apps/android/app/src/main/java/video/crumb/app/data/SecureStore.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/SecureStore.kt
@@ -223,6 +223,15 @@ class SecureStore(context: Context) {
         set(value) = safeWrite { it.putString(KEY_PLAYBACK_QUALITY, value) }
 
     /**
+     * LPR thumbnail image mode: "plate" (default) crops the thumbnail to the
+     * license plate; "vehicle" shows the full detection snapshot (the whole car).
+     * A device-level display preference, persisted across sessions.
+     */
+    var lprImageMode: String
+        get() = safeRead("plate") { it.getString(KEY_LPR_IMAGE_MODE, "plate") ?: "plate" }
+        set(value) = safeWrite { it.putString(KEY_LPR_IMAGE_MODE, value) }
+
+    /**
      * Live wall grid-layout ordinal (GridLayout: 0=single, 1=2x2, 2=list).
      * Persisted so the chosen layout survives navigating in/out of a camera AND
      * app restarts (a plain `remember` was resetting it to 2x2 on every return).
@@ -413,6 +422,7 @@ class SecureStore(context: Context) {
         private const val KEY_SHOW_ALL_CAMERAS_VIEW = "show_all_cameras_view"
         private const val KEY_PLAYBACK_SPAN_MS = "playback_span_ms"
         private const val KEY_PLATES_VIEW_MODE = "plates_view_mode"
+        private const val KEY_LPR_IMAGE_MODE = "lpr_image_mode"
         private const val KEY_SNAPSHOT_VIEW = "snapshot_captures_view"
         private const val KEY_VIEWS = "camera_views_json"
         private const val KEY_ACTIVE_VIEW = "active_view_id"

--- a/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesPdf.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesPdf.kt
@@ -21,24 +21,20 @@ import kotlinx.coroutines.withContext
 import video.crumb.app.data.MediaUrls
 import video.crumb.app.data.PlateRead
 import video.crumb.app.data.PlateWatchlistEntry
-import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
-import java.security.MessageDigest
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
-import java.util.UUID
 import kotlin.math.roundToInt
 
 /**
- * Renders a single plate read to an OpenALPR-style **single-plate report** PDF —
- * one sighting, forensically framed — using Android's built-in [PdfDocument] (no
- * third-party PDF dependency).
+ * Renders a single plate read to a **single-plate report** PDF using Android's
+ * built-in [PdfDocument] (no third-party PDF dependency).
  *
  * Layout (one A4 portrait page):
- *  - **Header**: exported-by, export timestamp, and a random report id.
+ *  - **Title** + divider.
  *  - **Watchlist/BOLO banner** (red) when the plate matches a `kind:"watch"`
  *    entry from `GET /lpr/watchlist`.
  *  - **Header block**: the plate (large monospace), confidence, the date+time in
@@ -48,14 +44,13 @@ import kotlin.math.roundToInt
  *    first image falls back to the full snapshot, labeled "vehicle".
  *  - **Details**: `plate_raw`, source.
  *  - **Dossier** (optional): every sighting of this plate — total, distinct
- *    cameras, first/last seen, and a small thumbnail strip.
- *  - **Footer**: the SHA-256 of each embedded image's bytes, labeled
- *    "tamper-evident".
+ *    cameras, first/last seen, and a thumbnail strip captioned with each
+ *    sighting's date/time.
  *
  * Snapshots are loaded exactly like the on-screen `PlateThumb`: each read's
  * sibling detection-event JPEG via the scoped-token proxy
  * ([MediaUrls.eventSnapshotUrl]), fetched through the shared Coil [ImageLoader]
- * with `allowHardware(false)` so we get a software bitmap to draw + hash.
+ * with `allowHardware(false)` so we get a software bitmap to draw.
  *
  * The finished PDF is written to the app-private `reports/` cache subdir (exposed
  * by `res/xml/file_paths.xml`) so [sharePlatesPdf] can hand it to the system
@@ -99,8 +94,6 @@ data class PlateReportInput(
     val read: PlateRead,
     /** Camera id → display name (resolves both the primary camera and dossier cameras). */
     val cameraNames: Map<String, String>,
-    /** Username that exported the report (from the session / `/auth/me`). */
-    val exportedBy: String,
     /** Timezone the timestamps are rendered in (defaults to device-local at the call site). */
     val zoneId: ZoneId,
     /** Whether to render the sighting-history dossier section. */
@@ -160,16 +153,9 @@ suspend fun generatePlateReportPdf(
             emptyList()
         }
 
-        // Tamper-evident hashes of the exact bytes embedded (each bitmap re-encoded
-        // to PNG deterministically). Null when the image is absent.
-        val shaPlate = plateImage?.let { sha256Hex(it.toPngBytes()) }
-        val shaVehicle = fullSnapshot?.let { sha256Hex(it.toPngBytes()) }
-
-        val reportId = "CR-" + UUID.randomUUID().toString().replace("-", "").take(8).uppercase(Locale.US)
         val tsFmt = DateTimeFormatter
             .ofPattern("EEE, MMM d yyyy · HH:mm:ss z", Locale.US)
             .withZone(input.zoneId)
-        val exportedAt = tsFmt.format(Instant.now())
 
         val doc = PdfDocument()
         try {
@@ -180,10 +166,6 @@ suspend fun generatePlateReportPdf(
                 cropIsFallback = cropIsFallback,
                 vehicleImage = fullSnapshot,
                 dossierThumbs = dossierThumbs,
-                shaPlate = shaPlate,
-                shaVehicle = shaVehicle,
-                reportId = reportId,
-                exportedAt = exportedAt,
                 tsFmt = tsFmt,
             )
             val dir = File(context.cacheDir, REPORTS_CACHE_SUBDIR).apply { mkdirs() }
@@ -255,12 +237,6 @@ private fun cropToBbox(src: Bitmap, bbox: List<Double>?): Bitmap? {
     }.getOrNull()
 }
 
-private fun sha256Hex(bytes: ByteArray): String =
-    MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
-
-private fun Bitmap.toPngBytes(): ByteArray =
-    ByteArrayOutputStream().also { compress(Bitmap.CompressFormat.PNG, 100, it) }.toByteArray()
-
 // ─── drawing ────────────────────────────────────────────────────────────────
 
 private fun drawReport(
@@ -270,10 +246,6 @@ private fun drawReport(
     cropIsFallback: Boolean,
     vehicleImage: Bitmap?,
     dossierThumbs: List<DossierThumb>,
-    shaPlate: String?,
-    shaVehicle: String?,
-    reportId: String,
-    exportedAt: String,
     tsFmt: DateTimeFormatter,
 ) {
     val read = input.read
@@ -282,20 +254,10 @@ private fun drawReport(
         textSize = 18f
         isFakeBoldText = true
     }
-    val idPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-        color = AndroidColor.rgb(0x5a, 0x66, 0x78)
-        textSize = 10f
-        textAlign = Paint.Align.RIGHT
-        typeface = android.graphics.Typeface.MONOSPACE
-    }
     val metaLabelPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         color = AndroidColor.rgb(0x8a, 0x93, 0xa2)
         textSize = 9f
         isFakeBoldText = true
-    }
-    val metaPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-        color = AndroidColor.rgb(0x33, 0x3b, 0x48)
-        textSize = 10f
     }
     val headerPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         color = AndroidColor.rgb(0x5a, 0x66, 0x78)
@@ -349,18 +311,9 @@ private fun drawReport(
 
     var y = MARGIN + 6f
 
-    // ── forensic header ────────────────────────────────────────────────────────
+    // ── header ──────────────────────────────────────────────────────────────────
     c.drawText("CrumbVMS — License Plate Report", contentLeft, y, titlePaint)
-    c.drawText("REPORT $reportId", contentRight, y, idPaint)
-    y += 16f
-    fun metaLine(label: String, value: String) {
-        c.drawText(label, contentLeft, y, metaLabelPaint)
-        c.drawText(value, contentLeft + 78f, y, metaPaint)
-        y += 13f
-    }
-    metaLine("EXPORTED BY", input.exportedBy.ifBlank { "—" })
-    metaLine("EXPORTED AT", exportedAt)
-    y += 4f
+    y += 14f
     c.drawLine(contentLeft, y, contentRight, y, linePaint)
     y += 14f
 
@@ -469,25 +422,6 @@ private fun drawReport(
             }
         }
     }
-
-    // ── footer: tamper-evident image hashes ─────────────────────────────────────
-    val footerPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-        color = AndroidColor.rgb(0x8a, 0x93, 0xa2)
-        textSize = 7.5f
-        typeface = android.graphics.Typeface.MONOSPACE
-    }
-    val footerLabelPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-        color = AndroidColor.rgb(0x5a, 0x66, 0x78)
-        textSize = 8f
-        isFakeBoldText = true
-    }
-    var fy = PAGE_H - MARGIN - 26f
-    c.drawLine(contentLeft, fy - 8f, contentRight, fy - 8f, linePaint)
-    c.drawText("TAMPER-EVIDENT — SHA-256 of each embedded image", contentLeft, fy, footerLabelPaint)
-    fy += 11f
-    c.drawText("plate:   ${shaPlate ?: "(no image)"}", contentLeft, fy, footerPaint)
-    fy += 10f
-    c.drawText("vehicle: ${shaVehicle ?: "(no image)"}", contentLeft, fy, footerPaint)
 
     doc.finishPage(page)
 }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesPdf.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesPdf.kt
@@ -38,8 +38,7 @@ import kotlin.math.roundToInt
  * third-party PDF dependency).
  *
  * Layout (one A4 portrait page):
- *  - **Forensic header**: server host, exported-by, export timestamp, a random
- *    report id, and the operator's Case #/description.
+ *  - **Header**: exported-by, export timestamp, and a random report id.
  *  - **Watchlist/BOLO banner** (red) when the plate matches a `kind:"watch"`
  *    entry from `GET /lpr/watchlist`.
  *  - **Header block**: the plate (large monospace), confidence, the date+time in
@@ -47,7 +46,7 @@ import kotlin.math.roundToInt
  *  - **Two images**: a zoomed plate crop (the snapshot cropped to [PlateRead.bbox])
  *    and the full "vehicle" snapshot. When bbox is null / the crop fails, the
  *    first image falls back to the full snapshot, labeled "vehicle".
- *  - **Details**: `plate_raw`, region, source.
+ *  - **Details**: `plate_raw`, source.
  *  - **Dossier** (optional): every sighting of this plate — total, distinct
  *    cameras, first/last seen, and a small thumbnail strip.
  *  - **Footer**: the SHA-256 of each embedded image's bytes, labeled
@@ -100,12 +99,8 @@ data class PlateReportInput(
     val read: PlateRead,
     /** Camera id → display name (resolves both the primary camera and dossier cameras). */
     val cameraNames: Map<String, String>,
-    /** Connected server host (from the session base URL). */
-    val serverHost: String,
     /** Username that exported the report (from the session / `/auth/me`). */
     val exportedBy: String,
-    /** Operator's Case # / free-text description (may be blank). */
-    val caseText: String,
     /** Timezone the timestamps are rendered in (defaults to device-local at the call site). */
     val zoneId: ZoneId,
     /** Whether to render the sighting-history dossier section. */
@@ -118,6 +113,10 @@ data class PlateReportInput(
     /** Server-reported total match count for the dossier query (may exceed `dossier.size`). */
     val dossierTotal: Int,
 )
+
+/** One sighting-history thumbnail: the decoded image paired with that sighting's
+ *  timestamp (ISO), so the strip can caption each thumbnail with its date/time. */
+private class DossierThumb(val bitmap: Bitmap, val ts: String)
 
 /**
  * Build the single-plate report PDF for [input]. Returns the written [File] on
@@ -144,16 +143,17 @@ suspend fun generatePlateReportPdf(
         val cropIsFallback = crop == null
         val plateImage = crop ?: fullSnapshot
 
-        // Dossier thumbnail strip (bounded). Skip the primary read's own event to
-        // avoid a duplicate of the header image where possible.
-        val dossierThumbs: List<Bitmap> = if (input.includeDossier) {
-            val out = ArrayList<Bitmap>(MAX_DOSSIER_THUMBS)
+        // Dossier thumbnail strip (bounded). Each thumb keeps its sighting's
+        // timestamp so the strip can caption it with a date/time (captions stay
+        // aligned even when a fetch is skipped, since ts travels with the image).
+        val dossierThumbs: List<DossierThumb> = if (input.includeDossier) {
+            val out = ArrayList<DossierThumb>(MAX_DOSSIER_THUMBS)
             for (d in input.dossier) {
                 if (out.size >= MAX_DOSSIER_THUMBS) break
                 val bmp = fetchSnapshotBitmap(
                     context, mediaUrls, imageLoader, d.cameraId, d.eventId, DOSSIER_THUMB_TARGET_PX,
                 ) ?: continue
-                out.add(bmp)
+                out.add(DossierThumb(bmp, d.ts))
             }
             out
         } else {
@@ -205,7 +205,7 @@ suspend fun generatePlateReportPdf(
             val owned = LinkedHashSet<Bitmap>()
             fullSnapshot?.let(owned::add)
             plateImage?.let(owned::add)
-            dossierThumbs.forEach(owned::add)
+            dossierThumbs.forEach { owned.add(it.bitmap) }
             owned.forEach { runCatching { it.recycle() } }
         }
     }
@@ -269,7 +269,7 @@ private fun drawReport(
     plateImage: Bitmap?,
     cropIsFallback: Boolean,
     vehicleImage: Bitmap?,
-    dossierThumbs: List<Bitmap>,
+    dossierThumbs: List<DossierThumb>,
     shaPlate: String?,
     shaVehicle: String?,
     reportId: String,
@@ -358,10 +358,8 @@ private fun drawReport(
         c.drawText(value, contentLeft + 78f, y, metaPaint)
         y += 13f
     }
-    metaLine("SERVER", input.serverHost.ifBlank { "—" })
     metaLine("EXPORTED BY", input.exportedBy.ifBlank { "—" })
     metaLine("EXPORTED AT", exportedAt)
-    metaLine("CASE", input.caseText.ifBlank { "—" })
     y += 4f
     c.drawLine(contentLeft, y, contentRight, y, linePaint)
     y += 14f
@@ -416,7 +414,6 @@ private fun drawReport(
         y += 14f
     }
     detailLine("PLATE RAW", read.plateRaw.ifBlank { "—" })
-    detailLine("REGION", read.region?.takeIf { it.isNotBlank() } ?: "—")
     detailLine("SOURCE", read.sourceId?.takeIf { it.isNotBlank() } ?: "—")
     y += 6f
 
@@ -448,17 +445,27 @@ private fun drawReport(
             y += 14f
             c.drawText("Last seen  $lastSeen", contentLeft, y, cellPaint)
             y += 16f
-            // Thumbnail strip (single bounded row).
+            // Thumbnail strip (single bounded row), each captioned with its
+            // sighting's date/time in the report's timezone.
             if (dossierThumbs.isNotEmpty()) {
+                val thumbTsFmt = DateTimeFormatter
+                    .ofPattern("MMM d, HH:mm", Locale.US)
+                    .withZone(input.zoneId)
+                val thumbCapPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                    color = AndroidColor.rgb(0x5a, 0x66, 0x78)
+                    textSize = 6.5f
+                    textAlign = Paint.Align.CENTER
+                }
                 val thumbGap = 8f
                 val thumbW = (contentWidth - thumbGap * (MAX_DOSSIER_THUMBS - 1)) / MAX_DOSSIER_THUMBS
                 val thumbH = thumbW * 0.62f
                 var tx = contentLeft
-                for (bmp in dossierThumbs) {
-                    drawImageBox(c, bmp, tx, y, thumbW, thumbH, placeholderPaint, placeholderTextPaint)
+                for (t in dossierThumbs) {
+                    drawImageBox(c, t.bitmap, tx, y, thumbW, thumbH, placeholderPaint, placeholderTextPaint)
+                    c.drawText(fmtTs(t.ts, thumbTsFmt), tx + thumbW / 2f, y + thumbH + 9f, thumbCapPaint)
                     tx += thumbW + thumbGap
                 }
-                y += thumbH + 8f
+                y += thumbH + 8f + 11f
             }
         }
     }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesScreen.kt
@@ -994,7 +994,7 @@ private fun PlateRow(
 private const val PLATE_CROP_DECODE_PX = 1024
 
 /** Convenience wrapper: the read's snapshot. Honors the "LPR thumbnail image" app
- *  option — cropped to the plate box (default) or the full vehicle snapshot.
+ *  option — the full vehicle snapshot (default) or cropped to the plate box.
  *  Decodes at [PLATE_CROP_DECODE_PX] so the cropped plate stays sharp at thumbnail
  *  size (harmless for the full-image mode, which just shows a crisp downscale). */
 @Composable

--- a/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesScreen.kt
@@ -984,16 +984,25 @@ private fun PlateRow(
     }
 }
 
-/** Larger decode ceiling (px) for the report-dialog plate preview, so the crop of
- *  a small plate region stays crisp. Only one such image is alive at a time (it's
- *  a modal dialog), so this stays well within the P2 bitmap budget; the list/grid
- *  thumbnails intentionally omit it and decode at their small display size. */
-private const val PLATE_DETAIL_DECODE_PX = 1024
+/** Decode ceiling (px) for plate-crop images. A plate is a small fraction of its
+ *  snapshot, so without this Coil decodes the snapshot at the tiny thumbnail
+ *  display size and the crop is a blurry upscale of a handful of pixels. Decoding
+ *  to ~1024 first makes the crop sharp. Memory stays bounded: the decode is
+ *  transient per image and Coil's memory cache holds only the (small) cropped
+ *  result — not the full-size decode — so this fits the P2 bitmap budget. Used by
+ *  both the list/grid thumbnails and the report-dialog preview. */
+private const val PLATE_CROP_DECODE_PX = 1024
 
-/** Convenience wrapper: the read's snapshot, cropped to the plate box. */
+/** Convenience wrapper: the read's snapshot, cropped to the plate box. Decodes at
+ *  [PLATE_CROP_DECODE_PX] so the cropped plate stays sharp at thumbnail size. */
 @Composable
 private fun PlateThumb(read: PlateRead, mediaUrls: MediaUrls, modifier: Modifier = Modifier) {
-    PlateSnapshotImage(read = read, mediaUrls = mediaUrls, modifier = modifier)
+    PlateSnapshotImage(
+        read = read,
+        mediaUrls = mediaUrls,
+        modifier = modifier,
+        decodePx = PLATE_CROP_DECODE_PX,
+    )
 }
 
 /**
@@ -1625,7 +1634,7 @@ private fun PlateReportDialog(
                         .fillMaxWidth()
                         .height(120.dp),
                     crop = true,
-                    decodePx = PLATE_DETAIL_DECODE_PX,
+                    decodePx = PLATE_CROP_DECODE_PX,
                 )
                 Text(
                     text = read.plate.ifEmpty { "—" },

--- a/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesScreen.kt
@@ -993,14 +993,18 @@ private fun PlateRow(
  *  both the list/grid thumbnails and the report-dialog preview. */
 private const val PLATE_CROP_DECODE_PX = 1024
 
-/** Convenience wrapper: the read's snapshot, cropped to the plate box. Decodes at
- *  [PLATE_CROP_DECODE_PX] so the cropped plate stays sharp at thumbnail size. */
+/** Convenience wrapper: the read's snapshot. Honors the "LPR thumbnail image" app
+ *  option — cropped to the plate box (default) or the full vehicle snapshot.
+ *  Decodes at [PLATE_CROP_DECODE_PX] so the cropped plate stays sharp at thumbnail
+ *  size (harmless for the full-image mode, which just shows a crisp downscale). */
 @Composable
 private fun PlateThumb(read: PlateRead, mediaUrls: MediaUrls, modifier: Modifier = Modifier) {
+    val showCrop = appContainer().store.lprImageMode != "vehicle"
     PlateSnapshotImage(
         read = read,
         mediaUrls = mediaUrls,
         modifier = modifier,
+        crop = showCrop,
         decodePx = PLATE_CROP_DECODE_PX,
     )
 }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesScreen.kt
@@ -352,7 +352,6 @@ fun PlatesScreen(
                 val camNames = state.cameras.associate { it.id to it.name }
                 val allCamIds = state.cameras.map { it.id }
                 val loader = context.imageLoader
-                val exportedBy = store.username ?: "—"
                 scope.launch {
                     // Resolve the watchlist match (BOLO banner) + the sighting dossier
                     // up front so the PDF builder stays a focused render step. The
@@ -377,7 +376,6 @@ fun PlatesScreen(
                     val input = PlateReportInput(
                         read = reportRead,
                         cameraNames = camNames,
-                        exportedBy = exportedBy,
                         zoneId = zoneId,
                         includeDossier = includeDossier,
                         watchMatch = watchMatch,

--- a/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesScreen.kt
@@ -345,15 +345,13 @@ fun PlatesScreen(
             read = reportRead,
             mediaUrls = mediaUrls,
             generating = generatingReport,
-            onDownload = { caseText, zoneId, includeDossier ->
+            onDownload = { zoneId, includeDossier ->
                 if (generatingReport) return@PlateReportDialog
                 generatingReport = true
                 val repo = container.repository
                 val camNames = state.cameras.associate { it.id to it.name }
                 val allCamIds = state.cameras.map { it.id }
                 val loader = context.imageLoader
-                val serverHost = runCatching { android.net.Uri.parse(store.serverUrl).authority }
-                    .getOrNull()?.takeIf { it.isNotBlank() } ?: store.serverUrl
                 val exportedBy = store.username ?: "—"
                 scope.launch {
                     // Resolve the watchlist match (BOLO banner) + the sighting dossier
@@ -379,9 +377,7 @@ fun PlatesScreen(
                     val input = PlateReportInput(
                         read = reportRead,
                         cameraNames = camNames,
-                        serverHost = serverHost,
                         exportedBy = exportedBy,
-                        caseText = caseText,
                         zoneId = zoneId,
                         includeDossier = includeDossier,
                         watchMatch = watchMatch,
@@ -1601,20 +1597,19 @@ private val REPORT_COMMON_ZONES: List<String> = listOf(
 )
 
 /**
- * Builder for the OpenALPR-style single-plate report: a Case #/description field,
- * a timezone picker (defaulting to device-local), and a toggle for the sighting
- * dossier — then "Download PDF" (which builds the report and hands it to the
- * system share sheet). Mirrors the [WatchlistDialog]/[CameraPickerDialog] pattern.
+ * Builder for the single-plate report: a timezone picker (defaulting to
+ * device-local) and a toggle for the sighting dossier — then "Download PDF"
+ * (which builds the report and hands it to the system share sheet). Mirrors the
+ * [WatchlistDialog]/[CameraPickerDialog] pattern.
  */
 @Composable
 private fun PlateReportDialog(
     read: PlateRead,
     mediaUrls: MediaUrls,
     generating: Boolean,
-    onDownload: (caseText: String, zoneId: java.time.ZoneId, includeDossier: Boolean) -> Unit,
+    onDownload: (zoneId: java.time.ZoneId, includeDossier: Boolean) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    var caseText by remember { mutableStateOf("") }
     var includeDossier by remember { mutableStateOf(true) }
     val defaultZone = remember { java.time.ZoneId.systemDefault().id }
     // Device-local first (the default), then the curated common set, de-duplicated.
@@ -1647,14 +1642,6 @@ private fun PlateReportDialog(
                     fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
                     style = MaterialTheme.typography.titleLarge,
                     modifier = Modifier.padding(top = 8.dp),
-                )
-                TextField(
-                    value = caseText,
-                    onValueChange = { caseText = it },
-                    placeholder = { Text("Case # / description") },
-                    singleLine = true,
-                    leadingIcon = { Icon(Icons.Filled.Event, contentDescription = null) },
-                    modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
                 )
                 // Timezone picker.
                 Row(
@@ -1702,7 +1689,7 @@ private fun PlateReportDialog(
         },
         confirmButton = {
             TextButton(
-                onClick = { onDownload(caseText, java.time.ZoneId.of(zoneId), includeDossier) },
+                onClick = { onDownload(java.time.ZoneId.of(zoneId), includeDossier) },
                 enabled = !generating,
             ) {
                 if (generating) {

--- a/apps/android/app/src/main/java/video/crumb/app/feature/settings/SettingsDialog.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/settings/SettingsDialog.kt
@@ -72,6 +72,7 @@ fun SettingsDialog(
     var ptzStyle by remember { mutableStateOf(store.ptzStyle) }
     var motionTunerOn by remember { mutableStateOf(store.motionTunerEnabled) }
     var snapshotView by remember { mutableStateOf(store.snapshotCapturesView) }
+    var lprImageMode by remember { mutableStateOf(store.lprImageMode) }
 
     // Security — biometric app lock.
     val context = LocalContext.current
@@ -236,6 +237,32 @@ fun SettingsDialog(
                     onSelect = {
                         snapshotView = true
                         store.snapshotCapturesView = true
+                    },
+                )
+
+                // ── LPR section ───────────────────────────────────────────────────
+                Text(
+                    text = "LPR — thumbnail image",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = TextSecondary,
+                    modifier = Modifier.padding(top = 12.dp),
+                )
+                PtzStyleRow(
+                    label = "License plate",
+                    description = "Crop each thumbnail to just the license plate.",
+                    selected = lprImageMode == "plate",
+                    onSelect = {
+                        lprImageMode = "plate"
+                        store.lprImageMode = "plate"
+                    },
+                )
+                PtzStyleRow(
+                    label = "Full image",
+                    description = "Show the whole detection snapshot (the vehicle).",
+                    selected = lprImageMode == "vehicle",
+                    onSelect = {
+                        lprImageMode = "vehicle"
+                        store.lprImageMode = "vehicle"
                     },
                 )
 

--- a/apps/desktop-flutter/lib/ui/plates/plate_pdf_report.dart
+++ b/apps/desktop-flutter/lib/ui/plates/plate_pdf_report.dart
@@ -465,10 +465,8 @@ pw.Widget _imagePanel({
 }
 
 pw.Widget _detailsBlock(PlateRead read) {
-  final region = (read.region ?? '').trim();
   final rows = <List<String>>[
     ['OCR raw', read.plateRaw.isEmpty ? '-' : read.plateRaw],
-    if (region.isNotEmpty) ['Region', region],
     ['Source', (read.sourceId ?? '').isEmpty ? '-' : read.sourceId!],
   ];
   return pw.Container(


### PR DESCRIPTION
A batch of LPR-client polish (android + one desktop tweak) from a maintainer review session.

## android
1. **Sharp plate-crop thumbnails (Fixes #173).** They rendered as a blurry smear — `PlateThumb`→`PlateSnapshotImage` had no decode ceiling, so Coil decoded at the tiny thumbnail size and cropped the small plate box out of that. Now decodes at ~1024px first (`PLATE_CROP_DECODE_PX`); memory stays bounded (transient decode; Coil caches only the small crop).
2. **"LPR — thumbnail image" app option** (Settings) — full vehicle image (default) or cropped plate. Desktop parity; persisted per device (`SecureStore.lprImageMode`).
3. **Simplified plate report** — removed the SERVER + CASE header lines and the REGION detail row; each sighting-history thumbnail is now captioned with its date/time; dropped the vestigial Case #/description input + its `serverHost`/`caseText` plumbing.

## desktop
- The report was already de-forensic (no server/case/report-id) and already captioned sightings with a date/time; removed its remaining **REGION** row for parity.

Android `assembleDebug` green; desktop `flutter analyze` clean. Built + served/installed for the maintainer's devices.