### PR TITLE
fix(android): don't auto-show clip transport controls over the video on play

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/ui/player/PlayerSurface.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/ui/player/PlayerSurface.kt
@@ -51,6 +51,11 @@ fun PlayerSurface(
             }
             view.apply {
                 this.useController = useController
+                // Don't auto-pop the transport controls over the video when
+                // playback starts (they briefly cover the clip before timing
+                // out); the user taps to reveal them. Only relevant when the
+                // controller is enabled (the clip player).
+                if (useController) controllerAutoShow = false
                 this.resizeMode = resizeMode
                 setKeepContentOnPlayerReset(keepContentOnReset)
                 setShutterBackgroundColor(android.graphics.Color.BLACK)


### PR DESCRIPTION
Opening a clip briefly flashed the Media3 play/pause controller over the video before it timed out. Media3 `PlayerView` auto-shows the controller on playback start; set `controllerAutoShow = false` when the controller is enabled (the clip player is the only user, so it's scoped) — the clip now plays unobstructed and a tap still reveals the controls. Built + on-device.