### PR TITLE
feat(desktop): HA badge shape/background/outline + snappy jelly motion (#170)

### DIFF
--- a/apps/desktop-flutter/lib/api/ha_api.dart
+++ b/apps/desktop-flutter/lib/api/ha_api.dart
@@ -225,6 +225,9 @@ extension HaApi on CrumbApi {
     bool showState = false,
     bool showAge = false,
     double opacity = 1.0,
+    String? shape,
+    String? bgColor,
+    bool outline = false,
     String? label,
   }) async {
     final resp = await _putPlacement(s, cameraId, linkId, {
@@ -236,6 +239,9 @@ extension HaApi on CrumbApi {
       'show_state': showState,
       'show_age': showAge,
       'opacity': opacity,
+      if (shape != null) 'shape': shape,
+      if (bgColor != null) 'bg_color': bgColor,
+      'outline': outline,
       if (label != null) 'label': label,
     });
     if (resp.statusCode != 200) {

--- a/apps/desktop-flutter/lib/api/ha_models.dart
+++ b/apps/desktop-flutter/lib/api/ha_models.dart
@@ -22,6 +22,9 @@ class HaLink {
     this.overlayShowState = false,
     this.overlayShowAge = false,
     this.overlayOpacity,
+    this.overlayShape,
+    this.overlayBgColor,
+    this.overlayOutline = false,
   });
 
   final String id; // UUID
@@ -62,6 +65,18 @@ class HaLink {
   /// Badge opacity (0.05..1.0, migration 0060), or null for fully opaque.
   final double? overlayOpacity;
 
+  /// Badge shape (migration 0062): `'dot'` (compact icon) or `'pill'`
+  /// (labelled). Null = the default dot.
+  final String? overlayShape;
+
+  /// Solid background '#RRGGBB' hex (migration 0062). Null = the default
+  /// dark background.
+  final String? overlayBgColor;
+
+  /// White outline + drop shadow so the badge pops on a busy scene
+  /// (migration 0062; default off).
+  final bool overlayOutline;
+
   bool get hasPlacement => overlayX != null && overlayY != null;
 
   /// The entity_id's domain prefix (`binary_sensor`, `light`, `switch`,
@@ -91,6 +106,9 @@ class HaLink {
     overlayShowState: (j['overlay_show_state'] as bool?) ?? false,
     overlayShowAge: (j['overlay_show_age'] as bool?) ?? false,
     overlayOpacity: (j['overlay_opacity'] as num?)?.toDouble(),
+    overlayShape: j['overlay_shape'] as String?,
+    overlayBgColor: j['overlay_bg_color'] as String?,
+    overlayOutline: (j['overlay_outline'] as bool?) ?? false,
   );
 }
 

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_badge_style_editor.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_badge_style_editor.dart
@@ -143,6 +143,30 @@ class _HaBadgeStyleFormState extends State<HaBadgeStyleForm> {
     widget.editor.notifyItemsChanged();
   }
 
+  Future<void> _pickBgColor() async {
+    final item = widget.item;
+    final result = await showColorSwatchPicker(
+      context,
+      title: 'Badge background',
+      current: parseOverlayColorHex(item.bgColorHex),
+      allowReset: item.bgColorHex != null,
+      resetLabel: 'Default (dark)',
+      allowCustom: true,
+    );
+    if (result == null || !mounted) return;
+    widget.editor.pushUndo();
+    item.bgColorHex = result.cleared ? null : overlayColorToHex(result.color!);
+    widget.editor.notifyItemsChanged();
+  }
+
+  void _setShape(String? shape) {
+    final item = widget.item;
+    if ((item.shape ?? 'dot') == (shape ?? 'dot')) return;
+    widget.editor.pushUndo();
+    item.shape = shape;
+    widget.editor.notifyItemsChanged();
+  }
+
   Future<void> _pickIcon() async {
     final item = widget.item;
     final chosen = await showDialog<Object?>(
@@ -236,6 +260,16 @@ class _HaBadgeStyleFormState extends State<HaBadgeStyleForm> {
           ),
         ),
         _row(
+          'Shape',
+          Row(
+            children: [
+              _seg('Dot', !item.isPill, () => _setShape(null)),
+              const SizedBox(width: 6),
+              _seg('Pill', item.isPill, () => _setShape('pill')),
+            ],
+          ),
+        ),
+        _row(
           'Size',
           Row(
             children: [
@@ -305,6 +339,32 @@ class _HaBadgeStyleFormState extends State<HaBadgeStyleForm> {
           ),
         ),
         _row(
+          'Background',
+          _propButton(
+            onTap: _pickBgColor,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  width: 16,
+                  height: 16,
+                  decoration: BoxDecoration(
+                    color: parseOverlayColorHex(item.bgColorHex) ??
+                        const Color(0xFF17171B),
+                    borderRadius: BorderRadius.circular(4),
+                    border: Border.all(color: Colors.white54),
+                  ),
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  item.bgColorHex == null ? 'Default dark' : 'Custom',
+                  style: const TextStyle(fontSize: 12),
+                ),
+              ],
+            ),
+          ),
+        ),
+        _row(
           'Icon',
           _propButton(
             onTap: _pickIcon,
@@ -347,6 +407,17 @@ class _HaBadgeStyleFormState extends State<HaBadgeStyleForm> {
           (v) {
             widget.editor.pushUndo();
             item.showAge = v;
+            widget.editor.notifyItemsChanged();
+          },
+        ),
+        _checkRow(
+          'Outline + shadow',
+          'Add a white outline and drop shadow so the badge pops on a busy '
+              'scene',
+          item.outline,
+          (v) {
+            widget.editor.pushUndo();
+            item.outline = v;
             widget.editor.notifyItemsChanged();
           },
         ),
@@ -416,6 +487,29 @@ class _HaBadgeStyleFormState extends State<HaBadgeStyleForm> {
                 RoundedRectangleBorder(borderRadius: BorderRadius.circular(5)),
           ),
           child: child,
+        ),
+      );
+
+  Widget _seg(String label, bool active, VoidCallback onTap) => Expanded(
+        child: SizedBox(
+          height: 30,
+          child: TextButton(
+            onPressed: onTap,
+            style: TextButton.styleFrom(
+              backgroundColor:
+                  active ? const Color(0xFF2CA3E8) : const Color(0xFF2A2F36),
+              foregroundColor: Colors.white,
+              padding: EdgeInsets.zero,
+              minimumSize: Size.zero,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(5),
+              ),
+            ),
+            child: Text(
+              label,
+              style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600),
+            ),
+          ),
         ),
       );
 

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_controller.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_controller.dart
@@ -45,7 +45,10 @@ class HaOverlayBadgeItem implements OverlayItem {
       colorHex = link.overlayColor,
       iconKey = link.overlayIcon,
       showState = link.overlayShowState,
-      showAge = link.overlayShowAge;
+      showAge = link.overlayShowAge,
+      shape = link.overlayShape,
+      bgColorHex = link.overlayBgColor,
+      outline = link.overlayOutline;
 
   final HaLink link;
 
@@ -69,12 +72,39 @@ class HaOverlayBadgeItem implements OverlayItem {
   bool showState;
   bool showAge;
 
+  /// Badge shape (migration 0062): `'dot'` (compact icon) or `'pill'`
+  /// (labelled); null = the default dot.
+  String? shape;
+
+  /// Solid background '#RRGGBB' override, or null for the default dark
+  /// background (migration 0062).
+  String? bgColorHex;
+
+  /// White outline + drop shadow so the badge pops on a busy scene.
+  bool outline;
+
+  /// True when this badge renders as a labelled pill (vs the compact dot).
+  bool get isPill => shape == 'pill';
+
   /// Display caption honoring the in-session edit (mirrors
   /// `HaLink.displayLabel`, against [labelText] instead of `link.label`).
   String get displayLabel =>
       (labelText != null && labelText!.trim().isNotEmpty)
           ? labelText!
           : link.entityId;
+
+  /// The text shown INSIDE a pill: the operator caption if set, else the
+  /// entity id minus its domain prefix (`binary_sensor.front_door` ->
+  /// `front_door`) — tidier than the raw id in a small chip. State is carried
+  /// by the icon color, not this text, so the pill width stays stable as the
+  /// entity changes.
+  String get pillLabel {
+    final t = labelText?.trim();
+    if (t != null && t.isNotEmpty) return t;
+    final id = link.entityId;
+    final dot = id.indexOf('.');
+    return dot < 0 ? id : id.substring(dot + 1);
+  }
 
   /// Session-only group membership — the placement PUT has no group field
   /// (see `OverlayItem.groupId`'s doc), so HA badge groups exist only within
@@ -103,7 +133,18 @@ class HaOverlayBadgeItem implements OverlayItem {
   static const double baseRefPx = 22;
 
   @override
-  (double w, double h) baseSize() => (baseRefPx * _scale, baseRefPx * _scale);
+  (double w, double h) baseSize() {
+    final h = baseRefPx * _scale;
+    if (!isPill) return (h, h);
+    // Pill: icon + label in one chip. The item box is a fixed size (badges
+    // aren't drag-resizable), so estimate the width from the label length in
+    // the same ref units as [baseRefPx]; the chip ellipsizes if the estimate
+    // runs short (`HaBadgeChip`), so an over-long label can't blow out the box.
+    final chars = pillLabel.length.clamp(1, 16);
+    final textRefPx = chars * baseRefPx * 0.42; // ~0.42 ref-px per glyph
+    final w = (baseRefPx * 1.5 + textRefPx) * _scale; // icon + paddings + text
+    return (w, h);
+  }
 
   @override
   void setBaseSize(double w, double h) {
@@ -139,6 +180,9 @@ class HaOverlayBadgeItem implements OverlayItem {
         icon: iconKey,
         showState: showState,
         showAge: showAge,
+        shape: shape,
+        bgColor: bgColorHex,
+        outline: outline,
         group: _groupId,
       );
 
@@ -154,6 +198,9 @@ class HaOverlayBadgeItem implements OverlayItem {
       String? icon,
       bool showState,
       bool showAge,
+      String? shape,
+      String? bgColor,
+      bool outline,
       String? group,
     });
     _x = s.x;
@@ -165,6 +212,9 @@ class HaOverlayBadgeItem implements OverlayItem {
     iconKey = s.icon;
     showState = s.showState;
     showAge = s.showAge;
+    shape = s.shape;
+    bgColorHex = s.bgColor;
+    outline = s.outline;
     _groupId = s.group;
   }
 }
@@ -288,6 +338,9 @@ class HaOverlayController {
           showState: item.showState,
           showAge: item.showAge,
           opacity: item.opacity,
+          shape: item.shape,
+          bgColor: item.bgColorHex,
+          outline: item.outline,
           label: newLabel == oldLabel ? null : newLabel,
         );
       } catch (e) {

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_layer.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_layer.dart
@@ -39,6 +39,7 @@
 //   )
 
 import 'package:flutter/material.dart';
+import 'package:flutter/physics.dart';
 
 import '../../api/ha_models.dart';
 import '../overlay_editor/overlay_editor_controller.dart';
@@ -72,44 +73,204 @@ OverlayItemBuilder haBadgeItemBuilder({
       iconOverride: badge.iconKey,
       colorOverride: parseOverlayColorHex(badge.colorHex),
     );
-    return HaBadgeChip(visual: visual, selected: selected);
+    return HaBadgeChip(
+      visual: visual,
+      selected: selected,
+      isPill: badge.isPill,
+      pillLabel: badge.pillLabel,
+      bgColor: parseOverlayColorHex(badge.bgColorHex),
+      outline: badge.outline,
+      // Jelly motion (entrance pop + state-change squish) runs only in view
+      // mode; while editing the badge is a static drag target.
+      animate: !editing,
+      // A change in this key (state string / staleness) drives the squish.
+      stateKey: '${state?.state ?? ''}|$stale',
+    );
   };
 }
 
-/// The badge chip itself: a circular dark-scrim container with the resolved
-/// icon, matching the tile-badge visual language (black-0.55 rounded scrim,
-/// `live_status/live_status_badges.dart`). Sizes itself to fill whatever
-/// rect the overlay layer gives it (see `overlay_editor_layer.dart`'s
-/// `SizedBox` wrap) and scales the icon/border proportionally.
-class HaBadgeChip extends StatelessWidget {
-  const HaBadgeChip({super.key, required this.visual, this.selected = false});
+/// The default opaque badge background (migration 0062) — a near-black chip,
+/// dimmed only by the item's `overlay_opacity` (applied by the overlay layer's
+/// `Opacity` wrapper), NOT a hardcoded translucent scrim. This is the #170
+/// readability fix: at the default opacity the chip reads solid.
+const Color _kBadgeDefaultBg = Color(0xFF17171B);
+
+/// Snappy spring (matches the operator-chosen preview: k380 / damping 21).
+const SpringDescription _kJellySpring = SpringDescription(
+  mass: 1.0,
+  stiffness: 380.0,
+  damping: 21.0,
+);
+
+/// The badge chip: a `dot` (compact icon) or `pill` (icon + label) with a
+/// solid, opaque background (color pickable), an optional white outline + drop
+/// shadow so it pops on a busy scene, and snappy "jelly" motion in view mode —
+/// a spring pop-in on appear and a squish-and-rebound whenever the entity's
+/// state changes. Sizes itself to fill whatever rect the overlay layer gives it
+/// (`overlay_editor_layer.dart`'s `SizedBox`/`Positioned` wrap) — for a pill
+/// that rect is pre-widened by `HaOverlayBadgeItem.baseSize()`.
+class HaBadgeChip extends StatefulWidget {
+  const HaBadgeChip({
+    super.key,
+    required this.visual,
+    this.selected = false,
+    this.isPill = false,
+    this.pillLabel,
+    this.bgColor,
+    this.outline = false,
+    this.animate = false,
+    this.stateKey,
+  });
 
   final HaVisual visual;
   final bool selected;
 
+  /// Render as a labelled pill (vs the compact icon dot).
+  final bool isPill;
+
+  /// Text inside the pill (ignored for a dot).
+  final String? pillLabel;
+
+  /// Solid background color; null = the default dark chip ([_kBadgeDefaultBg]).
+  final Color? bgColor;
+
+  /// Draw a white outline + drop shadow.
+  final bool outline;
+
+  /// Run the jelly animation (view mode only — off while editing).
+  final bool animate;
+
+  /// Opaque token; a change (state/staleness) triggers the squish.
+  final Object? stateKey;
+
+  @override
+  State<HaBadgeChip> createState() => _HaBadgeChipState();
+}
+
+class _HaBadgeChipState extends State<HaBadgeChip>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _scale;
+
+  @override
+  void initState() {
+    super.initState();
+    _scale = AnimationController.unbounded(vsync: this, value: 1.0);
+    if (widget.animate) {
+      // Entrance pop: spring up from nothing with a slight overshoot.
+      _scale.value = 0.0;
+      _scale.animateWith(SpringSimulation(_kJellySpring, 0.0, 1.0, 0.0));
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant HaBadgeChip old) {
+    super.didUpdateWidget(old);
+    // State changed while live → squish: kick the spring with a negative
+    // velocity from the current scale so it dips then rebounds to 1.
+    if (widget.animate && widget.stateKey != old.stateKey) {
+      _scale.animateWith(
+        SpringSimulation(_kJellySpring, _scale.value, 1.0, -7.0),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _scale.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final side = constraints.biggest.shortestSide;
-        return DecoratedBox(
-          decoration: BoxDecoration(
-            color: Colors.black.withValues(alpha: 0.55),
-            shape: BoxShape.circle,
-            border: Border.all(
-              color: selected ? Colors.white : visual.color.withValues(alpha: 0.85),
-              width: selected ? 2.4 : (side * 0.06).clamp(1.0, 2.5).toDouble(),
-            ),
+    final chip = LayoutBuilder(
+      builder: (context, constraints) => widget.isPill
+          ? _pill(constraints.biggest.height)
+          : _dot(constraints.biggest.shortestSide),
+    );
+    if (!widget.animate) return chip;
+    return AnimatedBuilder(
+      animation: _scale,
+      builder: (context, child) => Transform.scale(
+        scale: _scale.value <= 0 ? 0.0 : _scale.value,
+        child: child,
+      ),
+      child: chip,
+    );
+  }
+
+  BoxDecoration _decoration(BoxShape shape, BorderRadius? radius) {
+    final bg = widget.bgColor ?? _kBadgeDefaultBg;
+    return BoxDecoration(
+      color: bg,
+      shape: shape,
+      borderRadius: radius,
+      border: widget.selected
+          ? Border.all(color: Colors.white, width: 2.4)
+          : (widget.outline
+              ? Border.all(color: Colors.white.withValues(alpha: 0.9), width: 1.6)
+              : null),
+      boxShadow: widget.outline
+          ? const [
+              BoxShadow(
+                color: Color(0x99000000),
+                blurRadius: 5,
+                offset: Offset(0, 2),
+              ),
+            ]
+          : null,
+    );
+  }
+
+  Widget _dot(double side) => DecoratedBox(
+        decoration: _decoration(BoxShape.circle, null),
+        child: Center(
+          child: Icon(
+            widget.visual.icon,
+            color: widget.visual.color,
+            size: (side * 0.58).clamp(10.0, 40.0).toDouble(),
           ),
-          child: Center(
-            child: Icon(
-              visual.icon,
-              color: visual.color,
-              size: (side * 0.58).clamp(10.0, 40.0).toDouble(),
+        ),
+      );
+
+  Widget _pill(double height) {
+    final iconSize = (height * 0.56).clamp(10.0, 40.0).toDouble();
+    final fontSize = (height * 0.40).clamp(8.0, 26.0).toDouble();
+    final padH = (height * 0.28).clamp(5.0, 16.0).toDouble();
+    final gap = (height * 0.14).clamp(3.0, 8.0).toDouble();
+    final bg = widget.bgColor ?? _kBadgeDefaultBg;
+    // Label uses a neutral that always reads on the chosen background; the
+    // icon carries the state color.
+    final labelColor =
+        bg.computeLuminance() > 0.5 ? Colors.black : Colors.white;
+    return DecoratedBox(
+      decoration: _decoration(
+        BoxShape.rectangle,
+        BorderRadius.circular(height / 2),
+      ),
+      child: Padding(
+        padding: EdgeInsets.symmetric(horizontal: padH),
+        child: Row(
+          mainAxisSize: MainAxisSize.max,
+          children: [
+            Icon(widget.visual.icon, color: widget.visual.color, size: iconSize),
+            SizedBox(width: gap),
+            Flexible(
+              child: Text(
+                widget.pillLabel ?? '',
+                maxLines: 1,
+                softWrap: false,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  color: labelColor,
+                  fontSize: fontSize,
+                  fontWeight: FontWeight.w600,
+                  height: 1.0,
+                ),
+              ),
             ),
-          ),
-        );
-      },
+          ],
+        ),
+      ),
     );
   }
 }

--- a/db/migrations/0062_ha_overlay_shape_bg.sql
+++ b/db/migrations/0062_ha_overlay_shape_bg.sql
@@ -1,0 +1,28 @@
+-- Per-badge shape / background / outline for the HA on-video overlay (issue
+-- #170 readability follow-up): an operator can switch a placed badge between
+-- the compact icon "dot" and a labelled "pill", give it a solid background
+-- color, and add a white outline + drop shadow so it pops on a busy scene.
+-- All additive to migrations 0058-0060; NULL / false means "use the default"
+-- (dot shape, default dark background, no outline), so existing badges render
+-- unchanged in shape.
+--
+-- Note the paired client change: the badge background is now drawn OPAQUE and
+-- dimmed only by overlay_opacity (migration 0060), replacing a hardcoded
+-- translucent scrim — so an existing badge at the default opacity (NULL = 1.0)
+-- now reads as a solid dark chip instead of a see-through one. That is the
+-- intended readability fix (#170), not a data change.
+--
+-- overlay_bg_color is a '#RRGGBB' hex string (client-parsed; format-checked
+-- here, mirroring overlay_color's 0059 CHECK). overlay_shape is a tiny closed
+-- vocabulary. overlay_outline is a plain boolean (default off).
+
+ALTER TABLE camera_ha_links
+    ADD COLUMN IF NOT EXISTS overlay_shape    text,
+    ADD COLUMN IF NOT EXISTS overlay_bg_color text,
+    ADD COLUMN IF NOT EXISTS overlay_outline  boolean NOT NULL DEFAULT false;
+
+ALTER TABLE camera_ha_links
+    ADD CONSTRAINT camera_ha_links_overlay_shape_vocab
+        CHECK (overlay_shape IS NULL OR overlay_shape IN ('dot', 'pill')),
+    ADD CONSTRAINT camera_ha_links_overlay_bg_color_hex
+        CHECK (overlay_bg_color IS NULL OR overlay_bg_color ~ '^#[0-9a-fA-F]{6}$');

--- a/services/api/src/ha.rs
+++ b/services/api/src/ha.rs
@@ -171,6 +171,12 @@ struct HaLinkDto {
     overlay_show_age: bool,
     /// Badge opacity (0.05..1.0, migration 0060); `null` = fully opaque.
     overlay_opacity: Option<f32>,
+    /// Badge shape (migration 0062): `"dot"` or `"pill"`; `null` = default dot.
+    overlay_shape: Option<String>,
+    /// Solid background '#RRGGBB' (migration 0062); `null` = default dark.
+    overlay_bg_color: Option<String>,
+    /// White outline + drop shadow (migration 0062; default false).
+    overlay_outline: bool,
 }
 
 impl From<crumb_common::types::CameraHaLink> for HaLinkDto {
@@ -190,6 +196,9 @@ impl From<crumb_common::types::CameraHaLink> for HaLinkDto {
             overlay_show_state: l.overlay_show_state,
             overlay_show_age: l.overlay_show_age,
             overlay_opacity: l.overlay_opacity,
+            overlay_shape: l.overlay_shape,
+            overlay_bg_color: l.overlay_bg_color,
+            overlay_outline: l.overlay_outline,
         }
     }
 }
@@ -221,6 +230,15 @@ struct PlacementInput {
     /// Badge opacity (migration 0060); omitted = fully opaque.
     #[serde(default = "default_overlay_opacity")]
     opacity: f32,
+    /// Badge shape (migration 0062): `"dot"`/`"pill"`; omitted = default dot.
+    #[serde(default)]
+    shape: Option<String>,
+    /// Solid background '#RRGGBB' (migration 0062); omitted = default dark.
+    #[serde(default)]
+    bg_color: Option<String>,
+    /// White outline + drop shadow (migration 0062); omitted = false.
+    #[serde(default)]
+    outline: bool,
     #[serde(default)]
     label: Option<String>,
 }
@@ -240,6 +258,12 @@ fn valid_overlay_color(c: &str) -> bool {
         Some(hex) => hex.len() == 6 && hex.chars().all(|ch| ch.is_ascii_hexdigit()),
         None => false,
     }
+}
+
+/// Validate a badge shape token (migration 0062): the tiny closed vocabulary
+/// `dot` / `pill` (mirrors the migration CHECK so a bad value 400s clearly).
+fn valid_overlay_shape(s: &str) -> bool {
+    matches!(s, "dot" | "pill")
 }
 
 /// Validate a curated icon-slug override: short, lowercase `[a-z0-9_]` — the
@@ -430,6 +454,20 @@ async fn put_placement(
                     ));
                 }
             }
+            if let Some(s) = &p.shape {
+                if !valid_overlay_shape(s) {
+                    return Err(ApiError::BadRequest(
+                        "placement shape must be 'dot' or 'pill'".to_owned(),
+                    ));
+                }
+            }
+            if let Some(c) = &p.bg_color {
+                if !valid_overlay_color(c) {
+                    return Err(ApiError::BadRequest(
+                        "placement bg_color must be a '#RRGGBB' hex string".to_owned(),
+                    ));
+                }
+            }
             // Label edit rides the placement PUT: omitted = unchanged,
             // "" = cleared, non-empty = set (trimmed).
             label_update = p.label.as_deref().map(|l| {
@@ -449,6 +487,9 @@ async fn put_placement(
                 show_state: p.show_state,
                 show_age: p.show_age,
                 opacity: Some(p.opacity.clamp(0.05, 1.0)),
+                shape: p.shape.clone(),
+                bg_color: p.bg_color.clone(),
+                outline: p.outline,
             })
         }
     };
@@ -661,6 +702,9 @@ mod tests {
         assert!(!p.show_state);
         assert!(!p.show_age);
         assert!((p.opacity - 1.0).abs() < f32::EPSILON); // migration 0060 default
+        assert_eq!(p.shape, None); // shape/background/outline default off (0062)
+        assert_eq!(p.bg_color, None);
+        assert!(!p.outline);
         assert_eq!(p.label, None);
 
         // A null body deserializes to None (clears the placement).
@@ -674,6 +718,7 @@ mod tests {
             "x": 0.4, "y": 0.6, "size": 1.5,
             "color": "#FFB143", "icon": "doorbell",
             "show_state": true, "show_age": true, "opacity": 0.5,
+            "shape": "pill", "bg_color": "#101014", "outline": true,
             "label": "Front door"
         }))
         .unwrap();
@@ -682,7 +727,19 @@ mod tests {
         assert!(p.show_state);
         assert!(p.show_age);
         assert!((p.opacity - 0.5).abs() < f32::EPSILON);
+        assert_eq!(p.shape.as_deref(), Some("pill"));
+        assert_eq!(p.bg_color.as_deref(), Some("#101014"));
+        assert!(p.outline);
         assert_eq!(p.label.as_deref(), Some("Front door"));
+    }
+
+    #[test]
+    fn overlay_shape_validation() {
+        assert!(valid_overlay_shape("dot"));
+        assert!(valid_overlay_shape("pill"));
+        assert!(!valid_overlay_shape("square")); // not in the vocabulary
+        assert!(!valid_overlay_shape("Dot")); // case-sensitive
+        assert!(!valid_overlay_shape("")); // empty
     }
 
     #[test]

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -1625,6 +1625,9 @@ fn ha_link_from_row(row: &tokio_postgres::Row) -> CameraHaLink {
         overlay_show_state: row.get("overlay_show_state"),
         overlay_show_age: row.get("overlay_show_age"),
         overlay_opacity: row.get("overlay_opacity"),
+        overlay_shape: row.get("overlay_shape"),
+        overlay_bg_color: row.get("overlay_bg_color"),
+        overlay_outline: row.get("overlay_outline"),
     }
 }
 
@@ -1640,7 +1643,7 @@ pub async fn list_camera_ha_links(pool: &Pool, camera_id: Uuid) -> Result<Vec<Ca
             "SELECT id, camera_id, entity_id, role, device_class, label, sort_order,
                     overlay_x, overlay_y, overlay_size,
                     overlay_color, overlay_icon, overlay_show_state, overlay_show_age,
-                    overlay_opacity
+                    overlay_opacity, overlay_shape, overlay_bg_color, overlay_outline
              FROM camera_ha_links WHERE camera_id = $1
              ORDER BY sort_order, entity_id",
             &[&camera_id],
@@ -1668,7 +1671,7 @@ pub async fn get_camera_ha_links(
             "SELECT id, camera_id, entity_id, role, device_class, label, sort_order,
                     overlay_x, overlay_y, overlay_size,
                     overlay_color, overlay_icon, overlay_show_state, overlay_show_age,
-                    overlay_opacity
+                    overlay_opacity, overlay_shape, overlay_bg_color, overlay_outline
              FROM camera_ha_links WHERE camera_id = $1 AND role = $2
              ORDER BY sort_order, entity_id",
             &[&camera_id, &role],
@@ -1716,6 +1719,9 @@ pub async fn replace_camera_ha_links(
         bool,
         bool,
         Option<f32>,
+        Option<String>,
+        Option<String>,
+        bool,
     );
     let mut placements: std::collections::HashMap<(String, String), Placement> =
         std::collections::HashMap::new();
@@ -1723,7 +1729,7 @@ pub async fn replace_camera_ha_links(
         .query(
             "SELECT entity_id, role, overlay_x, overlay_y, overlay_size,
                     overlay_color, overlay_icon, overlay_show_state, overlay_show_age,
-                    overlay_opacity
+                    overlay_opacity, overlay_shape, overlay_bg_color, overlay_outline
              FROM camera_ha_links WHERE camera_id = $1",
             &[&camera_id],
         )
@@ -1742,6 +1748,9 @@ pub async fn replace_camera_ha_links(
                 row.get("overlay_show_state"),
                 row.get("overlay_show_age"),
                 row.get("overlay_opacity"),
+                row.get("overlay_shape"),
+                row.get("overlay_bg_color"),
+                row.get("overlay_outline"),
             ),
         );
     }
@@ -1752,17 +1761,32 @@ pub async fn replace_camera_ha_links(
     .await
     .context("replace_camera_ha_links: delete")?;
     for (entity_id, role, device_class, label, sort_order) in links {
-        let (ox, oy, osize, ocolor, oicon, oshow_state, oshow_age, oopacity) = placements
+        let (
+            ox,
+            oy,
+            osize,
+            ocolor,
+            oicon,
+            oshow_state,
+            oshow_age,
+            oopacity,
+            oshape,
+            obg_color,
+            ooutline,
+        ) = placements
             .get(&(entity_id.clone(), role.clone()))
             .cloned()
-            .unwrap_or((None, None, None, None, None, false, false, None));
+            .unwrap_or((
+                None, None, None, None, None, false, false, None, None, None, false,
+            ));
         tx.execute(
             "INSERT INTO camera_ha_links
                  (camera_id, entity_id, role, device_class, label, sort_order,
                   overlay_x, overlay_y, overlay_size,
                   overlay_color, overlay_icon, overlay_show_state, overlay_show_age,
-                  overlay_opacity)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)",
+                  overlay_opacity, overlay_shape, overlay_bg_color, overlay_outline)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
+                     $15, $16, $17)",
             &[
                 &camera_id,
                 entity_id,
@@ -1778,6 +1802,9 @@ pub async fn replace_camera_ha_links(
                 &oshow_state,
                 &oshow_age,
                 &oopacity,
+                &oshape,
+                &obg_color,
+                &ooutline,
             ],
         )
         .await
@@ -1813,6 +1840,12 @@ pub struct HaOverlayPlacement {
     pub show_age: bool,
     /// Badge opacity (0.05..1.0, migration 0060); `None` = fully opaque.
     pub opacity: Option<f32>,
+    /// Badge shape (migration 0062): `"dot"` or `"pill"`; `None` = default dot.
+    pub shape: Option<String>,
+    /// Solid background '#RRGGBB' (migration 0062); `None` = default dark.
+    pub bg_color: Option<String>,
+    /// White outline + drop shadow (migration 0062).
+    pub outline: bool,
 }
 
 /// Set (or clear) one link's on-video overlay placement (migrations 0058/0059).
@@ -1840,19 +1873,25 @@ pub async fn update_ha_link_placement(
     placement: Option<&HaOverlayPlacement>,
     label: Option<Option<&str>>,
 ) -> Result<Option<CameraHaLink>> {
-    let (x, y, size, color, icon, show_state, show_age, opacity) = match placement {
-        Some(p) => (
-            Some(p.x),
-            Some(p.y),
-            Some(p.size),
-            p.color.as_deref(),
-            p.icon.as_deref(),
-            p.show_state,
-            p.show_age,
-            p.opacity,
-        ),
-        None => (None, None, None, None, None, false, false, None),
-    };
+    let (x, y, size, color, icon, show_state, show_age, opacity, shape, bg_color, outline) =
+        match placement {
+            Some(p) => (
+                Some(p.x),
+                Some(p.y),
+                Some(p.size),
+                p.color.as_deref(),
+                p.icon.as_deref(),
+                p.show_state,
+                p.show_age,
+                p.opacity,
+                p.shape.as_deref(),
+                p.bg_color.as_deref(),
+                p.outline,
+            ),
+            None => (
+                None, None, None, None, None, false, false, None, None, None, false,
+            ),
+        };
     let set_label = label.is_some();
     let label_value: Option<&str> = label.flatten();
     let client = get_conn(pool).await?;
@@ -1863,12 +1902,13 @@ pub async fn update_ha_link_placement(
                     overlay_color = $6, overlay_icon = $7,
                     overlay_show_state = $8, overlay_show_age = $9,
                     overlay_opacity = $12,
+                    overlay_shape = $13, overlay_bg_color = $14, overlay_outline = $15,
                     label = CASE WHEN $10 THEN $11 ELSE label END
               WHERE id = $1 AND camera_id = $2
           RETURNING id, camera_id, entity_id, role, device_class, label, sort_order,
                     overlay_x, overlay_y, overlay_size,
                     overlay_color, overlay_icon, overlay_show_state, overlay_show_age,
-                    overlay_opacity",
+                    overlay_opacity, overlay_shape, overlay_bg_color, overlay_outline",
             &[
                 &link_id,
                 &camera_id,
@@ -1882,6 +1922,9 @@ pub async fn update_ha_link_placement(
                 &set_label,
                 &label_value,
                 &opacity,
+                &shape,
+                &bg_color,
+                &outline,
             ],
         )
         .await
@@ -9401,6 +9444,10 @@ static MIGRATIONS: &[(&str, &str)] = &[
     (
         "0061_camera_ptz_control.sql",
         include_str!("../../../db/migrations/0061_camera_ptz_control.sql"),
+    ),
+    (
+        "0062_ha_overlay_shape_bg.sql",
+        include_str!("../../../db/migrations/0062_ha_overlay_shape_bg.sql"),
     ),
 ];
 

--- a/services/common/src/types.rs
+++ b/services/common/src/types.rs
@@ -230,6 +230,15 @@ pub struct CameraHaLink {
     pub overlay_show_age: bool,
     /// Badge opacity (0.05..1.0, migration 0060). `None` = fully opaque.
     pub overlay_opacity: Option<f32>,
+    /// Badge shape (migration 0062): `"dot"` (compact icon) or `"pill"`
+    /// (labelled). `None` ⇒ the default dot.
+    pub overlay_shape: Option<String>,
+    /// Solid background color as a '#RRGGBB' hex string (migration 0062).
+    /// `None` ⇒ the client's default dark background.
+    pub overlay_bg_color: Option<String>,
+    /// Draw a white outline + drop shadow so the badge pops on a busy scene
+    /// (migration 0062; default false).
+    pub overlay_outline: bool,
 }
 
 // ─── recording_policies ──────────────────────────────────────────────────────


### PR DESCRIPTION
Readability follow-up to the on-video HA overlay (#170). Per placed badge, an operator can now choose a **shape** (compact icon *dot* or labelled *pill*), a **solid background color**, and a **white outline + drop shadow** — plus **snappy "jelly" motion** in view mode (spring pop-in on appear, squish-and-rebound on state change).

## Fixes the "translucent at 100% opacity" bug
The badge background was a hardcoded translucent scrim baked into the chip, so it never read solid even at full opacity. It's now an opaque fill, dimmed only by `overlay_opacity` (0060). Existing badges keep their shape/color and simply render solid.

## Backend
Migration **0062** adds `overlay_shape` / `overlay_bg_color` / `overlay_outline` (additive; NULL/false = prior look). Threaded through the placement PUT, the link DTO, and the replace-links placement-preservation path; registered in the `MIGRATIONS` array; shape/bg validated server-side mirroring the migration CHECKs.

## Surfaces
Backend (api + common) and the Flutter **desktop** client only — the on-video overlay is desktop-only (Android has the HA sheet, not overlay badges; admin has no badge editor).

## Jelly
Bare `AnimationController` + `SpringSimulation` (k380 / damping 21), no new dependency, native. Runs in view mode only; static while editing.

## Gate
`cargo fmt`/`clippy` clean; workspace tests pass against Postgres (migration 0062 applies cleanly); `flutter analyze` reports no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)