### PR TITLE
fix(android): resilient Live initial load on weak connectivity (#176)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveScreen.kt
@@ -59,7 +59,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -127,6 +129,17 @@ fun LiveScreen(
         },
     )
     val state by vm.uiState.collectAsStateWithLifecycle()
+
+    // Auto-recover (issue #176): when validated connectivity RETURNS after the
+    // initial load gave up with a "can't reach the server" error, kick a fresh
+    // Retry so the wall recovers on its own — no user tap needed. `retry()` drops
+    // any wedged pooled socket first. Fires only on the offline→online transition
+    // (LaunchedEffect keyed on the online flag), so a persistent server-unreachable
+    // error while already online doesn't hammer — that path keeps the manual Retry.
+    val isOnline = rememberIsOnline()
+    LaunchedEffect(isOnline) {
+        if (isOnline && state.error != null) vm.retry()
+    }
 
     // Update-available check (issue #7) — lives here because Live is the root
     // destination (always on the back stack, see MainActivity's popUpTo(LIVE)),
@@ -504,11 +517,25 @@ fun LiveScreen(
                 Box(modifier = Modifier.fillMaxSize()) {
                     when {
                         // ── Loading ─────────────────────────────────────────────────
+                        // Under a weak/flaky link the initial load retries (issue
+                        // #176); once it runs long, a "still trying…" hint appears
+                        // under the spinner so the wall is never a silent spinner.
                         state.loading -> {
-                            CircularProgressIndicator(
-                                modifier = Modifier.align(Alignment.Center),
-                                color = TealAccent,
-                            )
+                            Column(
+                                modifier = Modifier.align(Alignment.Center).padding(24.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.spacedBy(14.dp),
+                            ) {
+                                CircularProgressIndicator(color = TealAccent)
+                                state.connecting?.let { msg ->
+                                    Text(
+                                        text = msg,
+                                        color = Color.White.copy(alpha = 0.72f),
+                                        fontSize = 13.sp,
+                                        textAlign = TextAlign.Center,
+                                    )
+                                }
+                            }
                         }
 
                         // ── Viewer restricted (403) ──────────────────────────────────

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveScreen.kt
@@ -136,7 +136,7 @@ fun LiveScreen(
     // any wedged pooled socket first. Fires only on the offline→online transition
     // (LaunchedEffect keyed on the online flag), so a persistent server-unreachable
     // error while already online doesn't hammer — that path keeps the manual Retry.
-    val isOnline = rememberIsOnline()
+    val isOnline by rememberIsOnline()
     LaunchedEffect(isOnline) {
         if (isOnline && state.error != null) vm.retry()
     }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveViewModel.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveViewModel.kt
@@ -12,11 +12,15 @@ import video.crumb.app.data.toUserMessage
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import java.io.IOException
+import java.net.SocketTimeoutException
 import retrofit2.HttpException
 
 /**
@@ -37,6 +41,13 @@ import retrofit2.HttpException
  */
 data class LiveUiState(
     val loading: Boolean = true,
+    /**
+     * Non-null while an initial load is retrying under a weak/flaky link, e.g.
+     * "Weak connection, still trying…". Shown under the loading spinner so the
+     * wall is never a silent multi-second spinner (issue #176). Cleared once the
+     * load resolves to success or a hard error.
+     */
+    val connecting: String? = null,
     val error: String? = null,
     val cameras: List<CameraDto> = emptyList(),
     val streams: Map<String, LiveStreamsResponse> = emptyMap(),
@@ -121,9 +132,11 @@ class LiveViewModel(
     /** Reload cameras and re-resolve all RTSP URLs. Safe to call from the UI. */
     fun refresh() {
         viewModelScope.launch {
-            _uiState.update { it.copy(loading = true, error = null, isViewerRestricted = false) }
+            _uiState.update {
+                it.copy(loading = true, connecting = null, error = null, isViewerRestricted = false)
+            }
 
-            val camerasResult = repo.visibleCameras()
+            val camerasResult = loadCamerasWithRetry()
 
             camerasResult.fold(
                 onSuccess = { cameras ->
@@ -141,6 +154,7 @@ class LiveViewModel(
                     _uiState.update {
                         it.copy(
                             loading = false,
+                            connecting = null,
                             cameras = enabledCameras,
                             streams = streams,
                             error = null,
@@ -153,6 +167,7 @@ class LiveViewModel(
                     _uiState.update {
                         it.copy(
                             loading = false,
+                            connecting = null,
                             cameras = emptyList(),
                             streams = emptyMap(),
                             isViewerRestricted = is403,
@@ -162,6 +177,42 @@ class LiveViewModel(
                 },
             )
         }
+    }
+
+    /**
+     * Load the camera list tolerant of a weak/flaky link (issue #176): a few
+     * bounded attempts, each capped well under the client's 60 s call timeout so
+     * the wall never sits on a silent minute-long spinner. Between tries it drops
+     * pooled connections (a bad link often leaves a half-open socket that would
+     * wedge the retry too) and shows a "still trying…" hint. Returns the first
+     * success, or the last failure after all attempts — which the caller surfaces
+     * as the ErrorState + Retry. A 403 (viewer-restricted) is returned
+     * immediately; it is a permission answer, not a transient failure to retry.
+     */
+    private suspend fun loadCamerasWithRetry(): Result<List<CameraDto>> {
+        var last: Throwable? = null
+        for (attempt in 1..LOAD_MAX_ATTEMPTS) {
+            // Surface "still trying…" once the first attempt runs long, or right
+            // away on any re-attempt, so the spinner is never silent for long.
+            val hintJob = viewModelScope.launch {
+                delay(if (attempt == 1) LOAD_SLOW_HINT_MS else 0L)
+                _uiState.update { if (it.loading) it.copy(connecting = "Weak connection, still trying…") else it }
+            }
+            val result = withTimeoutOrNull(LOAD_ATTEMPT_TIMEOUT_MS) { repo.visibleCameras() }
+            hintJob.cancel()
+
+            when {
+                result == null -> last = SocketTimeoutException("live load attempt $attempt timed out")
+                result.isSuccess -> return result
+                (result.exceptionOrNull() as? HttpException)?.code() == 403 -> return result
+                else -> last = result.exceptionOrNull()
+            }
+            // Drop wedged/half-open pooled sockets before the next try (mirrors the
+            // manual Retry path); then back off briefly.
+            repo.recoverConnections()
+            if (attempt < LOAD_MAX_ATTEMPTS) delay(LOAD_BACKOFF_MS * attempt)
+        }
+        return Result.failure(last ?: IOException("Can't reach the server."))
     }
 
     // ── low-bandwidth mode ────────────────────────────────────────────────────
@@ -250,6 +301,15 @@ class LiveViewModel(
     }
 
     companion object {
+        /** Initial-load resilience (issue #176): how many bounded attempts, the
+         *  per-attempt ceiling (well under the client's 60 s call timeout so the
+         *  wall never sits on one silent minute), the delay before the first
+         *  "still trying…" hint, and the base inter-attempt backoff (×attempt). */
+        private const val LOAD_MAX_ATTEMPTS = 3
+        private const val LOAD_ATTEMPT_TIMEOUT_MS = 15_000L
+        private const val LOAD_SLOW_HINT_MS = 5_000L
+        private const val LOAD_BACKOFF_MS = 1_500L
+
         /**
          * Number of distinct cameras that must each stall at least
          * [STALLS_PER_CAMERA_THRESHOLD] times within [AUTO_FALLBACK_WINDOW_MS]


### PR DESCRIPTION
Fixes #176.

## Problem
On very poor WiFi the Live wall could sit on a **silent centered spinner** with no feedback, no incremental retry, and no self-recovery.

**Diagnosis note:** the load was *not* truly infinite — the JSON API client already sets `callTimeout = 60s` (AppContainer) and exports use a separate client, so it was bounded at 60s. But a silent 60-second spinner that then hard-errors is exactly the "no timeout, feedback, or retry" UX failure the issue describes. This targets the **cold-launch initial-load** path — confirmed from the code as the hang point (the `LiveViewModel` is retained across backgrounding with no `onResume` re-fetch; a process kill while backgrounded resurfaces as a fresh cold launch, which reconciles with the "I think it was backgrounded" hunch).

## Fix (all in `feature/live`, no API change)
`LiveViewModel.refresh()` now loads via `loadCamerasWithRetry()`:
- up to **3 bounded attempts, 15s each** (well under the 60s call ceiling) — the wall never sits on one silent minute;
- a **"Weak connection, still trying…"** hint (new `LiveUiState.connecting`) appears under the spinner once an attempt runs long / on any re-attempt;
- **drops pooled connections between attempts** (`recoverConnections`) — a bad link often leaves a half-open socket that would wedge the retry too;
- brief ×attempt backoff; a **403** (viewer-restricted) returns immediately (a permission answer, not a transient failure to retry).

`LiveScreen`:
- the loading branch shows the spinner **+ the "still trying…" hint**;
- **auto-recover**: a `LaunchedEffect` keyed on `rememberIsOnline()` kicks `retry()` when validated connectivity **returns** while the "can't reach server" error is showing — the wall recovers on its own, no tap needed (the manual **Retry** button is still there).

## Verification
- `:app:compileDebugKotlin` and `:app:assembleDebug` pass clean.
- **On-device dead-zone verification pending** (the reporter has a reliable poor-WiFi spot) — a debug APK is built and ready to sideload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)