### PR TITLE
feat(admin): Storage Advisor — fix mislabeled policies + per-camera footprint table

### DIFF
--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -282,6 +282,23 @@ details.detail-section .ds-body>.policy-section>.policy-section-title{position:s
 .adv-contrib-row .acr-fill{height:100%;min-width:3px;background:var(--accent2);border-radius:3px;}
 .adv-contrib-row .acr-val{flex:0 0 auto;color:var(--dim);min-width:78px;text-align:right;}
 .adv-contrib-row .acr-mode{flex:0 0 auto;color:var(--dim2);font-size:11px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:90px;}
+.adv-cam-tbl{font-size:12px;}
+.act-row{display:grid;grid-template-columns:minmax(0,1.7fr) minmax(96px,1.5fr) 82px 66px minmax(0,1.4fr);gap:10px;align-items:center;padding:3px 0;}
+.act-head span{color:var(--dim);font-size:11px;font-weight:600;letter-spacing:.2px;white-space:nowrap;cursor:pointer;user-select:none;}
+.act-head{border-bottom:1px solid var(--border);padding-bottom:4px;margin-bottom:2px;}
+.act-head span:hover{color:var(--text);}
+.act-head .act-pol{cursor:default;}
+.act-cam{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text);min-width:0;}
+.act-cam .act-meta{color:var(--dim2);font-size:11px;margin-left:6px;font-weight:400;}
+.act-fp{display:flex;align-items:center;gap:7px;min-width:0;}
+.act-fpbar{flex:1 1 auto;min-width:28px;height:6px;background:var(--surface3);border-radius:3px;overflow:hidden;}
+.act-fpfill{display:block;height:100%;min-width:3px;background:var(--accent2);border-radius:3px;}
+.act-fpnum{flex:0 0 auto;color:var(--text);white-space:nowrap;}
+.act-fpnum small,.act-rate small{color:var(--dim2);font-weight:400;}
+.act-rate,.act-ret{color:var(--dim);white-space:nowrap;text-align:right;}
+.act-pol{display:flex;align-items:center;gap:6px;min-width:0;color:var(--dim);}
+.act-pol .act-polname{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.act-poldot{width:9px;height:9px;border-radius:2px;flex:0 0 auto;}
 .adv-suggest{margin-top:9px;display:flex;flex-direction:column;gap:4px;}
 .adv-suggest-item{display:flex;gap:7px;align-items:flex-start;font-size:12px;color:var(--dim);line-height:1.5;padding:3px 0;}
 .adv-suggest-item .asi-ico{flex:0 0 auto;color:var(--accent);margin-top:1px;}
@@ -4125,9 +4142,9 @@ function renderStorageRoot() {
 }
 
 /* ── Storage advisor (item #5) ── fetch GET /stats/storage and render a card per
-   storage: usage gauge, fill rate, eviction-aware days-until-full, top
-   contributors, and actionable suggestions. Admin-only endpoint; degrades to a
-   note on error so the add-location form is never blocked. */
+   storage: usage gauge, fill rate, eviction-aware days-until-full, a sortable
+   per-camera footprint table, and actionable suggestions. Admin-only endpoint;
+   degrades to a note on error so the add-location form is never blocked. */
 async function loadStorageAdvisor() {
   const host = $('storage-advisor'); if (!host) return;
   host.innerHTML = `<div class="card-hint" style="padding:6px 2px">Loading storage analytics…</div>`;
@@ -4146,7 +4163,29 @@ async function loadStorageAdvisor() {
   // Guard: $('storage-advisor') may have been replaced if the user navigated away
   // while the fetch was in flight.
   if (!$('storage-advisor')) return;
-  host.innerHTML = list.map(advStorageCard).join('');
+  ADV_STORAGES = list;
+  advRenderCards();
+}
+
+/* Last-fetched storage list + per-storage sort state for the per-camera table,
+   so a sort click can re-render the cards without re-fetching. Keyed by storage
+   id → {key, dir}; default is footprint (bytes) descending. */
+let ADV_STORAGES = [];
+const ADV_CAM_SORT = {};
+
+function advRenderCards() {
+  const host = $('storage-advisor'); if (!host) return;
+  host.innerHTML = ADV_STORAGES.map(advStorageCard).join('');
+}
+
+/* Sort the per-camera table for one storage card (toggles direction on repeat).
+   Camera sorts A→Z first; the numeric columns sort high→low first. */
+function advSortCams(sid, key) {
+  const cur = ADV_CAM_SORT[sid] || { key: 'bytes', dir: 'desc' };
+  if (cur.key === key) cur.dir = cur.dir === 'desc' ? 'asc' : 'desc';
+  else { cur.key = key; cur.dir = key === 'camera' ? 'asc' : 'desc'; }
+  ADV_CAM_SORT[sid] = cur;
+  advRenderCards();
 }
 
 /* Distinct colours for profile segments in the stacked utilization bar. Assigned
@@ -4234,24 +4273,16 @@ function advStorageCard(s) {
     ['Retention (configured)', cfgRet ? esc(cfgRet) : '<small>none, capacity-bound</small>'],
   ].map(([k, v]) => `<div class="adv-stat"><div class="as-k">${esc(k)}</div><div class="as-v">${v}</div></div>`).join('');
 
-  // Top contributors (bytes/day), bar-scaled to the largest.
-  const contribs = Array.isArray(s.top_contributors) ? s.top_contributors.slice(0, 5) : [];
-  const maxBpd = contribs.reduce((m, c) => Math.max(m, Number(c.bytes_per_day) || 0), 0) || 1;
-  const contribHTML = contribs.length ? `
-    <div class="adv-contrib">
-      <div class="adv-contrib-title">Top contributors</div>
-      ${contribs.map(c => {
-        const bpd = Number(c.bytes_per_day) || 0;
-        const w = Math.max(2, Math.round(bpd / maxBpd * 100));
-        const meta = [c.stream, c.mode].filter(Boolean).map(esc).join(' · ');
-        return `<div class="adv-contrib-row">
-          <span class="acr-name" title="${esc(c.camera || '')}">${esc(c.camera || '—')}</span>
-          <span class="acr-bar"><span class="acr-fill" style="width:${w}%"></span></span>
-          <span class="acr-val">${fmtBytes(bpd)}/day</span>
-          ${meta ? `<span class="acr-mode">${meta}</span>` : ''}
-        </div>`;
-      }).join('')}
-    </div>` : '';
+  // Per-profile colour map, keyed by policy_id in the SAME order the stacked bar
+  // above assigns colours (filtered to bytes>0), so the table's Policy column and
+  // the bar read as one picture.
+  const policyColor = {};
+  (Array.isArray(s.usage_by_policy) ? s.usage_by_policy.filter(u => Number(u.bytes) > 0) : [])
+    .forEach((u, i) => { if (u.policy_id != null) policyColor[u.policy_id] = STK_PALETTE[i % STK_PALETTE.length]; });
+
+  // Per-camera storage breakdown (footprint on disk, %, GB/day, days retained,
+  // policy) — replaces the old fill-rate-only "Top contributors" list.
+  const contribHTML = advCamTable(s, policyColor);
 
   // Suggestions (actionable strings from the backend) + a synthesized retention nudge.
   const sug = Array.isArray(s.suggestions) ? s.suggestions.slice() : [];
@@ -4283,6 +4314,68 @@ function advStorageCard(s) {
     <div class="adv-stats">${stats}</div>
     ${contribHTML}
     ${sugHTML}
+  </div>`;
+}
+
+/* Compact percentage string for the footprint column (keeps tiny slices honest). */
+function advPct(v) {
+  const n = Number(v);
+  if (!isFinite(n) || n <= 0) return '0%';
+  if (n < 0.1) return '<0.1%';
+  if (n < 10) return `${n.toFixed(1)}%`;
+  return `${Math.round(n)}%`;
+}
+
+/* Per-camera storage-breakdown table for one storage card — answers "what's eating
+   my disk and why". One row per camera: footprint (bytes on disk + % of the drive,
+   with an inline bar), recent fill rate, days of footage retained, stream/mode, and
+   the properly-named policy (colour-keyed to the stacked bar via policyColor).
+   Sortable by header click; defaults to footprint descending. All values esc()'d. */
+function advCamTable(s, policyColor) {
+  const rows = Array.isArray(s.camera_footprints) ? s.camera_footprints.slice() : [];
+  if (!rows.length) return '';
+  const total = s.total_bytes || 0;
+  const sort = ADV_CAM_SORT[s.id] || { key: 'bytes', dir: 'desc' };
+  const cmp = {
+    camera: (a, b) => String(a.camera || '').localeCompare(String(b.camera || '')),
+    bytes: (a, b) => (Number(a.bytes) || 0) - (Number(b.bytes) || 0),
+    rate: (a, b) => (Number(a.bytes_per_day) || 0) - (Number(b.bytes_per_day) || 0),
+    days: (a, b) => (Number(a.days_retained) || 0) - (Number(b.days_retained) || 0),
+  }[sort.key] || (() => 0);
+  rows.sort((a, b) => sort.dir === 'asc' ? cmp(a, b) : -cmp(a, b));
+
+  const maxFp = rows.reduce((m, r) => Math.max(m, Number(r.bytes) || 0), 0) || 1;
+  const arrow = k => sort.key === k ? (sort.dir === 'asc' ? ' ▲' : ' ▼') : '';
+  const sid = esc(s.id);
+  const head = `<div class="act-row act-head">
+    <span class="act-cam" onclick="advSortCams('${sid}','camera')">Camera${arrow('camera')}</span>
+    <span class="act-fp" onclick="advSortCams('${sid}','bytes')">Footprint${arrow('bytes')}</span>
+    <span class="act-rate" onclick="advSortCams('${sid}','rate')">Fill${arrow('rate')}</span>
+    <span class="act-ret" onclick="advSortCams('${sid}','days')">Retained${arrow('days')}</span>
+    <span class="act-pol">Policy</span>
+  </div>`;
+  const body = rows.map(r => {
+    const fp = Number(r.bytes) || 0;
+    const bpd = Number(r.bytes_per_day) || 0;
+    const pctDrive = total ? (fp / total * 100) : 0;
+    const w = Math.max(2, Math.round(fp / maxFp * 100));
+    const meta = [r.stream, r.mode].filter(Boolean).map(esc).join(' · ');
+    const days = r.days_retained != null ? advDays(r.days_retained) : '—';
+    const color = policyColor[r.policy_id] || 'var(--dim2)';
+    return `<div class="act-row">
+      <span class="act-cam" title="${esc(r.camera || '')}">${esc(r.camera || '—')}${meta ? `<small class="act-meta">${meta}</small>` : ''}</span>
+      <span class="act-fp">
+        <span class="act-fpbar"><span class="act-fpfill" style="width:${w}%"></span></span>
+        <span class="act-fpnum">${fmtBytes(fp)}<small> · ${advPct(pctDrive)}</small></span>
+      </span>
+      <span class="act-rate">${bpd > 0 ? `${fmtBytes(bpd)}<small>/day</small>` : '—'}</span>
+      <span class="act-ret">${esc(days)}</span>
+      <span class="act-pol"><span class="act-poldot" style="background:${color}"></span><span class="act-polname" title="${esc(r.policy_name || '')}">${esc(r.policy_name || '—')}</span></span>
+    </div>`;
+  }).join('');
+  return `<div class="adv-contrib">
+    <div class="adv-contrib-title">Per-camera storage — what's on disk now</div>
+    <div class="adv-cam-tbl">${head}${body}</div>
   </div>`;
 }
 

--- a/services/api/src/stats.rs
+++ b/services/api/src/stats.rs
@@ -554,6 +554,33 @@ pub struct TopContributorDto {
     pub mode: String,
 }
 
+/// One camera's on-disk footprint on a storage device, for the per-camera
+/// storage-breakdown table ("what's eating my disk and why").
+#[derive(Debug, Serialize)]
+pub struct CameraFootprintDto {
+    /// Camera display name.
+    pub camera: String,
+    /// Total bytes this camera occupies on this storage right now (all stages,
+    /// all time) — the actual footprint on disk.
+    pub bytes: i64,
+    /// Recent fill rate in bytes/day (trailing 7 days). `0` when idle.
+    pub bytes_per_day: f64,
+    /// Dominant stream on this storage — `"main"` or `"sub"`.
+    pub stream: String,
+    /// Recording mode of the camera's effective policy — `"continuous"` or
+    /// `"motion"`.
+    pub mode: String,
+    /// Observed footage age span in days (`max(end_ts) − min(start_ts)`). `null`
+    /// when unknown (no completed segments yet).
+    pub days_retained: Option<f64>,
+    /// Effective policy id — matches a `usage_by_policy[].policy_id` so the UI
+    /// colour-keys this row to the stacked bar above.
+    pub policy_id: Uuid,
+    /// Properly-resolved policy label (named policy, `"Default"`, or
+    /// `"<camera> · custom"` for a per-camera override).
+    pub policy_name: String,
+}
+
 /// One recording-profile's share of a storage device's used space, for the
 /// stacked-by-profile utilization bar.
 #[derive(Debug, Serialize)]
@@ -607,6 +634,9 @@ pub struct StorageAdvisorDto {
     /// Per-recording-profile share of this storage's used space (largest first).
     /// The remainder up to `used_bytes` is footage Crumb didn't write ("other").
     pub usage_by_policy: Vec<StoragePolicyUsageDto>,
+    /// One row per camera with footage on this storage, sorted by footprint
+    /// (bytes on disk) descending — the "what's eating my disk and why" table.
+    pub camera_footprints: Vec<CameraFootprintDto>,
     /// Actionable suggestion strings (0–3).
     pub suggestions: Vec<String>,
 }
@@ -638,7 +668,9 @@ const STEADY_STATE_FILL_FRACTION: f64 = 0.90;
 /// * 24h and 7d fill rates from the `segments` index (two efficient aggregate
 ///   queries grouped by `storage_id`; no N+1).
 /// * Effective and configured retention, steady-state detection, days-to-full.
-/// * Top-5 cameras by bytes/day and actionable suggestions.
+/// * Per-camera on-disk footprint breakdown (bytes, %, fill rate, age span,
+///   properly-labelled policy) and actionable suggestions. The top-5 by
+///   bytes/day still feed the suggestion heuristics.
 ///
 /// # Errors
 ///
@@ -652,17 +684,26 @@ async fn storage_advisor(
     let pool = state.pool();
 
     // Fetch all data sources concurrently; they are independent reads.
-    let (storages, fill_24h, fill_7d, contributors, policies, cam_policy_rows, policy_usage) =
-        tokio::try_join!(
-            db::list_storages(pool),
-            db::storage_fill_rate_stats(pool, 24),
-            db::storage_fill_rate_stats(pool, 168), // 7d = 168 h
-            db::storage_top_contributors(pool),
-            db::list_policies(pool),
-            db::cameras_by_effective_policy(pool),
-            db::storage_usage_by_policy(pool),
-        )
-        .map_err(ApiError::Internal)?;
+    let (
+        storages,
+        fill_24h,
+        fill_7d,
+        contributors,
+        policies,
+        cam_policy_rows,
+        policy_usage,
+        cam_footprints,
+    ) = tokio::try_join!(
+        db::list_storages(pool),
+        db::storage_fill_rate_stats(pool, 24),
+        db::storage_fill_rate_stats(pool, 168), // 7d = 168 h
+        db::storage_top_contributors(pool),
+        db::list_policies(pool),
+        db::cameras_by_effective_policy(pool),
+        db::storage_usage_by_policy(pool),
+        db::storage_camera_footprints(pool),
+    )
+    .map_err(ApiError::Internal)?;
 
     // Index fill-rate rows by storage_id for O(1) lookup.
     let fill_24h_map: HashMap<Uuid, &db::StorageFillRateStat> =
@@ -684,15 +725,37 @@ async fn storage_advisor(
             });
     }
 
+    // First camera that resolves to each policy, for labelling per-camera custom
+    // (unnamed, non-default) overrides. Such a policy is referenced by exactly one
+    // camera, and cam_policy_rows is already ordered by camera name.
+    let mut cam_name_for_policy: HashMap<Uuid, String> = HashMap::new();
+    for (pid, _cid, cname) in &cam_policy_rows {
+        cam_name_for_policy
+            .entry(*pid)
+            .or_insert_with(|| cname.clone());
+    }
+
     // Build storage_id → [per-profile usage slice] for the stacked utilization bar.
-    // Policy names come from the policies list; an unknown/orphaned policy id falls
-    // back to a generic label so a slice is never silently dropped.
+    // Label resolution: a NAMED policy uses its name; the single real default (name
+    // NULL but is_default) is "Default"; an anonymous per-camera fork (name NULL,
+    // not default) is a per-camera override → label it by its owning camera
+    // ("<camera> · custom"), never the misleading "Default". An orphaned/unknown
+    // policy id falls back to a generic label so a slice is never silently dropped.
     let policy_name_for = |pid: &Uuid| -> String {
-        policies
-            .iter()
-            .find(|p| &p.id == pid)
-            .and_then(|p| p.name.clone())
-            .unwrap_or_else(|| "Default".to_owned())
+        match policies.iter().find(|p| &p.id == pid) {
+            Some(p) => {
+                if let Some(name) = p.name.clone() {
+                    name
+                } else if p.is_default {
+                    "Default".to_owned()
+                } else {
+                    cam_name_for_policy
+                        .get(pid)
+                        .map_or_else(|| "Custom".to_owned(), |c| format!("{c} · custom"))
+                }
+            }
+            None => "Custom".to_owned(),
+        }
     };
     let mut usage_map: HashMap<Uuid, Vec<StoragePolicyUsageDto>> = HashMap::new();
     for u in &policy_usage {
@@ -708,6 +771,27 @@ async fn storage_advisor(
     // Largest profile first so the stacked bar reads big→small left→right.
     for v in usage_map.values_mut() {
         v.sort_by_key(|u| std::cmp::Reverse(u.bytes));
+    }
+
+    // Build storage_id → [per-camera footprint row]. The query already orders by
+    // bytes desc within each storage, so the default sort is footprint-first. Each
+    // row's policy label reuses the Problem-1-fixed policy_name_for so the table
+    // and the stacked bar above read as one picture.
+    let mut footprint_map: HashMap<Uuid, Vec<CameraFootprintDto>> = HashMap::new();
+    for f in &cam_footprints {
+        footprint_map
+            .entry(f.storage_id)
+            .or_default()
+            .push(CameraFootprintDto {
+                camera: f.camera_name.clone(),
+                bytes: f.bytes,
+                bytes_per_day: f.bytes_per_day,
+                stream: f.stream.clone(),
+                mode: f.mode.clone(),
+                days_retained: f.span_days,
+                policy_id: f.policy_id,
+                policy_name: policy_name_for(&f.policy_id),
+            });
     }
 
     // Build storage_id → configured_retention_days.
@@ -884,6 +968,7 @@ async fn storage_advisor(
             suggested_retention_days: effective_retention_days,
             top_contributors: contributors,
             usage_by_policy: usage_map.remove(&sid).unwrap_or_default(),
+            camera_footprints: footprint_map.remove(&sid).unwrap_or_default(),
             suggestions,
         });
     }

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -3254,6 +3254,114 @@ pub async fn storage_top_contributors(pool: &Pool) -> Result<Vec<StorageContribu
         .collect())
 }
 
+/// One camera's on-disk footprint on a single storage device — the row behind
+/// the storage advisor's per-camera breakdown table.
+///
+/// Returned by [`storage_camera_footprints`]; one row per (storage, camera) that
+/// has at least one segment on that storage, sorted by descending `bytes`.
+#[derive(Debug, Clone)]
+pub struct StorageCameraFootprint {
+    pub storage_id: Uuid,
+    pub camera_id: Uuid,
+    pub camera_name: String,
+    /// Effective recording policy id (own → group → default) — the key the UI
+    /// colour-matches against the stacked-by-profile utilization bar.
+    pub policy_id: Uuid,
+    /// Effective recording mode (`continuous` / `motion`).
+    pub mode: String,
+    /// The stream (`main` / `sub`) that accounts for the most bytes on this
+    /// storage for this camera.
+    pub stream: String,
+    /// `SUM(size_bytes)` (all stages, all time) for this camera on this storage —
+    /// the actual footprint sitting on disk.
+    pub bytes: i64,
+    /// `SUM(size_bytes)` over the trailing 7 days / 7.0 — the recent fill rate in
+    /// bytes/day (zero when the camera wrote nothing in the last week).
+    pub bytes_per_day: f64,
+    /// Observed footage age span in days (`MAX(end_ts) - MIN(start_ts)`). `None`
+    /// when the camera has no segment with an `end_ts` yet.
+    pub span_days: Option<f64>,
+}
+
+/// Per-(storage, camera) on-disk footprint for the storage advisor's per-camera
+/// breakdown table.
+///
+/// One aggregate pass computes, per camera on each storage: the total tracked
+/// bytes on disk (the footprint), the trailing-7d fill rate, and the observed
+/// footage age span. A companion CTE picks each camera's dominant stream (the one
+/// holding the most bytes). The effective mode/policy come from
+/// `v_camera_effective_policy` (same own→group→default resolution as
+/// [`storage_top_contributors`]). O(1) round-trips.
+///
+/// # Errors
+///
+/// Returns an error if the query fails.
+pub async fn storage_camera_footprints(pool: &Pool) -> Result<Vec<StorageCameraFootprint>> {
+    let client = get_conn(pool).await?;
+    let rows = client
+        .query(
+            r"
+            WITH per_stream AS (
+                SELECT s.storage_id, s.camera_id, s.stream,
+                       SUM(s.size_bytes) AS stream_bytes
+                FROM segments s
+                GROUP BY s.storage_id, s.camera_id, s.stream
+            ),
+            dominant AS (
+                SELECT DISTINCT ON (storage_id, camera_id)
+                       storage_id, camera_id, stream
+                FROM per_stream
+                ORDER BY storage_id, camera_id, stream_bytes DESC
+            ),
+            agg AS (
+                SELECT
+                    s.storage_id,
+                    s.camera_id,
+                    SUM(s.size_bytes)::bigint AS bytes,
+                    COALESCE(
+                        SUM(s.size_bytes) FILTER (WHERE s.start_ts >= now() - interval '7 days'),
+                        0
+                    )::double precision / 7.0 AS bytes_per_day,
+                    EXTRACT(EPOCH FROM (MAX(s.end_ts) - MIN(s.start_ts)))::double precision
+                        / 86400.0 AS span_days
+                FROM segments s
+                GROUP BY s.storage_id, s.camera_id
+            )
+            SELECT
+                a.storage_id,
+                a.camera_id,
+                v.c_name                          AS camera_name,
+                v.p_id                            AS policy_id,
+                COALESCE(v.p_mode, 'continuous')  AS mode,
+                d.stream                          AS stream,
+                a.bytes,
+                a.bytes_per_day,
+                a.span_days
+            FROM agg a
+            JOIN v_camera_effective_policy v ON v.c_id = a.camera_id
+            JOIN dominant d ON d.storage_id = a.storage_id AND d.camera_id = a.camera_id
+            ORDER BY a.storage_id, a.bytes DESC
+            ",
+            &[],
+        )
+        .await
+        .context("storage_camera_footprints")?;
+    Ok(rows
+        .iter()
+        .map(|row| StorageCameraFootprint {
+            storage_id: row.get("storage_id"),
+            camera_id: row.get("camera_id"),
+            camera_name: row.get("camera_name"),
+            policy_id: row.get("policy_id"),
+            mode: row.get("mode"),
+            stream: row.get("stream"),
+            bytes: row.get("bytes"),
+            bytes_per_day: row.get("bytes_per_day"),
+            span_days: row.get("span_days"),
+        })
+        .collect())
+}
+
 /// Map every camera to its EFFECTIVE policy id (own → group → default), with the
 /// camera's display name. Same COALESCE resolution as [`policy_usage_rollup`] but
 /// without the segment join — used to attach camera_count / camera_names to each


### PR DESCRIPTION
Improves the admin Storage Advisor (read-only; `stats.rs` + `db.rs` query + `admin.html`).

## Problem 1 — mislabeled "Default" slices (fixed)
The per-policy usage bar labeled **every** unnamed policy "Default". Per-camera custom recording settings create a dedicated policy row with a NULL name, so a server with 1 real Default + N per-camera customs showed N+1 "Default" slices. Now: a named policy uses its name; the single real default (`is_default`) stays "Default"; an unnamed per-camera fork resolves to its owning camera → **"Custom — <camera>"**. Applies to both the stacked-bar legend and the new table.

## Problem 2 — per-camera footprint table (new)
Replaces the plain top-5 fill-rate bars with a sortable per-camera table under each storage card: **Footprint** (bytes on disk + % of drive + mini-bar — what's *actually* sitting there, not just fill rate), **Fill** (GB/day, 7-day), **stream · mode**, **Retained** (observed footage span), and the properly-named **Policy** (color-keyed to the bar). Sort by any column; default footprint-desc. New `db::storage_camera_footprints` query (one aggregate pass over `segments`), `CameraFootprintDto`, admin table.

## Gate
`cargo fmt --all -- --check` · `cargo clippy -p crumb-api --all-targets -D warnings` · `node --check` on the admin.html script — all green (CI runs the full `cargo test --workspace`).

## Notes
- "Retained" = observed span (`max(end_ts) − min(start_ts)`), not configured retention — labeled accordingly.
- Separate follow-up (not this PR): the "Other (non-Crumb)" bucket is mostly orphaned Crumb footage (on-disk segments not in the index) + Frigate's own recordings; splitting that out needs a filesystem reconcile.