### PR TITLE
fix(desktop): smooth playback + frame-back + in-motion scrub

### DIFF
--- a/apps/desktop-flutter/lib/ui/playback/gapless_segment_pane_controller.dart
+++ b/apps/desktop-flutter/lib/ui/playback/gapless_segment_pane_controller.dart
@@ -39,6 +39,45 @@
 // [onTick] once per playhead tick for every active camera, and [resolveAt]
 // with `forceReload` for explicit jumps/seeks.
 //
+// ── Two clocks, and who wins at a segment boundary ────────────────────────
+// There are two independent clocks in play: the screen's shared playhead
+// (wall-clock × speed) and mpv's actual decode position. They are NEVER in
+// perfect lockstep — a fallback `open()` has open→seek→first-frame latency,
+// and a mid-segment decode/IO stall puts mpv behind the wall clock by the
+// stall length. Forcing the boundary advance (`_player.next()`) off the WALL
+// clock therefore jumps mpv past every frame it hadn't shown yet: the
+// operator sees smooth playback, then a "BAM" skip forward at the segment /
+// motion-event boundary — worse after a stall, and non-deterministic because
+// open/decode latency varies run to run. That was the frame-skip bug this
+// header block documents the fix for.
+//
+// The fix is mode-dependent (see [onTick]'s `mpvDriven` flag):
+//
+//  * SINGLE active pane (maximized, or a 1-camera layout — the frame-accurate
+//    review case): the screen slaves the shared playhead to [mpvPlayhead]
+//    (segment start + mpv's real position), so the playhead can never run
+//    ahead of the video, and the boundary is crossed by mpv ITSELF hitting
+//    the real end of file: `prefetch-playlist=yes` + the appended next
+//    segment make mpv auto-advance the playlist at EOF with a warm decoder
+//    (the exact same mpv mechanism `playlist-next weak` rides on), showing
+//    every frame of the outgoing segment. [_onPlaylistChanged] observes that
+//    auto-advance and updates the segment bookkeeping after the fact. The
+//    wall-clock forced `next()` is disabled in this mode.
+//
+//  * MULTIPLE visible panes: cross-camera time alignment matters more than
+//    any one pane's last few frames, so the shared wall clock stays in charge
+//    and the boundary advance stays wall-driven (a lagging pane is yanked
+//    forward to stay in sync — the accepted trade-off, matching the old
+//    Tauri client's behavior).
+//
+// `/play/{camera_id}` only ever resolves a segment COVERING the requested ts
+// (404 otherwise — see services/api/src/playback.rs), so a prefetched
+// playlist entry is always time-contiguous with the current segment: mpv's
+// EOF auto-advance can never wander across a coverage gap into wrong-time
+// footage. Gaps therefore still play out exactly as before: no prefetch
+// resolves, mpv completes at EOF, the wall clock walks the gap, and the
+// per-tick resolve loads footage when the playhead reaches it.
+//
 // Segment-resolve and scoped-media-token logic is NOT duplicated here — it
 // calls the existing `PlaybackApi` extension (lib/api/playback_api.dart),
 // mirroring app.js's `pbFetchSegment` (which itself calls
@@ -62,6 +101,16 @@ const Duration kPrefetchLeadTime = Duration(milliseconds: 1000);
 /// Mirrors app.js's `segEndMs - 100` check.
 const Duration kBoundaryTolerance = Duration(milliseconds: 100);
 
+/// Trust window after [GaplessSegmentPaneController._current] changes before
+/// [GaplessSegmentPaneController.mpvPlayhead] reports a position. media_kit's
+/// `state.position` is updated from an async mpv property-change stream, so
+/// for a beat after an `open()` / playlist advance it can still hold the
+/// PREVIOUS file's position; `newSegment.start + oldPosition` would teleport
+/// the slaved playhead (forward by up to a whole segment). During this grace
+/// the screen falls back to its wall clock — indistinguishable from the old
+/// behavior for a few ticks, and the slaved model resumes immediately after.
+const Duration kMpvPlayheadGrace = Duration(milliseconds: 300);
+
 class GaplessSegmentPaneController extends ChangeNotifier {
   GaplessSegmentPaneController({
     required this.api,
@@ -71,6 +120,12 @@ class GaplessSegmentPaneController extends ChangeNotifier {
   }) : _session = session {
     _player = Player();
     _videoController = VideoController(_player);
+    // Watch mpv's playlist pointer: with `prefetch-playlist=yes` and the next
+    // segment appended, mpv auto-advances the playlist at the REAL end of the
+    // current file. In the single-pane mpv-driven mode that auto-advance IS
+    // the boundary crossing (no forced `next()` involved), so the segment
+    // bookkeeping must follow it after the fact — see [_onPlaylistChanged].
+    _playlistSub = _player.stream.playlist.listen(_onPlaylistChanged);
     unawaited(_configurePlayer());
   }
 
@@ -80,6 +135,7 @@ class GaplessSegmentPaneController extends ChangeNotifier {
   final String stream;
 
   late final Player _player;
+
   /// The underlying media_kit player — register it with whatever owns
   /// play/pause/speed for the pane grid (e.g.
   /// `PlaybackTransportController.registerPane(slot, controller.player)`).
@@ -91,6 +147,14 @@ class GaplessSegmentPaneController extends ChangeNotifier {
   ResolvedSegment? _current;
   ResolvedSegment? get currentSegment => _current;
   ResolvedSegment? _prefetched;
+
+  /// When [_current] last changed — gates [mpvPlayhead] behind
+  /// [kMpvPlayheadGrace] so a stale `state.position` from the previous file
+  /// never gets attributed to the new segment (see the const's doc).
+  DateTime? _currentSince;
+
+  /// Subscription to `player.stream.playlist` (see the constructor).
+  StreamSubscription<Playlist>? _playlistSub;
 
   bool _prefetching = false;
   bool _resolving = false;
@@ -159,6 +223,80 @@ class GaplessSegmentPaneController extends ChangeNotifier {
     }
   }
 
+  // ── mpv-truth position + EOF auto-advance bookkeeping ───────────────────
+
+  /// The absolute time of the frame mpv is ACTUALLY showing —
+  /// `currentSegment.start + player position`, clamped into the segment —
+  /// or `null` when that mapping can't be trusted and the caller should fall
+  /// back to its wall clock:
+  ///
+  ///  * no segment loaded / a resolve or advance is in flight (`position`
+  ///    may belong to the outgoing file);
+  ///  * within [kMpvPlayheadGrace] of the segment changing (same reason —
+  ///    media_kit's position stream is async, see the const's doc);
+  ///  * mpv completed the playlist (EOF with nothing appended — a coverage
+  ///    gap or a lost prefetch race): position is frozen at the file end, and
+  ///    slaving to it would DEADLOCK the playhead at `cur.end` forever. The
+  ///    wall clock must take over to walk the gap so the per-tick resolve can
+  ///    re-arm footage under it;
+  ///  * not playing (paused/idle) — the transport owns pauses; a wedged pane
+  ///    must not freeze the shared playhead.
+  ///
+  /// The playback screen slaves the shared playhead to this in the
+  /// single-active-pane mode, which is what makes the UI playhead and the
+  /// video physically unable to disagree (the frame-skip fix — see the file
+  /// header). Polled from the screen's existing 100 ms tick rather than
+  /// pushing `stream.position` events upstream: the tick already exists, and
+  /// 10 Hz is well inside the timeline's visual granularity.
+  DateTime? get mpvPlayhead {
+    final cur = _current;
+    if (cur == null || _resolving || _advancing) return null;
+    final since = _currentSince;
+    if (since == null || DateTime.now().difference(since) < kMpvPlayheadGrace) {
+      return null;
+    }
+    if (_player.state.completed || !_player.state.playing) return null;
+    final ms = (cur.startMs + _player.state.position.inMilliseconds)
+        .clamp(cur.startMs, cur.endMs)
+        .toInt();
+    return DateTime.fromMillisecondsSinceEpoch(ms, isUtc: true);
+  }
+
+  /// mpv moved its playlist pointer. If that was mpv's own EOF auto-advance
+  /// onto the appended prefetch (single-pane mpv-driven boundaries — and, as
+  /// a latent-desync fix, a wall-mode pane whose decode outran the wall
+  /// clock), adopt the prefetched segment as current so [mpvPlayhead] and the
+  /// covers()-based tick logic stay truthful. Explicit [_advanceOrResolve]
+  /// advances and in-flight resolves do their own bookkeeping and are
+  /// excluded via the `_advancing` / `_resolving` guards (a stale playlist
+  /// event landing mid-`open()` must not resurrect a dropped prefetch).
+  ///
+  /// Contiguity is guaranteed: `/play/` only resolves segments COVERING
+  /// `cur.end + 1ms` (see the file header), so this can never skip the
+  /// playhead across a coverage gap.
+  void _onPlaylistChanged(Playlist pl) {
+    if (_advancing || _resolving) return;
+    final pre = _prefetched;
+    if (pre == null || pl.index <= 0) return;
+    // State flips are synchronous (before any await) so a burst of playlist
+    // events can't double-apply the same prefetch.
+    _current = pre;
+    _currentSince = DateTime.now();
+    _prefetched = null;
+    noFootage = false;
+    error = null;
+    notifyListeners();
+    // Trim the played entry so the playlist never grows past {current, next}
+    // — the async twin of the explicit advance's `remove(0)`.
+    unawaited(() async {
+      try {
+        await _player.remove(0);
+      } catch (_) {
+        /* best-effort trim */
+      }
+    }());
+  }
+
   // ── the per-pane tick body (port of pbTick's per-slot segment bookkeeping,
   //    called once per tick by the shared playhead clock) ────────────────
 
@@ -170,7 +308,21 @@ class GaplessSegmentPaneController extends ChangeNotifier {
   /// footage under the advancing playhead loads as soon as it exists —
   /// mirrors `pbTick` re-resolving empty slots every tick. `playing` is the
   /// transport's play/pause state, applied to any fallback `loadfile`.
-  Future<void> onTick(DateTime playhead, {bool playing = false}) async {
+  ///
+  /// `mpvDriven` selects the boundary-crossing model (see the file header):
+  /// `false` (multi-pane wall-clock mode, the historical behavior) forces the
+  /// playlist advance the moment the SHARED playhead hits the boundary — even
+  /// if mpv is behind and would skip unseen frames — because cross-camera
+  /// alignment wins there. `true` (single active pane, playhead slaved to
+  /// [mpvPlayhead]) leaves the crossing to mpv's own EOF auto-advance so no
+  /// decoded-but-unshown frame is ever jumped over; the wall-clock trigger
+  /// below then only acts as the FALLBACK for the cases mpv can't advance
+  /// itself out of (a coverage gap or a lost prefetch race → `completed`).
+  Future<void> onTick(
+    DateTime playhead, {
+    bool playing = false,
+    bool mpvDriven = false,
+  }) async {
     final cur = _current;
     if (cur == null) {
       if (!_resolving) await resolveAt(playhead, playing: playing);
@@ -178,6 +330,17 @@ class GaplessSegmentPaneController extends ChangeNotifier {
     }
 
     if (playhead.isBefore(cur.start)) {
+      // Ride-through tolerance: when a segment FILE is slightly shorter than
+      // its indexed span, mpv hits EOF "early" and auto-advances onto the
+      // next segment ([_onPlaylistChanged] adopts it) while the playhead is
+      // still just shy of its start. Resolving here would reopen the OLD
+      // file only to replay/skip its missing tail — a pointless stutter at
+      // the boundary. Let the playhead catch up instead (a beat of the next
+      // segment's first frame; the slaved clock snaps forward ≤ this bound).
+      // Anything further behind is a genuine backward move — really resolve.
+      if (cur.start.difference(playhead) <= const Duration(milliseconds: 750)) {
+        return;
+      }
       // The playhead is BEHIND the loaded segment (a backwards nudge, or a
       // pane re-activated after the operator scrubbed back while it was
       // hidden) — the linear boundary logic below can never get there, so do
@@ -186,15 +349,47 @@ class GaplessSegmentPaneController extends ChangeNotifier {
       return;
     }
 
+    // Prefetch lead is scaled by the playback rate: at 8× the playhead covers
+    // 8 s of timeline per real second, so a fixed 1 s lead left only ~125 ms
+    // of real time for the resolve+append round-trip and the boundary kept
+    // losing the race (falling back to a stuttery fresh load). The scaled
+    // lead keeps ~1 s of REAL time regardless of speed.
+    final leadMs = (kPrefetchLeadTime.inMilliseconds * (rate > 1 ? rate : 1))
+        .round();
     final untilEnd = cur.end.difference(playhead);
-    if (untilEnd <= kPrefetchLeadTime && _prefetched == null && !_prefetching) {
+    if (untilEnd.inMilliseconds <= leadMs &&
+        _prefetched == null &&
+        !_prefetching) {
       unawaited(_prefetchNext());
     }
 
     if (!playhead.isBefore(cur.end.subtract(kBoundaryTolerance)) &&
         !_advancing &&
         !_resolving) {
-      unawaited(_advanceOrResolve(playhead, playing: playing));
+      if (!mpvDriven) {
+        // Wall-clock mode: force the crossing now to keep panes time-aligned.
+        unawaited(_advanceOrResolve(playhead, playing: playing));
+      } else if (_player.state.completed &&
+          (_player.state.playlist.medias.length <= 1 ||
+              playhead.isAfter(cur.end.add(const Duration(seconds: 1))))) {
+        // mpv-driven mode: normally mpv auto-advances at real EOF and
+        // [_onPlaylistChanged] has already moved [_current] on before the
+        // playhead (slaved to mpv) can even sit at the boundary — so reaching
+        // here with `completed` means mpv genuinely ran out of playlist:
+        // nothing was appended (gap / prefetch too slow), or the appended
+        // entry failed to play (the `playhead > end + 1s` escape hatch, wall
+        // clock having taken over via [mpvPlayhead] returning null). Fall
+        // back to a plain resolve at the playhead — for contiguous footage
+        // that loads the next segment (non-gapless but correct); in a gap it
+        // resolves null → noFootage and the wall clock walks the gap exactly
+        // as before. The `medias.length <= 1` guard keeps a transient
+        // completed flicker during a normal auto-advance (next entry still
+        // queued) from racing [_onPlaylistChanged] with a redundant open().
+        unawaited(resolveAt(playhead, playing: playing));
+      }
+      // else: mpv is still showing real frames from this segment while the
+      // slaved playhead waits (clamped) at `cur.end` — its EOF auto-advance
+      // will cross the boundary without skipping any of them.
     }
   }
 
@@ -234,7 +429,9 @@ class GaplessSegmentPaneController extends ChangeNotifier {
   }
 
   // ── boundary crossing (port of the gapless branch in
-  //    pbResolveAllPanesInner) ────────────────────────────────────────────
+  //    pbResolveAllPanesInner) — WALL-CLOCK MODE ONLY: the single-pane
+  //    mpv-driven mode never forces this; mpv's own EOF auto-advance +
+  //    [_onPlaylistChanged] cross the boundary there (see onTick) ─────────
 
   Future<void> _advanceOrResolve(
     DateTime playhead, {
@@ -246,7 +443,11 @@ class GaplessSegmentPaneController extends ChangeNotifier {
       try {
         // mpv `playlist-next weak` — the prefetch already demuxed this file
         // (prefetch-playlist=yes), so this is just a pointer move: no
-        // re-init stutter.
+        // re-init stutter. If mpv is still mid-segment this deliberately
+        // jumps it forward (the multi-pane sync-over-smoothness trade-off);
+        // if mpv already auto-advanced at EOF on its own, `next()` on the
+        // last playlist entry is a no-op and [_onPlaylistChanged] (or the
+        // bookkeeping below) has already/will have converged `_current`.
         await _player.next();
         // mpv `playlist-clear` (keeps the now-current file) — drop the
         // played entry so the playlist never grows past {current, next}
@@ -257,6 +458,7 @@ class GaplessSegmentPaneController extends ChangeNotifier {
           /* best-effort trim */
         }
         _current = pre;
+        _currentSince = DateTime.now();
         _prefetched = null;
         noFootage = false;
         error = null;
@@ -326,10 +528,16 @@ class GaplessSegmentPaneController extends ChangeNotifier {
         return; // still covered — nothing to do (matches the cached-skip in app.js)
       }
 
-      final seg = await api.resolveSegment(_session, cameraId, ts, stream: stream);
+      final seg = await api.resolveSegment(
+        _session,
+        cameraId,
+        ts,
+        stream: stream,
+      );
       if (seg == null) {
         await _dropPrefetch();
         _current = null;
+        _currentSince = null; // no segment → mpvPlayhead has nothing to map
         noFootage = true;
         error = null;
         notifyListeners();
@@ -381,6 +589,7 @@ class GaplessSegmentPaneController extends ChangeNotifier {
         }
       }
       _current = seg;
+      _currentSince = DateTime.now();
       _prefetched = null;
       noFootage = false;
       error = null;
@@ -390,24 +599,206 @@ class GaplessSegmentPaneController extends ChangeNotifier {
       notifyListeners();
     } finally {
       _resolving = false;
-      // Replay the newest request that raced this resolve, if any. Snapshot and
-      // clear the pending slot first so a request arriving during the replay
-      // coalesces afresh instead of being lost.
-      final pendingTs = _pendingResolveTs;
-      if (pendingTs != null) {
-        final pendingForce = _pendingForceReload;
-        final pendingPlaying = _pendingResolvePlaying;
-        _pendingResolveTs = null;
-        _pendingForceReload = false;
-        _pendingResolvePlaying = false;
-        unawaited(
-          resolveAt(
-            pendingTs,
-            forceReload: pendingForce,
-            playing: pendingPlaying,
-          ),
-        );
+      _replayPendingResolve();
+    }
+  }
+
+  /// Replay the newest [resolveAt] request that raced an in-flight resolve
+  /// (or a boundary-crossing frame-step, which holds the same `_resolving`
+  /// lock), if any. Snapshot and clear the pending slot first so a request
+  /// arriving during the replay coalesces afresh instead of being lost.
+  /// Extracted so every `_resolving = false` path releases the queue the
+  /// same way.
+  void _replayPendingResolve() {
+    final pendingTs = _pendingResolveTs;
+    if (pendingTs == null) return;
+    final pendingForce = _pendingForceReload;
+    final pendingPlaying = _pendingResolvePlaying;
+    _pendingResolveTs = null;
+    _pendingForceReload = false;
+    _pendingResolvePlaying = false;
+    unawaited(
+      resolveAt(pendingTs, forceReload: pendingForce, playing: pendingPlaying),
+    );
+  }
+
+  // ── frame-step (port of pbFrameStep, app.js:7627 →
+  //    `frame_step_pane`, src-tauri/src/lib.rs:1219) ───────────────────────
+
+  /// Step exactly ONE frame forward/backward using libmpv's native
+  /// `frame-step` / `frame-back-step` commands — the same commands the old
+  /// Tauri client invoked over IPC. The previous approximation (seek by
+  /// `1000/estimated-vf-fps` ms) broke down stepping BACKWARD: mpv resolves
+  /// a backward seek to the nearest keyframe, so repeated back-steps snapped
+  /// to the same keyframe forever — the "back button does nothing / gets
+  /// stuck" symptom. The native commands are frame-exact in both directions.
+  ///
+  /// Boundary crossing: when a back-step lands at (or a forward-step at the
+  /// end can't leave) the current file, this resolves the ADJACENT segment,
+  /// opens it paused, and lands on its nearest edge frame — so stepping
+  /// walks across segment boundaries instead of dead-ending at them.
+  ///
+  /// Returns the absolute time of the frame now showing (for the caller to
+  /// snap the shared playhead to, keeping the two clocks consistent — the
+  /// old code never updated the playhead on a step at all), or `null` if
+  /// nothing moved (no footage loaded, adjacent-segment miss, or an error —
+  /// all non-fatal, mirroring pbFrameStep's per-slot `.catch(warn)`).
+  ///
+  /// Caller contract: pause the transport BEFORE stepping (mpv's step
+  /// commands pause the player themselves; the transport state must agree).
+  Future<DateTime?> frameStep(bool forward) async {
+    final cur = _current;
+    if (cur == null || _resolving || _advancing) return null;
+    final p = _player.platform;
+    if (p is! NativePlayer) return null; // desktop is always NativePlayer
+    final before = _player.state.position;
+    final idxBefore = _player.state.playlist.index;
+    try {
+      await p.command([forward ? 'frame-step' : 'frame-back-step']);
+    } catch (_) {
+      return null;
+    }
+    // The step decodes asynchronously — wait for the position to actually
+    // move (or time out: mpv's step commands are silent no-ops at the file
+    // edges, which is exactly the boundary case handled below).
+    final after = await _positionAfter(before);
+    // A forward step at the very last frame trips EOF instead of showing a
+    // new frame. `completed` (playlist ran out) is checked BEFORE trusting a
+    // position emission, because media_kit may reset the position on
+    // playlist end — mapping that reset as "movement" would snap the
+    // playhead to the segment start.
+    if (_player.state.completed) {
+      return forward ? _openAdjacentForStep(cur, forward: true) : null;
+    }
+    if (after != null) {
+      if (_player.state.playlist.index != idxBefore) {
+        // The forward step at the last frame tripped EOF and mpv auto-
+        // advanced onto the appended prefetch (only possible when the
+        // operator paused within the prefetch window). [_onPlaylistChanged]
+        // adopts the new segment; give the position stream a beat to reflect
+        // the NEW file before mapping, then fall through to the re-read of
+        // [_current] below.
+        await Future<void>.delayed(const Duration(milliseconds: 50));
       }
+      final seg = _current ?? cur;
+      final ms = (seg.startMs + _player.state.position.inMilliseconds)
+          .clamp(seg.startMs, seg.endMs)
+          .toInt();
+      return DateTime.fromMillisecondsSinceEpoch(ms, isUtc: true);
+    }
+    // No movement — at a file edge (or a very slow decode; the thresholds
+    // keep a mid-file timeout from being misread as an edge).
+    if (!forward && before <= const Duration(milliseconds: 200)) {
+      return _openAdjacentForStep(cur, forward: false);
+    }
+    final dur = _player.state.duration;
+    if (forward &&
+        dur > Duration.zero &&
+        dur - before <= const Duration(milliseconds: 200)) {
+      return _openAdjacentForStep(cur, forward: true);
+    }
+    return null;
+  }
+
+  /// First position emitted by the player that differs from [before], or
+  /// `null` on timeout. Used to observe an async mpv command (frame-step)
+  /// landing.
+  Future<Duration?> _positionAfter(
+    Duration before, {
+    Duration timeout = const Duration(milliseconds: 300),
+  }) async {
+    try {
+      return await _player.stream.position
+          .firstWhere((pos) => pos != before)
+          .timeout(timeout);
+    } catch (_) {
+      // TimeoutException, or the stream closed under us (dispose race).
+      return null;
+    }
+  }
+
+  /// Frame-step ran off the edge of the current file: resolve the segment
+  /// adjacent to it, open it paused, and land near the edge we stepped over
+  /// (its first frame going forward; just shy of its last frame going
+  /// backward). Returns the landed absolute time, or `null` when there is no
+  /// adjacent footage (retention edge, or a coverage gap — stepping does NOT
+  /// jump gaps; that's a scrub/jump decision, not a one-frame nudge).
+  ///
+  /// Probes the edge ±1 ms first (contiguous files), then ±750 ms as a
+  /// fallback for the sub-second indexing seams a recorder restart can leave
+  /// (still under the server's 1 s span-merge tolerance, so anything the
+  /// timeline paints as continuous is steppable). `/play/` only resolves
+  /// COVERING segments, so a probe inside a real gap misses both times.
+  ///
+  /// Holds the `_resolving` lock (and replays coalesced [resolveAt] requests
+  /// on release) so a concurrent seek/jump can't open a different file
+  /// mid-step.
+  Future<DateTime?> _openAdjacentForStep(
+    ResolvedSegment cur, {
+    required bool forward,
+  }) async {
+    if (_resolving) return null;
+    _resolving = true;
+    try {
+      ResolvedSegment? seg;
+      for (final probeMs
+          in forward
+              ? [cur.endMs + 1, cur.endMs + 750]
+              : [cur.startMs - 1, cur.startMs - 750]) {
+        seg = await api.resolveSegment(
+          _session,
+          cameraId,
+          DateTime.fromMillisecondsSinceEpoch(probeMs, isUtc: true),
+          stream: stream,
+        );
+        if (seg != null) break;
+      }
+      if (seg == null) return null; // no adjacent footage — stay put
+      // Direction sanity: the probe must have found a genuinely earlier /
+      // later file, never the current one again (mirrors _prefetchNext's
+      // same/overlapping guard).
+      if (forward
+          ? seg.startMs < cur.endMs - 250
+          : seg.startMs >= cur.startMs) {
+        return null;
+      }
+      final url = await api.mediaUrlForSegment(_session, seg);
+      if (url == null) return null;
+      // open() replaces the whole playlist, taking any appended prefetch
+      // with it — forget the bookkeeping to match.
+      _prefetched = null;
+      await _player.open(Playlist([Media(url)]), play: false);
+      try {
+        await _player.setRate(rate);
+      } catch (_) {
+        /* non-fatal — the transport owner reasserts speed on its next change */
+      }
+      // Landing offset: first frame going forward. Going backward, aim a few
+      // frames shy of the end (200 ms) rather than the exact last frame —
+      // the indexed duration can slightly overshoot the real file, and a
+      // paused seek pinned to/past EOF risks tripping playlist-end (a black
+      // pane). Absolute seeks are hr-precise in mpv, so this lands where it
+      // aims.
+      final offMs = forward
+          ? 0
+          : (seg.durationMs - 200).clamp(0, seg.durationMs).toInt();
+      try {
+        await _player.seek(Duration(milliseconds: offMs));
+      } catch (_) {
+        /* non-fatal */
+      }
+      _current = seg;
+      _currentSince = DateTime.now();
+      noFootage = false;
+      error = null;
+      notifyListeners();
+      final ms = (seg.startMs + offMs).clamp(seg.startMs, seg.endMs).toInt();
+      return DateTime.fromMillisecondsSinceEpoch(ms, isUtc: true);
+    } catch (_) {
+      return null;
+    } finally {
+      _resolving = false;
+      _replayPendingResolve();
     }
   }
 
@@ -430,6 +821,10 @@ class GaplessSegmentPaneController extends ChangeNotifier {
 
   @override
   void dispose() {
+    // Cancel before disposing the player so a final playlist event can't
+    // touch a disposed Player from [_onPlaylistChanged].
+    unawaited(_playlistSub?.cancel());
+    _playlistSub = null;
     _player.dispose();
     super.dispose();
   }

--- a/apps/desktop-flutter/lib/ui/playback/gapless_segment_pane_controller.dart
+++ b/apps/desktop-flutter/lib/ui/playback/gapless_segment_pane_controller.dart
@@ -111,6 +111,22 @@ const Duration kBoundaryTolerance = Duration(milliseconds: 100);
 /// behavior for a few ticks, and the slaved model resumes immediately after.
 const Duration kMpvPlayheadGrace = Duration(milliseconds: 300);
 
+/// Positions at/below this count as "on the first frame of the file" for the
+/// backward frame-step edge decision (cross into the previous segment).
+/// One frame at 30 fps is ~33 ms, so 20 ms is safely inside frame zero for
+/// any camera at ≤ 50 fps. Deliberately TIGHT: a silent
+/// `frame-back-step` no-op anywhere above this falls back to an exact
+/// in-file reverse seek instead — treating a mid-file no-op as an edge is
+/// what made one back-click skip a whole segment.
+const Duration kFirstFrameEpsilon = Duration(milliseconds: 20);
+
+/// How far the exact-seek fallback steps backward when the native
+/// `frame-back-step` reports no movement mid-file: one frame at 30 fps.
+/// At lower frame rates the target still lands inside the previous frame
+/// (frames are wider); at higher ones it may skip a single frame — an
+/// acceptable rare-fallback error that can never skip a whole segment.
+const int kReverseStepFallbackMs = 33;
+
 class GaplessSegmentPaneController extends ChangeNotifier {
   GaplessSegmentPaneController({
     required this.api,
@@ -194,7 +210,16 @@ class GaplessSegmentPaneController extends ChangeNotifier {
       ['cache', 'yes'],
       ['demuxer-readahead-secs', '2.0'],
       ['demuxer-max-bytes', '32MiB'],
-      ['demuxer-max-back-bytes', '1MiB'],
+      // The back-buffer must hold AT LEAST one full GOP or mpv's native
+      // `frame-back-step` cannot reach the previous frame from a paused
+      // mid-GOP position and silently no-ops (the "one back-click jumps a
+      // whole segment" bug: the no-movement fallback then misread the no-op
+      // as a file edge). Typical main streams here run a ~1 s keyframe
+      // interval at ~16 Mbps — 1 MiB was only ~0.5 s. 32 MiB retains the
+      // demuxed packets of an entire multi-second segment (4 s @ 16 Mbps is
+      // ~8 MiB), keeping reverse stepping cache-local; actual memory use per
+      // pane is bounded by the current file's size, not by this cap.
+      ['demuxer-max-back-bytes', '32MiB'],
       ['network-timeout', '10'],
       // Start muted, exactly like the live wall tiles (wall_screen.dart's
       // _WallTile sets mute=yes at creation). The shared AudioFollowController
@@ -660,8 +685,17 @@ class GaplessSegmentPaneController extends ChangeNotifier {
     }
     // The step decodes asynchronously — wait for the position to actually
     // move (or time out: mpv's step commands are silent no-ops at the file
-    // edges, which is exactly the boundary case handled below).
-    final after = await _positionAfter(before);
+    // edges, which is exactly the boundary case handled below). Backward
+    // steps get a longer wait: a `frame-back-step` whose GOP fell out of the
+    // demuxer back-buffer is a real (possibly network) seek plus a
+    // decode-forward of up to a whole GOP, easily slower than the forward
+    // step's single-frame decode.
+    final after = await _positionAfter(
+      before,
+      timeout: forward
+          ? const Duration(milliseconds: 300)
+          : const Duration(milliseconds: 500),
+    );
     // A forward step at the very last frame trips EOF instead of showing a
     // new frame. `completed` (playlist ran out) is checked BEFORE trusting a
     // position emission, because media_kit may reset the position on
@@ -686,18 +720,65 @@ class GaplessSegmentPaneController extends ChangeNotifier {
           .toInt();
       return DateTime.fromMillisecondsSinceEpoch(ms, isUtc: true);
     }
-    // No movement — at a file edge (or a very slow decode; the thresholds
-    // keep a mid-file timeout from being misread as an edge).
-    if (!forward && before <= const Duration(milliseconds: 200)) {
-      return _openAdjacentForStep(cur, forward: false);
+    // No position emission inside the wait — but that is NOT proof of a
+    // file edge. Re-sample first: the step (or a just-finished open/seek's
+    // async position update) may have landed between the timeout and now.
+    final resampled = _player.state.position;
+    if (resampled != before) {
+      final seg = _current ?? cur;
+      final ms = (seg.startMs + resampled.inMilliseconds)
+          .clamp(seg.startMs, seg.endMs)
+          .toInt();
+      return DateTime.fromMillisecondsSinceEpoch(ms, isUtc: true);
+    }
+    if (!forward) {
+      // A silent backward no-op mid-file means mpv could not REACH the
+      // previous frame (its GOP evicted from the demuxer back-buffer, or the
+      // internal re-seek outran the wait) — it does not mean there is no
+      // previous frame. Cross to the previous segment ONLY when the position
+      // is genuinely on the file's first frame; anywhere else, fall back to
+      // an exact in-file reverse seek of ~one frame, which can never skip a
+      // whole segment. (Misreading the mid-file no-op as an edge was the
+      // "one back-click jumps ~a whole segment" bug.)
+      if (before <= kFirstFrameEpsilon) {
+        return _openAdjacentForStep(cur, forward: false);
+      }
+      return _reverseStepFallback(cur, before);
     }
     final dur = _player.state.duration;
-    if (forward &&
-        dur > Duration.zero &&
+    if (dur > Duration.zero &&
         dur - before <= const Duration(milliseconds: 200)) {
       return _openAdjacentForStep(cur, forward: true);
     }
     return null;
+  }
+
+  /// The native `frame-back-step` reported no movement while mid-file (see
+  /// [frameStep]): step backward with an exact absolute seek instead.
+  /// Absolute seeks are hr-precise in mpv, so this decodes and shows the
+  /// frame covering `before − ~1 frame` — nearest-frame rather than
+  /// frame-exact at unusual frame rates, but strictly bounded to about one
+  /// frame of error. Returns the mapped absolute time of the target (using
+  /// the observed landing position when the player confirms it in time).
+  Future<DateTime?> _reverseStepFallback(
+    ResolvedSegment cur,
+    Duration before,
+  ) async {
+    final targetMs = (before.inMilliseconds - kReverseStepFallbackMs)
+        .clamp(0, before.inMilliseconds)
+        .toInt();
+    try {
+      await _player.seek(Duration(milliseconds: targetMs));
+    } catch (_) {
+      return null;
+    }
+    // Best-effort settle so `state.position` is truthful for the NEXT step;
+    // fall back to the seek target (the seek was issued — mpv will land it).
+    final landed = await _positionAfter(before);
+    final posMs = landed?.inMilliseconds ?? targetMs;
+    final seg = _current ?? cur;
+    final ms = (seg.startMs + posMs).clamp(seg.startMs, seg.endMs).toInt();
+    return DateTime.fromMillisecondsSinceEpoch(ms, isUtc: true);
   }
 
   /// First position emitted by the player that differs from [before], or
@@ -786,6 +867,19 @@ class GaplessSegmentPaneController extends ChangeNotifier {
         await _player.seek(Duration(milliseconds: offMs));
       } catch (_) {
         /* non-fatal */
+      }
+      // Give the async position stream a bounded beat to reflect the fresh
+      // open+seek: `open()` resets `state.position` to zero, and an
+      // immediate follow-up [frameStep] reading that stale zero would judge
+      // itself "at the file start" and cross ANOTHER segment backward (the
+      // repeated whole-segment back-jump). Best-effort — stepping stays
+      // correct without it thanks to frameStep's re-sample, just less sharp.
+      try {
+        await _player.stream.position.first.timeout(
+          const Duration(milliseconds: 400),
+        );
+      } catch (_) {
+        /* best-effort */
       }
       _current = seg;
       _currentSince = DateTime.now();

--- a/apps/desktop-flutter/lib/ui/playback/playback_screen.dart
+++ b/apps/desktop-flutter/lib/ui/playback/playback_screen.dart
@@ -185,9 +185,11 @@ class _PlaybackScreenState extends State<PlaybackScreen> {
 
   // ── filmstrip scrubbing ──────────────────────────────────────────────────
   // While dragging the scrubber we DON'T reopen the video players (that caused
-  // black flashing crossing segment boundaries). Instead the focused pane shows
-  // a server-extracted filmstrip frame at the drag position — "rock solid"
-  // scrubbing — and the real video resolve happens once on release.
+  // black flashing crossing segment boundaries). While the drag position stays
+  // inside the focused pane's loaded segment the video itself tracks it via
+  // hr-exact in-segment seeks; once the drag LEAVES the loaded segment the
+  // focused pane shows a server-extracted filmstrip frame instead (4 s-grid
+  // granularity — see _liveSeek). The real resolve happens once on release.
   bool _scrubbing = false;
   final Map<String, Uint8List?> _scrubFrames = {};
   int _scrubToken = 0;
@@ -603,10 +605,12 @@ class _PlaybackScreenState extends State<PlaybackScreen> {
 
   /// Live-scrub, fired continuously while dragging the scrubber. Panes are NOT
   /// reopened here (that flashes black across segment boundaries): panes whose
-  /// loaded segment covers `t` do a cheap in-segment keyframe seek, and the
-  /// focused pane additionally shows a server-extracted filmstrip frame so it
-  /// tracks the scrubber rock-solid even across segments. The real cross-segment
-  /// resolve happens once on release ([_commitSeek]).
+  /// loaded segment covers `t` do a cheap in-segment seek (absolute seeks are
+  /// hr-exact in mpv, so the video itself tracks `t`), and the focused pane
+  /// falls back to a server-extracted filmstrip frame only when `t` has LEFT
+  /// its loaded segment — the one case the video can't follow without a
+  /// (black-flashing) reopen. The real cross-segment resolve happens once on
+  /// release ([_commitSeek]).
   void _liveSeek(DateTime t) {
     if (!_scrubbing) {
       setState(() => _scrubbing = true);
@@ -616,10 +620,27 @@ class _PlaybackScreenState extends State<PlaybackScreen> {
       // cross-segment resolve happens once on release, in _commitSeek).
       unawaited(_panes[cam.id]?.seekWithinSegment(t) ?? Future.value());
     }
-    // Filmstrip frame for the focused pane, throttled (~8/sec) to cap the
-    // server-side extract load, superseded-request-safe via a token.
     final focusId = _maximizedCameraId ?? _selectedCameraId;
     if (focusId == null) return;
+    // The server's frame endpoint snaps `ts` to a fixed 4 s grid
+    // (services/api/src/filmstrip.rs::serve_frame — shared cache keys), so
+    // the filmstrip is inherently 4 s-granular: fine for a coarse
+    // multi-segment drag, but a fine scrub (zoomed-in timeline, feeling
+    // through one motion event) moves `t` less than a grid cell and the
+    // overlay freezes on a single frame — while COVERING the live video that
+    // is tracking `t` exactly via the in-segment seeks above. So while `t`
+    // is inside the focused pane's loaded segment, drop the overlay and let
+    // the real video show through; the filmstrip remains the cross-segment
+    // fallback only.
+    if (_panes[focusId]?.currentSegment?.covers(t) ?? false) {
+      if (_scrubFrames.isNotEmpty) {
+        _scrubToken++; // an in-flight fetch must not repaint the overlay
+        setState(_scrubFrames.clear);
+      }
+      return;
+    }
+    // Filmstrip frame for the focused pane, throttled (~8/sec) to cap the
+    // server-side extract load, superseded-request-safe via a token.
     final now = DateTime.now();
     if (now.difference(_lastScrubFetch) < const Duration(milliseconds: 120)) {
       return;

--- a/apps/desktop-flutter/lib/ui/playback/playback_screen.dart
+++ b/apps/desktop-flutter/lib/ui/playback/playback_screen.dart
@@ -15,9 +15,12 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
+// NOTE: no direct `package:media_kit/media_kit.dart` import — every mpv
+// interaction (frame-step commands, position mapping, playlist bookkeeping)
+// goes through GaplessSegmentPaneController now; this screen only renders and
+// drives play/pause/rate via the pane's Player members.
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 
 import 'package:crumb_desktop/api/crumb_api.dart';
@@ -532,10 +535,7 @@ class _PlaybackScreenState extends State<PlaybackScreen> {
   /// Overlaps and sub-second seams are merged with the same 1 s tolerance as
   /// the server's GAP_TOLERANCE_MS so a live-edge top-up extends the current
   /// span instead of stacking a duplicate next to it.
-  List<RecordedSpan> _unionSpans(
-    List<RecordedSpan> a,
-    List<RecordedSpan> b,
-  ) {
+  List<RecordedSpan> _unionSpans(List<RecordedSpan> a, List<RecordedSpan> b) {
     const gapMs = 1000;
     final all = [...a, ...b]..sort((x, y) => x.startMs.compareTo(y.startMs));
     final out = <RecordedSpan>[];
@@ -578,10 +578,14 @@ class _PlaybackScreenState extends State<PlaybackScreen> {
   /// coverage gap or a lost prefetch race. See [GaplessSegmentPaneController].
   /// `playing` overrides the transport's play/pause state for freshly opened
   /// files (the forward shuttle decodes while `_playing` stays false).
+  /// `mpvDriven` = the single-active-pane playhead-slaved mode (see [_onTick]):
+  /// the pane then crosses segment boundaries on mpv's own EOF instead of the
+  /// wall clock, so it never skips frames mpv hasn't shown.
   Future<void> _resolveAll(
     DateTime t, {
     bool force = false,
     bool? playing,
+    bool mpvDriven = false,
   }) async {
     final play = playing ?? _playing;
     final futures = <Future<void>>[];
@@ -590,7 +594,7 @@ class _PlaybackScreenState extends State<PlaybackScreen> {
       futures.add(
         force
             ? pane.resolveAt(t, forceReload: true, playing: play)
-            : pane.onTick(t, playing: play),
+            : pane.onTick(t, playing: play, mpvDriven: mpvDriven),
       );
     }
     await Future.wait(futures);
@@ -723,9 +727,13 @@ class _PlaybackScreenState extends State<PlaybackScreen> {
         : (m > 0 ? '${m}m ${sec}s' : '${sec}s');
     // Show the ACTUAL start/end times (local), not just the length — so a
     // precise export window can be read straight off the bar.
-    final startT = DateTime.fromMillisecondsSinceEpoch(ss, isUtc: true).toLocal();
+    final startT = DateTime.fromMillisecondsSinceEpoch(
+      ss,
+      isUtc: true,
+    ).toLocal();
     final endT = DateTime.fromMillisecondsSinceEpoch(se, isUtc: true).toLocal();
-    final sameDay = startT.year == endT.year &&
+    final sameDay =
+        startT.year == endT.year &&
         startT.month == endT.month &&
         startT.day == endT.day;
     final startLabel = '${_mmdd(startT)}${_hms(startT)}';
@@ -783,32 +791,37 @@ class _PlaybackScreenState extends State<PlaybackScreen> {
     if (target != null) await _seekToMs(target);
   }
 
-  /// Nudge every active pane's player by ±1 frame (pauses first). Approximate
-  /// (uses estimated-vf-fps), good enough for frame-by-frame review.
+  /// Step every active pane by exactly ±1 frame (pauses first) using libmpv's
+  /// native `frame-step` / `frame-back-step` via
+  /// [GaplessSegmentPaneController.frameStep]. Replaces the old fps-seek
+  /// approximation (`position ± 1000/estimated-vf-fps`), whose backward seeks
+  /// mpv resolved to the nearest KEYFRAME — so repeated back-steps snapped to
+  /// the same keyframe forever ("step back does nothing / gets stuck") and
+  /// could never cross a segment boundary. The pane's native step is
+  /// frame-exact and walks into the adjacent segment at a file edge.
+  ///
+  /// The shared playhead is then snapped to the reference pane's REAL
+  /// resulting frame time (maximized else selected camera) so the timeline
+  /// and the video stay consistent — the old code left the playhead where it
+  /// was, silently desyncing the two clocks with every step.
   Future<void> _frameStep(bool forward) async {
+    if (_shuttling) return; // the shuttle owns the transport until release
     if (_playing) _togglePlay();
+    final refId = _maximizedCameraId ?? _selectedCameraId;
+    DateTime? refTime;
     for (final cam in _activeCameras()) {
-      final player = _panes[cam.id]?.player;
-      if (player == null) continue;
-      try {
-        double fps = 30;
-        final p = player.platform;
-        if (p is NativePlayer) {
-          final raw = await p.getProperty('estimated-vf-fps');
-          final parsed = double.tryParse(raw);
-          if (parsed != null && parsed > 0) fps = parsed;
-        }
-        final frameMs = (1000 / fps).round().clamp(1, 1000);
-        final cur = player.state.position;
-        var target = forward
-            ? cur + Duration(milliseconds: frameMs)
-            : cur - Duration(milliseconds: frameMs);
-        if (target < Duration.zero) target = Duration.zero;
-        await player.seek(target);
-      } catch (_) {
-        /* non-fatal per-pane */
-      }
+      // Sequential on purpose: stepping is an explicit low-rate operator
+      // action, and the boundary-crossing path does its own /play/ resolve —
+      // no need to fan out.
+      final t = await _panes[cam.id]?.frameStep(forward);
+      if (t == null) continue;
+      // Prefer the focused camera's landing time; any pane's beats none.
+      if (refTime == null || cam.id == refId) refTime = t;
     }
+    if (refTime != null) {
+      _timeline.setPlayhead(refTime, now: DateTime.now().toUtc());
+    }
+    if (mounted) setState(() {});
   }
 
   // ── transport ─────────────────────────────────────────────────────────────
@@ -864,15 +877,55 @@ class _PlaybackScreenState extends State<PlaybackScreen> {
     final elapsedMs = wallNow.difference(_lastTickWall).inMilliseconds;
     _lastTickWall = wallNow;
 
-    final advanceMs = (elapsedMs * _speeds[_speedIdx]).round();
     final nowUtc = DateTime.now().toUtc();
-    var next = _timeline.playhead.add(Duration(milliseconds: advanceMs));
+
+    // ── which clock owns the playhead this tick? ──────────────────────────
+    // With exactly ONE active pane (maximized, or a single-camera layout —
+    // frame-accurate review of one camera), the playhead is SLAVED to that
+    // pane's real mpv position (`segment.start + position`): the UI playhead
+    // and the video physically cannot disagree, so there is never a wall-
+    // clock lead for the video to "catch up" to and the segment boundary
+    // can't jump mpv past frames it hasn't shown (the frame-skip bug — see
+    // the header of gapless_segment_pane_controller.dart). With MULTIPLE
+    // panes the free-running wall clock stays in charge because it's the one
+    // reference every camera can be aligned to (per-pane slaving would let
+    // one slow camera drag every other pane's time around).
+    //
+    // `mpvPlayhead` is null whenever the pane's position can't be trusted —
+    // no segment, mid-resolve, EOF'd into a coverage gap, just-swapped file —
+    // and this falls back to the wall clock for those ticks, which is exactly
+    // the old behavior. When slaving resumes after such a window the playhead
+    // may snap BACK slightly (the wall clock ran ahead of the video during
+    // an open); that direction is the safe one — the video never jumps.
+    final active = _activeCameras();
+    final soloPane = active.length == 1 ? _panes[active.first.id] : null;
+    // While the operator is dragging the scrubber the DRAG owns the playhead
+    // (filmstrip scrub, committed on release) — slaving during the drag would
+    // yank the playhead back to mpv's keyframe-lagged in-segment seeks and
+    // jitter the timeline under the cursor. The boundary model below still
+    // follows the pane count; only the clock source defers to the drag.
+    final mpvTime = _scrubbing ? null : soloPane?.mpvPlayhead;
+
+    DateTime next;
+    if (mpvTime != null) {
+      next = mpvTime;
+    } else {
+      // Free-running wall clock: advance by wall delta × speed.
+      final advanceMs = (elapsedMs * _speeds[_speedIdx]).round();
+      next = _timeline.playhead.add(Duration(milliseconds: advanceMs));
+    }
     if (next.isAfter(nowUtc)) next = nowUtc;
     _timeline.setPlayhead(next, now: nowUtc);
 
     if (!_resolvePending) {
       _resolvePending = true;
-      _resolveAll(next).whenComplete(() => _resolvePending = false);
+      // Boundary model follows the clock model: mpv-driven (EOF-crossing)
+      // whenever a single pane is active — even during a null-mpvPlayhead
+      // fallback tick, so the mode can't flip-flop mid-boundary.
+      _resolveAll(
+        next,
+        mpvDriven: soloPane != null,
+      ).whenComplete(() => _resolvePending = false);
     }
 
     // Pause at the live edge — caught up to "now", nothing more to play.
@@ -1103,8 +1156,18 @@ class _PlaybackScreenState extends State<PlaybackScreen> {
   }
 
   static const List<String> _monthAbbr = [
-    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
   ];
 
   /// Compact local label for the goto button, e.g. "Jul 11, 6:26:41 PM".
@@ -1151,8 +1214,15 @@ class _PlaybackScreenState extends State<PlaybackScreen> {
     );
     // Newly-active panes (e.g. the whole grid again after un-maximizing)
     // may not hold the right segment yet — force a resolve at the current
-    // playhead for whichever set is now active.
-    _resolveAll(_timeline.playhead, force: false);
+    // playhead for whichever set is now active. Pass the boundary model that
+    // matches the NEW active-pane count so a maximize landing right on a
+    // segment boundary doesn't get one stray wall-forced advance (a skip)
+    // before the next tick re-evaluates it.
+    _resolveAll(
+      _timeline.playhead,
+      force: false,
+      mpvDriven: _activeCameras().length == 1,
+    );
   }
 
   // ── build ────────────────────────────────────────────────────────────────
@@ -2027,9 +2097,7 @@ class _PbTileState extends State<_PbTile> {
                       color: Colors.white,
                       fontSize: 13,
                       fontWeight: FontWeight.w700,
-                      shadows: [
-                        Shadow(color: Colors.black, blurRadius: 4),
-                      ],
+                      shadows: [Shadow(color: Colors.black, blurRadius: 4)],
                     ),
                   ),
                   if (subtitle != null) ...[

--- a/apps/desktop-flutter/lib/ui/playback/playback_transport_controller.dart
+++ b/apps/desktop-flutter/lib/ui/playback/playback_transport_controller.dart
@@ -99,17 +99,23 @@ class PlaybackTransportController extends ChangeNotifier {
 
   /// pbFrameStep (app.js:7627). Pauses first (stepping while playing makes no
   /// sense — matches the old client), then steps every registered pane by
-  /// ~1 frame.
+  /// exactly 1 frame.
   ///
-  /// The old client called a native libmpv `frame-step` / `frame-back-step`
-  /// command via a Tauri Rust command (src-tauri/src/lib.rs:1219). media_kit's
-  /// cross-platform `Player` API has no equivalent single-frame-step command,
-  /// so this approximates it: read the decoder's estimated fps off the native
-  /// mpv property (`estimated-vf-fps`; falls back to 30fps if unavailable —
-  /// same non-fatal-property pattern as wall_screen.dart's setProperty calls)
-  /// and seek by ±1 frame duration from the current position. Good enough for
-  /// a "nudge by a frame" review; not guaranteed keyframe/frame-exact the way
-  /// a real mpv frame-step is.
+  /// Uses libmpv's native `frame-step` / `frame-back-step` commands through
+  /// the media_kit [NativePlayer] command channel — the same commands the old
+  /// client invoked via a Tauri Rust command (src-tauri/src/lib.rs:1219).
+  /// These are frame-exact in BOTH directions. Do not "simplify" this back to
+  /// a `position ± 1000/fps` seek: mpv resolves backward seeks to the nearest
+  /// KEYFRAME, so a seek-based back-step repeatedly snapped to the same
+  /// keyframe and appeared dead (the frame-step-stuck bug). The fps-seek
+  /// remains only as the fallback for a non-native platform (never the case
+  /// on desktop).
+  ///
+  /// NOTE: this controller is segment-agnostic (see the class doc), so its
+  /// step dead-ends at the loaded file's edges. The playback screen's actual
+  /// transport uses `GaplessSegmentPaneController.frameStep`, which
+  /// additionally crosses segment boundaries and reports the landed frame
+  /// time for playhead sync.
   Future<void> frameStep(bool forward) async {
     if (_playing) {
       _playing = false;
@@ -123,22 +129,21 @@ class PlaybackTransportController extends ChangeNotifier {
 
   Future<void> _stepOnePane(Player player, bool forward) async {
     try {
-      double fps = 30;
       final p = player.platform;
       if (p is NativePlayer) {
-        try {
-          final raw = await p.getProperty('estimated-vf-fps');
-          final parsed = double.tryParse(raw);
-          if (parsed != null && parsed > 0) fps = parsed;
-        } catch (_) {
-          // Property unavailable on this platform/build — keep 30fps fallback.
-        }
+        // Frame-exact native step (pauses the pane itself — matches the
+        // transport pause above).
+        await p.command([forward ? 'frame-step' : 'frame-back-step']);
+        return;
       }
-      final frameMs = (1000 / fps).round().clamp(1, 1000);
+      // Non-native fallback: approximate a frame by the decoder's estimated
+      // fps (assume 30 when unknown) and seek. Backward seeks may snap to a
+      // keyframe here — acceptable for a platform that has no native step.
+      const frameMs = 1000 ~/ 30;
       final current = player.state.position;
       var target = forward
-          ? current + Duration(milliseconds: frameMs)
-          : current - Duration(milliseconds: frameMs);
+          ? current + const Duration(milliseconds: frameMs)
+          : current - const Duration(milliseconds: frameMs);
       if (target < Duration.zero) target = Duration.zero;
       await player.seek(target);
     } catch (_) {


### PR DESCRIPTION
Playback correctness on the Flutter desktop client, hardware-verified by the maintainer.

- **Smooth playback** (`9e95e60`): slave the playhead to mpv, EOF-driven gapless segment advance, native frame-step.
- **Frame-back one-frame** (`19fbf97`): paused frame-back stepped a whole ~4 s segment outside a warm region — `demuxer-max-back-bytes` was 1 MiB (~0.5 s) < the 1 s GOP, so the step couldn't reach the prior frame and the fallback misread it as a segment edge. Now 32 MiB back-buffer (holds the current segment; live/clip/plate/tuner players stay at 1 MiB), a 500 ms backward-step wait, a position re-sample + exact `position-33ms` seek fallback that can never cross a whole segment, and a settle-wait so rapid clicks can't chain a jump.
- **In-motion scrub** (`19fbf97`): dragging a short distance froze on one frame — the single-frame endpoint snaps every ts to a 4 s grid, so a sub-cell drag returned the same JPEG while the overlay hid the real (correctly-tracking) video. Now the filmstrip overlay is dropped while `t` is inside the loaded segment (real hr-seeking video shows through), kept only once `t` leaves it.

Client-only; no new APIs. Verified on the maintainer's wall: frame-back is one frame everywhere, in-motion scrub tracks live, boundaries stay gapless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)