### PR TITLE
fix: land the car in the plate clip (server backward-weighted window + worker best-frame ts)

### DIFF
--- a/services/alpr-worker/worker.py
+++ b/services/alpr-worker/worker.py
@@ -74,6 +74,14 @@ CONFIG_POLL_S = float(os.environ.get("LPR_CONFIG_POLL_SECONDS", "30"))
 # once per pass. Lower = quicker to treat a brief disappearance as a new arrival;
 # higher = stricter about re-reads.
 REAPPEAR_GAP_S = float(os.environ.get("LPR_REAPPEAR_GAP_SECONDS", "45"))
+# The frame the worker timestamps was captured EARLIER in the real world than
+# when we process it: the go2rtc restream + network buffer the stream, so
+# `time.time()` at the best frame overshoots the real capture moment by ~1-2s.
+# The recorder's segments are closer to real-time, so a clip centred on our
+# raw timestamp lands a second or two AFTER the car. Subtract this offset to
+# pull the read time back onto the car. Biased slightly generous (a hair early
+# shows the approach, which beats cutting the car off). Tune per-deployment.
+TS_OFFSET_S = float(os.environ.get("LPR_TS_OFFSET_SECONDS", "2.0"))
 # The read's stored image is the WHOLE frame (a Frigate-style context snapshot),
 # not a pre-cropped plate: the clients derive the tight plate crop themselves from
 # the normalized bbox, so shipping the full frame lets crumb-alpr reads render the
@@ -300,7 +308,9 @@ def post_read(session: requests.Session, plate: str, conf: float, vote: PassVote
         # in frame), not emit time — so the plate-clip pop-up centres on the car.
         # RFC3339 UTC (chrono parses it). Falls back to server now() if unset.
         "ts": (
-            datetime.fromtimestamp(vote.best_epoch, tz=timezone.utc).isoformat()
+            datetime.fromtimestamp(
+                vote.best_epoch - TS_OFFSET_S, tz=timezone.utc
+            ).isoformat()
             if vote.best_epoch
             else None
         ),

--- a/services/alpr-worker/worker.py
+++ b/services/alpr-worker/worker.py
@@ -14,6 +14,7 @@ constants below and ``services/alpr-worker/README.md``.
 from __future__ import annotations
 
 import base64
+from datetime import datetime, timezone
 import logging
 import os
 import sys
@@ -126,6 +127,11 @@ class PassVote:
     best_crop: bytes | None = None
     best_bbox: list[float] | None = None  # [x, y, w, h] normalized
     best_region: str | None = None
+    # Wall-clock (epoch seconds) of the best frame — sent as the read's `ts` so
+    # the clip player centres on when the plate was actually IN FRAME. Without
+    # it the server stamps now() at INGEST, which is at pass-emit (after voting,
+    # after the car has left), and the plate-clip pop-up lands seconds too late.
+    best_epoch: float = 0.0
     started: float = 0.0
 
     def active(self) -> bool:
@@ -143,6 +149,7 @@ class PassVote:
                 bbox,
                 region,
             )
+            self.best_epoch = time.time()
 
     def winner(self) -> tuple[str, float] | None:
         """Plate with the most summed confidence; its mean confidence."""
@@ -289,7 +296,14 @@ def post_read(session: requests.Session, plate: str, conf: float, vote: PassVote
         "region": vote.best_region,
         "bbox": vote.best_bbox,
         "provider_event_id": uuid.uuid4().hex,
-        "ts": None,  # server stamps now() when omitted
+        # Timestamp of the BEST frame (when the plate was clearest / the car was
+        # in frame), not emit time — so the plate-clip pop-up centres on the car.
+        # RFC3339 UTC (chrono parses it). Falls back to server now() if unset.
+        "ts": (
+            datetime.fromtimestamp(vote.best_epoch, tz=timezone.utc).isoformat()
+            if vote.best_epoch
+            else None
+        ),
     }
     if vote.best_crop:
         body["crop_jpeg_b64"] = base64.standard_b64encode(vote.best_crop).decode()

--- a/services/api/src/clips.rs
+++ b/services/api/src/clips.rs
@@ -424,6 +424,34 @@ fn overview_window(
     (win_start, win_end)
 }
 
+/// A license-plate read is a **point in time**, not a bounded activity: the
+/// detection ingester stamps `start_ts == end_ts` at the moment the plate was
+/// voted (Frigate) or at the worker's best-frame capture (`crumb-alpr`). Running
+/// that zero-length event through [`overview_window`] yields a tight
+/// `[ts − pre, ts + post]` sliver (~10 s, the read barely 2 s in), so even a
+/// couple of seconds of pipeline skew — the OCR engine's decode/restream buffer
+/// runs behind the recorder's own segment clock — pushes the car right out of
+/// the frame the operator opens ("the car's already gone"). Chasing an exact
+/// per-deployment offset is fragile; instead a plate clip gets a generous,
+/// **backward-weighted** window centered on the read. It leans back further than
+/// forward because the read timestamp structurally *lags* the moment the car was
+/// actually in front of the lens (voting/decoding latency only ever accrues
+/// after the plate appears), so looking back reliably brackets the pass. The
+/// window is symmetric-ish around the true pass and comfortably absorbs a lag
+/// difference anywhere in `[−LPR_CLIP_TRAIL, +LPR_CLIP_LEAD]`. Still bounded by
+/// the compiled hard ceiling ([`MAX_CLIP_MEDIA_SECS`]).
+const LPR_CLIP_LEAD_SECS: i64 = 8;
+const LPR_CLIP_TRAIL_SECS: i64 = 4;
+
+fn plate_window(read_ts: DateTime<Utc>) -> (DateTime<Utc>, DateTime<Utc>) {
+    let win_start = read_ts - Duration::seconds(LPR_CLIP_LEAD_SECS);
+    let hard_cap = win_start + Duration::seconds(MAX_CLIP_MEDIA_SECS);
+    let win_end = (read_ts + Duration::seconds(LPR_CLIP_TRAIL_SECS))
+        .min(hard_cap)
+        .max(win_start);
+    (win_start, win_end)
+}
+
 /// A resolved clip window plus the metadata the media handlers need: the tunable
 /// window parameters (part of the cache key/ETag, so a settings change never
 /// serves a stale rendition), whether the underlying event is still open, and the
@@ -470,11 +498,18 @@ async fn resolve_clip(state: &AppState, id: &str) -> Result<ResolvedClip, ApiErr
         let ev = ev
             .parse::<Uuid>()
             .map_err(|_| ApiError::BadRequest("malformed clip id".to_owned()))?;
-        let (cam, ev_start, ev_end) = db::get_clip_event_window(state.pool(), ev)
+        let (cam, ev_start, ev_end, label) = db::get_clip_event_window(state.pool(), ev)
             .await
             .map_err(ApiError::Internal)?
             .ok_or_else(|| ApiError::NotFound(format!("clip {id} not found")))?;
-        let (start, end) = overview_window(ev_start, ev_end, pre_secs, overview_secs);
+        // Plate reads are a point in time — a generous backward-weighted window
+        // (see `plate_window`) brackets the car far more reliably than the tight
+        // overview a zero-length event would otherwise produce.
+        let (start, end) = if label == "license_plate" {
+            plate_window(ev_start)
+        } else {
+            overview_window(ev_start, ev_end, pre_secs, overview_secs)
+        };
         Ok(ResolvedClip {
             camera_id: cam,
             start,
@@ -664,12 +699,21 @@ fn clip_etag(id: &str, kind: &str) -> String {
     format!("\"{}-{}\"", sanitize_id(id), kind)
 }
 
+/// Bumped whenever the clip **windowing scheme** changes in a way the tunable
+/// `(overview, pre)` params alone don't capture — so old cached renditions (and
+/// pinned client `ETag`s) fall out of the keyspace and re-render under the new
+/// logic instead of being served stale. `v2` introduced the dedicated
+/// backward-weighted window for license-plate reads (see [`plate_window`]),
+/// whose bounds no longer derive from `(overview, pre)` at all.
+const CLIP_WINDOW_SCHEME: u32 = 2;
+
 /// The window-parameter suffix that makes a clip rendition's cache identity
-/// depend on the (now tunable) overview length + pre-roll. Without it, a 30-day
-/// immutable `ETag` would pin a stale rendition client-side after a settings
-/// change (§2.5.3). E.g. `30s2s` for a 30 s overview with 2 s pre-roll.
+/// depend on the (now tunable) overview length + pre-roll, plus the windowing
+/// scheme version. Without it, a 30-day immutable `ETag` would pin a stale
+/// rendition client-side after a settings or scheme change (§2.5.3). E.g.
+/// `v2-30s2s` for scheme 2 with a 30 s overview and 2 s pre-roll.
 fn clip_window_tag(overview_secs: i64, pre_secs: i64) -> String {
-    format!("{overview_secs}s{pre_secs}s")
+    format!("v{CLIP_WINDOW_SCHEME}-{overview_secs}s{pre_secs}s")
 }
 
 /// Cache filename for a clip rendition: `{sanitized_id}.{len}s{pre}s.{quality}.mp4`.
@@ -1253,6 +1297,21 @@ mod tests {
         let start = t(50_000);
         let (s, e) = overview_window(start, Some(t(0)), 0, 30);
         assert_eq!(e, s);
+    }
+
+    #[test]
+    fn plate_window_is_backward_weighted_and_brackets_the_read() {
+        // A plate read is a point in time; the window leans back further than
+        // forward so the (structurally lagging) read ts still lands the car.
+        let read = t(60_000);
+        let (s, e) = plate_window(read);
+        assert_eq!(read - s, Duration::seconds(LPR_CLIP_LEAD_SECS));
+        assert_eq!(e - read, Duration::seconds(LPR_CLIP_TRAIL_SECS));
+        // The read sits comfortably inside, with more footage before than after.
+        assert!(s < read && read < e);
+        assert!((read - s) > (e - read));
+        // Total length is well under the compiled ceiling (no truncation).
+        assert!((e - s).num_seconds() <= MAX_CLIP_MEDIA_SECS);
     }
 
     #[test]

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -7828,11 +7828,11 @@ pub async fn frigate_http_base(pool: &Pool) -> Result<Option<String>> {
 pub async fn get_clip_event_window(
     pool: &Pool,
     event_id: Uuid,
-) -> Result<Option<(Uuid, DateTime<Utc>, Option<DateTime<Utc>>)>> {
+) -> Result<Option<(Uuid, DateTime<Utc>, Option<DateTime<Utc>>, String)>> {
     let client = get_conn(pool).await?;
     let row = client
         .query_opt(
-            "SELECT camera_id, ts, end_ts FROM events WHERE id = $1",
+            "SELECT camera_id, ts, end_ts, label FROM events WHERE id = $1",
             &[&event_id],
         )
         .await
@@ -7841,7 +7841,8 @@ pub async fn get_clip_event_window(
         let cam: Uuid = r.get("camera_id");
         let start: DateTime<Utc> = r.get("ts");
         let end: Option<DateTime<Utc>> = r.get("end_ts");
-        (cam, start, end)
+        let label: String = r.get("label");
+        (cam, start, end, label)
     }))
 }
 


### PR DESCRIPTION
Clicking a plate read opened a clip where **the car had already passed**.

## Root cause
A plate read is a *point in time* — the detection ingester stamps `start_ts == end_ts` at the vote/best-frame moment. Run through the normal `overview_window`, a zero-length event yields a tight `[ts − pre, ts + post]` sliver (~9–10s, the read barely 1–2s in). A couple seconds of pipeline skew — the OCR engine's decode/restream buffer runs behind the recorder's own segment clock — then pushes the car right out of that window.

## Fix (two parts)
1. **Server (primary):** `license_plate` clips now get a dedicated **backward-weighted window** centered on the read — lead 8s / trail 4s, hard-capped at 30s (`plate_window`). It leans back further than forward because the read ts structurally *lags* the real pass (voting/decode latency only accrues after the plate appears), so looking back reliably brackets the car. This absorbs a per-deployment lag difference across a wide range instead of chasing a fragile exact offset. Frigate 0.17 car-attribute events keep their real duration via `overview_window` (branch is label-gated). `get_clip_event_window` now also returns the event label. Clip cache tag bumped to `v2` so old tight-window renditions fall out of the keyspace.
2. **Worker:** sends the best-frame capture ts (not `None`, which the server stamped at ingest = after the car left) so the read time in the Plates list is accurate and the window centers correctly. `LPR_TS_OFFSET_SECONDS` (default 2s) trims residual restream lag.

## Tests
`plate_window_is_backward_weighted_and_brackets_the_read` + existing `overview_window` suite. Gate green (fmt/clippy/test).

Deployed to prod for testing via the batch override; cached detection clips cleared so existing plate reads re-render with the new window.

Part of the post-ship LPR work list (item #6).