### PR TITLE
feat(camera): per-camera PTZ controls toggle (migration 0061)

### DIFF
--- a/db/migrations/0061_camera_ptz_control.sql
+++ b/db/migrations/0061_camera_ptz_control.sql
@@ -1,0 +1,87 @@
+-- 0061_camera_ptz_control.sql
+--
+-- Per-camera "PTZ controls" toggle.
+--
+-- Until now a camera's PTZ capability was computed purely from whether it has an
+-- ONVIF host configured (`ViewerCameraDto.ptz = onvif_host IS NOT NULL`), which
+-- every client gates its PTZ controls on. But plenty of ONVIF cameras are FIXED
+-- (no pan/tilt/zoom motor) — they speak ONVIF only for stream discovery — yet
+-- they wrongly show PTZ controls. This adds an explicit operator switch so PTZ
+-- can be turned off for such a camera.
+--
+-- Default TRUE = NO behavior change on upgrade: an ONVIF camera keeps showing
+-- PTZ controls until the operator turns the switch off. The computed capability
+-- becomes `ptz = onvif_host IS NOT NULL AND ptz_control_enabled` (folded in the
+-- API's ViewerCameraDto), so NO client change is needed — the clients already
+-- gate on `camera.ptz`.
+
+ALTER TABLE cameras
+    ADD COLUMN IF NOT EXISTS ptz_control_enabled boolean NOT NULL DEFAULT true;
+
+-- Re-declare v_camera_effective_policy to expose the new column. Per the
+-- CREATE OR REPLACE VIEW rule, every existing column keeps its name AND order
+-- and the new column is APPENDED at the very end (after c_motion_ha_enabled).
+-- This mirrors the 0049 body verbatim with one appended column. Idempotent +
+-- safe to re-run.
+CREATE OR REPLACE VIEW v_camera_effective_policy AS
+SELECT
+    c.id              AS c_id,
+    c.name            AS c_name,
+    c.enabled         AS c_enabled,
+    c.go2rtc_name     AS c_go2rtc_name,
+    c.main_url        AS c_main_url,
+    c.sub_url         AS c_sub_url,
+    c.source_url      AS c_source_url,
+    c.source_sub_url  AS c_source_sub_url,
+    c.policy_id       AS c_policy_id,
+    m.group_id        AS c_group_id,
+    c.motion_mask     AS c_motion_mask,
+    c.onvif_motion    AS c_onvif_motion,
+    c.motion_source     AS c_motion_source,
+    c.motion_algorithm  AS c_motion_algorithm,
+    c.camera_type       AS c_camera_type,
+    c.icon              AS c_icon,
+    c.motion_grid_cols  AS c_motion_grid_cols,
+    c.motion_grid_rows  AS c_motion_grid_rows,
+    c.created_at        AS c_created_at,
+    c.served_by         AS c_served_by,
+    c.source_camera_name AS c_source_camera_name,
+    c.onvif_host        AS c_onvif_host,
+    c.onvif_port        AS c_onvif_port,
+    c.onvif_user        AS c_onvif_user,
+    c.onvif_password    AS c_onvif_password,
+    p.id                      AS p_id,
+    p.name                    AS p_name,
+    p.is_default              AS p_is_default,
+    p.mode                    AS p_mode,
+    p.live_storage_id         AS p_live_storage_id,
+    p.live_retention_hours    AS p_live_retention_hours,
+    p.archive_enabled         AS p_archive_enabled,
+    p.archive_storage_id      AS p_archive_storage_id,
+    p.archive_schedule        AS p_archive_schedule,
+    p.archive_retention_hours AS p_archive_retention_hours,
+    p.live_max_bytes          AS p_live_max_bytes,
+    p.archive_max_bytes       AS p_archive_max_bytes,
+    p.live_min_free_pct          AS p_live_min_free_pct,
+    p.live_min_free_bytes        AS p_live_min_free_bytes,
+    p.live_spill_low_water_bytes AS p_live_spill_low_water_bytes,
+    p.motion_pre_seconds      AS p_motion_pre_seconds,
+    p.motion_post_seconds     AS p_motion_post_seconds,
+    p.motion_sensitivity      AS p_motion_sensitivity,
+    p.motion_threshold        AS p_motion_threshold,
+    p.motion_keyframes_only   AS p_motion_keyframes_only,
+    p.record_stream           AS p_record_stream,
+    p.record_audio            AS p_record_audio,
+    p.max_retention_days      AS p_max_retention_days,
+    c.motion_pixel_enabled    AS c_motion_pixel_enabled,
+    c.motion_frigate_enabled  AS c_motion_frigate_enabled,
+    c.motion_ha_enabled       AS c_motion_ha_enabled,
+    c.ptz_control_enabled     AS c_ptz_control_enabled
+FROM cameras c
+LEFT JOIN camera_group_members m ON m.camera_id = c.id
+LEFT JOIN camera_groups g ON g.id = m.group_id
+JOIN recording_policies p ON p.id = COALESCE(
+    c.policy_id,
+    g.policy_id,
+    (SELECT id FROM recording_policies WHERE is_default LIMIT 1)
+);

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -4601,6 +4601,8 @@ function renderCamInfoTab(c) {
         <div class="fg-ctl"><input id="ce-onvif-user" autocomplete="off" value="${esc(c.onvif_user||'')}" style="max-width:220px" /></div>
         <label class="fg-label" for="ce-onvif-pass">ONVIF password</label>
         <div class="fg-ctl"><input id="ce-onvif-pass" type="password" autocomplete="new-password" placeholder="${c.onvif_has_password?'•••• (unchanged)':'(none set)'}" style="max-width:220px" /></div>
+        <label class="fg-label" for="ce-ptz-enabled">PTZ controls</label>
+        <div class="fg-ctl"><label class="chk"><input type="checkbox" id="ce-ptz-enabled" ${(c.ptz_control_enabled ?? true)?'checked':''}/> This camera has pan/tilt/zoom controls ${infoHint('Turn OFF for a fixed ONVIF camera (no pan/tilt/zoom motor). Off hides the PTZ joystick on every client and rejects PTZ commands, even though the camera still uses ONVIF for stream discovery.')}</label></div>
       </div>
     </div>
 
@@ -6897,6 +6899,8 @@ async function saveCamEdit() {
     if ($('ce-onvif-user')) camBody.onvif_user = $('ce-onvif-user').value.trim() || null;
     if ($('ce-onvif-port')) { const pv = $('ce-onvif-port').value.trim(); camBody.onvif_port = pv === '' ? null : Number(pv); }
     if ($('ce-onvif-pass') && $('ce-onvif-pass').value) camBody.onvif_password = $('ce-onvif-pass').value;
+    // PTZ-controls toggle (Info tab). Only present when the Info tab DOM is mounted.
+    if ($('ce-ptz-enabled')) camBody.ptz_control_enabled = $('ce-ptz-enabled').checked;
     if ($('ce-src')) {
       const src = $('ce-src').value.trim();
       const sub = $('ce-src-sub').value.trim() || null;

--- a/services/api/src/cameras.rs
+++ b/services/api/src/cameras.rs
@@ -90,7 +90,10 @@ async fn list_visible_cameras(
             name: c.name,
             enabled: c.enabled,
             has_sub: c.sub_url.is_some(),
-            ptz: c.onvif_host.is_some(),
+            // PTZ capability = has an ONVIF host AND the operator hasn't turned
+            // PTZ controls off (migration 0061). Every client gates its PTZ UI on
+            // this single `ptz` flag, so the toggle needs no client change.
+            ptz: c.onvif_host.is_some() && c.ptz_control_enabled,
             camera_type: c.camera_type,
             icon: c.icon,
             served_by: c.served_by,

--- a/services/api/src/config_routes.rs
+++ b/services/api/src/config_routes.rs
@@ -865,6 +865,7 @@ async fn create_camera(
         onvif_port: body.onvif_port,
         onvif_user: onvif_user_create,
         onvif_password: onvif_password_create,
+        ptz_control_enabled: body.ptz_control_enabled,
     };
 
     let camera = db::create_camera(pool, &params).await.map_err(|e| {
@@ -926,6 +927,11 @@ async fn update_camera(
         .to_owned();
     let enabled = body.enabled.unwrap_or(existing.enabled);
     let onvif_motion = body.onvif_motion.unwrap_or(existing.onvif_motion);
+    // PTZ-controls toggle (migration 0061): a provided value sets it; omitted
+    // keeps the existing value. Simple bool, same pattern as `enabled`.
+    let ptz_control_enabled = body
+        .ptz_control_enabled
+        .unwrap_or(existing.ptz_control_enabled);
 
     // source_url / source_sub_url: Option<Option<String>>; trimmed to non-empty.
     let clean = |s: Option<String>| s.map(|v| v.trim().to_owned()).filter(|v| !v.is_empty());
@@ -1155,7 +1161,8 @@ async fn update_camera(
                 motion_ha_enabled      = $25,
                 make                   = $26,
                 model                  = $27,
-                firmware               = $28
+                firmware               = $28,
+                ptz_control_enabled    = $29
             WHERE id = $1
             ",
             &[
@@ -1187,6 +1194,7 @@ async fn update_camera(
                 &make,
                 &model,
                 &firmware,
+                &ptz_control_enabled,
             ],
         )
         .await
@@ -4111,6 +4119,7 @@ fn camera_to_dto(c: Camera) -> CameraDto {
         onvif_port: c.onvif_port,
         onvif_user: c.onvif_user,
         onvif_has_password,
+        ptz_control_enabled: c.ptz_control_enabled,
     }
 }
 

--- a/services/api/src/dto.rs
+++ b/services/api/src/dto.rs
@@ -219,7 +219,9 @@ pub struct ViewerCameraDto {
     pub enabled: bool,
     /// `true` when a sub-stream is configured (`sub_url` is `Some`).
     pub has_sub: bool,
-    /// `true` when ONVIF PTZ is configured (`onvif_host` is `Some`).
+    /// `true` when the camera has an ONVIF host AND its per-camera PTZ-controls
+    /// toggle is on (`onvif_host.is_some() && ptz_control_enabled`, migration
+    /// 0061). Every client gates its PTZ UI on this flag.
     pub ptz: bool,
     /// Physical form-factor glyph hint (`"ptz"`, `"dome"`, `"bullet"`, `"lpr"`,
     /// `"other"`). `null` for legacy rows that pre-date the type column.
@@ -301,6 +303,11 @@ pub struct CameraDto {
     /// itself is NEVER returned — this flag lets the UI show "•••• (change)" vs
     /// an empty field.
     pub onvif_has_password: bool,
+    /// Whether this camera exposes PTZ controls (migration 0061). RAW stored
+    /// value (not the computed `ViewerCameraDto.ptz` capability) so the admin
+    /// camera editor can show + toggle it independently of the ONVIF host. When
+    /// `false`, the client-facing `ptz` capability is forced off.
+    pub ptz_control_enabled: bool,
 }
 
 /// `POST /config/cameras` request body.
@@ -352,6 +359,10 @@ pub struct CreateCameraRequest {
     pub onvif_user: Option<String>,
     /// ONVIF password — **write-only**. Never returned in responses.
     pub onvif_password: Option<String>,
+    /// Whether this camera exposes PTZ controls (migration 0061). Omitted/`null`
+    /// defaults to `true` (an ONVIF camera shows PTZ unless turned off).
+    #[serde(default = "default_true")]
+    pub ptz_control_enabled: bool,
 }
 
 /// `PUT /config/cameras/{id}` request body.
@@ -443,6 +454,9 @@ pub struct UpdateCameraRequest {
     /// double-option semantics as [`Self::make`].
     #[serde(default, deserialize_with = "double_option")]
     pub firmware: Option<Option<String>>,
+    /// Whether this camera exposes PTZ controls (migration 0061). A provided
+    /// value sets it; omitted = unchanged. Simple bool like [`Self::enabled`].
+    pub ptz_control_enabled: Option<bool>,
 }
 
 fn default_true() -> bool {

--- a/services/api/src/ptz.rs
+++ b/services/api/src/ptz.rs
@@ -199,6 +199,12 @@ async fn ptz_command(
         .map_err(ApiError::Internal)?
         .ok_or_else(|| ApiError::NotFound(format!("camera {camera_id} not found")))?;
 
+    // ── 2b. defense in depth: honor the per-camera PTZ-controls toggle ────────
+    // The clients already hide PTZ when `camera.ptz` is false, but a stale client
+    // (or a hand-crafted request) must not be able to drive a camera whose PTZ
+    // the operator turned off. Reject before touching the network (migration 0061).
+    ensure_ptz_enabled(&camera)?;
+
     // ── 3. resolve ONVIF config (DB columns → env fallback) ───────────────────
     let onvif_cfg = resolve_onvif_config(&state, &camera)?;
 
@@ -357,6 +363,10 @@ async fn imaging_command(
         .map_err(ApiError::Internal)?
         .ok_or_else(|| ApiError::NotFound(format!("camera {camera_id} not found")))?;
 
+    // Defense in depth: honor the per-camera PTZ-controls toggle (migration 0061),
+    // same as the PTZ move/preset path — focus/iris is a PTZ control too.
+    ensure_ptz_enabled(&camera)?;
+
     let onvif_cfg = resolve_onvif_config(&state, &camera)?;
 
     let (imaging_client, vst) = build_onvif_imaging(&onvif_cfg).await.map_err(|e| {
@@ -389,6 +399,22 @@ async fn imaging_command(
 }
 
 // ─── ONVIF helpers ────────────────────────────────────────────────────────────
+
+/// Reject a PTZ/imaging command when the operator has turned this camera's
+/// PTZ controls off (migration 0061). Returns `403 Forbidden` with a clear
+/// message. This is the server-side backstop behind the client-facing `ptz`
+/// capability (`ViewerCameraDto.ptz`), so a stale client cannot drive a camera
+/// whose PTZ is disabled.
+fn ensure_ptz_enabled(camera: &crumb_common::types::Camera) -> Result<(), ApiError> {
+    if camera.ptz_control_enabled {
+        Ok(())
+    } else {
+        Err(ApiError::Forbidden(format!(
+            "PTZ controls are disabled for camera '{}'",
+            camera.name
+        )))
+    }
+}
 
 /// Resolve a camera's ONVIF connection config: DB columns are authoritative, with
 /// the legacy `ONVIF_CONFIG` env map as a fallback for pre-DB-column installs.

--- a/services/api/tests/support/mod.rs
+++ b/services/api/tests/support/mod.rs
@@ -576,6 +576,7 @@ pub async fn seed_camera(pool: &Pool) -> Uuid {
         onvif_port: None,
         onvif_user: None,
         onvif_password: None,
+        ptz_control_enabled: true,
     };
     let camera = db::create_camera(pool, &params)
         .await

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -495,6 +495,9 @@ fn camera_from_row(row: &tokio_postgres::Row) -> Result<Camera> {
         onvif_port: row.try_get("c_onvif_port").unwrap_or(None),
         onvif_user: row.try_get("c_onvif_user").unwrap_or(None),
         onvif_password: row.try_get("c_onvif_password").unwrap_or(None),
+        // migration 0061 — default true if the view predates the column (mirrors
+        // the served_by shim above), so a PTZ camera keeps working during upgrade.
+        ptz_control_enabled: row.try_get("c_ptz_control_enabled").unwrap_or(true),
     })
 }
 
@@ -3286,6 +3289,9 @@ pub struct CreateCameraParams<'a> {
     pub onvif_user: Option<&'a str>,
     /// ONVIF authentication password (nullable; never returned by the API).
     pub onvif_password: Option<&'a str>,
+    /// Whether this camera exposes PTZ controls (migration 0061). Callers pass
+    /// `true` unless the operator has explicitly turned PTZ off.
+    pub ptz_control_enabled: bool,
 }
 
 /// Insert a new camera row and return the full `Camera` (with joined policy).
@@ -3301,14 +3307,17 @@ pub async fn create_camera(pool: &Pool, p: &CreateCameraParams<'_>) -> Result<Ca
                  motion_source, motion_algorithm, camera_type, icon,
                  served_by, source_camera_name,
                  onvif_host, onvif_port, onvif_user, onvif_password,
-                 motion_pixel_enabled, motion_frigate_enabled, motion_ha_enabled)
+                 motion_pixel_enabled, motion_frigate_enabled, motion_ha_enabled,
+                 ptz_control_enabled)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
                     $15, $16, $17, $18, $19, $20,
                     -- additive source set (migration 0049) derived from the
                     -- legacy motion_source until callers set the booleans directly
                     ($11::text = '' OR $11::text = 'pixel'),
                     ($11::text = 'frigate'),
-                    ($11::text = 'ha'))
+                    ($11::text = 'ha'),
+                    -- PTZ-controls toggle (migration 0061)
+                    $21)
             RETURNING id
             ",
             &[
@@ -3332,6 +3341,7 @@ pub async fn create_camera(pool: &Pool, p: &CreateCameraParams<'_>) -> Result<Ca
                 &p.onvif_port,
                 &p.onvif_user,
                 &p.onvif_password,
+                &p.ptz_control_enabled,
             ],
         )
         .await
@@ -9388,6 +9398,10 @@ static MIGRATIONS: &[(&str, &str)] = &[
         "0060_ha_overlay_opacity.sql",
         include_str!("../../../db/migrations/0060_ha_overlay_opacity.sql"),
     ),
+    (
+        "0061_camera_ptz_control.sql",
+        include_str!("../../../db/migrations/0061_camera_ptz_control.sql"),
+    ),
 ];
 
 /// The actual migration-application body, run while [`run_migrations`] holds
@@ -11813,6 +11827,7 @@ mod tests {
             onvif_port: None,
             onvif_user: None,
             onvif_password: None,
+            ptz_control_enabled: true,
         };
         create_camera(pool, &params)
             .await

--- a/services/common/src/types.rs
+++ b/services/common/src/types.rs
@@ -606,6 +606,13 @@ pub struct Camera {
     /// Carried in the `Camera` struct ONLY so `ptz.rs` and `discover.rs` can read
     /// it from the DB without an extra query.
     pub onvif_password: Option<String>,
+    /// `cameras.ptz_control_enabled` (migration 0061) — operator switch for
+    /// whether this camera exposes pan/tilt/zoom controls. Default `true`. Folded
+    /// into the client-facing computed capability (`ViewerCameraDto.ptz =
+    /// onvif_host.is_some() && ptz_control_enabled`) so a FIXED ONVIF camera (one
+    /// that speaks ONVIF only for stream discovery, no motor) can have PTZ turned
+    /// off. Also enforced defensively at the PTZ/imaging endpoints in `ptz.rs`.
+    pub ptz_control_enabled: bool,
 }
 
 impl Camera {

--- a/services/recorder/src/main.rs
+++ b/services/recorder/src/main.rs
@@ -1483,6 +1483,7 @@ mod tests {
             onvif_port: None,
             onvif_user: None,
             onvif_password: None,
+            ptz_control_enabled: true,
             policy_id: Some(policy.id),
             group_id: None,
             policy,


### PR DESCRIPTION
A camera's PTZ capability was computed purely from whether it has an ONVIF host (`ViewerCameraDto.ptz = onvif_host.is_some()`), which every client gates its PTZ UI on. But many ONVIF cameras are **fixed** (no pan/tilt/zoom motor) and speak ONVIF only for stream discovery — yet they wrongly showed PTZ controls.

## Change
- **Migration 0061**: `ptz_control_enabled` column on `cameras` (default `true` → no behavior change on upgrade), appended to `v_camera_effective_policy`.
- **Computed flag**: `ptz = onvif_host.is_some() && ptz_control_enabled`, folded into `ViewerCameraDto` — so turning it off hides PTZ on **every client with zero client change** (they already gate on `camera.ptz`).
- **Server guard**: PTZ / imaging commands return 403 when the toggle is off, even though the camera still uses ONVIF for discovery.
- **Admin**: a 'PTZ controls' checkbox on the camera Info tab.

## Gate
fmt + clippy clean; `cargo test --workspace` green (an api integration suite passes, which requires migration 0061 to apply on a fresh DB); `admin.html` `node --check` OK.

Re-implemented cleanly on current `main` from an earlier un-merged worktree; the only rebase point was appending 0061 after 0059/0060 in the `MIGRATIONS` array.