### PR TITLE
ci: build amd64-only images (drop the arm64 QEMU leg)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,13 +223,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # QEMU so the release (push) build can cross-build arm64 alongside amd64
-      # (Apple Silicon / ARM SBCs). Cheap to set up; only the push path actually
-      # builds multi-arch (the local-load CI path stays single amd64, since
-      # `docker load` can't take a multi-arch manifest).
-      - name: Set up QEMU (multi-arch emulation)
-        uses: docker/setup-qemu-action@v3
-
       # Decide where images go. We push to a real registry ONLY on a release
       # event (push to main / a v* tag) when REGISTRY is configured. Pull
       # requests always build locally (load into the runner's docker) so the
@@ -284,10 +277,11 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
-          # Release (push) builds are multi-arch so Apple Silicon / ARM SBCs get a
-          # native image; the local-load CI path stays single amd64 because
-          # `docker load` cannot import a multi-arch manifest.
-          platforms: ${{ steps.cfg.outputs.push == 'true' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          # amd64 only. The Crumb server (recorder + api) is self-hosted on x86
+          # in practice; arm64 was a QEMU-emulated Rust compile that added ~60 min
+          # per deploy for no known ARM operator. See docs/DECISIONS.md
+          # (2026-07-16) for the revisit trigger.
+          platforms: linux/amd64
           push: ${{ steps.cfg.outputs.push }}
           load: ${{ steps.cfg.outputs.push == 'false' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,33 @@ revisit.
 
 ---
 
+## 2026-07-16, CI publishes amd64-only Docker images (dropped the arm64 multi-arch leg)
+
+CI (`.github/workflows/ci.yml`) built the api + recorder images multi-arch
+(`linux/amd64,linux/arm64`) on every push to `main`. The arm64 leg is a
+QEMU-emulated Rust release compile that took ~60-70 min, so every backend
+deploy off a `main` sha waited well over an hour for an image, versus ~7 min
+for amd64 alone.
+
+**Chosen:** build `linux/amd64` only (dropped the arm64 platform and the QEMU
+setup step).
+
+**Rejected:** amd64 on every push + arm64 only on release tags (`v*`). Cleaner
+in theory, but the project has no tagged releases yet and no known ARM
+operator, so it was ceremony for a hypothetical.
+
+**Trade-off accepted:** anyone wanting to run the **Crumb server** (recorder +
+api) on ARM hardware — a Raspberry Pi / ARM SBC, an ARM cloud instance, or an
+Apple Silicon Mac via Docker Desktop — no longer gets a native image and would
+run amd64 under emulation (slow) or build it locally. The clients are
+unaffected (Android ships its own APK; the desktop app is a separate build).
+
+**Revisit when:** a real operator wants to self-host the server on ARM, or the
+project starts cutting tagged public releases for varied hardware — at which
+point re-add arm64, ideally gated to `tags: v*` so per-push deploys stay fast.
+
+---
+
 ## 2026-07-15, One shared drag-to-place overlay editor (PTZ panels + HA badges) with raw-tracked snapping; per-badge HA style stored on camera_ha_links (migration 0059)
 
 The desktop client had two drag-to-place editors: the shared


### PR DESCRIPTION
The api/recorder images were built multi-arch (`linux/amd64,linux/arm64`) on every push to `main`. The arm64 leg is a QEMU-emulated Rust release compile that took **~60-70 min**, so every backend deploy off a `main` sha waited well over an hour for an image versus ~7 min for amd64 alone.

No tagged releases yet and no known operator running the server on ARM, so this was pure cost. This drops `arm64` (and the now-unused QEMU setup step); images are `linux/amd64` only.

Clients are unaffected — Android ships its own APK, the desktop app is a separate build. Anyone self-hosting the server on ARM would run amd64 under emulation or build locally.

Revisit trigger (a real ARM operator, or tagged public releases → re-add arm64 gated to `tags: v*`) is recorded in `docs/DECISIONS.md`.