### PR TITLE
Desktop: HA connection settings + per-camera entity linking

### DIFF
--- a/apps/desktop-flutter/lib/api/ha_api.dart
+++ b/apps/desktop-flutter/lib/api/ha_api.dart
@@ -1,21 +1,42 @@
-// Home Assistant on-video overlay API calls (issue #170): a camera's linked
-// entities + on-video placement, and the live states feed. Kept as an
-// extension on the shared `CrumbApi` (see crumb_api.dart) rather than editing
-// that file directly — same approach as `status_api.dart`, using the shared
-// process-wide `TimeoutClient` since `CrumbApi`'s own client is private to
-// that file.
+// Home Assistant integration API calls: connection config + entity linking
+// (issue #52, desktop port of the admin console's flow) and the on-video
+// overlay's linked entities + placement + live states feed (issue #170).
+// Kept as an extension on the shared `CrumbApi` (see crumb_api.dart) rather
+// than editing that file directly — same approach as `status_api.dart`,
+// using the shared process-wide `TimeoutClient` since `CrumbApi`'s own
+// client is private to that file.
 //
 // Route facts (services/api/src/ha.rs):
-//   GET /cameras/{id}/ha/links                      -> HaLinkDto[] (any user
+//   GET  /config/ha                                 -> HaConfigDto. Admin.
+//   PUT  /config/ha            body {enabled,base_url,token?} -> HaConfigDto.
+//                                                       Admin. Omit `token`
+//                                                       to leave it
+//                                                       unchanged, `""` to
+//                                                       clear, non-empty to
+//                                                       set — write-only,
+//                                                       never returned.
+//   POST /config/ha/test                             -> {ok:true} or an
+//                                                       error. Admin. Tests
+//                                                       the SAVED config —
+//                                                       save first.
+//   GET  /ha/entities?domain=binary_sensor|controls  -> HaEntity[]. Admin.
+//                                                       The picker's data
+//                                                       source; `controls` =
+//                                                       light+switch+scene.
+//   GET  /cameras/{id}/ha/links                      -> HaLinkDto[] (any user
 //                                                       with camera access)
-//   PUT /cameras/{id}/ha/links/{link_id}/placement   body {x,y,size} pins the
+//   PUT  /cameras/{id}/ha/links  body {links:[...]}  -> HaLinkDto[]. Admin.
+//                                                       Replaces the
+//                                                       camera's FULL link
+//                                                       set (not a diff).
+//   PUT  /cameras/{id}/ha/links/{link_id}/placement   body {x,y,size} pins the
 //                                                       badge; a literal JSON
 //                                                       `null` body clears it.
 //                                                       Admin-only server-side
 //                                                       (matches link writes).
 //                                                       Returns the updated
 //                                                       link.
-//   GET /ha/states                                   -> HaStatesResponse (any
+//   GET  /ha/states                                  -> HaStatesResponse (any
 //                                                       authenticated user;
 //                                                       RBAC-projected to the
 //                                                       caller's cameras)
@@ -30,6 +51,121 @@ import 'http_client.dart';
 import 'models.dart';
 
 extension HaApi on CrumbApi {
+  /// GET /config/ha — admin. The Home Assistant connection config (never
+  /// includes the token itself — see [HaConfig.hasToken]).
+  Future<HaConfig> getHaConfig(Session s) async {
+    final resp = await sharedHttpClient.get(
+      Uri.parse('${s.base}/config/ha'),
+      headers: {'authorization': 'Bearer ${s.token}'},
+    );
+    if (resp.statusCode != 200) {
+      throw CrumbApiException(
+        'Failed to load Home Assistant settings '
+        '(HTTP ${resp.statusCode}): ${_errorDetail(resp)}',
+        statusCode: resp.statusCode,
+      );
+    }
+    return HaConfig.fromJson(jsonDecode(resp.body) as Map<String, dynamic>);
+  }
+
+  /// PUT /config/ha — admin. `token` is write-only: pass `null` to leave the
+  /// stored token unchanged, `''` to clear it, or a non-empty string to set
+  /// it — mirrors the admin console's `saveHa()` (never sends `token` unless
+  /// the operator typed one). Returns the updated config.
+  Future<HaConfig> putHaConfig(
+    Session s, {
+    required bool enabled,
+    required String baseUrl,
+    String? token,
+  }) async {
+    final resp = await sharedHttpClient.put(
+      Uri.parse('${s.base}/config/ha'),
+      headers: {
+        'authorization': 'Bearer ${s.token}',
+        'content-type': 'application/json',
+      },
+      body: jsonEncode({
+        'enabled': enabled,
+        'base_url': baseUrl,
+        if (token != null) 'token': token,
+      }),
+    );
+    if (resp.statusCode != 200) {
+      throw CrumbApiException(
+        'Failed to save Home Assistant settings '
+        '(HTTP ${resp.statusCode}): ${_errorDetail(resp)}',
+        statusCode: resp.statusCode,
+      );
+    }
+    return HaConfig.fromJson(jsonDecode(resp.body) as Map<String, dynamic>);
+  }
+
+  /// POST /config/ha/test — admin. Authenticated reachability check against
+  /// the STORED (already-saved) config — mirrors the admin console's "Save
+  /// first, then Test" note. Throws [CrumbApiException] with the server's
+  /// detail message on failure; returns normally on success.
+  Future<void> testHaConfig(Session s) async {
+    final resp = await sharedHttpClient.post(
+      Uri.parse('${s.base}/config/ha/test'),
+      headers: {'authorization': 'Bearer ${s.token}'},
+    );
+    if (resp.statusCode != 200) {
+      throw CrumbApiException(_errorDetail(resp), statusCode: resp.statusCode);
+    }
+  }
+
+  /// GET /ha/entities?domain=... — admin. The entity picker's data source;
+  /// `domain` is `binary_sensor` (sensor picker) or `controls` (light+switch
+  /// +scene, actuator picker) — mirrors the admin console's `haOpenPicker`.
+  Future<List<HaEntity>> haEntities(Session s, {required String domain}) async {
+    final resp = await sharedHttpClient.get(
+      Uri.parse(
+        '${s.base}/ha/entities',
+      ).replace(queryParameters: {'domain': domain}),
+      headers: {'authorization': 'Bearer ${s.token}'},
+    );
+    if (resp.statusCode != 200) {
+      throw CrumbApiException(
+        'Failed to load Home Assistant entities '
+        '(HTTP ${resp.statusCode}): ${_errorDetail(resp)}',
+        statusCode: resp.statusCode,
+      );
+    }
+    final list = jsonDecode(resp.body) as List<dynamic>;
+    return list
+        .map((e) => HaEntity.fromJson(e as Map<String, dynamic>))
+        .toList(growable: false);
+  }
+
+  /// PUT /cameras/{id}/ha/links — admin. Replaces the camera's FULL link set
+  /// (mirrors the admin console's `saveHaLinks()` — the whole array, not a
+  /// diff). Returns the saved links (with server-assigned ids).
+  Future<List<HaLink>> saveCameraHaLinks(
+    Session s,
+    String cameraId,
+    List<HaLinkInput> links,
+  ) async {
+    final resp = await sharedHttpClient.put(
+      Uri.parse('${s.base}/cameras/$cameraId/ha/links'),
+      headers: {
+        'authorization': 'Bearer ${s.token}',
+        'content-type': 'application/json',
+      },
+      body: jsonEncode({'links': links.map((l) => l.toJson()).toList()}),
+    );
+    if (resp.statusCode != 200) {
+      throw CrumbApiException(
+        'Failed to save Home Assistant links '
+        '(HTTP ${resp.statusCode}): ${_errorDetail(resp)}',
+        statusCode: resp.statusCode,
+      );
+    }
+    final list = jsonDecode(resp.body) as List<dynamic>;
+    return list
+        .map((e) => HaLink.fromJson(e as Map<String, dynamic>))
+        .toList(growable: false);
+  }
+
   /// GET /cameras/{id}/ha/links — the camera's linked HA entities, including
   /// on-video placement if any.
   Future<List<HaLink>> cameraHaLinks(Session s, String cameraId) async {
@@ -127,5 +263,19 @@ extension HaApi on CrumbApi {
     return HaStatesSnapshot.fromJson(
       jsonDecode(resp.body) as Map<String, dynamic>,
     );
+  }
+}
+
+/// Best-effort extraction of the server's `{"error":..., "message":...}`
+/// JSON error body (services/api/src/error.rs) down to a human-readable
+/// string; falls back to the raw body. Mirrors `export_api.dart`'s identical
+/// inline pattern, factored out here since four methods above need it.
+String _errorDetail(http.Response resp) {
+  try {
+    return (jsonDecode(resp.body) as Map<String, dynamic>)['message']
+            as String? ??
+        resp.body;
+  } catch (_) {
+    return resp.body;
   }
 }

--- a/apps/desktop-flutter/lib/api/ha_models.dart
+++ b/apps/desktop-flutter/lib/api/ha_models.dart
@@ -1,6 +1,8 @@
-// Data shapes for the Home Assistant on-video overlay feature (issue #170).
-// Snake_case JSON -> camelCase Dart, mirroring the server DTOs exactly:
-// `HaLinkDto` / `HaEntityState` / `HaStatesResponse` (services/api/src/ha.rs).
+// Data shapes for the Home Assistant integration (issue #52 connection +
+// entity linking, issue #170 on-video overlay). Snake_case JSON -> camelCase
+// Dart, mirroring the server DTOs exactly (services/api/src/ha.rs):
+// `HaConfigDto` / `HaEntity` / `HaLinkDto` / `HaEntityState` /
+// `HaStatesResponse`.
 
 /// A camera's linked HA entity (`GET /cameras/:id/ha/links`), including its
 /// on-video overlay placement, if any. One link -> at most one badge.
@@ -65,6 +67,99 @@ class HaLink {
     overlayY: (j['overlay_y'] as num?)?.toDouble(),
     overlaySize: (j['overlay_size'] as num?)?.toDouble(),
   );
+}
+
+/// The Home Assistant connection config (`GET /config/ha`). The token itself
+/// is NEVER returned — write-only server-side (`HaConfigDto`,
+/// services/api/src/ha.rs) — [hasToken] is the only signal a client gets
+/// about whether one is stored.
+class HaConfig {
+  HaConfig({required this.enabled, required this.baseUrl, required this.hasToken});
+
+  final bool enabled;
+  final String baseUrl;
+
+  /// True when a non-empty token is already stored server-side.
+  final bool hasToken;
+
+  factory HaConfig.fromJson(Map<String, dynamic> j) => HaConfig(
+    enabled: (j['enabled'] as bool?) ?? false,
+    baseUrl: (j['base_url'] as String?) ?? '',
+    hasToken: (j['has_token'] as bool?) ?? false,
+  );
+}
+
+/// One HA entity from the picker's data source (`GET /ha/entities`) — NOT
+/// yet linked to any camera. Mirrors the server's `HaEntity` DTO
+/// (services/api/src/ha.rs), which itself proxies HA's `/api/states` so the
+/// HA token never reaches the client.
+class HaEntity {
+  HaEntity({required this.entityId, required this.friendlyName, this.deviceClass});
+
+  final String entityId;
+  final String friendlyName;
+
+  /// HA `device_class` (`door`, `motion`, ...) — `binary_sensor` entities
+  /// only; null for lights/switches/scenes.
+  final String? deviceClass;
+
+  /// The entity_id's domain prefix (`binary_sensor`, `light`, `switch`,
+  /// `scene`, ...); empty string if [entityId] has no dot.
+  String get domain {
+    final i = entityId.indexOf('.');
+    return i < 0 ? '' : entityId.substring(0, i);
+  }
+
+  factory HaEntity.fromJson(Map<String, dynamic> j) => HaEntity(
+    entityId: j['entity_id'] as String,
+    friendlyName: (j['friendly_name'] as String?) ?? (j['entity_id'] as String),
+    deviceClass: j['device_class'] as String?,
+  );
+}
+
+/// One entry of the `PUT /cameras/:id/ha/links` request body — mirrors the
+/// admin console's link-editing working set (`HA_LINKS`,
+/// services/api/src/admin.html's `saveHaLinks()`): the FULL desired link set
+/// is sent on every save, not a diff.
+class HaLinkInput {
+  HaLinkInput({
+    required this.entityId,
+    required this.role,
+    this.deviceClass,
+    this.label,
+    required this.sortOrder,
+  });
+
+  final String entityId;
+
+  /// `"motion"` (binary_sensor picker) or `"actuator"` (light/switch/scene
+  /// picker) — the desktop linking dialog only ever produces these two, same
+  /// as the admin console's `haOpenPicker('motion' | 'actuator')`. `"sensor"`
+  /// is reserved server-side for a later status-only-overlay role and is
+  /// never written by this UI.
+  final String role;
+  final String? deviceClass;
+  final String? label;
+  final int sortOrder;
+
+  /// Round-trip an already-saved [HaLink] back into an editable input (e.g.
+  /// loading the working set from `GET /cameras/:id/ha/links`, or carrying
+  /// an unchanged link forward into the next save).
+  factory HaLinkInput.fromLink(HaLink l) => HaLinkInput(
+    entityId: l.entityId,
+    role: l.role,
+    deviceClass: l.deviceClass,
+    label: l.label,
+    sortOrder: l.sortOrder,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'entity_id': entityId,
+    'role': role,
+    'device_class': deviceClass,
+    'label': label,
+    'sort_order': sortOrder,
+  };
 }
 
 /// One entity's current reading from `GET /ha/states`.

--- a/apps/desktop-flutter/lib/main.dart
+++ b/apps/desktop-flutter/lib/main.dart
@@ -973,6 +973,7 @@ class _MainShellState extends State<MainShell> with WindowListener {
       session: session,
       cameras: widget.cameras,
       updateCheck: widget.updateCheck,
+      isAdmin: _isAdmin,
       clientOptions: widget.clientOptions,
       streamPrefs: widget.streamPrefs,
       hotkeys: widget.hotkeys,
@@ -1305,6 +1306,10 @@ class _MainShellState extends State<MainShell> with WindowListener {
           session: session,
           cameras: widget.cameras,
           onLogout: widget.onLogout,
+          // Gates the tile right-click menu's "Link HA entities…" item
+          // (issue #52 desktop port) — `PUT /cameras/:id/ha/links` is
+          // admin-enforced server-side regardless.
+          isAdmin: _isAdmin,
           // The wall listens to client options so the per-tile header bar
           // (showInfoBar) restyles live when toggled in the Settings panel.
           clientOptions: widget.clientOptions,

--- a/apps/desktop-flutter/lib/ui/ha_link/ha_link_dialog.dart
+++ b/apps/desktop-flutter/lib/ui/ha_link/ha_link_dialog.dart
@@ -1,0 +1,534 @@
+// Per-camera Home Assistant entity linking — desktop port of the admin
+// console's camera-editor flow (services/api/src/admin.html ~4810-4960:
+// `loadCameraHaLinks`/`renderHaLinks`/`haOpenPicker`/`renderHaResults`/
+// `haPick`/`removeHaLink`/`saveHaLinks`, issue #52). Lets an admin link this
+// camera's HA motion/door sensors (role `motion`, domain `binary_sensor`)
+// and lights/switches/scenes (role `actuator`, domain `controls`) without
+// leaving the desktop app. The desktop's separate "Edit HA overlay…" editor
+// (issue #170) then places any of these linked entities as an on-video
+// badge — this dialog only manages WHICH entities are linked, not where
+// they're drawn.
+//
+// Mirrors the admin console's picker exactly:
+//   - Sensors: whitelisted device_classes (`_kSensorClasses`, mirrors
+//     `HA_SENSOR_CLASSES`) grouped first (sorted), the rest bucketed under
+//     "Other sensors" — hidden unless "Show all binary sensors" is checked
+//     or there's a search query.
+//   - Controls: grouped by entity_id domain (light/switch/scene), sorted.
+//   - A search box filters both by friendly_name/entity_id substring.
+//   - An already-linked-for-this-role entity is shown dimmed "(linked)" but
+//     stays tappable (a no-op re-pick, matching `haPick`'s guard).
+// Save sends the FULL working link set (not a diff), same as `saveHaLinks`.
+//
+// If Home Assistant isn't configured+enabled+token-set yet, the dialog shows
+// only a "configure it first" hint — mirrors `renderHaLinks`'s `configured`
+// gate (admin.html:4845-4850), which doesn't even show existing links in
+// that state.
+
+import 'package:flutter/material.dart';
+
+import 'package:crumb_desktop/api/crumb_api.dart';
+import 'package:crumb_desktop/api/ha_api.dart';
+import 'package:crumb_desktop/api/ha_models.dart';
+import 'package:crumb_desktop/api/models.dart';
+
+/// device_classes worth linking to a camera by default; the rest hide under
+/// "Other sensors" until searched or shown. Mirrors admin.html's
+/// `HA_SENSOR_CLASSES` exactly.
+const List<String> _kSensorClasses = [
+  'motion',
+  'occupancy',
+  'presence',
+  'moving',
+  'door',
+  'window',
+  'opening',
+  'garage_door',
+];
+
+/// Shows the "Link HA entities…" dialog for one camera. Returns when the
+/// dialog is dismissed; [onSaved] fires once per successful save (not just
+/// on dismiss) so the caller can refresh its own cached links right away —
+/// see `wall_screen.dart`'s `_showTileMenu` for the intended wiring.
+Future<void> showHaLinkDialog(
+  BuildContext context, {
+  required CrumbApi api,
+  required Session session,
+  required String cameraId,
+  required String cameraName,
+  VoidCallback? onSaved,
+}) {
+  return showDialog<void>(
+    context: context,
+    builder: (_) => _HaLinkDialog(
+      api: api,
+      session: session,
+      cameraId: cameraId,
+      cameraName: cameraName,
+      onSaved: onSaved,
+    ),
+  );
+}
+
+class _HaLinkDialog extends StatefulWidget {
+  const _HaLinkDialog({
+    required this.api,
+    required this.session,
+    required this.cameraId,
+    required this.cameraName,
+    required this.onSaved,
+  });
+
+  final CrumbApi api;
+  final Session session;
+  final String cameraId;
+  final String cameraName;
+  final VoidCallback? onSaved;
+
+  @override
+  State<_HaLinkDialog> createState() => _HaLinkDialogState();
+}
+
+class _HaLinkDialogState extends State<_HaLinkDialog> {
+  bool _loading = true;
+  String? _loadError;
+
+  /// True iff HA is enabled, has a base URL, and has a stored token —
+  /// mirrors admin.html's `configured` check (`renderHaLinks`).
+  bool _configured = false;
+
+  /// The working link set for this camera — mirrors admin.html's `HA_LINKS`
+  /// mutable array. Edited locally; only sent to the server on Save.
+  List<HaLinkInput> _links = const [];
+
+  bool _saving = false;
+  String? _saveError;
+
+  // ── picker state (mirrors HA_PICKER/HA_PICKER_SEARCH/HA_PICKER_SHOWALL) ──
+  String? _pickerRole; // 'motion' | 'actuator' | null (closed)
+  final TextEditingController _searchCtrl = TextEditingController();
+  String _pickerSearch = '';
+  bool _pickerShowAll = false;
+  bool _pickerLoading = false;
+  String? _pickerError;
+  final Map<String, List<HaEntity>> _entityCache = {}; // domain -> entities
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  @override
+  void dispose() {
+    _searchCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _loadError = null;
+    });
+    try {
+      final results = await Future.wait([
+        widget.api.getHaConfig(widget.session),
+        widget.api.cameraHaLinks(widget.session, widget.cameraId),
+      ]);
+      if (!mounted) return;
+      final cfg = results[0] as HaConfig;
+      final links = results[1] as List<HaLink>;
+      setState(() {
+        _configured = cfg.enabled && cfg.baseUrl.trim().isNotEmpty && cfg.hasToken;
+        _links = [for (final l in links) HaLinkInput.fromLink(l)];
+        _loading = false;
+      });
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _loadError = '$e';
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _openPicker(String role) async {
+    setState(() {
+      _pickerRole = role;
+      _pickerSearch = '';
+      _pickerShowAll = false;
+      _pickerError = null;
+    });
+    _searchCtrl.clear();
+    final domain = role == 'motion' ? 'binary_sensor' : 'controls';
+    if (_entityCache.containsKey(domain)) return;
+    setState(() => _pickerLoading = true);
+    try {
+      final entities = await widget.api.haEntities(widget.session, domain: domain);
+      if (!mounted) return;
+      setState(() => _entityCache[domain] = entities);
+    } catch (e) {
+      if (mounted) setState(() => _pickerError = '$e');
+    } finally {
+      if (mounted) setState(() => _pickerLoading = false);
+    }
+  }
+
+  void _closePicker() => setState(() => _pickerRole = null);
+
+  void _pick(HaEntity e) {
+    final role = _pickerRole;
+    if (role == null) return;
+    if (_links.any((l) => l.entityId == e.entityId && l.role == role)) {
+      return; // already linked for this role — no-op re-pick, matches haPick
+    }
+    setState(() {
+      _links = [
+        ..._links,
+        HaLinkInput(
+          entityId: e.entityId,
+          role: role,
+          deviceClass: e.deviceClass,
+          label: e.friendlyName,
+          sortOrder: _links.length,
+        ),
+      ];
+    });
+  }
+
+  void _removeAt(int index) {
+    setState(() => _links = [..._links]..removeAt(index));
+  }
+
+  Future<void> _save() async {
+    setState(() {
+      _saving = true;
+      _saveError = null;
+    });
+    try {
+      final body = [
+        for (var i = 0; i < _links.length; i++)
+          HaLinkInput(
+            entityId: _links[i].entityId,
+            role: _links[i].role,
+            deviceClass: _links[i].deviceClass,
+            label: _links[i].label,
+            sortOrder: i,
+          ),
+      ];
+      final saved = await widget.api.saveCameraHaLinks(
+        widget.session,
+        widget.cameraId,
+        body,
+      );
+      if (!mounted) return;
+      setState(() {
+        _links = [for (final l in saved) HaLinkInput.fromLink(l)];
+        _pickerRole = null;
+      });
+      widget.onSaved?.call();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Home Assistant links saved.')),
+      );
+    } catch (e) {
+      if (mounted) setState(() => _saveError = '$e');
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  String _rolePill(HaLinkInput l) =>
+      l.role == 'actuator' ? 'control' : (l.deviceClass ?? 'sensor');
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text('Link HA entities — ${widget.cameraName}'),
+      content: SizedBox(width: 580, height: 520, child: _body()),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Close'),
+        ),
+        if (_configured)
+          FilledButton(
+            onPressed: _saving ? null : _save,
+            child: _saving
+                ? const SizedBox(
+                    width: 14,
+                    height: 14,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('Save links'),
+          ),
+      ],
+    );
+  }
+
+  Widget _body() {
+    if (_loading) return const Center(child: CircularProgressIndicator());
+    if (_loadError != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(_loadError!),
+            const SizedBox(height: 12),
+            OutlinedButton(onPressed: _load, child: const Text('Retry')),
+          ],
+        ),
+      );
+    }
+    if (!_configured) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(12),
+          child: Text(
+            'Configure Home Assistant in Settings first, then link this '
+            "camera's sensors and controls here.",
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+    final scheme = Theme.of(context).colorScheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          flex: _pickerRole == null ? 2 : 1,
+          child: _links.isEmpty
+              ? const Center(
+                  child: Text('No links yet.', style: TextStyle(fontSize: 12)),
+                )
+              : ListView.builder(
+                  itemCount: _links.length,
+                  itemBuilder: (context, i) => _linkRow(scheme, i),
+                ),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            OutlinedButton(
+              onPressed: () => _openPicker('motion'),
+              child: const Text('+ Add sensor'),
+            ),
+            const SizedBox(width: 8),
+            OutlinedButton(
+              onPressed: () => _openPicker('actuator'),
+              child: const Text('+ Add control'),
+            ),
+          ],
+        ),
+        if (_pickerRole != null) ...[
+          const SizedBox(height: 8),
+          Expanded(flex: 2, child: _pickerPanel(scheme)),
+        ],
+        if (_saveError != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: Text(_saveError!, style: const TextStyle(color: Colors.red)),
+          ),
+      ],
+    );
+  }
+
+  Widget _linkRow(ColorScheme scheme, int index) {
+    final l = _links[index];
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        children: [
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            decoration: BoxDecoration(
+              color: scheme.surfaceContainerHighest,
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Text(_rolePill(l), style: const TextStyle(fontSize: 11)),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              l.label ?? l.entityId,
+              style: const TextStyle(fontSize: 13),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            l.entityId,
+            style: TextStyle(
+              fontFamily: 'monospace',
+              fontSize: 11,
+              color: scheme.onSurfaceVariant,
+            ),
+          ),
+          IconButton(
+            tooltip: 'Remove',
+            icon: const Icon(Icons.close, size: 16),
+            onPressed: () => _removeAt(index),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _pickerPanel(ColorScheme scheme) {
+    final role = _pickerRole!;
+    final kind = role == 'motion' ? 'sensors' : 'controls';
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: _searchCtrl,
+                autofocus: true,
+                decoration: InputDecoration(
+                  isDense: true,
+                  hintText: 'Search $kind…',
+                  border: const OutlineInputBorder(),
+                ),
+                onChanged: (v) => setState(() => _pickerSearch = v),
+              ),
+            ),
+            const SizedBox(width: 8),
+            TextButton(onPressed: _closePicker, child: const Text('Done')),
+          ],
+        ),
+        const SizedBox(height: 6),
+        Expanded(
+          child: _pickerLoading
+              ? const Center(child: CircularProgressIndicator())
+              : _pickerError != null
+              ? Center(
+                  child: Text(
+                    _pickerError!,
+                    style: const TextStyle(color: Colors.red, fontSize: 12),
+                  ),
+                )
+              : _pickerResults(scheme, role),
+        ),
+      ],
+    );
+  }
+
+  Widget _pickerResults(ColorScheme scheme, String role) {
+    final domain = role == 'motion' ? 'binary_sensor' : 'controls';
+    final all = _entityCache[domain] ?? const <HaEntity>[];
+    final q = _pickerSearch.trim().toLowerCase();
+    bool match(HaEntity e) =>
+        q.isEmpty ||
+        e.entityId.toLowerCase().contains(q) ||
+        e.friendlyName.toLowerCase().contains(q);
+    final filtered = all.where(match).toList(growable: false);
+    final linked = {
+      for (final l in _links.where((l) => l.role == role)) l.entityId,
+    };
+
+    final groups = <(String, List<HaEntity>)>[];
+    Widget? showAllToggle;
+
+    if (role == 'motion') {
+      final relevant = <HaEntity>[];
+      final other = <HaEntity>[];
+      for (final e in filtered) {
+        (_kSensorClasses.contains(e.deviceClass) ? relevant : other).add(e);
+      }
+      final byClass = <String, List<HaEntity>>{};
+      for (final e in relevant) {
+        (byClass[e.deviceClass ?? 'sensor'] ??= []).add(e);
+      }
+      for (final c in byClass.keys.toList()..sort()) {
+        groups.add((c, byClass[c]!));
+      }
+      if (other.isNotEmpty && (_pickerShowAll || q.isNotEmpty)) {
+        groups.add(('Other sensors', other));
+      }
+      if (other.isNotEmpty && q.isEmpty) {
+        showAllToggle = CheckboxListTile(
+          dense: true,
+          contentPadding: EdgeInsets.zero,
+          controlAffinity: ListTileControlAffinity.leading,
+          value: _pickerShowAll,
+          onChanged: (v) => setState(() => _pickerShowAll = v ?? false),
+          title: Text(
+            'Show all binary sensors (${other.length} more)',
+            style: const TextStyle(fontSize: 12),
+          ),
+        );
+      }
+    } else {
+      final byDom = <String, List<HaEntity>>{};
+      for (final e in filtered) {
+        (byDom[e.domain] ??= []).add(e);
+      }
+      for (final d in byDom.keys.toList()..sort()) {
+        groups.add((d, byDom[d]!));
+      }
+    }
+
+    if (groups.isEmpty && showAllToggle == null) {
+      return const Center(
+        child: Text('No matching entities.', style: TextStyle(fontSize: 12)),
+      );
+    }
+
+    return ListView(
+      children: [
+        if (showAllToggle != null) showAllToggle,
+        for (final (title, items) in groups) ...[
+          Padding(
+            padding: const EdgeInsets.only(top: 6, bottom: 2),
+            child: Text(
+              title.toUpperCase(),
+              style: TextStyle(
+                fontSize: 10.5,
+                letterSpacing: 0.4,
+                color: scheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          for (final e in items) _pickerRow(scheme, e, linked.contains(e.entityId)),
+        ],
+      ],
+    );
+  }
+
+  Widget _pickerRow(ColorScheme scheme, HaEntity e, bool alreadyLinked) {
+    return InkWell(
+      onTap: () => _pick(e),
+      child: Opacity(
+        opacity: alreadyLinked ? 0.45 : 1.0,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 3),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  alreadyLinked ? '${e.friendlyName} (linked)' : e.friendlyName,
+                  style: const TextStyle(fontSize: 13),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                e.entityId,
+                style: TextStyle(
+                  fontFamily: 'monospace',
+                  fontSize: 11,
+                  color: scheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/desktop-flutter/lib/ui/settings/ha_settings_screen.dart
+++ b/apps/desktop-flutter/lib/ui/settings/ha_settings_screen.dart
@@ -1,0 +1,304 @@
+// Home Assistant connection settings — desktop port of the admin console's
+// "Home Assistant" section (services/api/src/admin.html ~5893-5911's markup,
+// `saveHa()`/`testHa()` ~6073-6095). A "PANE" section of the floating
+// Settings window (see settings_window.dart's file header) — admin-only; the
+// caller (SettingsWindow) hides this section's nav entry entirely for
+// non-admins, and `PUT`/`POST /config/ha*` are admin-enforced server-side
+// regardless (services/api/src/ha.rs).
+//
+// Fields: an enable toggle, Base URL, and a write-only long-lived access
+// token (never pre-filled — the server never returns it, only whether one is
+// stored, `HaConfig.hasToken`), a "Test connection" button that checks the
+// SAVED config (mirrors the admin console's "Save first, then Test" note),
+// and Save.
+
+import 'package:flutter/material.dart';
+
+import 'package:crumb_desktop/api/crumb_api.dart';
+import 'package:crumb_desktop/api/ha_api.dart';
+import 'package:crumb_desktop/api/ha_models.dart';
+import 'package:crumb_desktop/api/models.dart';
+
+class HaSettingsScreen extends StatelessWidget {
+  const HaSettingsScreen({super.key, required this.api, required this.session});
+
+  final CrumbApi api;
+  final Session session;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Home Assistant')),
+      body: _HaConfigLoader(api: api, session: session),
+    );
+  }
+}
+
+/// Loads the current config, then hands off to [_HaSettingsForm] once it's
+/// available — mirrors `server_dashboard_screen.dart`'s `_AsyncSection`
+/// loading/error/content split (that class is private to that file, so this
+/// screen keeps its own small copy rather than importing it).
+class _HaConfigLoader extends StatefulWidget {
+  const _HaConfigLoader({required this.api, required this.session});
+
+  final CrumbApi api;
+  final Session session;
+
+  @override
+  State<_HaConfigLoader> createState() => _HaConfigLoaderState();
+}
+
+class _HaConfigLoaderState extends State<_HaConfigLoader> {
+  late Future<HaConfig> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = widget.api.getHaConfig(widget.session);
+  }
+
+  void _reload() =>
+      setState(() => _future = widget.api.getHaConfig(widget.session));
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<HaConfig>(
+      future: _future,
+      builder: (context, snap) {
+        if (snap.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (snap.hasError) {
+          return Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text('${snap.error}'),
+                const SizedBox(height: 12),
+                OutlinedButton(onPressed: _reload, child: const Text('Retry')),
+              ],
+            ),
+          );
+        }
+        return _HaSettingsForm(
+          api: widget.api,
+          session: widget.session,
+          initial: snap.data!,
+        );
+      },
+    );
+  }
+}
+
+class _HaSettingsForm extends StatefulWidget {
+  const _HaSettingsForm({
+    required this.api,
+    required this.session,
+    required this.initial,
+  });
+
+  final CrumbApi api;
+  final Session session;
+  final HaConfig initial;
+
+  @override
+  State<_HaSettingsForm> createState() => _HaSettingsFormState();
+}
+
+class _HaSettingsFormState extends State<_HaSettingsForm> {
+  late bool _enabled = widget.initial.enabled;
+  late final TextEditingController _baseUrlCtrl = TextEditingController(
+    text: widget.initial.baseUrl,
+  );
+
+  /// The token field always starts empty — the server never returns the
+  /// actual token, only [_hasToken] (see [HaConfig.hasToken]).
+  final TextEditingController _tokenCtrl = TextEditingController();
+  late bool _hasToken = widget.initial.hasToken;
+
+  bool _saving = false;
+  String? _saveError;
+
+  bool _testing = false;
+  String? _testResult;
+  bool _testOk = false;
+
+  @override
+  void dispose() {
+    _baseUrlCtrl.dispose();
+    _tokenCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    final baseUrl = _baseUrlCtrl.text.trim();
+    if (_enabled && baseUrl.isEmpty) {
+      setState(() => _saveError = 'Base URL is required when enabled.');
+      return;
+    }
+    setState(() {
+      _saving = true;
+      _saveError = null;
+    });
+    try {
+      // Write-only: only sent when the operator typed something (mirrors the
+      // admin console's `saveHa()` — `if (tok) body.token = tok;`).
+      final tok = _tokenCtrl.text;
+      final cfg = await widget.api.putHaConfig(
+        widget.session,
+        enabled: _enabled,
+        baseUrl: baseUrl,
+        token: tok.isEmpty ? null : tok,
+      );
+      if (!mounted) return;
+      setState(() {
+        _hasToken = cfg.hasToken;
+        _tokenCtrl.clear();
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Home Assistant settings saved.')),
+      );
+    } catch (e) {
+      if (mounted) setState(() => _saveError = '$e');
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  Future<void> _test() async {
+    setState(() {
+      _testing = true;
+      _testResult = null;
+    });
+    try {
+      await widget.api.testHaConfig(widget.session);
+      if (!mounted) return;
+      setState(() {
+        _testResult = 'Connected';
+        _testOk = true;
+      });
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _testResult = '$e';
+          _testOk = false;
+        });
+      }
+    } finally {
+      if (mounted) setState(() => _testing = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Text(
+          'Optional. Links your Home Assistant motion/door sensors and '
+          'lights to cameras (right-click a camera on the wall, '
+          '"Link HA entities…"). Use a token from a non-admin HA user: in '
+          'Home Assistant add a user under Settings, People, then open that '
+          "user's profile and create a Long-Lived Access Token.",
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+        const SizedBox(height: 12),
+        InkWell(
+          onTap: () => setState(() => _enabled = !_enabled),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 6),
+            child: Row(
+              children: [
+                const Expanded(
+                  child: Text(
+                    'Enable Home Assistant integration',
+                    style: TextStyle(fontSize: 13, fontWeight: FontWeight.w500),
+                  ),
+                ),
+                Transform.scale(
+                  scale: 0.72,
+                  child: Switch(
+                    value: _enabled,
+                    onChanged: (v) => setState(() => _enabled = v),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 8),
+        TextField(
+          controller: _baseUrlCtrl,
+          decoration: const InputDecoration(
+            labelText: 'Base URL',
+            hintText: 'http://<home-assistant-host>:8123',
+            isDense: true,
+            border: OutlineInputBorder(),
+          ),
+        ),
+        const SizedBox(height: 12),
+        TextField(
+          controller: _tokenCtrl,
+          obscureText: true,
+          autocorrect: false,
+          decoration: InputDecoration(
+            labelText: 'Long-lived access token',
+            hintText: _hasToken ? '•••••••• (unchanged)' : '(none set)',
+            isDense: true,
+            border: const OutlineInputBorder(),
+          ),
+        ),
+        const SizedBox(height: 16),
+        Row(
+          children: [
+            OutlinedButton(
+              onPressed: _testing ? null : _test,
+              child: _testing
+                  ? const SizedBox(
+                      width: 14,
+                      height: 14,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Test connection'),
+            ),
+            const SizedBox(width: 10),
+            if (_testResult != null)
+              Expanded(
+                child: Text(
+                  _testResult!,
+                  style: TextStyle(
+                    color: _testOk ? Colors.green : Colors.red,
+                    fontSize: 12,
+                  ),
+                ),
+              ),
+          ],
+        ),
+        Padding(
+          padding: const EdgeInsets.only(top: 4),
+          child: Text(
+            'Save first, then Test (Test checks the saved connection).',
+            style: TextStyle(fontSize: 11, color: scheme.onSurfaceVariant),
+          ),
+        ),
+        const SizedBox(height: 16),
+        FilledButton(
+          onPressed: _saving ? null : _save,
+          child: _saving
+              ? const SizedBox(
+                  width: 14,
+                  height: 14,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('Save'),
+        ),
+        if (_saveError != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: Text(_saveError!, style: const TextStyle(color: Colors.red)),
+          ),
+      ],
+    );
+  }
+}

--- a/apps/desktop-flutter/lib/ui/settings/settings_window.dart
+++ b/apps/desktop-flutter/lib/ui/settings/settings_window.dart
@@ -27,6 +27,7 @@ import 'package:crumb_desktop/ui/client_options/client_options_screen.dart';
 import 'package:crumb_desktop/ui/hotkeys/hotkey_remap_screen.dart';
 import 'package:crumb_desktop/ui/hotkeys/keyboard_shortcuts_screen.dart';
 import 'package:crumb_desktop/ui/server/server_dashboard_screen.dart';
+import 'package:crumb_desktop/ui/settings/ha_settings_screen.dart';
 import 'package:crumb_desktop/ui/updates/about_panel.dart';
 import 'package:crumb_desktop/ui/updates/update_check_controller.dart';
 
@@ -38,6 +39,10 @@ enum SettingsSection {
       pane: true),
   hotkeys(Icons.keyboard_outlined, 'Camera Hotkeys', pane: true),
   serverDashboard(Icons.dns_outlined, 'Server dashboard', pane: true),
+  // Admin-only (issue #52 desktop port) — SettingsWindow hides this nav
+  // entry entirely for non-admins (see `_leftNav`); `PUT/POST /config/ha*`
+  // are admin-enforced server-side regardless.
+  homeAssistant(Icons.home_outlined, 'Home Assistant', pane: true),
   about(Icons.info_outline, 'About', pane: true),
   serverConsole(Icons.admin_panel_settings_outlined, 'Server console',
       pane: false),
@@ -63,6 +68,7 @@ class SettingsWindow extends StatefulWidget {
     required this.onOpenServerConsole,
     required this.onOpenMotionTuner,
     required this.updateCheck,
+    required this.isAdmin,
     this.clientOptions,
     this.streamPrefs,
     this.hotkeys,
@@ -72,6 +78,13 @@ class SettingsWindow extends StatefulWidget {
   final CrumbApi api;
   final Session session;
   final List<Camera> cameras;
+
+  /// Server-side truth (`GET /auth/me`, see `main.dart`'s `_isAdmin`) for
+  /// whether this account is an admin. Gates the "Home Assistant" nav entry
+  /// entirely (hidden, not just disabled, for non-admins) — the server is
+  /// still the authority (`PUT`/`POST /config/ha*` are admin-enforced there
+  /// regardless), this only avoids showing a section that would 403 anyway.
+  final bool isAdmin;
 
   /// Close the panel (X button, or after a LAUNCH section is picked).
   final VoidCallback onClose;
@@ -245,11 +258,14 @@ class _SettingsWindowState extends State<SettingsWindow> {
         child: ListView(
           padding: const EdgeInsets.symmetric(vertical: 6),
           children: [
-            for (final s in SettingsSection.values) ...[
-              if (s == SettingsSection.serverConsole)
-                Divider(height: 9, color: scheme.outlineVariant),
-              _navTile(scheme, s),
-            ],
+            for (final s in SettingsSection.values)
+              // Non-admins never see the entry at all (not just disabled) —
+              // it would just 403 server-side.
+              if (s != SettingsSection.homeAssistant || widget.isAdmin) ...[
+                if (s == SettingsSection.serverConsole)
+                  Divider(height: 9, color: scheme.outlineVariant),
+                _navTile(scheme, s),
+              ],
           ],
         ),
       ),
@@ -313,6 +329,12 @@ class _SettingsWindowState extends State<SettingsWindow> {
         return HotkeyRemapScreen(store: hk, cameras: widget.cameras);
       case SettingsSection.serverDashboard:
         return ServerDashboardScreen(api: widget.api, session: widget.session);
+      case SettingsSection.homeAssistant:
+        // Defensive fallback: the nav entry is hidden for non-admins (see
+        // `_leftNav`), so this only fires if `_section` is somehow forced to
+        // this value some other way.
+        if (!widget.isAdmin) return const _Unavailable('Home Assistant');
+        return HaSettingsScreen(api: widget.api, session: widget.session);
       case SettingsSection.about:
         return AboutPanel(controller: widget.updateCheck);
       case SettingsSection.serverConsole:

--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -24,6 +24,7 @@ import 'package:crumb_desktop/state/client_options.dart';
 import 'package:crumb_desktop/state/hotkey_config.dart';
 import 'package:crumb_desktop/state/keyboard_shortcuts.dart';
 import 'package:crumb_desktop/state/stream_prefs.dart';
+import 'package:crumb_desktop/ui/ha_link/ha_link_dialog.dart';
 import 'package:crumb_desktop/ui/ha_overlay/ha_entity_palette.dart';
 import 'package:crumb_desktop/ui/ha_overlay/ha_overlay_controller.dart';
 import 'package:crumb_desktop/ui/ha_overlay/ha_overlay_layer.dart';
@@ -70,6 +71,7 @@ class WallScreen extends StatefulWidget {
     required this.session,
     required this.cameras,
     required this.onLogout,
+    required this.isAdmin,
     this.clientOptions,
     this.streamPrefs,
     this.view,
@@ -85,6 +87,13 @@ class WallScreen extends StatefulWidget {
   final Session session;
   final List<Camera> cameras;
   final VoidCallback onLogout;
+
+  /// Server-side truth (`GET /auth/me`, see `main.dart`'s `_isAdmin`) for
+  /// whether this account is an admin. Gates the tile right-click menu's
+  /// "Link HA entities…" item (issue #52 desktop port) — reads of a
+  /// camera's HA links need only camera access, but writing them
+  /// (`PUT /cameras/:id/ha/links`) is admin-enforced server-side regardless.
+  final bool isAdmin;
 
   /// Play-on-focus audio controller (single audible pane). Tiles register
   /// their Player; selection/maximize pick the active pane.
@@ -725,6 +734,7 @@ class _WallScreenState extends State<WallScreen> {
                     onEditHaOverlay: () =>
                         unawaited(_beginHaOverlayEdit(cam)),
                     onHaLinksLoaded: _onHaLinksLoaded,
+                    isAdmin: widget.isAdmin,
                   );
           }
           children.add(
@@ -793,6 +803,7 @@ class _WallScreenState extends State<WallScreen> {
                 onEditHaOverlay: () =>
                     unawaited(_beginHaOverlayEdit(cam)),
                 onHaLinksLoaded: _onHaLinksLoaded,
+                isAdmin: widget.isAdmin,
               ),
             ),
           );
@@ -867,6 +878,7 @@ class _WallTile extends StatefulWidget {
     this.onEditPtzPanel,
     this.onEditHaOverlay,
     this.onHaLinksLoaded,
+    this.isAdmin = false,
   });
 
   final CrumbApi api;
@@ -891,6 +903,12 @@ class _WallTile extends StatefulWidget {
   /// can track which visible cameras have a placed badge and drive
   /// `LiveStatusController.wantHaStates` (desktop P0 plan §4.4).
   final void Function(String cameraId, List<HaLink> links)? onHaLinksLoaded;
+
+  /// Gates the right-click menu's "Link HA entities…" item (issue #52
+  /// desktop port) — `PUT /cameras/:id/ha/links` is admin-enforced
+  /// server-side regardless; this only avoids showing an item that would
+  /// 403 for a non-admin.
+  final bool isAdmin;
 
   /// When true, digitally zooming this tile past 100% temporarily loads its
   /// main stream (reverting to sub at 100%). From the "Zoom switches to main
@@ -1284,16 +1302,27 @@ class _WallTileState extends State<_WallTile> {
             ),
           const PopupMenuDivider(),
         ],
-        // HA on-video badges (issue #170 P0) — deliberately OUTSIDE the
-        // `camera.ptz` block above: HA badges must work on non-PTZ cameras
-        // too. Gated on the camera actually having linked entities (not on
-        // any of them being PLACED yet — the editor's palette is where an
-        // operator places the first one).
-        if (_haLinks.isNotEmpty && widget.onEditHaOverlay != null) ...[
-          const PopupMenuItem(
-            value: 'ha-overlay',
-            child: Text('Edit HA overlay…'),
-          ),
+        // HA entity linking (issue #52 desktop port) + on-video badges
+        // (issue #170 P0) — deliberately OUTSIDE the `camera.ptz` block
+        // above: HA works on non-PTZ cameras too. "Link HA entities…" is
+        // admin-only (matches `PUT /cameras/:id/ha/links` server-side) and
+        // shown regardless of whether the camera has any links yet — it's
+        // the entry point to CREATE the first one. "Edit HA overlay…" is
+        // placement (unchanged) and stays gated on the camera actually
+        // having linked entities (not on any of them being PLACED yet — the
+        // editor's palette is where an operator places the first one).
+        if (widget.isAdmin ||
+            (_haLinks.isNotEmpty && widget.onEditHaOverlay != null)) ...[
+          if (widget.isAdmin)
+            const PopupMenuItem(
+              value: 'ha-link',
+              child: Text('Link HA entities…'),
+            ),
+          if (_haLinks.isNotEmpty && widget.onEditHaOverlay != null)
+            const PopupMenuItem(
+              value: 'ha-overlay',
+              child: Text('Edit HA overlay…'),
+            ),
           const PopupMenuDivider(),
         ],
         CheckedPopupMenuItem(
@@ -1332,6 +1361,21 @@ class _WallTileState extends State<_WallTile> {
         setState(() {}); // no reload needed — only affects maximized PTZ UI
       case 'ptz-panel':
         widget.onEditPtzPanel?.call();
+      case 'ha-link':
+        unawaited(
+          showHaLinkDialog(
+            context,
+            api: widget.api,
+            session: widget.session,
+            cameraId: widget.camera.id,
+            cameraName: widget.camera.name,
+            // Refresh this tile's own cached links immediately on each save
+            // (not just on dialog close) so "Edit HA overlay…" and the
+            // badges pick up new/removed links right away — reuses the same
+            // reload path the config-changed signal already drives.
+            onSaved: () => unawaited(_loadHaLinks()),
+          ),
+        );
       case 'ha-overlay':
         widget.onEditHaOverlay?.call();
       case 'main':


### PR DESCRIPTION
Brings the full Home Assistant setup into the desktop client, so an admin can connect HA and link entities to a camera without leaving the app. This is the missing piece in front of the HA on-video overlay (#170) — "Edit HA overlay…" only *places* entities that were already linked; until now, linking required the web admin console.

## What's new
- **Settings → Home Assistant** (admin-only): base URL, write-only token (never pre-filled; only sent when changed), enable toggle, **Test connection**. `GET/PUT /config/ha` + `POST /config/ha/test`.
- **Camera right-click → "Link HA entities…"** (admin-only): the grouped + searchable entity picker mirroring the console — **"+ Add sensor"** (binary_sensor grouped by `device_class`, whitelist-first + show-all) / **"+ Add control"** (light/switch/scene by domain), remove, save. `GET /ha/entities` + `PUT /cameras/:id/ha/links`. Saving carries existing overlay placements forward (`replace_camera_ha_links` preserves them by entity/role), so linking never wipes a placed badge.
- `ha_api`/`ha_models`: `HaConfig`, `HaEntity`, `HaLinkInput` + the five endpoints.
- `isAdmin` threaded to `SettingsWindow` + `WallScreen` (from `/auth/me`); the server independently enforces admin on all the writes.

Mirrors the admin console's proven flow (`admin.html` HA config + per-camera links). `flutter analyze` clean; release build green; packaged + served for the maintainer to try.

Follows the HA overlay POC (#172, merged). Part of #170.