### PR TITLE
feat(desktop): collapse duplicate plate reads into one row per car

### DIFF
--- a/apps/desktop-flutter/lib/ui/plates/plate_collapse.dart
+++ b/apps/desktop-flutter/lib/ui/plates/plate_collapse.dart
@@ -1,0 +1,175 @@
+// Client-side collapse of duplicate plate reads into one row per physical car.
+//
+// Two independent things create duplicate rows in the Plates list:
+//   1. "both"-mode cameras: Frigate AND the crumb-alpr worker each read every
+//      car, so one pass yields one row per engine (often a character apart).
+//   2. Frigate on its own emits several reads for a single pass as its OCR
+//      refines (e.g. 9GXVL98 then 9GXV498 a few seconds later).
+//
+// Both are the SAME underlying event — one car going by — so the list should
+// show one representative row, annotated with which engine(s) saw it and (when
+// they disagree) the alternate reading. The raw reads are untouched server-side;
+// this is purely how the client presents them, and the operator can switch it
+// off to see every raw read (e.g. to eyeball the A/B disagreement directly).
+//
+// Grouping key: same camera + fuzzy-equal plate + within a short time window.
+// The time+camera gate makes the fuzzy plate threshold safe — two genuinely
+// different cars with near-identical plates on the same camera seconds apart
+// essentially never happens, whereas one car misread twice is common.
+
+import 'dart:math' as math;
+
+import '../../api/plates_api.dart';
+
+/// How far apart (in time) two reads on the same camera can be and still be
+/// treated as the same pass. Comfortably covers Frigate's multi-second OCR
+/// refinements and the ~2s offset between the two engines, while staying well
+/// under the worker's 45s parked-car re-appear gap (a genuine re-appearance is
+/// a new row, as it should be).
+const Duration kPlateCollapseWindow = Duration(seconds: 15);
+
+/// One physical vehicle pass: the best read plus every raw read that collapsed
+/// into it. [members] and the group list stay newest-first.
+class PlateGroup {
+  PlateGroup(this.representative, this.members);
+
+  /// Highest-confidence read in the group — its plate/image/confidence are what
+  /// the collapsed row shows.
+  final PlateRead representative;
+
+  /// Every raw read that collapsed here, newest-first (includes [representative]).
+  final List<PlateRead> members;
+
+  int get count => members.length;
+  DateTime get ts => representative.ts;
+
+  /// Distinct engines that saw this car, in first-seen order (stable for UI).
+  List<String> get sources {
+    final out = <String>[];
+    for (final m in members) {
+      final s = m.sourceId;
+      if (s != null && s.isNotEmpty && !out.contains(s)) out.add(s);
+    }
+    return out;
+  }
+
+  /// The best (highest-confidence) read from a given engine, or null.
+  PlateRead? bestFrom(String source) {
+    PlateRead? best;
+    for (final m in members) {
+      if (m.sourceId != source) continue;
+      if (best == null ||
+          (m.confidence ?? 0) > (best.confidence ?? 0)) {
+        best = m;
+      }
+    }
+    return best;
+  }
+
+  /// Alternate readings that differ from the representative's plate, keyed by
+  /// engine — i.e. the engines that disagreed. Empty when everyone agreed.
+  Map<String, String> get disagreements {
+    final out = <String, String>{};
+    for (final s in sources) {
+      final r = bestFrom(s);
+      if (r != null && r.plate.isNotEmpty && r.plate != representative.plate) {
+        out[s] = r.plate;
+      }
+    }
+    return out;
+  }
+}
+
+/// Collapse [readsNewestFirst] into one [PlateGroup] per physical car. The input
+/// must be sorted newest-first (the Plates screen already guarantees this); the
+/// output preserves that order by representative timestamp.
+List<PlateGroup> collapsePlateReads(
+  List<PlateRead> readsNewestFirst, {
+  Duration window = kPlateCollapseWindow,
+}) {
+  final groups = <_MutableGroup>[];
+  for (final r in readsNewestFirst) {
+    _MutableGroup? target;
+    for (final g in groups) {
+      if (g.cameraId != r.cameraId) continue;
+      // Reads arrive newest→oldest, so `r` is at or before the group's oldest
+      // member; the closest boundary is that oldest ts.
+      if (g.oldestTs.difference(r.ts).abs() > window) continue;
+      if (_platesSimilar(g.keyPlate, r.plate)) {
+        target = g;
+        break;
+      }
+    }
+    if (target != null) {
+      target.add(r);
+    } else {
+      groups.add(_MutableGroup(r));
+    }
+  }
+  return groups.map((g) => g.freeze()).toList(growable: false);
+}
+
+class _MutableGroup {
+  _MutableGroup(PlateRead first)
+      : cameraId = first.cameraId,
+        _best = first,
+        oldestTs = first.ts,
+        _members = [first];
+
+  final String cameraId;
+  PlateRead _best;
+  DateTime oldestTs;
+  final List<PlateRead> _members;
+
+  /// Match new reads against the current best plate (updated as the best read
+  /// changes) so a low-confidence garbage first read doesn't anchor the group.
+  String get keyPlate => _best.plate;
+
+  void add(PlateRead r) {
+    _members.add(r);
+    if (r.ts.isBefore(oldestTs)) oldestTs = r.ts;
+    if ((r.confidence ?? 0) > (_best.confidence ?? 0)) _best = r;
+  }
+
+  PlateGroup freeze() {
+    // Keep members newest-first for display.
+    _members.sort((a, b) => b.ts.compareTo(a.ts));
+    return PlateGroup(_best, List.unmodifiable(_members));
+  }
+}
+
+/// Two normalized plates are "the same car" when they're within a small,
+/// length-scaled edit distance (~a third of the characters). Plates arrive
+/// already normalized (uppercase alphanumeric) from the server.
+bool _platesSimilar(String a, String b) {
+  if (a == b) return true;
+  if (a.isEmpty || b.isEmpty) return false;
+  final maxLen = math.max(a.length, b.length);
+  final maxEdits = math.max(1, (maxLen * 0.34).round());
+  return _boundedLevenshtein(a, b, maxEdits) <= maxEdits;
+}
+
+/// Levenshtein distance, short-circuiting once it provably exceeds [maxEdits]
+/// (returns maxEdits + 1). Two-row DP — fine for the short strings here.
+int _boundedLevenshtein(String a, String b, int maxEdits) {
+  if ((a.length - b.length).abs() > maxEdits) return maxEdits + 1;
+  var prev = List<int>.generate(b.length + 1, (i) => i);
+  var curr = List<int>.filled(b.length + 1, 0);
+  for (var i = 1; i <= a.length; i++) {
+    curr[0] = i;
+    var rowMin = curr[0];
+    for (var j = 1; j <= b.length; j++) {
+      final cost = a.codeUnitAt(i - 1) == b.codeUnitAt(j - 1) ? 0 : 1;
+      curr[j] = math.min(
+        math.min(curr[j - 1] + 1, prev[j] + 1),
+        prev[j - 1] + cost,
+      );
+      if (curr[j] < rowMin) rowMin = curr[j];
+    }
+    if (rowMin > maxEdits) return maxEdits + 1;
+    final tmp = prev;
+    prev = curr;
+    curr = tmp;
+  }
+  return prev[b.length];
+}

--- a/apps/desktop-flutter/lib/ui/plates/plates_prefs.dart
+++ b/apps/desktop-flutter/lib/ui/plates/plates_prefs.dart
@@ -42,6 +42,7 @@ class PlatesPrefs {
   static const String _kImageDisplay = 'crumb_plates_image_display';
   static const String _kCropCorner = 'crumb_plates_crop_corner';
   static const String _kCropSize = 'crumb_plates_crop_size';
+  static const String _kCollapse = 'crumb_plates_collapse_dupes';
 
   /// The last-used view mode, or [PlatesViewMode.list] when the operator has
   /// never changed it (or persistence is unavailable).
@@ -132,6 +133,28 @@ class PlatesPrefs {
     try {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(_kCropSize, size.name);
+    } catch (_) {
+      /* best-effort persistence */
+    }
+  }
+
+  /// Whether the list collapses duplicate reads of one car (both engines +
+  /// Frigate's own OCR refinements) into a single row. Defaults to true — the
+  /// clutter it removes is almost never wanted raw; operators comparing the two
+  /// engines can turn it off to see every read.
+  static Future<bool> getCollapseDuplicates() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      return prefs.getBool(_kCollapse) ?? true;
+    } catch (_) {
+      return true;
+    }
+  }
+
+  static Future<void> setCollapseDuplicates(bool on) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_kCollapse, on);
     } catch (_) {
       /* best-effort persistence */
     }

--- a/apps/desktop-flutter/lib/ui/plates/plates_screen.dart
+++ b/apps/desktop-flutter/lib/ui/plates/plates_screen.dart
@@ -31,6 +31,7 @@ import 'package:crumb_desktop/api/crumb_api.dart';
 import 'package:crumb_desktop/api/http_client.dart';
 import 'package:crumb_desktop/api/models.dart';
 import 'package:crumb_desktop/api/plates_api.dart';
+import 'package:crumb_desktop/ui/plates/plate_collapse.dart';
 import 'package:crumb_desktop/ui/plates/plate_crop.dart';
 import 'package:crumb_desktop/ui/plates/plate_report_dialog.dart';
 import 'package:crumb_desktop/ui/plates/plates_prefs.dart';
@@ -123,6 +124,9 @@ class _PlatesScreenState extends State<PlatesScreen> {
   PlateImageDisplay _imageDisplay = PlateImageDisplay.both;
   PlateCropCorner _cropCorner = PlateCropCorner.bottomRight;
   PlateCropSize _cropSize = PlateCropSize.medium;
+  // Collapse duplicate reads of one car (both engines + Frigate OCR refinements)
+  // into a single row (persisted via [PlatesPrefs]).
+  bool _collapse = true;
 
   Timer? _searchDebounce;
   final _thumbGate = _ConcurrencyGate(_thumbConcurrency);
@@ -144,13 +148,21 @@ class _PlatesScreenState extends State<PlatesScreen> {
     final display = await PlatesPrefs.getImageDisplay();
     final corner = await PlatesPrefs.getCropCorner();
     final size = await PlatesPrefs.getCropSize();
+    final collapse = await PlatesPrefs.getCollapseDuplicates();
     if (!mounted) return;
     setState(() {
       _viewMode = mode;
       _imageDisplay = display;
       _cropCorner = corner;
       _cropSize = size;
+      _collapse = collapse;
     });
+  }
+
+  void _setCollapse(bool on) {
+    if (on == _collapse) return;
+    setState(() => _collapse = on);
+    PlatesPrefs.setCollapseDuplicates(on);
   }
 
   void _setViewMode(PlatesViewMode mode) {
@@ -607,6 +619,22 @@ class _PlatesScreenState extends State<PlatesScreen> {
               child: const Text('Now', style: TextStyle(fontSize: 12)),
             ),
           _ViewModeToggle(value: _viewMode, onChanged: _setViewMode),
+          if (_viewMode == PlatesViewMode.list)
+            Tooltip(
+              message: _collapse
+                  ? 'Collapsing duplicate reads of the same car (both engines +\nrepeat reads) into one row. Click to show every raw read.'
+                  : 'Showing every raw read. Click to collapse duplicates of the\nsame car into one row.',
+              child: IconButton(
+                onPressed: () => _setCollapse(!_collapse),
+                icon: Icon(
+                  _collapse ? Icons.layers : Icons.layers_clear,
+                  size: 18,
+                  color: _collapse
+                      ? Theme.of(context).colorScheme.primary
+                      : Colors.white54,
+                ),
+              ),
+            ),
           _DisplayOptionsButton(
             imageMode: _imageDisplay,
             cropCorner: _cropCorner,
@@ -672,16 +700,23 @@ class _PlatesScreenState extends State<PlatesScreen> {
     String camName(String id) => byId[id]?.name ?? '(unknown camera)';
     switch (_viewMode) {
       case PlatesViewMode.list:
+        // Collapse duplicate reads of one car (both engines + Frigate's own OCR
+        // refinements) into a single representative row; off = every raw read.
+        final groups = _collapse
+            ? collapsePlateReads(_plates)
+            : [for (final p in _plates) PlateGroup(p, [p])];
         return ListView.separated(
           padding: const EdgeInsets.symmetric(vertical: 6),
-          itemCount: _plates.length,
+          itemCount: groups.length,
           separatorBuilder: (_, _) =>
               const Divider(height: 1, color: Colors.white10),
           itemBuilder: (context, i) {
-            final p = _plates[i];
+            final g = groups[i];
+            final p = g.representative;
             return _PlateRow(
               key: ValueKey(p.id),
               read: p,
+              group: g,
               cameraName: camName(p.cameraId),
               api: widget.api,
               session: widget.session,
@@ -1008,9 +1043,15 @@ class _PlateRow extends StatelessWidget {
     required this.watched,
     required this.onAddToWatchlist,
     required this.onReport,
+    this.group,
   });
 
   final PlateRead read;
+
+  /// The collapsed group this row represents — which engine(s) saw the car, how
+  /// many raw reads merged, and any disagreeing readings. Null renders a plain
+  /// row (no engine chips). A single-read group shows just its source chip.
+  final PlateGroup? group;
   final String cameraName;
   final CrumbApi api;
   final Session session;
@@ -1031,6 +1072,59 @@ class _PlateRow extends StatelessWidget {
 
   /// Open the single-plate report builder for this read.
   final VoidCallback onReport;
+
+  /// A small engine chip per source that saw this car (Frigate / Crumb), plus a
+  /// "×N" badge when more than one raw read collapsed here. Empty when there's
+  /// no group or no known source.
+  List<Widget> _engineChips() {
+    final g = group;
+    if (g == null) return const [];
+    final chips = <Widget>[];
+    for (final s in g.sources) {
+      chips
+        ..add(const SizedBox(width: 6))
+        ..add(_engineChip(s));
+    }
+    if (g.count > 1) {
+      chips
+        ..add(const SizedBox(width: 6))
+        ..add(Text(
+          '×${g.count}',
+          style: const TextStyle(
+            color: Colors.white38,
+            fontSize: 11,
+            fontWeight: FontWeight.w600,
+          ),
+        ));
+    }
+    return chips;
+  }
+
+  /// When the engines disagreed on the plate, a subtle line naming each engine's
+  /// alternate reading — the at-a-glance A/B signal in the collapsed list.
+  List<Widget> _disagreementLine() {
+    final d = group?.disagreements;
+    if (d == null || d.isEmpty) return const [];
+    final parts =
+        d.entries.map((e) => '${_engineLabel(e.key)} read ${e.value}').join('  •  ');
+    return [
+      const SizedBox(height: 2),
+      Row(
+        children: [
+          const Icon(Icons.compare_arrows, size: 12, color: Color(0xFFE8A33D)),
+          const SizedBox(width: 4),
+          Flexible(
+            child: Text(
+              parts,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(color: Color(0xFFE8A33D), fontSize: 11),
+            ),
+          ),
+        ],
+      ),
+    ];
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -1097,6 +1191,7 @@ class _PlateRow extends StatelessWidget {
                           ),
                         ),
                       ],
+                      ..._engineChips(),
                     ],
                   ),
                   const SizedBox(height: 2),
@@ -1104,6 +1199,7 @@ class _PlateRow extends StatelessWidget {
                     _fmtDateTime(read.ts),
                     style: const TextStyle(color: Colors.white54, fontSize: 11),
                   ),
+                  ..._disagreementLine(),
                 ],
               ),
             ),
@@ -3653,4 +3749,51 @@ String _fmtDateTime(DateTime t) {
   final mm = local.minute.toString().padLeft(2, '0');
   final ss = local.second.toString().padLeft(2, '0');
   return '${_months[local.month - 1]} ${local.day}, $h12:$mm:$ss $ampm';
+}
+
+/// Short, human label for a plate read's `source_id` engine tag.
+String _engineLabel(String source) {
+  switch (source) {
+    case 'crumb-alpr':
+      return 'Crumb';
+    case 'frigate':
+      return 'Frigate';
+    default:
+      return source;
+  }
+}
+
+/// The accent color for an engine's chip — Crumb green vs Frigate blue, distinct
+/// from the amber disagreement marker.
+Color _engineColor(String source) {
+  switch (source) {
+    case 'crumb-alpr':
+      return const Color(0xFF3DA35D);
+    case 'frigate':
+      return const Color(0xFF4C82C3);
+    default:
+      return const Color(0xFF6B7280);
+  }
+}
+
+/// A compact, color-coded chip naming the engine that produced a read.
+Widget _engineChip(String source) {
+  final c = _engineColor(source);
+  return Container(
+    padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+    decoration: BoxDecoration(
+      color: c.withValues(alpha: 0.18),
+      borderRadius: BorderRadius.circular(4),
+      border: Border.all(color: c.withValues(alpha: 0.55)),
+    ),
+    child: Text(
+      _engineLabel(source),
+      style: TextStyle(
+        color: c,
+        fontSize: 10,
+        fontWeight: FontWeight.w700,
+        letterSpacing: 0.3,
+      ),
+    ),
+  );
 }

--- a/apps/desktop-flutter/test/plate_collapse_test.dart
+++ b/apps/desktop-flutter/test/plate_collapse_test.dart
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Unit tests for the Plates list duplicate-collapse (plate_collapse.dart).
+//
+// The list must show one row per physical car even though a single pass can
+// produce several reads: both engines read a "both"-mode camera, and Frigate
+// on its own re-emits a pass as its OCR refines. These are pure, deterministic
+// assertions on the grouping — same camera + fuzzy plate + short time window.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:crumb_desktop/api/plates_api.dart';
+import 'package:crumb_desktop/ui/plates/plate_collapse.dart';
+
+// A fixed anchor so tests are deterministic (no wall-clock).
+final _t0 = DateTime.utc(2026, 7, 17, 20, 30, 0);
+
+PlateRead _read(
+  String plate, {
+  required int secAgo,
+  String source = 'frigate',
+  double conf = 0.9,
+  String camera = 'cam-A',
+  String? id,
+}) {
+  return PlateRead(
+    id: id ?? '$plate-$source-$secAgo',
+    cameraId: camera,
+    ts: _t0.subtract(Duration(seconds: secAgo)),
+    plate: plate,
+    plateRaw: plate,
+    confidence: conf,
+    region: null,
+    sourceId: source,
+    eventId: null,
+    snapshotUrl: null,
+    bbox: null,
+  );
+}
+
+void main() {
+  group('collapsePlateReads', () {
+    test('cross-engine reads of the same car collapse to one group', () {
+      final groups = collapsePlateReads([
+        _read('8EWS547', secAgo: 0, source: 'crumb-alpr', conf: 1.0),
+        _read('8EWS547', secAgo: 2, source: 'frigate', conf: 0.99),
+      ]);
+      expect(groups, hasLength(1));
+      expect(groups.single.count, 2);
+      expect(groups.single.sources.toSet(), {'crumb-alpr', 'frigate'});
+      // Highest confidence wins the representative.
+      expect(groups.single.representative.sourceId, 'crumb-alpr');
+      expect(groups.single.disagreements, isEmpty);
+    });
+
+    test("Frigate's own OCR refinement (1-char drift) collapses to the best", () {
+      // 9GXV498 <-> 9GXVL98 is edit distance 1: same pass, same engine. We keep
+      // the higher-confidence read and DON'T flag it as a disagreement — an
+      // engine wobbling on its own is noise, not an A/B signal.
+      final groups = collapsePlateReads([
+        _read('9GXVL98', secAgo: 0, conf: 0.94),
+        _read('9GXV498', secAgo: 5, conf: 0.98),
+      ]);
+      expect(groups, hasLength(1));
+      expect(groups.single.count, 2);
+      expect(groups.single.representative.plate, '9GXV498');
+      expect(groups.single.disagreements, isEmpty);
+    });
+
+    test('cross-engine disagreement is surfaced (Frigate vs Crumb)', () {
+      // The two engines read the same pass one character apart — the A/B signal
+      // the disagreement line exists to show.
+      final groups = collapsePlateReads([
+        _read('9GXV498', secAgo: 0, source: 'crumb-alpr', conf: 0.98),
+        _read('9GXVL98', secAgo: 2, source: 'frigate', conf: 0.94),
+      ]);
+      expect(groups, hasLength(1));
+      expect(groups.single.representative.plate, '9GXV498'); // higher conf
+      expect(groups.single.disagreements['frigate'], '9GXVL98');
+      expect(groups.single.disagreements.containsKey('crumb-alpr'), isFalse);
+    });
+
+    test('distinct plates on the same camera stay separate', () {
+      final groups = collapsePlateReads([
+        _read('8EWS547', secAgo: 0),
+        _read('7BWP213', secAgo: 3),
+      ]);
+      expect(groups, hasLength(2));
+    });
+
+    test('the same plate outside the time window is a new pass', () {
+      final groups = collapsePlateReads([
+        _read('8EWS547', secAgo: 0),
+        _read('8EWS547', secAgo: 60), // > 15s window => re-appearance
+      ]);
+      expect(groups, hasLength(2));
+    });
+
+    test('same plate, same instant, different cameras do not merge', () {
+      final groups = collapsePlateReads([
+        _read('8EWS547', secAgo: 0, camera: 'cam-A'),
+        _read('8EWS547', secAgo: 0, camera: 'cam-B'),
+      ]);
+      expect(groups, hasLength(2));
+    });
+
+    test('a slow pass chains beyond the window via consecutive reads', () {
+      // 0,8,16,24s apart — each hop <= 15s — is one car passing slowly.
+      final groups = collapsePlateReads([
+        _read('8EWS547', secAgo: 0),
+        _read('8EWS547', secAgo: 8),
+        _read('8EWS547', secAgo: 16),
+        _read('8EWS547', secAgo: 24),
+      ]);
+      expect(groups, hasLength(1));
+      expect(groups.single.count, 4);
+    });
+
+    test('only one engine saw the pass => single-source group', () {
+      final groups = collapsePlateReads([
+        _read('LDRG248', secAgo: 0, source: 'crumb-alpr'),
+      ]);
+      expect(groups, hasLength(1));
+      expect(groups.single.sources, ['crumb-alpr']);
+      expect(groups.single.count, 1);
+    });
+
+    test('members are newest-first regardless of input order within a group',
+        () {
+      final groups = collapsePlateReads([
+        _read('8EWS547', secAgo: 0, conf: 0.8),
+        _read('8EWS547', secAgo: 4, conf: 0.95),
+      ]);
+      final m = groups.single.members;
+      expect(m.first.ts.isAfter(m.last.ts), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Collapse duplicate plate reads into one row per car (desktop LPR list)

### Problem
Two things create duplicate rows in the LPR list: a camera running `lpr_engine = both` gets a read from *each* engine per car, and Frigate on its own re-emits a pass several times as its OCR refines (e.g. `9GXVL98` then `9GXV498`). Both are the same car going by, so the list should show one row.

### Change (client-only)
`collapsePlateReads` groups reads by **same camera + fuzzy-equal plate + within a 15 s window** (the time+camera gate makes the fuzzy plate threshold safe). Each group renders one representative row (highest confidence) annotated with:
- a small **engine chip** per source that saw the car (Frigate / Crumb),
- a **×N** badge when multiple raw reads merged,
- a subtle **disagreement line** when the engines read the plate differently (the at-a-glance A/B signal).

A toolbar toggle (default on, persisted) switches back to every raw read. Raw reads are untouched server-side — this is purely presentation. A genuinely re-appearing car (after the worker's re-appear gap) is still its own row.

### Testing
- Pure grouping logic is unit-tested (`plate_collapse_test.dart`): cross-engine collapse, intra-engine OCR-refinement collapse, distinct plates stay separate, window boundary, per-camera separation, a slow pass chaining, and cross-engine disagreement surfacing.
- `flutter analyze` clean.

### Merge order
Both this and `feat/lpr-ab-benchmark` touch the plates screen — suggest merging this first, then rebasing the benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
