### PR TITLE
test(api): fix flaky janitor_closes_stale_open_event (broke main CI after #200)

### DIFF
--- a/services/api/tests/clip_overview_model.rs
+++ b/services/api/tests/clip_overview_model.rs
@@ -95,10 +95,15 @@ async fn janitor_closes_stale_open_event() {
         seed_open_event_backdated(pool, cam, &pid, Utc::now() - Duration::hours(2)).await;
 
     let cutoff = Utc::now() - Duration::minutes(30);
-    let n = db::close_stale_open_events(pool, cutoff)
+    // The janitor closes ALL stale open events globally, so a concurrent
+    // DB-backed test's janitor call may have already closed ours by the time
+    // this one runs — the returned count is therefore not deterministic under
+    // parallel test execution against the shared DB. Assert the OUTCOME on our
+    // specific event instead (below): after this call returns, our stale event
+    // must be closed, whichever call did it.
+    db::close_stale_open_events(pool, cutoff)
         .await
         .expect("close_stale_open_events");
-    assert!(n >= 1, "at least our stale event was closed");
 
     let (end_ts, lifecycle) = read_event(pool, id).await;
     let end_ts = end_ts.expect("stale event now has a non-NULL end_ts");


### PR DESCRIPTION
`main` CI went red after #200 merged: `janitor_closes_stale_open_event` failed on `assert!(n >= 1)`.

**Cause:** `close_stale_open_events` closes ALL stale open events globally. DB-backed tests run in parallel against one shared Postgres, so a concurrent test's janitor call (e.g. `provider_end_self_heals_after_janitor_close`) can close this test's event first — making *this* call's returned count 0. Non-deterministic under parallelism; it happened to pass in the pre-merge run and failed on CI.

**Fix:** drop the assertion on the global count; the per-event outcome checks below (`end_ts` non-NULL, `lifecycle = 'end'`) already verify our event is closed, whichever call did it. Test-only.

Gate: `cargo fmt --check` + `cargo test -p crumb-api --test clip_overview_model` (Postgres) — all green.