### PR TITLE
feat(api): recording-policy model Phase 2 — explicit membership (policy_id NOT NULL, groups retire)

### DIFF
--- a/db/migrations/0068_recording_policy_explicit_membership.sql
+++ b/db/migrations/0068_recording_policy_explicit_membership.sql
@@ -1,0 +1,152 @@
+-- 0068_recording_policy_explicit_membership.sql
+--
+-- Phase 2 of the recording-policy model redesign (docs/design/POLICY-MODEL.md,
+-- section 5 "Migration B"). Server-only. FOOTAGE-SACRED: this repoints camera
+-- policy pointers and enforces NOT NULL, so a wrong pin could drop a camera from
+-- the recorder's inner JOIN (silent stop-recording) or change its effective
+-- retention. Read the design's migration-safety invariant (section 5) first.
+--
+-- Invariant held here: for every camera, the effective-policy field VALUES
+-- resolved by v_camera_effective_policy are UNCHANGED (ids may change, values may
+-- not). Every camera that was inheriting (policy_id IS NULL) is pinned to the
+-- SAME row the view's COALESCE resolves today: a grouped camera to its group's
+-- policy (else Default), an ungrouped inheritor to Default. No segment row is
+-- touched, and every policy DELETE below targets only an UNREFERENCED row, so no
+-- footage can be dropped or orphaned.
+--
+-- This whole file is a NON-CONCURRENTLY migration, so the runner applies it as
+-- ONE implicit transaction. It is idempotent: the trigger drops are IF EXISTS;
+-- after the first run no camera has a NULL policy_id and no policy has a NULL
+-- name, so the pin/backfill steps are no-ops and the SET NOT NULL / unique-index
+-- steps are already satisfied (IF NOT EXISTS on the index).
+--
+-- v_camera_effective_policy is intentionally left UNTOUCHED: with every
+-- cameras.policy_id now non-NULL the COALESCE always takes leg 1 and the group
+-- legs are dead but harmless — no append-only-view redefinition needed.
+
+-- 1. Drop the migration-0021 grouped-camera triggers + their functions. They
+--    exist to police the NULL-inherit + groups model this phase removes, and the
+--    reject trigger (BEFORE UPDATE OF policy_id, raising when a grouped camera is
+--    given a direct policy_id) would ABORT step 2's pin UPDATE if left in place
+--    (landmine L3). Drop triggers before functions; IF EXISTS so re-runs and a
+--    fresh DB (triggers created by 0021, always present here) are both safe.
+DROP TRIGGER IF EXISTS trg_reject_override_on_grouped_camera ON cameras;
+DROP TRIGGER IF EXISTS trg_clear_override_on_group_join ON camera_group_members;
+DROP FUNCTION IF EXISTS crumb_reject_override_on_grouped_camera();
+DROP FUNCTION IF EXISTS crumb_clear_override_on_group_join();
+
+-- 2. Pin every GROUPED inheritor to its group's effective policy — exactly the
+--    value the view's leg 2/3 resolves today (group's policy_id, else Default),
+--    so effective field-values are unchanged. Uses a per-row scalar subquery for
+--    the Default so a group WITH a policy still pins correctly even on a
+--    (degenerate/un-seeded) DB with no default row.
+UPDATE cameras c
+   SET policy_id = COALESCE(
+           g.policy_id,
+           (SELECT id FROM recording_policies WHERE is_default LIMIT 1)
+       )
+  FROM camera_group_members m
+  JOIN camera_groups g ON g.id = m.group_id
+ WHERE m.camera_id = c.id
+   AND c.policy_id IS NULL;
+
+-- 3. Pin every remaining (ungrouped) inheritor to the Default row — exactly the
+--    value the view's leg 3 resolves today.
+UPDATE cameras
+   SET policy_id = (SELECT id FROM recording_policies WHERE is_default LIMIT 1)
+ WHERE policy_id IS NULL;
+
+-- 4. Every camera now belongs to a policy: enforce it structurally. This is the
+--    recorder-correctness win (a camera can no longer resolve through a missing
+--    is_default fallback and silently stop recording). No-op if already NOT NULL.
+ALTER TABLE cameras ALTER COLUMN policy_id SET NOT NULL;
+
+-- 5a. Defensive backfill: name any NULL-name policy a mixed-version writer may
+--     have created since Phase 1 (0067). Same rule as 0067 step 4 — name after
+--     the owning camera, suffixed on collision; delete ownerless (unreferenced ⇒
+--     footage-safe) rows outright. Do NOT bake deployment camera names into this
+--     file; they come from data at run time.
+DO $name$
+DECLARE
+    p_id     uuid;
+    cam_name text;
+    cand     text;
+    n        int;
+BEGIN
+    FOR p_id IN
+        SELECT id FROM recording_policies
+         WHERE name IS NULL AND NOT is_default
+         ORDER BY id
+    LOOP
+        SELECT c.name INTO cam_name
+          FROM cameras c
+         WHERE c.policy_id = p_id
+         ORDER BY c.created_at, c.id
+         LIMIT 1;
+
+        IF cam_name IS NULL THEN
+            DELETE FROM recording_policies WHERE id = p_id;
+            CONTINUE;
+        END IF;
+
+        cand := cam_name;
+        n := 1;
+        WHILE EXISTS (
+            SELECT 1 FROM recording_policies WHERE name = cand AND id <> p_id
+        ) LOOP
+            n := n + 1;
+            cand := cam_name || ' ' || n::text;
+        END LOOP;
+
+        UPDATE recording_policies SET name = cand WHERE id = p_id;
+    END LOOP;
+END
+$name$;
+
+-- 5b. Resolve any DUPLICATE names before adding the unique index. Uniqueness was
+--     never enforced, so two operator templates could share a name. Keep the
+--     canonical one (Default wins, then oldest id) and suffix the rest " 2",
+--     " 3", … against ALL names so the result is globally unique.
+DO $dedupe$
+DECLARE
+    r    record;
+    cand text;
+    n    int;
+BEGIN
+    FOR r IN
+        SELECT p.id, p.name
+          FROM recording_policies p
+         WHERE p.name IS NOT NULL
+           AND p.id <> (
+                 SELECT p2.id FROM recording_policies p2
+                  WHERE p2.name = p.name
+                  ORDER BY p2.is_default DESC, p2.id
+                  LIMIT 1
+             )
+         ORDER BY p.name, p.id
+    LOOP
+        cand := r.name;
+        n := 1;
+        WHILE EXISTS (
+            SELECT 1 FROM recording_policies WHERE name = cand AND id <> r.id
+        ) LOOP
+            n := n + 1;
+            cand := r.name || ' ' || n::text;
+        END LOOP;
+        UPDATE recording_policies SET name = cand WHERE id = r.id;
+    END LOOP;
+END
+$dedupe$;
+
+-- 5c. Every policy now has a name: enforce it. No-op if already NOT NULL.
+ALTER TABLE recording_policies ALTER COLUMN name SET NOT NULL;
+
+-- 5d. And names are unique (the console's policy manager keys on them). IF NOT
+--     EXISTS so re-runs are a no-op.
+CREATE UNIQUE INDEX IF NOT EXISTS recording_policies_name_uidx
+    ON recording_policies (name);
+
+-- 6. camera_groups / camera_group_members are intentionally KEPT (dormant) for
+--    one release so a rollback to a group-aware binary still has its tables. A
+--    later cleanup migration drops them (design section 8, Phase 3). Do NOT drop
+--    them here.

--- a/docs/COMPONENT-MAP.md
+++ b/docs/COMPONENT-MAP.md
@@ -143,7 +143,7 @@ a "new camera capability" is usually also a "new/changed API endpoint" and a
 | Recorder code | `services/recorder/src/recording.rs`, `archive.rs`, `reconcile.rs`, `motion.rs` | |
 | Tests | mandatory for this area, no exceptions | |
 | Design docs | `docs/MOTION-RECORDING.md` if the mechanism changes | Documents the ratified mechanism |
-| Policy UI | `admin.html` policy/storage editors; desktop Recorder Health panels in `app.js` | Per-policy knobs (size caps, headroom, `max_retention_days`) surface here. Policy MODEL (named membership, `origin`, deviation-edit, collapse migration) is `docs/design/POLICY-MODEL.md`; Phase 1 is server-only (endpoint shapes unchanged, so no client change), Phase 3 reworks this UI |
+| Policy UI | `admin.html` policy/storage editors; desktop Recorder Health panels in `app.js` | Per-policy knobs (size caps, headroom, `max_retention_days`) surface here. Policy MODEL (named membership, `origin`, deviation-edit, collapse migration) is `docs/design/POLICY-MODEL.md`; Phases 1–2 are server-only (endpoint request/response shapes unchanged, so no client change): Phase 2 (migration `0068`) makes `policy_id`/`name` NOT NULL, retires the grouped-camera triggers, and makes group endpoints write-through. Phase 3 reworks this UI (policy manager + member lists + bulk assign, group-UI retirement) |
 | Decision log | `docs/DECISIONS.md` | Retention/recording design choices are exactly what it exists for |
 | Migration | rows C above if schema changes | |
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -10,12 +10,24 @@ revisit.
 
 ## 2026-07-16, Recording policies: explicit named membership replaces NULL-inherit + anonymous COW forks
 
-**Status.** Phase 1 (server-only) landed here: the `origin` column + the
-collapse migration (`0067`), `create_camera` joins Default, the deviation-edit
-semantics, and the reaper predicate. Phases 2 (explicit membership: `policy_id
-NOT NULL`, groups retire) and 3 (admin UI) are staged per
-`docs/design/POLICY-MODEL.md` §8 and NOT yet landed — NULL-inherit and the
-camera-groups tables are intentionally still live.
+**Status.** Phase 1 (server-only) landed the `origin` column + the collapse
+migration (`0067`), `create_camera` joins Default, the deviation-edit semantics,
+and the reaper predicate. **Phase 2 (server-only) landed here:** migration
+`0068` drops the 0020/0021 grouped-camera triggers, pins every inheriting camera
+to the policy the effective-policy view resolved (grouped → group's policy, else
+Default), and enforces `cameras.policy_id NOT NULL` + `recording_policies.name
+NOT NULL` + a unique index on `name`; the boot shim
+(`ensure_named_policies_and_groups`) that previously ran `ALTER COLUMN policy_id
+DROP NOT NULL` on **every boot** was inverted to a guarded `SET NOT NULL` (L4);
+the group endpoints became **write-through** (a group pins its members'
+`policy_id` directly — no inheritance), `camera` policy assignment maps the old
+`Some(None)` "clear to inherit" to joining Default, and `require_assignable_policy`
+reduced to existence. The `camera_groups`/`camera_group_members` tables are kept
+DORMANT for one release (rollback comfort); `v_camera_effective_policy` is
+untouched (its COALESCE degenerates to leg 1). Phase 3 (admin UI: policy
+manager, member lists, bulk assign, group-UI retirement, dropping the `"Custom —
+…"` label fallbacks, and the final groups-table drop) is staged per
+`docs/design/POLICY-MODEL.md` §8 and NOT yet landed.
 
 **Context.** A camera's effective recording policy resolved through a
 three-leg COALESCE (`v_camera_effective_policy`: own `policy_id` → group's

--- a/services/api/src/config_routes.rs
+++ b/services/api/src/config_routes.rs
@@ -1261,28 +1261,27 @@ async fn update_camera(
         })?;
 
     // Recording-policy ASSIGNMENT (distinct from editing policy fields): pin the
-    // camera to a named policy, or clear it so the camera inherits from its group
-    // / the default. `Some(Some(id))` pins; `Some(None)` clears; omitted leaves it.
+    // camera to a named policy. `Some(Some(id))` pins to that policy;
+    // `Some(None)` — an old client's "clear to inherit" — now means "record like
+    // Default" (Phase 2: every camera belongs to a policy), so it joins the
+    // Default row. Omitted leaves the assignment untouched. The Phase-3
+    // grouped-camera rejection is gone: groups no longer resolve a camera's
+    // policy (they write through to `policy_id`).
     if let Some(assignment) = body.policy_id {
-        if let Some(pid) = assignment {
-            // Phase 3: a grouped camera is governed by its GROUP's profile and
-            // may not hold a direct per-camera policy. Reject the pin (but still
-            // allow `Some(None)`, i.e. clear-to-inherit — that's how you make a
-            // grouped camera follow its group). Ungrouped cameras pass through.
-            if let Some(group_name) = db::camera_group_name(pool, id)
-                .await
-                .context("camera_group_name")?
-            {
-                return Err(ApiError::BadRequest(format!(
-                    "camera is in group '{group_name}' — change the group's profile \
-                     or ungroup the camera first to give it its own recording profile"
-                )));
+        let target = match assignment {
+            Some(pid) => {
+                // Must exist (404, not an FK 500).
+                require_assignable_policy(pool, pid).await?;
+                pid
             }
-            // Must exist (404, not an FK 500) AND be assignable: a camera may only be
-            // pinned to a named or the default policy, never to an anonymous fork.
-            require_assignable_policy(pool, pid).await?;
-        }
-        db::set_camera_policy(pool, id, assignment)
+            None => {
+                db::get_default_policy(pool)
+                    .await
+                    .context("get_default_policy")?
+                    .id
+            }
+        };
+        db::set_camera_policy(pool, id, Some(target))
             .await
             .context("set_camera_policy")?;
     }
@@ -4188,15 +4187,11 @@ async fn cancel_migration(
 /// in `update_camera_policy_locked` silently mutate a now-shared policy. Rejecting
 /// non-named policies here is the clean invariant that closes both assignment paths.
 async fn require_assignable_policy(pool: &Pool, id: Uuid) -> Result<RecordingPolicy, ApiError> {
-    let policy = require_policy(pool, id).await?;
-    if !policy.is_default && policy.name.is_none() {
-        return Err(ApiError::BadRequest(
-            "cannot assign to an anonymous per-camera policy; choose a named policy \
-             (or clear the assignment to inherit)"
-                .to_owned(),
-        ));
-    }
-    Ok(policy)
+    // Phase 2: every policy is named (no anonymous per-camera forks exist), so
+    // "assignable" collapses to "exists". Kept as a distinct helper so the
+    // assignment call sites read intent-fully and still 404 (not FK-500) on a
+    // bogus id.
+    require_policy(pool, id).await
 }
 
 /// Load a camera group by ID or return `404 Not Found`.

--- a/services/api/tests/recording_policy_model.rs
+++ b/services/api/tests/recording_policy_model.rs
@@ -519,6 +519,9 @@ async fn inline_reap_targets_only_orphan_deviations() {
 const MIGRATION_0067_SQL: &str =
     include_str!("../../../db/migrations/0067_recording_policy_origin_collapse.sql");
 
+const MIGRATION_0068_SQL: &str =
+    include_str!("../../../db/migrations/0068_recording_policy_explicit_membership.sql");
+
 /// A throwaway, fully-migrated database that DROPs itself on scope exit — the
 /// migration test mutates GLOBAL policy state (the single default row + every
 /// anonymous fork), so it must not share the public test schema.
@@ -679,6 +682,19 @@ async fn migration_collapse_pool_and_drain_guards_and_invariant() {
         return;
     };
     let pool = &iso.pool;
+
+    // The isolated DB is migrated through 0068, which makes recording_policies.name
+    // NOT NULL. This test reconstructs the PRE-0067 ghost state (anonymous
+    // NULL-name forks via clone_default_policy), so relax that one constraint
+    // first. The name-uniqueness index stays (Postgres treats NULLs as distinct,
+    // so multiple NULL-name forks coexist) and still validates 0067's survivor
+    // naming. Everything else 0068 established is irrelevant to the 0067 body.
+    pool.get()
+        .await
+        .expect("pool.get (relax name)")
+        .batch_execute("ALTER TABLE recording_policies ALTER COLUMN name DROP NOT NULL")
+        .await
+        .expect("relax recording_policies.name for pre-0067 simulation");
 
     // Default carries a small live cap so a large fork can't merge into it.
     let cap: i64 = 1000;
@@ -854,4 +870,305 @@ async fn migration_collapse_pool_and_drain_guards_and_invariant() {
         !policy_exists(pool, f5).await,
         "ownerless fork must be deleted"
     );
+}
+
+// ── Phase 2 (migration 0068 — explicit membership) ────────────────────────────
+
+/// Group write-through (Phase 2): adding a camera to a group PINS the member's
+/// `policy_id` to the group's policy; changing the group's policy re-pins the
+/// members. Inheritance is gone, so the group assigns the pointer directly.
+#[tokio::test]
+async fn group_assignment_writes_through_to_members() {
+    let app = TestApp::new().await;
+    let admin = seed_admin(app.pool()).await;
+    let token = login(&app, &admin.username, &admin.password).await;
+    let pool = app.pool();
+
+    let base = db::get_default_policy(pool).await.expect("default");
+    let mode = base.mode.as_str().to_owned();
+    let sens = base.motion_sensitivity.as_str().to_owned();
+    let stream = base.record_stream.as_str().to_owned();
+
+    // Two operator templates to move the group between.
+    let name_a = unique("GrpA");
+    let name_b = unique("GrpB");
+    let pa = db::create_policy(
+        pool,
+        &mk_fields(&name_a, uniq_hours(), &mode, &sens, &stream),
+        "operator",
+    )
+    .await
+    .expect("create pa");
+    let pb = db::create_policy(
+        pool,
+        &mk_fields(&name_b, uniq_hours(), &mode, &sens, &stream),
+        "operator",
+    )
+    .await
+    .expect("create pb");
+
+    let (cam_id, _n) = create_camera_on_default(&app, &token).await;
+
+    // Create a group on policy A and add the camera → the member is pinned to A.
+    let grp = db::create_group(pool, &unique("grp"), Some(pa.id))
+        .await
+        .expect("create_group");
+    db::set_group_members(pool, grp.id, &[cam_id])
+        .await
+        .expect("set_group_members");
+    assert_eq!(
+        camera_policy_id(pool, cam_id).await,
+        Some(pa.id),
+        "adding a camera to a group pins its policy_id to the group's policy"
+    );
+
+    // Move the group to policy B → the member is re-pinned to B.
+    db::update_group(pool, grp.id, &unique("grp"), Some(pb.id))
+        .await
+        .expect("update_group");
+    assert_eq!(
+        camera_policy_id(pool, cam_id).await,
+        Some(pb.id),
+        "changing the group's policy re-pins its members"
+    );
+}
+
+/// The migration-0068 body pins every inheriting camera to the SAME policy the
+/// effective-policy view resolves today (a grouped camera to its group's policy,
+/// an ungrouped inheritor to Default), enforces `cameras.policy_id NOT NULL`,
+/// names + de-nulls every policy uniquely, and holds the sacred invariant that no
+/// camera's effective policy VALUES change.
+#[tokio::test]
+async fn migration_0068_pins_and_enforces_membership() {
+    let Some(iso) = make_isolated_db().await else {
+        eprintln!("skipping: no reachable test Postgres / cannot CREATE DATABASE");
+        return;
+    };
+    let pool = &iso.pool;
+
+    // The isolated DB is migrated through 0068 (policy_id + name are NOT NULL and
+    // the triggers are gone). Reconstruct the PRE-0068 world — inheriting cameras
+    // (NULL policy_id) and an anonymous NULL-name fork — by relaxing exactly those
+    // two constraints, then re-run the migration body over the reconstructed state.
+    pool.get()
+        .await
+        .expect("pool.get (relax)")
+        .batch_execute(
+            "ALTER TABLE cameras ALTER COLUMN policy_id DROP NOT NULL; \
+             ALTER TABLE recording_policies ALTER COLUMN name DROP NOT NULL;",
+        )
+        .await
+        .expect("relax constraints for pre-0068 simulation");
+
+    let default_id = insert_default_policy_with_cap(pool, 1_000_000_000).await;
+
+    // Named operator templates used as group policies / a direct pin.
+    let p2_name = unique("P2");
+    let p3_name = unique("P3");
+    let p2 = db::create_policy(
+        pool,
+        &mk_fields(&p2_name, uniq_hours(), "continuous", "dynamic", "main"),
+        "operator",
+    )
+    .await
+    .expect("create p2")
+    .id;
+    let p3 = db::create_policy(
+        pool,
+        &mk_fields(&p3_name, uniq_hours(), "continuous", "dynamic", "main"),
+        "operator",
+    )
+    .await
+    .expect("create p3")
+    .id;
+
+    // Helper: a camera whose direct policy_id is then NULLed (an inheritor).
+    async fn null_policy_cam(pool: &deadpool_postgres::Pool, seed_policy: Uuid) -> Uuid {
+        let (id, _n) = seed_cam(pool, seed_policy).await;
+        pool.get()
+            .await
+            .unwrap()
+            .execute("UPDATE cameras SET policy_id = NULL WHERE id = $1", &[&id])
+            .await
+            .unwrap();
+        id
+    }
+    async fn add_member(pool: &deadpool_postgres::Pool, group_id: Uuid, cam_id: Uuid) {
+        pool.get()
+            .await
+            .unwrap()
+            .execute(
+                "INSERT INTO camera_group_members (group_id, camera_id) VALUES ($1, $2)",
+                &[&group_id, &cam_id],
+            )
+            .await
+            .unwrap();
+    }
+
+    // Group G on policy P2, group G2 with no policy (→ resolves to Default).
+    let g = db::create_group(pool, &unique("G"), Some(p2))
+        .await
+        .expect("create G");
+    let g2 = db::create_group(pool, &unique("G2"), None)
+        .await
+        .expect("create G2");
+
+    // cam_grouped: inheriting + member of G(P2) ⇒ effective = P2 today.
+    let cam_grouped = null_policy_cam(pool, default_id).await;
+    add_member(pool, g.id, cam_grouped).await;
+    // cam_group_nopol: inheriting + member of G2(no policy) ⇒ effective = Default.
+    let cam_group_nopol = null_policy_cam(pool, default_id).await;
+    add_member(pool, g2.id, cam_group_nopol).await;
+    // cam_inherit: inheriting + ungrouped ⇒ effective = Default.
+    let cam_inherit = null_policy_cam(pool, default_id).await;
+    // cam_pinned: already pinned to P3 ⇒ unchanged.
+    let (cam_pinned, _pn) = seed_cam(pool, p3).await;
+
+    // fork_pol: an anonymous NULL-name deviation fork with one owner (exercises
+    // step 5a naming). Distinct retention so it is a genuine survivor.
+    let fork_pol: Uuid = pool
+        .get()
+        .await
+        .unwrap()
+        .query_one(
+            r"
+            INSERT INTO recording_policies
+                (is_default, name, origin, mode, live_retention_hours, archive_enabled,
+                 motion_pre_seconds, motion_post_seconds, motion_sensitivity,
+                 motion_keyframes_only, record_stream)
+            VALUES (false, NULL, 'deviation', 'continuous', $1, false, 5, 10, 'dynamic', false, 'main')
+            RETURNING id
+            ",
+            &[&uniq_hours()],
+        )
+        .await
+        .expect("insert fork_pol")
+        .get(0);
+    let (cam_fork, cam_fork_name) = seed_cam(pool, fork_pol).await;
+
+    // ── invariant: snapshot effective values BEFORE, run the migration on the
+    //    SAME connection (so the TEMP TABLE is visible), assert row-for-row equal.
+    let client = pool.get().await.expect("pool.get (invariant)");
+    client
+        .batch_execute(
+            r"
+            CREATE TEMP TABLE inv_before AS
+            SELECT c_id, p_mode, p_live_retention_hours, p_archive_enabled,
+                   p_archive_retention_hours, p_live_max_bytes, p_archive_max_bytes,
+                   p_motion_sensitivity, p_motion_threshold, p_record_stream,
+                   p_record_audio, p_live_storage_id, p_archive_storage_id,
+                   p_motion_pre_seconds, p_motion_post_seconds
+            FROM v_camera_effective_policy;
+            ",
+        )
+        .await
+        .expect("snapshot effective policy");
+
+    client
+        .batch_execute(MIGRATION_0068_SQL)
+        .await
+        .expect("run migration 0068 body");
+
+    let violations: i64 = client
+        .query_one(
+            r"
+            SELECT COUNT(*)::bigint
+            FROM v_camera_effective_policy v
+            JOIN inv_before b ON b.c_id = v.c_id
+            WHERE NOT (
+                    v.p_mode                    IS NOT DISTINCT FROM b.p_mode
+                AND v.p_live_retention_hours    IS NOT DISTINCT FROM b.p_live_retention_hours
+                AND v.p_archive_enabled         IS NOT DISTINCT FROM b.p_archive_enabled
+                AND v.p_archive_retention_hours IS NOT DISTINCT FROM b.p_archive_retention_hours
+                AND v.p_live_max_bytes          IS NOT DISTINCT FROM b.p_live_max_bytes
+                AND v.p_archive_max_bytes       IS NOT DISTINCT FROM b.p_archive_max_bytes
+                AND v.p_motion_sensitivity      IS NOT DISTINCT FROM b.p_motion_sensitivity
+                AND v.p_motion_threshold        IS NOT DISTINCT FROM b.p_motion_threshold
+                AND v.p_record_stream           IS NOT DISTINCT FROM b.p_record_stream
+                AND v.p_record_audio            IS NOT DISTINCT FROM b.p_record_audio
+                AND v.p_live_storage_id         IS NOT DISTINCT FROM b.p_live_storage_id
+                AND v.p_archive_storage_id      IS NOT DISTINCT FROM b.p_archive_storage_id
+                AND v.p_motion_pre_seconds      IS NOT DISTINCT FROM b.p_motion_pre_seconds
+                AND v.p_motion_post_seconds     IS NOT DISTINCT FROM b.p_motion_post_seconds
+            )
+            ",
+            &[],
+        )
+        .await
+        .expect("invariant compare")
+        .get(0);
+    assert_eq!(
+        violations, 0,
+        "MIGRATION 0068 INVARIANT VIOLATED: a camera's effective policy values changed"
+    );
+    drop(client);
+
+    // Every camera is now pinned (NOT NULL) to the value the view resolved before.
+    assert_eq!(
+        camera_policy_id(pool, cam_grouped).await,
+        Some(p2),
+        "a formerly-grouped camera resolves to its group's policy"
+    );
+    assert_eq!(
+        camera_policy_id(pool, cam_group_nopol).await,
+        Some(default_id),
+        "a grouped camera whose group had no policy resolves to Default"
+    );
+    assert_eq!(
+        camera_policy_id(pool, cam_inherit).await,
+        Some(default_id),
+        "an ungrouped inheritor resolves to Default"
+    );
+    assert_eq!(
+        camera_policy_id(pool, cam_pinned).await,
+        Some(p3),
+        "an already-pinned camera is unchanged"
+    );
+
+    // The NULL-name fork is named after its owning camera (step 5a).
+    assert_eq!(
+        camera_policy_id(pool, cam_fork).await,
+        Some(fork_pol),
+        "the fork's owner is unchanged"
+    );
+    assert_eq!(
+        policy_name(pool, fork_pol).await.as_deref(),
+        Some(cam_fork_name.as_str()),
+        "an anonymous fork is named after its owning camera"
+    );
+
+    // Structural guarantees: no NULL policy_id, no NULL name, names unique.
+    let client = pool.get().await.expect("pool.get (structural)");
+    let null_pids: i64 = client
+        .query_one(
+            "SELECT COUNT(*)::bigint FROM cameras WHERE policy_id IS NULL",
+            &[],
+        )
+        .await
+        .expect("count null policy_id")
+        .get(0);
+    assert_eq!(
+        null_pids, 0,
+        "no camera may have a NULL policy_id after 0068"
+    );
+    let null_names: i64 = client
+        .query_one(
+            "SELECT COUNT(*)::bigint FROM recording_policies WHERE name IS NULL",
+            &[],
+        )
+        .await
+        .expect("count null names")
+        .get(0);
+    assert_eq!(null_names, 0, "no policy may have a NULL name after 0068");
+    let dup_names: i64 = client
+        .query_one(
+            "SELECT COUNT(*)::bigint FROM ( \
+               SELECT name FROM recording_policies GROUP BY name HAVING COUNT(*) > 1 \
+             ) d",
+            &[],
+        )
+        .await
+        .expect("count duplicate names")
+        .get(0);
+    assert_eq!(dup_names, 0, "policy names must be unique after 0068");
 }

--- a/services/api/tests/recording_policy_model.rs
+++ b/services/api/tests/recording_policy_model.rs
@@ -1172,3 +1172,50 @@ async fn migration_0068_pins_and_enforces_membership() {
         .get(0);
     assert_eq!(dup_names, 0, "policy names must be unique after 0068");
 }
+
+/// Whether `cameras.policy_id` currently carries a NOT NULL constraint.
+async fn cameras_policy_id_is_not_null(pool: &deadpool_postgres::Pool) -> bool {
+    let client = pool.get().await.expect("pool.get (is_nullable)");
+    let is_nullable: String = client
+        .query_one(
+            "SELECT is_nullable FROM information_schema.columns \
+             WHERE table_schema = current_schema() \
+               AND table_name = 'cameras' AND column_name = 'policy_id'",
+            &[],
+        )
+        .await
+        .expect("read is_nullable")
+        .get(0);
+    is_nullable == "NO"
+}
+
+/// Landmine L4 regression: the boot shim (`ensure_named_policies_and_groups`)
+/// must NEVER drop `cameras.policy_id`'s NOT NULL constraint that migration 0068
+/// established — it historically ran `ALTER COLUMN policy_id DROP NOT NULL` on
+/// every boot, which would silently undo the migration on the next restart.
+/// `TestApp::new()` has already run the full migration chain AND the boot shim
+/// once; run the shim twice more and assert the column stays NOT NULL.
+#[tokio::test]
+async fn boot_shim_keeps_policy_id_not_null_idempotently() {
+    let app = TestApp::new().await;
+    assert!(
+        cameras_policy_id_is_not_null(app.pool()).await,
+        "migration 0068 must leave cameras.policy_id NOT NULL"
+    );
+
+    db::ensure_named_policies_and_groups(app.pool())
+        .await
+        .expect("boot shim (run 2)");
+    assert!(
+        cameras_policy_id_is_not_null(app.pool()).await,
+        "boot shim run 2 must keep cameras.policy_id NOT NULL"
+    );
+
+    db::ensure_named_policies_and_groups(app.pool())
+        .await
+        .expect("boot shim (run 3)");
+    assert!(
+        cameras_policy_id_is_not_null(app.pool()).await,
+        "boot shim run 3 must keep cameras.policy_id NOT NULL (idempotent)"
+    );
+}

--- a/services/api/tests/support/mod.rs
+++ b/services/api/tests/support/mod.rs
@@ -301,13 +301,13 @@ async fn seed_default_policy_if_absent(pool: &Pool) {
         .execute(
             r"
             INSERT INTO recording_policies (
-                is_default, mode, live_storage_id, live_retention_hours,
+                name, is_default, mode, live_storage_id, live_retention_hours,
                 archive_enabled, archive_storage_id, archive_schedule, archive_retention_hours,
                 motion_pre_seconds, motion_post_seconds, motion_sensitivity,
                 motion_keyframes_only, record_stream
             )
             VALUES (
-                true, 'continuous', NULL, 48,
+                'Default', true, 'continuous', NULL, 48,
                 false, NULL, NULL, NULL,
                 5, 10, 'dynamic',
                 false, 'main'

--- a/services/api/tests/support/mod.rs
+++ b/services/api/tests/support/mod.rs
@@ -547,14 +547,16 @@ pub async fn seed_storage(pool: &Pool, path: &str) -> Uuid {
     storage.id
 }
 
-/// Seed a minimal camera (own policy cloned from the global default) and
-/// return its id.
+/// Seed a minimal camera JOINED to the global Default policy row and return its
+/// id. (Phase 2: cameras belong to a named policy; `recording_policies.name` is
+/// `NOT NULL`, so the old `clone_default_policy` NULL-name fork is gone.)
 pub async fn seed_camera(pool: &Pool) -> Uuid {
     let name = unique("cam");
     let go2rtc_name = unique("go2rtc");
-    let policy_id = db::clone_default_policy(pool)
+    let policy_id = db::get_default_policy(pool)
         .await
-        .expect("clone_default_policy");
+        .expect("get_default_policy")
+        .id;
     let params = db::CreateCameraParams {
         name: &name,
         go2rtc_name: &go2rtc_name,

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -12175,69 +12175,6 @@ mod tests {
         );
     }
 
-    /// Whether `cameras.policy_id` currently carries a NOT NULL constraint, read
-    /// from the catalog in the fixture's search-path schema.
-    async fn cameras_policy_id_is_not_null(pool: &Pool) -> bool {
-        let client = get_conn(pool).await.expect("get_conn (is_nullable)");
-        let is_nullable: String = client
-            .query_one(
-                "SELECT is_nullable FROM information_schema.columns \
-                 WHERE table_schema = current_schema() \
-                   AND table_name = 'cameras' AND column_name = 'policy_id'",
-                &[],
-            )
-            .await
-            .expect("read is_nullable")
-            .get(0);
-        is_nullable == "NO"
-    }
-
-    /// Landmine L4 regression: the boot shim ([`ensure_named_policies_and_groups`])
-    /// must NEVER drop `cameras.policy_id`'s NOT NULL constraint that migration
-    /// 0068 established — it historically ran `ALTER COLUMN policy_id DROP NOT
-    /// NULL` on every boot, which would silently undo the migration on the next
-    /// restart. Run the shim twice and assert the column stays NOT NULL.
-    #[tokio::test]
-    async fn boot_shim_keeps_policy_id_not_null_idempotently() {
-        // Accept either the db-tests convention (TEST_DATABASE_URL) or the plain
-        // DATABASE_URL the workspace gate uses, so this runs under both.
-        let Some(url) = std::env::var("TEST_DATABASE_URL")
-            .ok()
-            .filter(|s| !s.trim().is_empty())
-            .or_else(|| {
-                std::env::var("DATABASE_URL")
-                    .ok()
-                    .filter(|s| !s.trim().is_empty())
-            })
-        else {
-            eprintln!("skipping: neither TEST_DATABASE_URL nor DATABASE_URL set");
-            return;
-        };
-
-        let fx = setup_schema(&url).await;
-        run_migrations(&fx.pool).await.expect("run_migrations");
-        assert!(
-            cameras_policy_id_is_not_null(&fx.pool).await,
-            "migration 0068 must leave cameras.policy_id NOT NULL"
-        );
-
-        // The boot shim must NOT drop the constraint (L4) — run it twice.
-        ensure_named_policies_and_groups(&fx.pool)
-            .await
-            .expect("boot shim (run 1)");
-        assert!(
-            cameras_policy_id_is_not_null(&fx.pool).await,
-            "boot shim run 1 must keep cameras.policy_id NOT NULL"
-        );
-        ensure_named_policies_and_groups(&fx.pool)
-            .await
-            .expect("boot shim (run 2)");
-        assert!(
-            cameras_policy_id_is_not_null(&fx.pool).await,
-            "boot shim run 2 must keep cameras.policy_id NOT NULL (idempotent)"
-        );
-    }
-
     /// An INVALID index whose locks are HELD by another session must be
     /// skipped (with a WARN), not dropped and not turned into a boot-failing
     /// error — this is the "operator's manual CREATE INDEX CONCURRENTLY is

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -12420,13 +12420,13 @@ mod tests {
             .query_one(
                 r"
                 INSERT INTO recording_policies (
-                    is_default, mode, live_storage_id, live_retention_hours,
+                    name, is_default, mode, live_storage_id, live_retention_hours,
                     archive_enabled, archive_storage_id, archive_schedule, archive_retention_hours,
                     motion_pre_seconds, motion_post_seconds, motion_sensitivity,
                     motion_keyframes_only, record_stream
                 )
                 VALUES (
-                    false, 'continuous', NULL, 48,
+                    'Test Non-Default Policy', false, 'continuous', NULL, 48,
                     false, NULL, NULL, NULL,
                     5, 10, 'dynamic',
                     false, 'main'

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -4286,17 +4286,23 @@ pub async fn create_group(pool: &Pool, name: &str, policy_id: Option<Uuid>) -> R
     Ok(camera_group_from_row(&row))
 }
 
-/// Update a camera group's name and/or policy. `policy_id = None` clears the
-/// group's policy (members then inherit the global default). Returns the updated
-/// group, or `None` if no such group.
+/// Update a camera group's name and/or policy, then WRITE THROUGH the (new)
+/// policy onto every current member's `policy_id`. `policy_id = None` pins the
+/// members to the global Default row. Returns the updated group, or `None` if no
+/// such group.
+///
+/// Phase 2: a group PINS its members (no inheritance), so changing the group's
+/// policy must re-pin the members in the same transaction — otherwise the group
+/// row and the cameras it names would disagree.
 pub async fn update_group(
     pool: &Pool,
     id: Uuid,
     name: &str,
     policy_id: Option<Uuid>,
 ) -> Result<Option<CameraGroup>> {
-    let client = get_conn(pool).await?;
-    let opt = client
+    let mut client = get_conn(pool).await?;
+    let tx = client.transaction().await.context("update_group: begin")?;
+    let opt = tx
         .query_opt(
             r"
             UPDATE camera_groups SET name = $2, policy_id = $3 WHERE id = $1
@@ -4306,6 +4312,23 @@ pub async fn update_group(
         )
         .await
         .context("update_group")?;
+    if opt.is_some() {
+        // Write-through: re-pin every current member to the group's effective
+        // policy (its policy_id, else the Default row).
+        tx.execute(
+            r"
+            UPDATE cameras SET policy_id = COALESCE(
+                $2,
+                (SELECT id FROM recording_policies WHERE is_default LIMIT 1)
+            )
+            WHERE id IN (SELECT camera_id FROM camera_group_members WHERE group_id = $1)
+            ",
+            &[&id, &policy_id],
+        )
+        .await
+        .context("update_group: re-pin members to the group policy")?;
+    }
+    tx.commit().await.context("update_group: commit")?;
     Ok(opt.as_ref().map(camera_group_from_row))
 }
 
@@ -4328,17 +4351,17 @@ pub async fn delete_group(pool: &Pool, id: Uuid) -> Result<u64> {
 /// 1. delete all current members of THIS group,
 /// 2. delete any membership of the incoming cameras in OTHER groups (the move),
 /// 3. insert the new memberships,
-/// 4. clear the DIRECT per-camera `policy_id` on every added camera.
+/// 4. PIN each added camera's `policy_id` to the group's effective policy
+///    (write-through).
 ///
-/// Step 4 enforces the Phase-3 authoritative-grouping invariant: a grouped
-/// camera is governed by its GROUP's recording profile, so it may not also hold
-/// a direct per-camera policy/fork. The effective-policy COALESCE puts
-/// `cameras.policy_id` FIRST (it would shadow the group), so leaving it set
-/// would silently ignore the group profile. Clearing it makes the group win.
-/// Only the cameras being ADDED here are touched; a camera DROPPED from this
-/// group (a former member not in `camera_ids`) becomes ungrouped and keeps its
-/// `policy_id` — an ungrouped camera is allowed a direct override. A cleared
-/// camera's now-unreferenced anonymous fork (if any) is left for the periodic
+/// Step 4 is the Phase-2 write-through: inheritance is gone (`cameras.policy_id`
+/// is `NOT NULL`), so a group no longer resolves a member's policy through the
+/// effective-policy view — it assigns the pointer directly. Each ADDED camera is
+/// pinned to the group's own `policy_id`, or the Default row when the group has
+/// none. Only the cameras being ADDED here are touched; a camera DROPPED from
+/// this group (a former member not in `camera_ids`) keeps whatever policy it
+/// holds — an ungrouped camera may deviate freely. A camera repointed away from
+/// a now-memberless deviation policy leaves it for the periodic
 /// [`reap_orphan_policy_forks`] reaper.
 pub async fn set_group_members(pool: &Pool, group_id: Uuid, camera_ids: &[Uuid]) -> Result<()> {
     let mut client = get_conn(pool).await?;
@@ -4376,17 +4399,25 @@ pub async fn set_group_members(pool: &Pool, group_id: Uuid, camera_ids: &[Uuid])
         .await
         .context("set_group_members: insert")?;
 
-        // 4. Phase 3: a grouped camera is AUTHORITATIVELY governed by its
-        //    group's profile and may not also hold a direct per-camera
-        //    override. Clear the direct policy_id on exactly the cameras being
-        //    added so the group wins (the effective-policy COALESCE puts
-        //    camera.policy_id first). Same transaction as the membership change.
+        // 4. Phase 2 (write-through): inheritance is gone (cameras.policy_id is
+        //    NOT NULL), so a group no longer RESOLVES a member's policy — it PINS
+        //    it. Set each ADDED camera's policy_id directly to the group's
+        //    effective policy (its own policy_id, else the Default row), in the
+        //    same transaction as the membership change. Only the cameras being
+        //    added are touched; a camera DROPPED from this group keeps whatever
+        //    policy it holds (an ungrouped camera may deviate freely).
         tx.execute(
-            "UPDATE cameras SET policy_id = NULL WHERE id = ANY($1)",
-            &[&camera_ids],
+            r"
+            UPDATE cameras SET policy_id = COALESCE(
+                (SELECT g.policy_id FROM camera_groups g WHERE g.id = $2),
+                (SELECT id FROM recording_policies WHERE is_default LIMIT 1)
+            )
+            WHERE id = ANY($1)
+            ",
+            &[&camera_ids, &group_id],
         )
         .await
-        .context("set_group_members: clear direct policy on added members")?;
+        .context("set_group_members: pin added members to the group policy")?;
     }
 
     tx.commit().await.context("set_group_members: commit")?;
@@ -6362,12 +6393,14 @@ pub async fn ensure_policy_advanced_storage_columns(pool: &Pool) -> Result<()> {
 /// * `recording_policies.name` — adds a nullable label; backfills only the
 ///   single default row to `"Default"`. Every other (cloned per-camera) policy
 ///   keeps `name = NULL` ("custom").
-/// * `cameras.policy_id` becomes nullable so a camera can INHERIT (NULL ⇒ its
-///   group's policy, else the global default). Every existing camera already has
-///   a non-NULL `policy_id`, so the `COALESCE` join keeps its exact current
-///   policy — zero behaviour change.
-/// * `camera_groups` / `camera_group_members` are created empty; with no groups,
-///   inheritance is inert until an operator creates one.
+/// * `cameras.policy_id` is kept `NOT NULL` (Phase 2, migration 0068): every
+///   camera belongs to a named policy. The shim re-adds the constraint, guarded
+///   on "no NULL rows exist" so a mixed-version boot that left an inheriting
+///   camera won't crash it. (It historically DROPped NOT NULL here — landmine
+///   L4; that is the line this phase inverts.)
+/// * `camera_groups` / `camera_group_members` are retained (dormant) for
+///   rollback comfort; groups no longer resolve a camera's policy (write-through
+///   pins members directly). A later cleanup migration drops the tables.
 /// * `one_group_per_camera` enforces a camera belongs to AT MOST ONE group.
 ///
 /// Safe to re-run on every startup (`IF NOT EXISTS` / `IF EXISTS` / idempotent
@@ -6401,11 +6434,25 @@ pub async fn ensure_named_policies_and_groups(pool: &Pool) -> Result<()> {
                 ALTER TABLE recording_policies ADD COLUMN IF NOT EXISTS name text;
                 UPDATE recording_policies SET name = 'Default' WHERE is_default AND name IS NULL;
 
-                -- 2. Allow a camera to inherit (NULL policy_id). Idempotent: DROP NOT
-                --    NULL is a no-op if already nullable.
-                ALTER TABLE cameras ALTER COLUMN policy_id DROP NOT NULL;
+                -- 2. Every camera belongs to a policy (Phase 2, migration 0068).
+                --    RE-ADD the NOT NULL constraint that migration established, so
+                --    this per-boot shim can never silently undo it (landmine L4:
+                --    it previously DROPed NOT NULL on every boot). GUARDED on the
+                --    absence of NULL policy_id rows so a mixed-version boot that
+                --    left an inheriting camera (only an OLD binary can still write
+                --    NULL) will not crash the shim -- the new code never writes
+                --    NULL, and the next clean boot re-adds it. No-op once already SET.
+                DO $ensure_policy_not_null$
+                BEGIN
+                    IF NOT EXISTS (SELECT 1 FROM cameras WHERE policy_id IS NULL) THEN
+                        ALTER TABLE cameras ALTER COLUMN policy_id SET NOT NULL;
+                    END IF;
+                END
+                $ensure_policy_not_null$;
 
-                -- 3. Camera groups + their (optional) shared policy.
+                -- 3. Camera groups + their (optional) shared policy. Retained
+                --    (dormant) post-Phase-2 for rollback comfort; a later cleanup
+                --    migration drops them.
                 CREATE TABLE IF NOT EXISTS camera_groups (
                     id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
                     name       text NOT NULL,
@@ -9887,6 +9934,10 @@ static MIGRATIONS: &[(&str, &str)] = &[
         "0067_recording_policy_origin_collapse.sql",
         include_str!("../../../db/migrations/0067_recording_policy_origin_collapse.sql"),
     ),
+    (
+        "0068_recording_policy_explicit_membership.sql",
+        include_str!("../../../db/migrations/0068_recording_policy_explicit_membership.sql"),
+    ),
 ];
 
 /// The actual migration-application body, run while [`run_migrations`] holds
@@ -12121,6 +12172,69 @@ mod tests {
         assert!(
             valid_index_survives,
             "reap_invalid_indexes must never touch a VALID index"
+        );
+    }
+
+    /// Whether `cameras.policy_id` currently carries a NOT NULL constraint, read
+    /// from the catalog in the fixture's search-path schema.
+    async fn cameras_policy_id_is_not_null(pool: &Pool) -> bool {
+        let client = get_conn(pool).await.expect("get_conn (is_nullable)");
+        let is_nullable: String = client
+            .query_one(
+                "SELECT is_nullable FROM information_schema.columns \
+                 WHERE table_schema = current_schema() \
+                   AND table_name = 'cameras' AND column_name = 'policy_id'",
+                &[],
+            )
+            .await
+            .expect("read is_nullable")
+            .get(0);
+        is_nullable == "NO"
+    }
+
+    /// Landmine L4 regression: the boot shim ([`ensure_named_policies_and_groups`])
+    /// must NEVER drop `cameras.policy_id`'s NOT NULL constraint that migration
+    /// 0068 established — it historically ran `ALTER COLUMN policy_id DROP NOT
+    /// NULL` on every boot, which would silently undo the migration on the next
+    /// restart. Run the shim twice and assert the column stays NOT NULL.
+    #[tokio::test]
+    async fn boot_shim_keeps_policy_id_not_null_idempotently() {
+        // Accept either the db-tests convention (TEST_DATABASE_URL) or the plain
+        // DATABASE_URL the workspace gate uses, so this runs under both.
+        let Some(url) = std::env::var("TEST_DATABASE_URL")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| {
+                std::env::var("DATABASE_URL")
+                    .ok()
+                    .filter(|s| !s.trim().is_empty())
+            })
+        else {
+            eprintln!("skipping: neither TEST_DATABASE_URL nor DATABASE_URL set");
+            return;
+        };
+
+        let fx = setup_schema(&url).await;
+        run_migrations(&fx.pool).await.expect("run_migrations");
+        assert!(
+            cameras_policy_id_is_not_null(&fx.pool).await,
+            "migration 0068 must leave cameras.policy_id NOT NULL"
+        );
+
+        // The boot shim must NOT drop the constraint (L4) — run it twice.
+        ensure_named_policies_and_groups(&fx.pool)
+            .await
+            .expect("boot shim (run 1)");
+        assert!(
+            cameras_policy_id_is_not_null(&fx.pool).await,
+            "boot shim run 1 must keep cameras.policy_id NOT NULL"
+        );
+        ensure_named_policies_and_groups(&fx.pool)
+            .await
+            .expect("boot shim (run 2)");
+        assert!(
+            cameras_policy_id_is_not_null(&fx.pool).await,
+            "boot shim run 2 must keep cameras.policy_id NOT NULL (idempotent)"
         );
     }
 

--- a/services/recorder/src/archive.rs
+++ b/services/recorder/src/archive.rs
@@ -3555,9 +3555,9 @@ mod tests {
                 let policy_row = client
                     .query_one(
                         "INSERT INTO recording_policies
-                            (is_default, live_storage_id, archive_storage_id,
+                            (name, is_default, live_storage_id, archive_storage_id,
                              live_max_bytes, archive_max_bytes, archive_enabled)
-                         VALUES (true, $1, $2, $3, $4, $5)
+                         VALUES ('Default', true, $1, $2, $3, $4, $5)
                          RETURNING id",
                         &[
                             &live_storage.id,

--- a/services/recorder/src/archive.rs
+++ b/services/recorder/src/archive.rs
@@ -5997,10 +5997,11 @@ mod tests {
             (p, g)
         }
 
-        /// Phase 3 (a): set_group_members ADDING a camera that had a direct policy
-        /// clears its policy_id (NULL) and the view resolves it to the GROUP profile.
+        /// Phase 2 (write-through): set_group_members ADDING a camera PINS its
+        /// policy_id directly to the group's policy (no inheritance), and the view
+        /// resolves it to that same policy.
         #[tokio::test]
-        async fn set_group_members_clears_added_camera_override() {
+        async fn set_group_members_pins_added_camera_to_group_policy() {
             let Some(url) = test_db_url() else {
                 eprintln!("skipping: CRUMB_TEST_DATABASE_URL not set");
                 return;
@@ -6008,12 +6009,12 @@ mod tests {
             let fx = setup_policy(&url, None, None, false).await;
             let (p2, grp) = named_policy_and_group(&fx.pool, "P2", "G").await;
 
-            // A camera that initially holds a DIRECT override distinct from the group's.
+            // A camera that initially holds a DIRECT policy distinct from the group's.
             let cam = insert_cam(&fx.pool, Some(fx.policy_id)).await;
             assert_eq!(
                 cam_policy_id(&fx.pool, cam).await,
                 Some(fx.policy_id),
-                "precondition: camera has a direct override"
+                "precondition: camera has its own direct policy"
             );
 
             // Add it to the group (the wire path the admin UI / config-routes use).
@@ -6021,8 +6022,8 @@ mod tests {
 
             assert_eq!(
                 cam_policy_id(&fx.pool, cam).await,
-                None,
-                "joining a group must clear the direct policy_id"
+                Some(p2),
+                "joining a group PINS the member's policy_id to the group's policy"
             );
             assert_eq!(
                 effective_pid(&fx.pool, cam).await,
@@ -6031,10 +6032,9 @@ mod tests {
             );
         }
 
-        /// Phase 3 (b): a camera NOT added to any group keeps its direct policy.
-        /// set_group_members must only clear the cameras it ADDS — a pre-existing
-        /// member dropped from the new set, and an unrelated ungrouped camera, are
-        /// untouched.
+        /// Phase 2 (write-through): set_group_members must only re-pin the cameras
+        /// it ADDS — a pre-existing member dropped from the new set, and an
+        /// unrelated ungrouped camera, keep whatever policy they hold.
         #[tokio::test]
         async fn set_group_members_leaves_nonmembers_override_intact() {
             let Some(url) = test_db_url() else {
@@ -6065,17 +6065,17 @@ mod tests {
                 fx.policy_id,
                 "ungrouped camera still resolves to its own direct policy"
             );
-            // The joiner was cleared.
+            // The joiner was re-pinned to the group's policy.
             assert_eq!(
                 cam_policy_id(&fx.pool, joiner).await,
-                None,
-                "the added camera's override is cleared"
+                Some(p2),
+                "the added camera is pinned to the group's policy"
             );
 
             // Now DROP the joiner from the group (members = []) — it becomes ungrouped
-            // and is NOT re-cleared (it was already NULL; the point is the UPDATE only
-            // touches camera_ids, never a removed member). Give it a direct policy back
-            // first to prove dropped members are left alone by the clear.
+            // and is NOT re-pinned (the UPDATE only touches camera_ids, never a removed
+            // member). Give it a different direct policy first to prove dropped members
+            // are left alone by the write-through.
             db::set_camera_policy_id(&fx.pool, joiner, fx.policy_id)
                 .await
                 .unwrap();

--- a/services/recorder/src/bin/seed.rs
+++ b/services/recorder/src/bin/seed.rs
@@ -271,6 +271,7 @@ async fn seed_default_policy(
         .query_one(
             r"
             INSERT INTO recording_policies (
+                name,
                 is_default,
                 mode,
                 live_storage_id,
@@ -286,6 +287,7 @@ async fn seed_default_policy(
                 record_stream
             )
             VALUES (
+                'Default',  -- name
                 true,       -- is_default
                 'continuous',
                 $1,         -- live_storage_id

--- a/services/recorder/src/reconcile.rs
+++ b/services/recorder/src/reconcile.rs
@@ -1919,8 +1919,8 @@ mod tests {
             let client = pool.get().await.expect("conn");
             let policy = client
                 .query_one(
-                    "INSERT INTO recording_policies (is_default, live_storage_id)
-                     VALUES (true, $1) RETURNING id",
+                    "INSERT INTO recording_policies (name, is_default, live_storage_id)
+                     VALUES ('Default', true, $1) RETURNING id",
                     &[&live_storage.id],
                 )
                 .await


### PR DESCRIPTION
## Summary

Phase 2 of the recording-policy model redesign (`docs/design/POLICY-MODEL.md` §5 "Migration B"). Builds on Phase 1 (#204). **Every camera now belongs to exactly one named policy — no more inheritance, no more anonymous ghost forks.**

- **Migration 0068**: pins every inheriting camera to the *exact* policy the effective-policy view resolves today (grouped → its group's policy, else Default; ungrouped → Default), then makes `cameras.policy_id` **NOT NULL** and `recording_policies.name` **NOT NULL + unique**. Drops the 0021 grouped-camera triggers. Idempotent, single-transaction, footage-safe (no segment row touched; every policy DELETE targets an unreferenced row).
- **Boot-shim footgun fixed**: `ensure_named_policies_and_groups` historically ran `ALTER COLUMN policy_id DROP NOT NULL` on *every boot* — which would silently undo the migration on the next restart (landmine L4). Now a guarded `SET NOT NULL`.
- **Groups go write-through**: with inheritance gone, `set_group_members` / `update_group` pin members directly to the group's policy (`COALESCE(group.policy_id, Default)`) in the same transaction, instead of clearing `policy_id` to NULL (which would now violate the constraint).
- **config_routes**: legacy `Some(None)` "clear to inherit" now joins Default; the grouped-camera assignment rejection is removed; `require_assignable_policy` collapses to an existence check (no anonymous forks remain).
- `camera_groups` / `camera_group_members` kept dormant for one release (rollback comfort); a later cleanup migration drops them (Phase 3).

## Footage-correctness invariant

For every camera, the values resolved by `v_camera_effective_policy` are **unchanged** — only the id it resolves *through* changes. Verified against the view's `COALESCE(c.policy_id, g.policy_id, default)` and the `one_group_per_camera` unique index (rules out multi-group ambiguity). Migration test asserts a before/after `IS NOT DISTINCT FROM` snapshot of every effective field.

## Review fixes on top of the implementation commit

The maintainer review + full workspace gate caught three issues, fixed here:
1. **`0068` NOT NULL vs. test seeders** — five raw `INSERT INTO recording_policies` helpers omitted `name` and broke under the new constraint; named them all. (`clone_default_policy`/`clone_policy` deliberately kept NULL-name — test-only, used solely by the 0067 collapse test with the constraint relaxed.)
2. **Boot-shim regression test relocated** — it ran full `run_migrations` inside the crumb-common schema-isolation harness, which isn't built for the whole chain (0018 `information_schema` cross-schema ambiguity + 0051 `pg_trgm` not on the narrow search_path). Moved to the api integration suite (`recording_policy_model.rs`) whose `TestApp::new()` already runs full migrations against a single-schema DB. No shipped migration touched.

## Tests
- `migration_0068_pins_and_enforces_membership`, `group_assignment_writes_through_to_members`, `boot_shim_keeps_policy_id_not_null_idempotently`, updated write-through group tests.
- Gate green: `cargo fmt --all --check` ✓, `cargo clippy --all-targets -D warnings` ✓, `cargo test --workspace` ✓ (real Postgres).

## Deploy note
API-only; migration 0068 does DDL (`SET NOT NULL`, unique index) + repoints `policy_id`. Take a DB backup before deploy. Recorder unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)