### PR TITLE
feat(desktop): HA badge polish — full-gamut picker, live caption preview, tile-scaled captions

### DIFF
--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_badge_style_editor.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_badge_style_editor.dart
@@ -20,6 +20,25 @@ import 'ha_entity_palette.dart';
 import 'ha_icons.dart';
 import 'ha_overlay_controller.dart' show HaOverlayBadgeItem, HaOverlayController;
 
+/// Full-gamut swatch set for the badge color + background pickers — NOT the
+/// pastel camera palette (which is tuned for timeline distinguishability).
+/// Neutrals (black → white) plus saturated hues across bright and deep, so an
+/// operator can pick anything from a solid black chip to a bright accent; the
+/// custom wheel covers everything in between.
+const List<Color> kBadgeSwatchPalette = [
+  // neutrals
+  Color(0xFF000000), Color(0xFF3A3A3A), Color(0xFF757575),
+  Color(0xFFBDBDBD), Color(0xFFFFFFFF),
+  // bright saturated
+  Color(0xFFF44336), Color(0xFFFF7043), Color(0xFFFF9800), Color(0xFFFFC107),
+  Color(0xFFFFEB3B), Color(0xFFCDDC39), Color(0xFF8BC34A), Color(0xFF4CAF50),
+  Color(0xFF009688), Color(0xFF00BCD4), Color(0xFF03A9F4), Color(0xFF2196F3),
+  Color(0xFF3F51B5), Color(0xFF673AB7), Color(0xFF9C27B0), Color(0xFFE91E63),
+  // deep / dark
+  Color(0xFFB71C1C), Color(0xFFE65100), Color(0xFF1B5E20), Color(0xFF006064),
+  Color(0xFF0D47A1), Color(0xFF4A148C),
+];
+
 /// Format a picked color back to the stored '#RRGGBB' form
 /// (the inverse of `parseOverlayColorHex`).
 String overlayColorToHex(Color c) =>
@@ -136,6 +155,7 @@ class _HaBadgeStyleFormState extends State<HaBadgeStyleForm> {
       allowReset: item.colorHex != null,
       resetLabel: 'Use state color',
       allowCustom: true,
+      palette: kBadgeSwatchPalette,
     );
     if (result == null || !mounted) return;
     widget.editor.pushUndo();
@@ -152,6 +172,7 @@ class _HaBadgeStyleFormState extends State<HaBadgeStyleForm> {
       allowReset: item.bgColorHex != null,
       resetLabel: 'Default (dark)',
       allowCustom: true,
+      palette: kBadgeSwatchPalette,
     );
     if (result == null || !mounted) return;
     widget.editor.pushUndo();

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_controller.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_controller.dart
@@ -148,8 +148,11 @@ class HaOverlayBadgeItem implements OverlayItem {
 
   @override
   void setBaseSize(double w, double h) {
-    final v = (w > h ? w : h) / baseRefPx;
-    _scale = v.clamp(0.1, 8.0).toDouble();
+    // Derive scale from HEIGHT — the shape-invariant. A pill's baseSize width
+    // is wider than tall, so using max(w,h) made every resize multiply the
+    // scale by the pill's width factor and balloon the badge (and the dot
+    // after switching back). Height is baseRefPx*scale for both shapes.
+    _scale = (h / baseRefPx).clamp(0.1, 8.0).toDouble();
   }
 
   /// The `overlay_size` multiplier to persist (mirrors the server's clamp,

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_layer.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_layer.dart
@@ -275,6 +275,158 @@ class _HaBadgeChipState extends State<HaBadgeChip>
   }
 }
 
+/// The pinned/hover captions (live state text + relative age) for a set of
+/// placed badges, laid over the same video-frame geometry as the badges
+/// themselves. Extracted so BOTH view mode (`HaOverlayLayer`) and the maximized
+/// pane's EDIT mode can show them — in edit mode driven by the editor's live
+/// items, so toggling "Pin state"/"Pin time" previews immediately instead of
+/// only after save. Non-interactive (the whole layer is wrapped in
+/// `IgnorePointer` by the caller in edit mode; in view mode each chip is its
+/// own `IgnorePointer`). Caption size scales with the badge's rendered size, so
+/// it stays legible-but-proportional on a small wall tile (issue: captions were
+/// a fixed size in a fixed 180px anchor box that drifted off small tiles).
+class HaBadgeCaptions extends StatelessWidget {
+  const HaBadgeCaptions({
+    super.key,
+    required this.items,
+    required this.stateFor,
+    required this.stale,
+    required this.videoW,
+    required this.videoH,
+    this.hoverLinkId,
+  });
+
+  final List<HaOverlayBadgeItem> items;
+  final HaEntityState? Function(String entityId) stateFor;
+  final bool stale;
+  final int? videoW;
+  final int? videoH;
+
+  /// Link id currently hovered (view mode) — reveals its state+age even when
+  /// not pinned. Null in edit mode.
+  final String? hoverLinkId;
+
+  @override
+  Widget build(BuildContext context) {
+    if (videoW == null || videoH == null) return const SizedBox.shrink();
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final paneW = constraints.maxWidth;
+        final paneH = constraints.maxHeight;
+        if (paneW <= 0 || paneH <= 0) return const SizedBox.shrink();
+        final children = <Widget>[];
+        for (final item in items) {
+          final hovered = item.id == hoverLinkId;
+          if (!item.showState && !item.showAge && !hovered) continue;
+          final w = _captionFor(item, paneW, paneH, hovered);
+          if (w != null) children.add(w);
+        }
+        if (children.isEmpty) return const SizedBox.shrink();
+        return Stack(clipBehavior: Clip.none, children: children);
+      },
+    );
+  }
+
+  Widget? _captionFor(
+    HaOverlayBadgeItem item,
+    double paneW,
+    double paneH,
+    bool hovered,
+  ) {
+    final (x, y, w, h) = OverlayGeometry.rectFor(
+      item,
+      paneW,
+      paneH,
+      videoW: videoW,
+      videoH: videoH,
+    );
+    final link = item.link;
+    final state = stateFor(link.entityId);
+    final visual = haVisualFor(
+      domain: link.domain,
+      deviceClass: link.deviceClass,
+      state: state?.state,
+      stale: stale,
+      iconOverride: item.iconKey,
+      colorOverride: parseOverlayColorHex(item.colorHex),
+    );
+
+    final showState = item.showState || hovered;
+    final showAge = (item.showAge || hovered) && state?.lastChanged != null;
+    if (!showState && !showAge && !hovered) return null;
+
+    // Scale text with the badge so captions stay proportional on small tiles.
+    final fState = (h * 0.42).clamp(8.0, 13.0).toDouble();
+    final fAge = (h * 0.34).clamp(7.0, 11.0).toDouble();
+    final gap = (h * 0.14).clamp(2.0, 6.0).toDouble();
+
+    final lines = <Widget>[
+      if (hovered)
+        Text(
+          item.displayLabel,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: TextStyle(
+            color: Colors.white,
+            fontSize: fState,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      if (showState)
+        Text(
+          visual.label ?? (state?.state ?? 'Unknown'),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: TextStyle(
+            color: visual.color,
+            fontSize: fState,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      if (showAge)
+        Text(
+          haRelativeAgo(state!.lastChanged!),
+          maxLines: 1,
+          style: TextStyle(color: Colors.white70, fontSize: fAge),
+        ),
+    ];
+    if (lines.isEmpty) return null;
+
+    final chip = Container(
+      padding: EdgeInsets.symmetric(
+        horizontal: (h * 0.16).clamp(4.0, 8.0).toDouble(),
+        vertical: (h * 0.08).clamp(2.0, 4.0).toDouble(),
+      ),
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.62),
+        borderRadius: BorderRadius.circular(5),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: lines,
+      ),
+    );
+
+    // Center the chip on the badge horizontally (FractionalTranslation, so no
+    // fixed anchor box to drift), placed just below — flipped above near the
+    // bottom edge. Overflow at the tile edge is clipped by the tile, far less
+    // wrong than the old center-in-a-wide-box drift.
+    final cx = x + w / 2;
+    final estH = fState * (lines.length) * 1.4 + 8;
+    final below = y + h + gap + estH <= paneH;
+    return Positioned(
+      left: cx,
+      top: below ? y + h + gap : null,
+      bottom: below ? null : (paneH - y + gap),
+      child: FractionalTranslation(
+        translation: const Offset(-0.5, 0),
+        child: chip,
+      ),
+    );
+  }
+}
+
 class HaOverlayLayer extends StatefulWidget {
   const HaOverlayLayer({
     super.key,
@@ -333,7 +485,6 @@ class _HaOverlayLayerState extends State<HaOverlayLayer> {
   /// Rough height estimates for flip/clamp decisions (the real widgets
   /// self-size; these only pick which side of the badge to render on).
   static const double _cardEstHeight = 150;
-  static const double _captionEstHeight = 40;
 
   @override
   void dispose() {
@@ -398,12 +549,20 @@ class _HaOverlayLayerState extends State<HaOverlayLayer> {
               ),
             ),
 
-            // Pinned / hover-revealed captions, anchored to each badge.
-            for (final item in items)
-              if (item.showState ||
-                  item.showAge ||
-                  item.id == _hoverLinkId)
-                ..._captionFor(item, rectOf(item), paneW, paneH),
+            // Pinned / hover-revealed captions (shared with the edit-mode
+            // live preview via HaBadgeCaptions).
+            Positioned.fill(
+              child: IgnorePointer(
+                child: HaBadgeCaptions(
+                  items: items,
+                  stateFor: widget.stateFor,
+                  stale: widget.stale,
+                  videoW: widget.videoW,
+                  videoH: widget.videoH,
+                  hoverLinkId: _hoverLinkId,
+                ),
+              ),
+            ),
 
             if (open != null) ...[
               // Tap-away scrim: any tap outside the card dismisses it. Sits
@@ -432,104 +591,6 @@ class _HaOverlayLayerState extends State<HaOverlayLayer> {
     return null;
   }
 
-  /// The caption chip(s) for one badge: live state text (pinned via
-  /// `overlay_show_state` or hover) and/or relative age (`overlay_show_age`
-  /// or hover), rendered just below the badge — flipped above it near the
-  /// bottom edge, clamped horizontally. Non-interactive (IgnorePointer) so
-  /// the video pane's own gestures keep working through them.
-  List<Widget> _captionFor(
-    HaOverlayBadgeItem item,
-    (double, double, double, double) rect,
-    double paneW,
-    double paneH,
-  ) {
-    final (x, y, w, h) = rect;
-    final link = item.link;
-    final hovered = item.id == _hoverLinkId;
-    final state = widget.stateFor(link.entityId);
-    final visual = haVisualFor(
-      domain: link.domain,
-      deviceClass: link.deviceClass,
-      state: state?.state,
-      stale: widget.stale,
-      iconOverride: item.iconKey,
-      colorOverride: parseOverlayColorHex(item.colorHex),
-    );
-
-    final showState = item.showState || hovered;
-    final showAge = (item.showAge || hovered) && state?.lastChanged != null;
-    if (!showState && !showAge) return const [];
-
-    final lines = <Widget>[
-      if (hovered)
-        Text(
-          item.displayLabel,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: const TextStyle(
-            color: Colors.white,
-            fontSize: 10.5,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-      if (showState)
-        Text(
-          visual.label ?? (state?.state ?? 'Unknown'),
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: TextStyle(
-            color: visual.color,
-            fontSize: 11,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-      if (showAge)
-        Text(
-          haRelativeAgo(state!.lastChanged!),
-          maxLines: 1,
-          style: const TextStyle(color: Colors.white54, fontSize: 10),
-        ),
-    ];
-
-    final chip = IgnorePointer(
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
-        decoration: BoxDecoration(
-          color: Colors.black.withValues(alpha: 0.55),
-          borderRadius: BorderRadius.circular(5),
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: lines,
-        ),
-      ),
-    );
-
-    // A fixed-width anchor box centered on the badge (clamped into the
-    // pane); the chip centers itself inside and hugs its content.
-    const anchorW = 180.0;
-    final left = (x + w / 2 - anchorW / 2)
-        .clamp(2.0, (paneW - anchorW - 2).clamp(2.0, double.infinity))
-        .toDouble();
-    final below = y + h + 4 + _captionEstHeight <= paneH;
-    return [
-      if (below)
-        Positioned(
-          left: left,
-          top: y + h + 4,
-          width: anchorW,
-          child: Center(child: chip),
-        )
-      else
-        Positioned(
-          left: left,
-          bottom: paneH - y + 4,
-          width: anchorW,
-          child: Center(child: chip),
-        ),
-    ];
-  }
 
   /// The tap card, placed BESIDE the tapped badge (right by preference,
   /// flipped left near the right edge; vertically clamped into the pane) —

--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -2488,6 +2488,31 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
                     ),
                   ),
 
+                // While editing, mirror the pinned state/time captions from the
+                // in-session editor items so toggling "Pin state"/"Pin time"
+                // previews immediately (not only after Done + save). Layered
+                // above the editor, IgnorePointer so it never eats a drag.
+                if (widget.haOverlay != null && _haEditing)
+                  Positioned.fill(
+                    child: IgnorePointer(
+                      child: AnimatedBuilder(
+                        animation: widget.haOverlay!.editor,
+                        builder: (context, _) => ListenableBuilder(
+                          listenable: widget.liveStatus,
+                          builder: (context, _) => HaBadgeCaptions(
+                            items: widget.haOverlay!.editor.items
+                                .whereType<HaOverlayBadgeItem>()
+                                .toList(),
+                            stateFor: widget.liveStatus.haStateFor,
+                            stale: widget.liveStatus.haStale,
+                            videoW: _videoW,
+                            videoH: _videoH,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+
                 // Close (back to wall) + camera name + zoom level.
                 Positioned(
                   top: 12,

--- a/apps/desktop-flutter/test/ha_badge_scale_test.dart
+++ b/apps/desktop-flutter/test/ha_badge_scale_test.dart
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Regression test for the HA badge "pill size-down balloons" bug.
+//
+// The overlay editor stores each item's geometry as a (w, h) box and, on some
+// interactions (notably a dot<->pill shape switch), round-trips it through
+// `baseSize()` -> `setBaseSize()`. A pill's baseSize width is much wider than
+// its height, so the old `setBaseSize` (which took `max(w, h)`) multiplied the
+// persisted scale by the pill's width factor on EVERY round trip — the badge
+// ballooned, and a "shrink" could actually enlarge it. The fix derives scale
+// from HEIGHT (the shape-invariant): `scale = h / baseRefPx`.
+//
+// These are pure, headless, deterministic assertions on that math.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:crumb_desktop/api/ha_models.dart';
+import 'package:crumb_desktop/ui/ha_overlay/ha_overlay_controller.dart';
+
+HaOverlayBadgeItem _badge({
+  required String shape,
+  double scale = 1.0,
+  String label = 'Garage',
+}) {
+  return HaOverlayBadgeItem(
+    HaLink(
+      id: 'test-link',
+      entityId: 'binary_sensor.garage_door',
+      role: 'sensor',
+      sortOrder: 0,
+      overlaySize: scale,
+      overlayShape: shape,
+      label: label,
+    ),
+  );
+}
+
+void main() {
+  group('HA badge scale is height-derived (pill no longer balloons)', () {
+    for (final shape in ['dot', 'pill']) {
+      test('$shape: setBaseSize(baseSize()) is a fixed point', () {
+        final item = _badge(shape: shape, scale: 1.3);
+        final (w, h) = item.baseSize();
+        item.setBaseSize(w, h);
+        // A no-op geometry round-trip (e.g. a shape switch) must leave the
+        // persisted scale exactly as it was. The old max(w,h) code failed this
+        // for pills (scale grew every round trip) — the balloon bug.
+        expect(item.scale, closeTo(1.3, 1e-9));
+      });
+
+      test('$shape: halving the box halves the scale (shrinks, never grows)',
+          () {
+        final item = _badge(shape: shape, scale: 2.0);
+        final (w, h) = item.baseSize();
+        item.setBaseSize(w * 0.5, h * 0.5);
+        expect(item.scale, closeTo(1.0, 1e-9));
+        expect(item.scale, lessThan(2.0));
+      });
+    }
+
+    test('a pill baseSize is wider than tall (why max(w,h) ballooned it)', () {
+      final (w, h) = _badge(shape: 'pill', label: 'Front Door').baseSize();
+      expect(w, greaterThan(h));
+    });
+  });
+}


### PR DESCRIPTION
Hardware-feedback follow-ups to the #170 badge styling (client-only).

- **Full-gamut color/background pickers** — a dedicated swatch set (neutrals black→white + saturated hues, bright and deep) instead of the pastel *camera* palette (which is tuned for timeline distinguishability, not badge fills). Custom wheel unchanged.
- **Live caption preview** — "Pin state text"/"Pin last-changed time" now show in the edit overlay the instant you toggle them, not only after Done+save. Caption rendering was extracted into a reusable `HaBadgeCaptions` widget and layered (IgnorePointer) over the editor, driven by the in-session items.
- **Tile-scaled captions** — captions now scale with the badge's rendered size and center on the badge via `FractionalTranslation` instead of a fixed 180px anchor box, fixing text drifting off the badge / reading oversized on small wall tiles.

`flutter analyze`: no new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)