### PR TITLE
fix(desktop): detach the last 3 player-teardown paths (#105)

### DIFF
--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -1129,7 +1129,7 @@ class _WallTileState extends State<_WallTile> {
       });
       await player.open(Media(url));
       if (!mounted) {
-        player.dispose();
+        _disposePlayerDetached(player);
         return;
       }
       if (_player == null) {
@@ -1137,8 +1137,11 @@ class _WallTileState extends State<_WallTile> {
       } else {
         // A stream swap: keep the old player rendering while this one decodes
         // toward its first keyframe; _onFirstFrame does the visible swap.
-        _pending?.dispose(); // superseded by an even newer swap
+        // Reassign the field first, then detach the superseded player's teardown
+        // so the native mpv wind-down never stalls the swap (#105 contract).
+        final superseded = _pending;
         _pending = player;
+        _disposePlayerDetached(superseded);
       }
       spawned = null; // ownership handed off — the catch must not dispose it
     } catch (_) {
@@ -2078,7 +2081,7 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
       });
       await player.open(Media(url));
       if (!mounted) {
-        player.dispose();
+        _disposePlayerDetached(player);
         return;
       }
       // While maximized, this pane is the snapshot + audio target.


### PR DESCRIPTION
The main maximize / restore / close teardown already routes through `_disposePlayerDetached` (added with the editor overhaul), so the ~10s UI freeze on those transitions should already be gone. But three **direct** `Player.dispose()` calls remained on the UI path and could still stall it while the native mpv handle winds down:

- two "widget unmounted while the new stream was still opening" cleanups (tile + maximized pane), and
- the superseded pending-swap dispose during a stream swap.

This routes all three through `_disposePlayerDetached`. For the pending swap, `_pending` is reassigned **before** the old player is detached, per the helper's null-the-field-first contract.

Completes the code side of #105. Leaving the issue open for on-hardware confirmation that the freeze is actually gone (it can only be observed against real libmpv on Windows). `flutter analyze` clean.