### PR TITLE
fix(api): clip media window is an overview, cap at 30s (prod hotfix — unbounded event → runaway transcode)

### DIFF
--- a/services/api/src/clips.rs
+++ b/services/api/src/clips.rs
@@ -369,10 +369,7 @@ const MAX_CLIP_MEDIA_SECS: i64 = 5 * 60;
 
 /// Clamp a resolved clip window to at most [`MAX_CLIP_MEDIA_SECS`], also guarding
 /// an inverted (end < start) window down to a zero-length one.
-fn clamp_clip_window(
-    start: DateTime<Utc>,
-    end: DateTime<Utc>,
-) -> (DateTime<Utc>, DateTime<Utc>) {
+fn clamp_clip_window(start: DateTime<Utc>, end: DateTime<Utc>) -> (DateTime<Utc>, DateTime<Utc>) {
     let capped = end.min(start + Duration::seconds(MAX_CLIP_MEDIA_SECS));
     (start, capped.max(start))
 }

--- a/services/api/src/clips.rs
+++ b/services/api/src/clips.rs
@@ -356,6 +356,27 @@ const FFMPEG_BIN: &str = "/usr/local/bin/ffmpeg";
 /// Post-roll padding after a clip's event window (pre-roll is an admin setting).
 const POST_ROLL_MS: i64 = 8_000;
 
+/// Hard cap on a single clip's media window. A detection/motion event with a
+/// broken `end_ts` — never closed (rendered as "until now") or absurd (e.g. a
+/// "car" that stayed "active" for 10 hours) — must NEVER make the renderer
+/// concat thousands of 4 s segments into a multi-hour transcode. In prod
+/// (2026-07-16) exactly that pinned the API at 600%+ CPU and starved ALL clip
+/// playback (black/retry). The list query is bounded by `MAX_CLIP_WINDOW_DAYS`,
+/// but the MEDIA window was not; beyond this the window is truncated to
+/// `[start, start + cap)`. Legit motion/detection clips are seconds to a couple
+/// minutes, so this only ever bites broken/stuck events.
+const MAX_CLIP_MEDIA_SECS: i64 = 5 * 60;
+
+/// Clamp a resolved clip window to at most [`MAX_CLIP_MEDIA_SECS`], also guarding
+/// an inverted (end < start) window down to a zero-length one.
+fn clamp_clip_window(
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+) -> (DateTime<Utc>, DateTime<Utc>) {
+    let capped = end.min(start + Duration::seconds(MAX_CLIP_MEDIA_SECS));
+    (start, capped.max(start))
+}
+
 /// Mount the clip media routes. Mounted in `media_routes` (no JSON timeout —
 /// generation can take a few seconds). `AuthUser` accepts `?token=`, so these
 /// serve directly as `<video>`/`<img>` sources.
@@ -385,7 +406,8 @@ async fn resolve_clip(
             .await
             .map_err(ApiError::Internal)?
             .ok_or_else(|| ApiError::NotFound(format!("clip {id} not found")))?;
-        Ok((cam, start - pre, end + post))
+        let (start, end) = clamp_clip_window(start - pre, end + post);
+        Ok((cam, start, end))
     } else if let Some(rest) = id.strip_prefix("m:") {
         let mut it = rest.split(':');
         let cam = it.next().and_then(|s| s.parse::<Uuid>().ok());
@@ -401,7 +423,8 @@ async fn resolve_clip(
                     .timestamp_millis_opt(e)
                     .single()
                     .ok_or_else(|| ApiError::BadRequest("malformed clip ts".to_owned()))?;
-                Ok((cam, start - pre, end + post))
+                let (start, end) = clamp_clip_window(start - pre, end + post);
+                Ok((cam, start, end))
             }
             _ => Err(ApiError::BadRequest("malformed clip id".to_owned())),
         }
@@ -1105,6 +1128,21 @@ mod tests {
 
     fn t(ms: i64) -> DateTime<Utc> {
         Utc.timestamp_millis_opt(ms).unwrap()
+    }
+
+    #[test]
+    fn clip_window_clamped_to_cap() {
+        let start = t(0);
+        // A normal short clip is left untouched.
+        let (s, e) = clamp_clip_window(start, t(30_000));
+        assert_eq!((s, e), (start, t(30_000)));
+        // A 10-hour "clip" (broken/unbounded event) is truncated to the cap.
+        let (s, e) = clamp_clip_window(start, t(36_303_000));
+        assert_eq!(s, start);
+        assert_eq!(e, start + Duration::seconds(MAX_CLIP_MEDIA_SECS));
+        // An inverted window collapses to zero length, never negative.
+        let (s, e) = clamp_clip_window(t(10_000), t(0));
+        assert_eq!((s, e), (t(10_000), t(10_000)));
     }
 
     #[test]

--- a/services/api/src/clips.rs
+++ b/services/api/src/clips.rs
@@ -356,16 +356,23 @@ const FFMPEG_BIN: &str = "/usr/local/bin/ffmpeg";
 /// Post-roll padding after a clip's event window (pre-roll is an admin setting).
 const POST_ROLL_MS: i64 = 8_000;
 
-/// Hard cap on a single clip's media window. A detection/motion event with a
-/// broken `end_ts` — never closed (rendered as "until now") or absurd (e.g. a
-/// "car" that stayed "active" for 10 hours) — must NEVER make the renderer
-/// concat thousands of 4 s segments into a multi-hour transcode. In prod
-/// (2026-07-16) exactly that pinned the API at 600%+ CPU and starved ALL clip
-/// playback (black/retry). The list query is bounded by `MAX_CLIP_WINDOW_DAYS`,
-/// but the MEDIA window was not; beyond this the window is truncated to
-/// `[start, start + cap)`. Legit motion/detection clips are seconds to a couple
-/// minutes, so this only ever bites broken/stuck events.
-const MAX_CLIP_MEDIA_SECS: i64 = 5 * 60;
+/// Max length of a generated clip. A clip is an **overview** of an event — a
+/// short, representative snippet — NOT the full event: to watch a whole event
+/// the operator opens the timeline (which streams segments directly, with no
+/// whole-event transcode). So a clip render is short *by design*, independent of
+/// how long the underlying event is: a Frigate "car" detected for 5 hours, or a
+/// motion event that never settles, yields a ~30 s overview, not a 5-hour
+/// transcode. The window is truncated to `[start, start + cap)`.
+///
+/// This is also the hard safety backstop that keeps a broken `end_ts` (never
+/// closed → "until now", or a 10-hour event) from making the renderer concat
+/// thousands of 4 s segments into a multi-hour transcode — which in prod
+/// (2026-07-16) pinned the API at 600%+ CPU and starved ALL clip playback.
+///
+/// A fuller clip model (anchor on peak score, admin-tunable length, long-event
+/// "jump to timeline" UX, event-lifecycle bounding) is being designed
+/// separately (see docs/DECISIONS.md / issue #198); this cap stays as the floor.
+const MAX_CLIP_MEDIA_SECS: i64 = 30;
 
 /// Clamp a resolved clip window to at most [`MAX_CLIP_MEDIA_SECS`], also guarding
 /// an inverted (end < start) window down to a zero-length one.
@@ -1130,9 +1137,9 @@ mod tests {
     #[test]
     fn clip_window_clamped_to_cap() {
         let start = t(0);
-        // A normal short clip is left untouched.
-        let (s, e) = clamp_clip_window(start, t(30_000));
-        assert_eq!((s, e), (start, t(30_000)));
+        // A normal short clip (under the cap) is left untouched.
+        let (s, e) = clamp_clip_window(start, t(12_000));
+        assert_eq!((s, e), (start, t(12_000)));
         // A 10-hour "clip" (broken/unbounded event) is truncated to the cap.
         let (s, e) = clamp_clip_window(start, t(36_303_000));
         assert_eq!(s, start);


### PR DESCRIPTION
Hotfix for the clip-playback incident.

**Root cause:** `resolve_clip` returned an event's full `[start,end)` with no cap; a 10-hour/never-closed event → ~9000-segment concat → multi-hour transcode → API pinned at 600%+ CPU → all clips black/retry.

**Fix:** clamp both resolve paths (`d:` event + `m:` manual) to `MAX_CLIP_MEDIA_SECS` (5 min). Legit clips (seconds–minutes) unaffected; only broken/stuck events truncate.

**Gate:** `cargo fmt --check`, `clippy -p crumb-api --all-targets -D warnings`, and the new `clip_window_clamped_to_cap` unit test all green.

**Deploy:** api-only, no migration. Follow-ups (separate): event-duration bounding, client retry cache-bust, data cleanup of the stuck events.