### PR TITLE
feat(desktop): shared clip-player shell — actions under video, backdrop-close, crop fill

### DIFF
--- a/apps/desktop-flutter/lib/api/admin_console_api.dart
+++ b/apps/desktop-flutter/lib/api/admin_console_api.dart
@@ -15,17 +15,27 @@
 
 import 'models.dart';
 
-/// Builds the `{server}/admin#token=<jwt>&embed=1` URL for [session].
+/// Builds the `{server}/admin?embedded=1#token=<jwt>&embed=1` URL for
+/// [session].
 ///
 /// Deliberately takes the *full* bearer JWT (matching the old client), not a
 /// scoped media token — the admin console needs the operator's real
 /// privileges (it's the same RBAC-gated admin UI, not a media stream) and
 /// admin.html's `bootSSO` expects a bearer-shaped token in the fragment.
-String adminConsoleUrl(Session session) {
+///
+/// `?embedded=1` (default) makes admin.html hide its own top header chrome
+/// (back arrow / title bar) so it doesn't double up with the Flutter shell's
+/// header around the webview; the legacy `&embed=1` fragment flag is kept so
+/// older servers that only understand it still get the old embed behavior.
+/// Pass `embedded: false` when the console will live in a real browser tab
+/// ("Open in browser") — there's no shell header there, so the console keeps
+/// its own.
+String adminConsoleUrl(Session session, {bool embedded = true}) {
   final base = session.base.endsWith('/')
       ? session.base.substring(0, session.base.length - 1)
       : session.base;
-  return '$base/admin#token=${Uri.encodeComponent(session.token)}&embed=1';
+  final q = embedded ? '?embedded=1' : '';
+  return '$base/admin$q#token=${Uri.encodeComponent(session.token)}&embed=1';
 }
 
 /// The console's hostname, for display next to the pane (e.g. in a header

--- a/apps/desktop-flutter/lib/ui/admin_console/admin_console_screen.dart
+++ b/apps/desktop-flutter/lib/ui/admin_console/admin_console_screen.dart
@@ -27,7 +27,9 @@ import 'package:webview_windows/webview_windows.dart';
 import 'package:crumb_desktop/api/admin_console_api.dart';
 import 'package:crumb_desktop/api/models.dart';
 
-/// Embeds `{server}/admin#token=<jwt>&embed=1` in a native WebView2 pane.
+/// Embeds `{server}/admin?embedded=1#token=<jwt>&embed=1` in a native
+/// WebView2 pane (`?embedded=1` hides admin.html's own header chrome so it
+/// doesn't double up with this shell's header).
 ///
 /// Give this widget a STABLE key across rebuilds of the surrounding nav (e.g.
 /// `const ValueKey('admin-console')`) so Flutter doesn't tear down and
@@ -107,7 +109,9 @@ class _AdminConsoleScreenState extends State<AdminConsoleScreen> {
   }
 
   Future<void> _openInBrowser() async {
-    final uri = Uri.parse(adminConsoleUrl(widget.session));
+    // A real browser tab has no Flutter shell header, so let the console keep
+    // its own chrome there.
+    final uri = Uri.parse(adminConsoleUrl(widget.session, embedded: false));
     try {
       final ok = await launchUrl(uri, mode: LaunchMode.externalApplication);
       if (!ok && mounted) _showLaunchFailure();

--- a/apps/desktop-flutter/lib/ui/clips/clip_player_shell.dart
+++ b/apps/desktop-flutter/lib/ui/clips/clip_player_shell.dart
@@ -67,6 +67,7 @@ class ClipPlayerShell extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.primary;
     return Material(
       color: Colors.black.withValues(alpha: 0.92),
       child: GestureDetector(
@@ -110,16 +111,39 @@ class ClipPlayerShell extends StatelessWidget {
                 if (actions.isNotEmpty)
                   _absorb(
                     Padding(
-                      padding: const EdgeInsets.only(top: 8),
+                      padding: const EdgeInsets.only(top: 10),
                       // Full-width so the tap-absorbing strip spans the row —
                       // a near-miss beside a button must not dismiss.
                       child: SizedBox(
                         width: double.infinity,
-                        child: Wrap(
-                          alignment: WrapAlignment.center,
-                          crossAxisAlignment: WrapCrossAlignment.center,
-                          spacing: 8,
-                          children: actions,
+                        // Give every action a consistent accent-tinted pill
+                        // (colour + a bordered background = clear separation)
+                        // so the buttons read as distinct controls, not a run
+                        // of plain white text.
+                        child: TextButtonTheme(
+                          data: TextButtonThemeData(
+                            style: TextButton.styleFrom(
+                              foregroundColor: accent,
+                              backgroundColor: accent.withValues(alpha: 0.15),
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 14,
+                                vertical: 9,
+                              ),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(8),
+                                side: BorderSide(
+                                  color: accent.withValues(alpha: 0.38),
+                                ),
+                              ),
+                            ),
+                          ),
+                          child: Wrap(
+                            alignment: WrapAlignment.center,
+                            crossAxisAlignment: WrapCrossAlignment.center,
+                            spacing: 12,
+                            runSpacing: 8,
+                            children: actions,
+                          ),
                         ),
                       ),
                     ),

--- a/apps/desktop-flutter/lib/ui/clips/clip_player_shell.dart
+++ b/apps/desktop-flutter/lib/ui/clips/clip_player_shell.dart
@@ -1,0 +1,136 @@
+// Shared lightbox scaffold for the pop-up clip players — the Clips tab's
+// _ClipPlayer and the Plates tab's _PlateClipPlayer both render through this
+// ONE widget so their chrome behaves identically:
+//
+//  * a tap on the dimmed backdrop AROUND the video closes the overlay
+//    (standard lightbox behavior; Esc and the top-right X still close too —
+//    Esc stays owned by each player's HardwareKeyboard handler),
+//  * the primary action buttons sit in a row BENEATH the video and transport,
+//    so the whole control cluster is together instead of floating top-right,
+//  * the title bar keeps only the context label and the close X.
+//
+// Regions that must NOT dismiss when clicked — the title bar, the video pane,
+// the transport, the actions row — absorb their own taps; everything else
+// falls through to the backdrop's close handler. Callers should size the
+// [video] widget to the video's real display rect (fitted pane / AspectRatio)
+// where possible, so the visually-dark area around the picture is genuine
+// tappable backdrop rather than letterbox inside an oversized video box.
+
+import 'package:flutter/material.dart';
+
+class ClipPlayerShell extends StatelessWidget {
+  const ClipPlayerShell({
+    super.key,
+    required this.title,
+    required this.onClose,
+    required this.video,
+    this.titleStyle,
+    this.header,
+    this.transport,
+    this.actions = const [],
+    this.overlays = const [],
+  });
+
+  /// Title text shown top-left (e.g. "Person — Driveway" / plate — camera).
+  final String title;
+
+  /// Style override for [title]; defaults to the players' shared white 15/600.
+  final TextStyle? titleStyle;
+
+  /// Closes the overlay — wired to the X button AND a tap on the backdrop.
+  final VoidCallback onClose;
+
+  /// The video pane (already sized/fitted by the caller). Its taps are
+  /// absorbed so only the dark area around it dismisses.
+  final Widget video;
+
+  /// Optional strip between the title bar and the video (the plate crop).
+  final Widget? header;
+
+  /// Optional transport bar rendered directly under the video.
+  final Widget? transport;
+
+  /// Action buttons rendered in a centered row under the transport (quality
+  /// toggle, report, snapshot, bookmark, view-on-timeline, …).
+  final List<Widget> actions;
+
+  /// Extra positioned widgets stacked over everything (e.g. a toast).
+  final List<Widget> overlays;
+
+  /// Swallow taps so a click on real content never reaches the backdrop's
+  /// close handler (opaque: even the gaps between buttons stay safe).
+  Widget _absorb(Widget child) => GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () {},
+        child: child,
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.black.withValues(alpha: 0.92),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onClose,
+        child: Stack(
+          children: [
+            Column(
+              children: [
+                // Title bar: label + close X only; actions live below the video.
+                _absorb(
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 12, 8, 8),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            title,
+                            style: titleStyle ??
+                                const TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 15,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        IconButton(
+                          tooltip: 'Close (Esc)',
+                          onPressed: onClose,
+                          icon: const Icon(Icons.close,
+                              color: Colors.white70, size: 22),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                if (header != null) _absorb(header!),
+                Expanded(child: Center(child: _absorb(video))),
+                if (transport != null) _absorb(transport!),
+                if (actions.isNotEmpty)
+                  _absorb(
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8),
+                      // Full-width so the tap-absorbing strip spans the row —
+                      // a near-miss beside a button must not dismiss.
+                      child: SizedBox(
+                        width: double.infinity,
+                        child: Wrap(
+                          alignment: WrapAlignment.center,
+                          crossAxisAlignment: WrapCrossAlignment.center,
+                          spacing: 8,
+                          children: actions,
+                        ),
+                      ),
+                    ),
+                  ),
+                const SizedBox(height: 16),
+              ],
+            ),
+            ...overlays,
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/desktop-flutter/lib/ui/clips/clips_screen.dart
+++ b/apps/desktop-flutter/lib/ui/clips/clips_screen.dart
@@ -33,6 +33,7 @@ import 'package:crumb_desktop/api/models.dart';
 import 'package:crumb_desktop/state/client_options.dart';
 import 'package:crumb_desktop/state/hotkey_config.dart';
 import 'package:crumb_desktop/state/keyboard_shortcuts.dart';
+import 'package:crumb_desktop/ui/clips/clip_player_shell.dart';
 import 'package:crumb_desktop/ui/fullscreen/fullscreen_controller.dart'
     show FullscreenController;
 import 'package:crumb_desktop/ui/fullscreen/native_picker_guard.dart';
@@ -814,6 +815,7 @@ class _ClipPlayerState extends State<_ClipPlayer> {
   Timer? _watchdog;
   StreamSubscription<bool>? _playingSub;
   StreamSubscription<int?>? _widthSub;
+  StreamSubscription<int?>? _heightSub;
   bool _highlighted = false;
 
   double _scale = 1.0;
@@ -922,10 +924,18 @@ class _ClipPlayerState extends State<_ClipPlayer> {
         if (playing) _watchdog?.cancel();
       });
       _widthSub = player.stream.width.listen((w) {
-        if (w != null && w > 0 && !_highlighted) {
+        if (w == null || w <= 0) return;
+        // Rebuild so the pane can shrink-wrap the now-known video aspect —
+        // the fitted pane is what makes the dark area around the picture
+        // genuine tappable backdrop (tap = close) rather than letterbox.
+        if (mounted) setState(() {});
+        if (!_highlighted) {
           _highlighted = true;
           _maybeHighlight();
         }
+      });
+      _heightSub = player.stream.height.listen((h) {
+        if (h != null && h > 0 && mounted) setState(() {});
       });
       final controller = VideoController(player);
       setState(() {
@@ -1141,6 +1151,7 @@ class _ClipPlayerState extends State<_ClipPlayer> {
     _toastTimer?.cancel();
     _playingSub?.cancel();
     _widthSub?.cancel();
+    _heightSub?.cancel();
     _player?.dispose();
     super.dispose();
   }
@@ -1169,19 +1180,38 @@ class _ClipPlayerState extends State<_ClipPlayer> {
           }
           return KeyEventResult.ignored;
         },
-        child: Material(
-          color: Colors.black.withValues(alpha: 0.92),
         child: LayoutBuilder(
           builder: (context, constraints) {
-            _paneSize = Size(constraints.maxWidth, constraints.maxHeight * 0.82);
-            return Stack(
-              children: [
-                Positioned.fill(child: _buildPlayerColumn(context, c, label)),
+            // Fit the pane to the video's aspect once dimensions are known:
+            // the pane then hugs the picture, so the dark space around it is
+            // genuine backdrop (tap = close) instead of letterbox inside an
+            // oversized pane. Falls back to the full-width pane while the
+            // dimensions are still unknown (loading). 0.78 (not the old 0.82)
+            // leaves room for the actions row now living under the video.
+            var paneW = constraints.maxWidth;
+            var paneH = constraints.maxHeight * 0.78;
+            final vw = (_player?.state.width ?? 0).toDouble();
+            final vh = (_player?.state.height ?? 0).toDouble();
+            if (vw > 0 && vh > 0 && paneW > 0 && paneH > 0) {
+              final va = vw / vh;
+              if (paneW / paneH > va) {
+                paneW = paneH * va;
+              } else {
+                paneH = paneW / va;
+              }
+            }
+            _paneSize = Size(paneW, paneH);
+            return ClipPlayerShell(
+              title: '$label — ${c.cameraName}',
+              onClose: widget.onClose,
+              video: _buildVideoPane(context),
+              actions: _buildActions(context),
+              overlays: [
                 if (_toastMsg != null)
                   Positioned(
                     left: 0,
                     right: 0,
-                    bottom: 48,
+                    bottom: 96,
                     child: Center(
                       child: Container(
                         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
@@ -1201,147 +1231,123 @@ class _ClipPlayerState extends State<_ClipPlayer> {
           },
         ),
       ),
-      ),
     );
   }
 
-  Widget _buildPlayerColumn(BuildContext context, ClipDescriptor c, String label) {
-    return Column(
-              children: [
-                // Title bar.
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 12, 8, 8),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: Text(
-                          '$label — ${c.cameraName}',
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 15,
-                            fontWeight: FontWeight.w600,
-                          ),
-                          overflow: TextOverflow.ellipsis,
+  /// Primary actions, in a row under the video (the shell lays them out):
+  /// quality toggle, snapshot, bookmark, view-on-timeline. The close X stays
+  /// in the shell's title bar.
+  List<Widget> _buildActions(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.primary;
+    return [
+      TextButton.icon(
+        onPressed: _qualityBusy ? null : _toggleQuality,
+        icon: Icon(
+          Icons.high_quality,
+          size: 16,
+          color: _quality == 'full' ? accent : Colors.white70,
+        ),
+        label: Text(
+          _quality == 'full' ? 'Full' : 'Preview',
+          style: TextStyle(
+            fontSize: 12,
+            color: _quality == 'full' ? accent : Colors.white70,
+          ),
+        ),
+      ),
+      TextButton.icon(
+        onPressed: _snapshot,
+        icon: const Icon(Icons.camera_alt_outlined, color: Colors.white70, size: 16),
+        label: const Text(
+          'Snapshot',
+          style: TextStyle(fontSize: 12, color: Colors.white70),
+        ),
+      ),
+      TextButton.icon(
+        onPressed: _bookmark,
+        icon: const Icon(Icons.bookmark_add_outlined, color: Colors.white70, size: 16),
+        label: const Text(
+          'Bookmark',
+          style: TextStyle(fontSize: 12, color: Colors.white70),
+        ),
+      ),
+      if (widget.onViewOnTimeline != null)
+        TextButton.icon(
+          onPressed: widget.onViewOnTimeline,
+          icon: const Icon(Icons.timeline, color: Colors.white70, size: 16),
+          label: const Text(
+            'View on timeline',
+            style: TextStyle(fontSize: 12, color: Colors.white70),
+          ),
+        ),
+    ];
+  }
+
+  /// The zoom/pan-enabled video pane, sized to [_paneSize] (already fitted to
+  /// the video's aspect by [build] when the dimensions are known).
+  Widget _buildVideoPane(BuildContext context) {
+    return SizedBox(
+      key: _paneKey,
+      width: _paneSize.width,
+      height: _paneSize.height,
+      child: _error != null
+          ? Center(
+              child: Text(_error!, style: const TextStyle(color: Colors.redAccent)),
+            )
+          : _controller == null
+              ? const Center(child: CircularProgressIndicator())
+              : Listener(
+                  onPointerSignal: (e) {
+                    if (e is PointerScrollEvent) {
+                      _takeOverZoom();
+                      final factor = e.scrollDelta.dy < 0 ? 1.15 : 1 / 1.15;
+                      final ns = (_scale * factor).clamp(1.0, _clipZoomMax);
+                      if (ns == 1.0) {
+                        _resetZoom();
+                        return;
+                      }
+                      final box =
+                          _paneKey.currentContext?.findRenderObject() as RenderBox?;
+                      final local = box?.globalToLocal(e.position) ??
+                          Offset(_paneSize.width / 2, _paneSize.height / 2);
+                      final px = local.dx - _paneSize.width / 2;
+                      final py = local.dy - _paneSize.height / 2;
+                      final k = ns / _scale;
+                      _applyZoom(
+                        ns,
+                        Offset(px - (px - _offset.dx) * k, py - (py - _offset.dy) * k),
+                      );
+                    }
+                  },
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onDoubleTap: _resetZoom,
+                    onPanStart: (d) {
+                      if (_scale <= 1.0) return;
+                      _dragStart = d.globalPosition;
+                      _dragStartOffset = _offset;
+                    },
+                    onPanUpdate: (d) {
+                      if (_scale <= 1.0 || _dragStart == null) return;
+                      _takeOverZoom();
+                      final delta = d.globalPosition - _dragStart!;
+                      _applyZoom(_scale, _dragStartOffset! + delta);
+                    },
+                    child: ClipRect(
+                      child: Transform(
+                        transform: Matrix4.identity()
+                          ..translateByDouble(_offset.dx, _offset.dy, 0, 1)
+                          ..scaleByDouble(_scale, _scale, 1, 1),
+                        alignment: Alignment.center,
+                        child: Video(
+                          controller: _controller!,
+                          controls: NoVideoControls,
+                          fit: BoxFit.contain,
                         ),
                       ),
-                      TextButton.icon(
-                        onPressed: _qualityBusy ? null : _toggleQuality,
-                        icon: Icon(
-                          Icons.high_quality,
-                          size: 16,
-                          color: _quality == 'full'
-                              ? Theme.of(context).colorScheme.primary
-                              : Colors.white70,
-                        ),
-                        label: Text(
-                          _quality == 'full' ? 'Full' : 'Preview',
-                          style: TextStyle(
-                            fontSize: 12,
-                            color: _quality == 'full'
-                                ? Theme.of(context).colorScheme.primary
-                                : Colors.white70,
-                          ),
-                        ),
-                      ),
-                      // (accent follows the active tab colour)
-                      IconButton(
-                        tooltip: 'Snapshot',
-                        onPressed: _snapshot,
-                        icon: const Icon(Icons.camera_alt_outlined, color: Colors.white70, size: 20),
-                      ),
-                      IconButton(
-                        tooltip: 'Bookmark',
-                        onPressed: _bookmark,
-                        icon: const Icon(Icons.bookmark_add_outlined, color: Colors.white70, size: 20),
-                      ),
-                      if (widget.onViewOnTimeline != null)
-                        IconButton(
-                          tooltip: 'View on timeline',
-                          onPressed: widget.onViewOnTimeline,
-                          icon: const Icon(
-                            Icons.timeline,
-                            color: Colors.white70,
-                            size: 20,
-                          ),
-                        ),
-                      IconButton(
-                        tooltip: 'Close (Esc)',
-                        onPressed: widget.onClose,
-                        icon: const Icon(Icons.close, color: Colors.white70, size: 22),
-                      ),
-                    ],
-                  ),
-                ),
-                // Video pane with zoom/pan gestures.
-                Expanded(
-                  child: Center(
-                    child: SizedBox(
-                      key: _paneKey,
-                      width: _paneSize.width,
-                      height: _paneSize.height,
-                      child: _error != null
-                          ? Center(
-                              child: Text(_error!, style: const TextStyle(color: Colors.redAccent)),
-                            )
-                          : _controller == null
-                              ? const Center(child: CircularProgressIndicator())
-                              : Listener(
-                                  onPointerSignal: (e) {
-                                    if (e is PointerScrollEvent) {
-                                      _takeOverZoom();
-                                      final factor = e.scrollDelta.dy < 0 ? 1.15 : 1 / 1.15;
-                                      final ns = (_scale * factor).clamp(1.0, _clipZoomMax);
-                                      if (ns == 1.0) {
-                                        _resetZoom();
-                                        return;
-                                      }
-                                      final box =
-                                          _paneKey.currentContext?.findRenderObject() as RenderBox?;
-                                      final local = box?.globalToLocal(e.position) ??
-                                          Offset(_paneSize.width / 2, _paneSize.height / 2);
-                                      final px = local.dx - _paneSize.width / 2;
-                                      final py = local.dy - _paneSize.height / 2;
-                                      final k = ns / _scale;
-                                      _applyZoom(
-                                        ns,
-                                        Offset(px - (px - _offset.dx) * k, py - (py - _offset.dy) * k),
-                                      );
-                                    }
-                                  },
-                                  child: GestureDetector(
-                                    behavior: HitTestBehavior.opaque,
-                                    onDoubleTap: _resetZoom,
-                                    onPanStart: (d) {
-                                      if (_scale <= 1.0) return;
-                                      _dragStart = d.globalPosition;
-                                      _dragStartOffset = _offset;
-                                    },
-                                    onPanUpdate: (d) {
-                                      if (_scale <= 1.0 || _dragStart == null) return;
-                                      _takeOverZoom();
-                                      final delta = d.globalPosition - _dragStart!;
-                                      _applyZoom(_scale, _dragStartOffset! + delta);
-                                    },
-                                    child: ClipRect(
-                                      child: Transform(
-                                        transform: Matrix4.identity()
-                                          ..translateByDouble(_offset.dx, _offset.dy, 0, 1)
-                                          ..scaleByDouble(_scale, _scale, 1, 1),
-                                        alignment: Alignment.center,
-                                        child: Video(
-                                          controller: _controller!,
-                                          controls: NoVideoControls,
-                                          fit: BoxFit.contain,
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                ),
                     ),
                   ),
                 ),
-                const SizedBox(height: 16),
-              ],
     );
   }
 }

--- a/apps/desktop-flutter/lib/ui/plates/plates_screen.dart
+++ b/apps/desktop-flutter/lib/ui/plates/plates_screen.dart
@@ -31,6 +31,7 @@ import 'package:crumb_desktop/api/crumb_api.dart';
 import 'package:crumb_desktop/api/http_client.dart';
 import 'package:crumb_desktop/api/models.dart';
 import 'package:crumb_desktop/api/plates_api.dart';
+import 'package:crumb_desktop/ui/clips/clip_player_shell.dart';
 import 'package:crumb_desktop/ui/plates/ab_benchmark.dart';
 import 'package:crumb_desktop/ui/plates/plate_collapse.dart';
 import 'package:crumb_desktop/ui/plates/plate_crop.dart';
@@ -1433,8 +1434,10 @@ class _PlateThumbState extends State<_PlateThumb> {
     } else if (showCrop && showFull && full != null) {
       content = _overlay(full, crop, cacheW);
     } else if (showCrop) {
-      // Crop only: letterbox (a plate is wide/short) on black.
-      content = _img(crop, BoxFit.contain, cacheW, background: true);
+      // Crop only: box the crop at its OWN aspect (from the read's bbox) so
+      // `contain` fills it edge-to-edge — a wide/short plate no longer floats
+      // between big black letterbox bars in a near-square slot.
+      content = _fittedCrop(crop, cacheW);
     } else if (full != null) {
       content = _img(full, BoxFit.cover, cacheW);
     } else {
@@ -1456,6 +1459,41 @@ class _PlateThumbState extends State<_PlateThumb> {
     );
     if (!background) return image;
     return Container(color: Colors.black, child: image);
+  }
+
+  /// Display aspect (w/h) of the plate crop, derived from the read's
+  /// normalized bbox. The bbox is in frame FRACTIONS, so its w/h must be
+  /// scaled by the frame's own aspect (snapshots are 16:9 — the same
+  /// assumption [_sideBySide] makes for the full frame) to get the crop's
+  /// pixel aspect. Clamped to a sane band so a degenerate box can't produce
+  /// an absurd slot. Null when the read has no usable bbox.
+  double? get _cropAspect {
+    final bb = widget.read.bbox;
+    if (bb == null || bb.length < 4) return null;
+    final bw = bb[2], bh = bb[3];
+    if (bw <= 0 || bh <= 0) return null;
+    return ((bw / bh) * (16 / 9)).clamp(1.0, 8.0).toDouble();
+  }
+
+  /// The crop centered in its (fixed) slot with the black backing sized to
+  /// the crop's OWN aspect instead of the whole slot — `contain` then fills
+  /// the backing edge-to-edge, so a wide/short plate shows no letterbox bars.
+  /// Falls back to the old letterboxed render when the bbox is unusable.
+  Widget _fittedCrop(Uint8List crop, int cacheW) {
+    final aspect = _cropAspect;
+    final image = _img(crop, BoxFit.contain, cacheW, background: true);
+    if (aspect == null) {
+      return ClipRRect(
+        borderRadius: BorderRadius.circular(widget.radius),
+        child: image,
+      );
+    }
+    return Center(
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(widget.radius),
+        child: AspectRatio(aspectRatio: aspect, child: image),
+      ),
+    );
   }
 
   Widget _placeholder() {
@@ -1548,18 +1586,24 @@ class _PlateThumbState extends State<_PlateThumb> {
             ),
           ),
           const SizedBox(width: 6),
-          ClipRRect(
-            borderRadius: r,
-            child: Container(
-              width: cropW,
-              height: h,
-              color: Colors.black,
-              alignment: Alignment.center,
-              child: crop != null
-                  ? Image.memory(crop, fit: BoxFit.contain, gaplessPlayback: true)
-                  : Icon(Icons.no_photography_outlined,
-                      color: Colors.white24, size: widget.iconSize),
-            ),
+          // Crop slot: fixed OUTER width so the plate text stays aligned
+          // across rows, but the black backing inside is sized to the crop's
+          // own aspect (via [_fittedCrop]) so the plate fills it edge-to-edge
+          // instead of floating between black letterbox bars.
+          SizedBox(
+            width: cropW,
+            height: h,
+            child: crop != null
+                ? _fittedCrop(crop, cacheW)
+                : ClipRRect(
+                    borderRadius: r,
+                    child: Container(
+                      color: Colors.black,
+                      alignment: Alignment.center,
+                      child: Icon(Icons.no_photography_outlined,
+                          color: Colors.white24, size: widget.iconSize),
+                    ),
+                  ),
           ),
         ],
       ),
@@ -2072,9 +2116,11 @@ class _PlateTimeline extends StatelessWidget {
 // ─── pop-up plate-hit clip player ──────────────────────────────────────────
 
 /// Dismissible overlay that plays a plate read's short detection clip — the
-/// same style/behavior as the Clips tab's clip player (Positioned.fill overlay
-/// over the tab, closes on Esc and a close button), trimmed to what a plate hit
-/// needs: no zoom/snapshot/bookmark, plus a "View on timeline" hand-off.
+/// same style/behavior as the Clips tab's clip player (both render through the
+/// shared [ClipPlayerShell]: Positioned.fill overlay over the tab, closes on
+/// Esc / the close X / a tap on the dark backdrop, actions under the video),
+/// trimmed to what a plate hit needs: no zoom/snapshot/bookmark, plus a "View
+/// on timeline" hand-off.
 ///
 /// The clip is resolved exactly like a Clips detection clip: the read's
 /// [PlateRead.eventId] is the `d:<event-uuid>` clip id, played from
@@ -2120,6 +2166,8 @@ class _PlateClipPlayerState extends State<_PlateClipPlayer> {
   int _loadAttempt = 0;
   Timer? _watchdog;
   StreamSubscription<bool>? _playingSub;
+  StreamSubscription<int?>? _widthSub;
+  StreamSubscription<int?>? _heightSub;
   String? _error;
   // Clip rendition: 'preview' (SD, fast on-demand transcode) or 'full' (HD, the
   // original segment quality). Mirrors the Clips player's quality toggle — a
@@ -2242,6 +2290,16 @@ class _PlateClipPlayerState extends State<_PlateClipPlayer> {
         }
         if (mounted) setState(() => _playing = playing);
       });
+      // Rebuild once the video's dimensions are known so the pane can
+      // shrink-wrap the video's aspect — the dark space around it is then
+      // genuine backdrop (tap = close) rather than letterbox inside an
+      // oversized video box.
+      _widthSub = player.stream.width.listen((w) {
+        if (w != null && w > 0 && mounted) setState(() {});
+      });
+      _heightSub = player.stream.height.listen((h) {
+        if (h != null && h > 0 && mounted) setState(() {});
+      });
       final controller = VideoController(player);
       setState(() {
         _player = player;
@@ -2294,6 +2352,8 @@ class _PlateClipPlayerState extends State<_PlateClipPlayer> {
     HardwareKeyboard.instance.removeHandler(_onKeyEvent);
     _watchdog?.cancel();
     _playingSub?.cancel();
+    _widthSub?.cancel();
+    _heightSub?.cancel();
     _player?.dispose();
     super.dispose();
   }
@@ -2303,95 +2363,81 @@ class _PlateClipPlayerState extends State<_PlateClipPlayer> {
     final read = widget.read;
     final plate = read.plate.isEmpty ? '—' : read.plate;
     return Positioned.fill(
-      child: Material(
-        color: Colors.black.withValues(alpha: 0.92),
-        child: Column(
-          children: [
-            // Title bar.
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 12, 8, 8),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      '$plate — ${widget.cameraName}',
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 15,
-                        fontWeight: FontWeight.w600,
-                        letterSpacing: 1.2,
-                        fontFamily: 'monospace',
-                      ),
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                  _QualityToggle(
-                    quality: _quality,
-                    busy: _qualityBusy,
-                    onChanged: _setQuality,
-                  ),
-                  const SizedBox(width: 4),
-                  TextButton.icon(
-                    onPressed: widget.onReport,
-                    icon: const Icon(Icons.description_outlined,
-                        size: 16, color: Colors.white70),
-                    label: const Text(
-                      'Report',
-                      style: TextStyle(fontSize: 12, color: Colors.white70),
-                    ),
-                  ),
-                  TextButton.icon(
-                    onPressed: widget.onViewOnTimeline,
-                    icon: const Icon(Icons.timeline, size: 16, color: Colors.white70),
-                    label: const Text(
-                      'View on timeline',
-                      style: TextStyle(fontSize: 12, color: Colors.white70),
-                    ),
-                  ),
-                  IconButton(
-                    tooltip: 'Close (Esc)',
-                    onPressed: widget.onClose,
-                    icon: const Icon(Icons.close, color: Colors.white70, size: 22),
-                  ),
-                ],
-              ),
-            ),
-            // Prominent plate crop (bbox region of the snapshot) pinned above
-            // the clip. Fetches the snapshot itself if a tile hasn't cached it,
-            // so it shows reliably. Renders nothing when the read has no bbox;
-            // hidden entirely when the operator chose full-frame-only.
-            if (widget.imageMode != PlateImageDisplay.fullOnly)
-              _PlateDetailCrop(
+      child: ClipPlayerShell(
+        title: '$plate — ${widget.cameraName}',
+        titleStyle: const TextStyle(
+          color: Colors.white,
+          fontSize: 15,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 1.2,
+          fontFamily: 'monospace',
+        ),
+        onClose: widget.onClose,
+        // Prominent plate crop (bbox region of the snapshot) pinned above
+        // the clip. Fetches the snapshot itself if a tile hasn't cached it,
+        // so it shows reliably. Renders nothing when the read has no bbox;
+        // hidden entirely when the operator chose full-frame-only.
+        header: widget.imageMode != PlateImageDisplay.fullOnly
+            ? _PlateDetailCrop(
                 read: read,
                 session: widget.session,
                 cropSize: widget.cropSize,
-              ),
-            // Video pane.
-            Expanded(
-              child: Center(
-                child: _error != null
-                    ? Text(
-                        _error!,
-                        style: const TextStyle(color: Colors.redAccent),
-                      )
-                    : _controller == null
-                        ? const CircularProgressIndicator()
-                        : Video(
-                            controller: _controller!,
-                            controls: NoVideoControls,
-                            fit: BoxFit.contain,
-                          ),
-              ),
+              )
+            : null,
+        video: _buildVideoPane(),
+        // Our own minimal transport (issue #143): restart + frame-step +
+        // play/pause, directly under the video. Native media_kit controls are
+        // suppressed via NoVideoControls.
+        transport: (_error == null && _controller != null) ? _buildTransport() : null,
+        // Primary actions live in a row under the transport (the shell lays
+        // them out); the title bar keeps just the plate label and the X.
+        actions: [
+          _QualityToggle(
+            quality: _quality,
+            busy: _qualityBusy,
+            onChanged: _setQuality,
+          ),
+          TextButton.icon(
+            onPressed: widget.onReport,
+            icon: const Icon(Icons.description_outlined,
+                size: 16, color: Colors.white70),
+            label: const Text(
+              'Report',
+              style: TextStyle(fontSize: 12, color: Colors.white70),
             ),
-            // Our own minimal transport (issue #143): restart + play/pause,
-            // styled like the rest of the pop-up. Native media_kit controls are
-            // suppressed above via NoVideoControls.
-            if (_error == null && _controller != null) _buildTransport(),
-            const SizedBox(height: 16),
-          ],
-        ),
+          ),
+          TextButton.icon(
+            onPressed: widget.onViewOnTimeline,
+            icon: const Icon(Icons.timeline, size: 16, color: Colors.white70),
+            label: const Text(
+              'View on timeline',
+              style: TextStyle(fontSize: 12, color: Colors.white70),
+            ),
+          ),
+        ],
       ),
     );
+  }
+
+  /// The video pane, shrink-wrapped to the video's aspect once known so the
+  /// dark space around it is genuine backdrop (tap = close) rather than
+  /// letterbox inside an oversized video box.
+  Widget _buildVideoPane() {
+    if (_error != null) {
+      return Text(_error!, style: const TextStyle(color: Colors.redAccent));
+    }
+    if (_controller == null) return const CircularProgressIndicator();
+    final video = Video(
+      controller: _controller!,
+      controls: NoVideoControls,
+      fit: BoxFit.contain,
+    );
+    final vw = (_player?.state.width ?? 0).toDouble();
+    final vh = (_player?.state.height ?? 0).toDouble();
+    if (vw > 0 && vh > 0) {
+      return AspectRatio(aspectRatio: vw / vh, child: video);
+    }
+    return video;
   }
 
   /// Minimal control bar: back-to-start and play/pause, driven by the player.


### PR DESCRIPTION
## Shared clip-player shell: actions under the video, backdrop-close, crop fill, colored buttons

Refactors the plate and clips pop-up players onto one shared `ClipPlayerShell`, and fixes several UX papercuts.

- **Actions under the video** — the SD/HD·Report·timeline (plates) and Preview·Snapshot·Bookmark·timeline (clips) action rows moved from the top-right (by the X) to a row beneath the transport, and are now **accent-tinted pills** with borders + spacing (were plain white text).
- **Click-outside to close** — tapping the dark backdrop dismisses both players (X and Esc kept). To make the backdrop real, both players shrink-wrap the video pane to its aspect ratio.
- **#5 Plate crop fills its box** — the letterboxed crop now sizes its container to the plate's aspect ratio (from the bbox) so `contain` fills edge-to-edge with no black bars.
- **Double back-arrow (Flutter half)** — the embedded admin console loads with `?embedded=1` so the web admin drops its own header (the admin.html side ships in the LPR-admin PR); "Open in browser" keeps full chrome.

`flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
