### PR TITLE
fix(android): clamp playback frame rate to reject garbage container fps

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
@@ -350,7 +350,12 @@ fun PlaybackScreen(
             vm.setPlaying(false)
             player.pause()
             player.playWhenReady = false
-            val fps = player.videoFormat?.frameRate?.takeIf { it > 1f } ?: 30f
+            // Clamp to a plausible range: fragmented-mp4 segments often report a
+            // garbage container frame rate (a real camera here reports 90000 fps),
+            // which without an UPPER bound yields frameMs = 1000/90000 -> 0 -> a
+            // 1 ms "step" that never leaves the current frame. Reject anything
+            // outside 1.5..120 fps and fall back to 30.
+            val fps = player.videoFormat?.frameRate?.takeIf { it in 1.5f..120f } ?: 30f
             val frameMs = (1000f / fps).toLong().coerceAtLeast(1L)
             val duration = player.duration.takeIf { it > 0L } ?: Long.MAX_VALUE
             val target = (player.currentPosition + if (forward) frameMs else -frameMs)


### PR DESCRIPTION
Fragmented-mp4 segments frequently report a bogus container frame rate (a real fleet camera reports `90000/1`). The guard `takeIf { it > 1f }` let it through → `frameMs = 1000/90000 → 0 → coerceAtLeast(1) = 1 ms` → a 1 ms "step" that never leaves the current frame. Clamp to a plausible `1.5..120` fps, else fall back to 30 fps.

Independent P0 from the Android playback seek/step analysis (the fleet-wide fix — serving recordings as HLS — is separate). Kotlin compile-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)