### PR TITLE
feat: Crumb data footprint in the Storage Advisor

### DIFF
--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -302,6 +302,18 @@ details.detail-section .ds-body>.policy-section>.policy-section-title{position:s
 .adv-suggest{margin-top:9px;display:flex;flex-direction:column;gap:4px;}
 .adv-suggest-item{display:flex;gap:7px;align-items:flex-start;font-size:12px;color:var(--dim);line-height:1.5;padding:3px 0;}
 .adv-suggest-item .asi-ico{flex:0 0 auto;color:var(--accent);margin-top:1px;}
+/* ── Crumb data footprint (server-wide breakdown card) ── */
+.cf-list{margin-top:10px;display:flex;flex-direction:column;gap:2px;}
+.cf-row{display:grid;grid-template-columns:12px minmax(0,1.5fr) minmax(48px,1.1fr) 118px minmax(0,1.5fr);gap:10px;align-items:center;font-size:12px;padding:3px 0;}
+.cf-dot{width:10px;height:10px;border-radius:2px;flex:0 0 auto;}
+.cf-label{color:var(--text);font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0;}
+.cf-label .cf-loc{color:var(--dim2);font-weight:400;font-size:11px;margin-left:7px;font-family:ui-monospace,monospace;}
+.cf-bar{height:6px;background:var(--surface3);border-radius:3px;overflow:hidden;min-width:28px;}
+.cf-fill{display:block;height:100%;min-width:3px;border-radius:3px;}
+.cf-size{color:var(--text);white-space:nowrap;text-align:right;font-weight:600;}
+.cf-size small{color:var(--dim2);font-weight:400;margin-left:3px;}
+.cf-meta{color:var(--dim);font-size:11px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0;}
+@media (max-width:720px){.cf-row{grid-template-columns:12px minmax(0,1.4fr) 100px;}.cf-row .cf-bar,.cf-row .cf-meta{display:none;}}
 /* ── Cards → raised group panels (fill + hairline + soft shadow) ── */
 .card{background:var(--card-bg);border:1px solid var(--border);border-radius:var(--radius);padding:14px 16px;margin-bottom:var(--sp-5);box-shadow:var(--shadow);}
 .card-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:8px;}
@@ -4287,6 +4299,8 @@ async function loadStorageAdvisor() {
   // while the fetch was in flight.
   if (!$('storage-advisor')) return;
   ADV_STORAGES = list;
+  ADV_CRUMB = (data && Array.isArray(data.crumb_data)) ? data.crumb_data : [];
+  ADV_CRUMB_TOTAL = Number(data && data.crumb_data_total_bytes) || 0;
   advRenderCards();
 }
 
@@ -4294,11 +4308,74 @@ async function loadStorageAdvisor() {
    so a sort click can re-render the cards without re-fetching. Keyed by storage
    id → {key, dir}; default is footprint (bytes) descending. */
 let ADV_STORAGES = [];
+/* Server-wide "Crumb data footprint" breakdown (every store across all volumes)
+   + its total, from the same /stats/storage fetch. */
+let ADV_CRUMB = [];
+let ADV_CRUMB_TOTAL = 0;
 const ADV_CAM_SORT = {};
 
 function advRenderCards() {
   const host = $('storage-advisor'); if (!host) return;
-  host.innerHTML = ADV_STORAGES.map(advStorageCard).join('');
+  host.innerHTML = ADV_STORAGES.map(advStorageCard).join('') + advFootprintPanel();
+}
+
+/* Stable colour per Crumb data-store key, so the stacked bar and legend read as
+   one picture and the palette is meaningful (recordings = the Default blue). */
+const CRUMB_DATA_COLORS = {
+  recordings: '#38BDD6', lpr: '#E8A33D', clips: '#A78BFA',
+  playback_cache: '#2DD4BF', thumbnails: '#34C759', exports: '#F472B6', database: '#94A3B8',
+};
+
+/* Server-wide "Crumb data footprint" card: one stacked bar + a row per store
+   (recordings, LPR plate images, clip/playback/thumbnail caches, exports, DB),
+   with size, share of the total, physical location, and a budget meter for the
+   capped caches. Rendered once below the per-device cards. All values esc()'d. */
+function advFootprintPanel() {
+  const stores = Array.isArray(ADV_CRUMB) ? ADV_CRUMB.filter(d => Number(d.bytes) > 0) : [];
+  if (!stores.length) return '';
+  const total = ADV_CRUMB_TOTAL > 0 ? ADV_CRUMB_TOTAL : stores.reduce((a, d) => a + Number(d.bytes), 0);
+  const colorFor = d => CRUMB_DATA_COLORS[d.key] || 'var(--surface3)';
+
+  const segs = stores.map(d => {
+    const w = total ? Math.max(0, Number(d.bytes) / total * 100) : 0;
+    if (w <= 0) return '';
+    return `<span class="stk-seg" style="width:${w}%;background:${colorFor(d)}" title="${esc(d.label)} — ${esc(fmtBytes(d.bytes))}"></span>`;
+  }).join('');
+
+  const rows = stores.map(d => {
+    const bytes = Number(d.bytes);
+    const share = total ? bytes / total * 100 : 0;
+    const w = Math.max(0, share);
+    // Budget meter for capped caches; otherwise the store's detail line.
+    let meta;
+    if (d.budget_bytes != null && Number(d.budget_bytes) > 0) {
+      const bpct = Math.min(100, Math.round(bytes / Number(d.budget_bytes) * 100));
+      meta = `<span class="cf-meta">${bpct}% of ${esc(fmtBytes(Number(d.budget_bytes)))} budget</span>`;
+    } else if (d.detail) {
+      meta = `<span class="cf-meta">${esc(d.detail)}</span>`;
+    } else {
+      meta = `<span class="cf-meta"></span>`;
+    }
+    return `<div class="cf-row">
+      <span class="cf-dot" style="background:${colorFor(d)}"></span>
+      <span class="cf-label">${esc(d.label)}<span class="cf-loc">${esc(d.location || '')}</span></span>
+      <span class="cf-bar"><span class="cf-fill" style="width:${w}%;background:${colorFor(d)}"></span></span>
+      <span class="cf-size">${esc(fmtBytes(bytes))}<small> ${advPct(share)}</small></span>
+      ${meta}
+    </div>`;
+  }).join('');
+
+  return `<div class="adv-card cf-card">
+    <div class="adv-card-head">
+      <div style="min-width:0">
+        <div class="adv-card-title"><span class="ac-ico">${icon('database', 18)}</span><span class="ac-name">Crumb data footprint</span></div>
+        <div class="adv-card-path" style="font-family:inherit;color:var(--dim)">Everything Crumb stores, across every volume — not just recordings.</div>
+      </div>
+      <span class="adv-badge">${esc(fmtBytes(total))} total</span>
+    </div>
+    <div class="stk-track">${segs}</div>
+    <div class="cf-list">${rows}</div>
+  </div>`;
 }
 
 /* Sort the per-camera table for one storage card (toggles direction on repeat).

--- a/services/api/src/stats.rs
+++ b/services/api/src/stats.rs
@@ -633,10 +633,41 @@ pub struct StorageAdvisorDto {
     pub suggestions: Vec<String>,
 }
 
+/// One Crumb-managed data store in the server-wide "Crumb data footprint"
+/// breakdown — everything Crumb keeps on disk (or in Postgres), not just the
+/// recordings shown in the per-location bars. Answers "what is Crumb storing,
+/// where, and how much" across every volume.
+#[derive(Debug, Serialize)]
+pub struct CrumbDataStoreDto {
+    /// Stable key for colour-keying in the UI: `recordings` | `lpr` | `clips` |
+    /// `playback_cache` | `thumbnails` | `exports` | `database`.
+    pub key: String,
+    /// Human label (e.g. `"LPR plate images"`, `"Clips cache"`).
+    pub label: String,
+    /// Bytes this store occupies right now.
+    pub bytes: i64,
+    /// Where it physically lives — a filesystem path, `"Postgres"`, or a summary
+    /// like `"3 recording locations"`.
+    pub location: String,
+    /// Optional one-line detail (e.g. `"1,240 reads · oldest 12d"` for LPR, or a
+    /// cache's TTL note). `null` when there's nothing useful to add.
+    pub detail: Option<String>,
+    /// Optional soft budget (max bytes) for stores that are capped caches, so the
+    /// UI can show "X of Y". `null` for uncapped stores (recordings, exports, DB).
+    pub budget_bytes: Option<i64>,
+}
+
 /// `GET /stats/storage` response.
 #[derive(Debug, Serialize)]
 pub struct StorageAdvisorResponse {
     pub storages: Vec<StorageAdvisorDto>,
+    /// Server-wide breakdown of every Crumb data store (recordings, LPR images,
+    /// clip/playback/thumbnail caches, exports, database), largest first. Empty
+    /// entries (0 bytes) are omitted except recordings and the database, which
+    /// always appear.
+    pub crumb_data: Vec<CrumbDataStoreDto>,
+    /// Sum of `crumb_data[].bytes` — the total Crumb footprint across all volumes.
+    pub crumb_data_total_bytes: i64,
     pub generated_at: DateTime<Utc>,
 }
 
@@ -965,10 +996,180 @@ async fn storage_advisor(
         });
     }
 
+    // ── server-wide "Crumb data footprint" ──────────────────────────────────
+    // Everything Crumb stores, across every volume — not just the recordings in
+    // the per-location bars above. Recordings live on the configured storage
+    // devices; the caches + exports live under `export_dir`; the LPR plate images
+    // + all other metadata live in Postgres. Measured on demand (admin-only
+    // endpoint): a directory walk for the on-disk caches, two aggregate queries
+    // for Postgres. Failures degrade to 0 rather than failing the whole advisor.
+    let recordings_bytes: i64 = out
+        .iter()
+        .flat_map(|s| s.usage_by_policy.iter())
+        .map(|u| u.bytes)
+        .sum();
+    let export_dir = state.config().export_dir.clone();
+    let (dir_sizes, lpr_stats, db_size) = tokio::join!(
+        tokio::task::spawn_blocking(move || measure_export_dirs(&export_dir)),
+        db::lpr_storage_stats(pool),
+        db::database_size_bytes(pool),
+    );
+    let (clips_bytes, segcache_bytes, thumbs_bytes, export_total_bytes) =
+        dir_sizes.unwrap_or((0, 0, 0, 0));
+    let (lpr_reads, lpr_crop_bytes, lpr_oldest) = lpr_stats.unwrap_or((0, 0, None));
+    let db_total_bytes = db_size.unwrap_or(0);
+    // User exports = everything under export_dir that isn't one of the three
+    // managed caches. Clamp against races (a cache growing mid-walk).
+    let exports_bytes = (export_total_bytes - clips_bytes - segcache_bytes - thumbs_bytes).max(0);
+    // The database minus the LPR crop images, so the two read as distinct lines
+    // (the crops dominate DB size when LPR is on; the remainder is the event /
+    // segment index + config + bookmarks + everything else).
+    let db_meta_bytes = (db_total_bytes - lpr_crop_bytes).max(0);
+    let cfg = state.config();
+
+    let loc_count = out.len();
+    let recordings_location = match loc_count {
+        0 => "no recording location".to_owned(),
+        1 => out[0].name.clone(),
+        n => format!("{n} recording locations"),
+    };
+    let now = Utc::now();
+
+    let mut crumb_data = vec![CrumbDataStoreDto {
+        key: "recordings".to_owned(),
+        label: "Recordings".to_owned(),
+        bytes: recordings_bytes,
+        location: recordings_location,
+        detail: None,
+        budget_bytes: None,
+    }];
+    // LPR plate images — only when there are any reads (LPR may be off).
+    if lpr_reads > 0 || lpr_crop_bytes > 0 {
+        let oldest_detail = lpr_oldest.map(|ts| {
+            let days = (now - ts).num_days().max(0);
+            format!("{} reads · oldest {days}d", fmt_count(lpr_reads))
+        });
+        crumb_data.push(CrumbDataStoreDto {
+            key: "lpr".to_owned(),
+            label: "LPR plate images".to_owned(),
+            bytes: lpr_crop_bytes,
+            location: "Postgres".to_owned(),
+            detail: oldest_detail,
+            budget_bytes: None,
+        });
+    }
+    // On-disk caches — omit when empty (they self-populate on demand).
+    if clips_bytes > 0 {
+        crumb_data.push(CrumbDataStoreDto {
+            key: "clips".to_owned(),
+            label: "Clips cache".to_owned(),
+            bytes: clips_bytes,
+            location: format!("{}/clips", cfg.export_dir),
+            detail: Some("on-demand renders, auto-evicted".to_owned()),
+            budget_bytes: i64::try_from(cfg.clip_cache_max_bytes).ok(),
+        });
+    }
+    if segcache_bytes > 0 {
+        crumb_data.push(CrumbDataStoreDto {
+            key: "playback_cache".to_owned(),
+            label: "Playback cache".to_owned(),
+            bytes: segcache_bytes,
+            location: format!("{}/segcache", cfg.export_dir),
+            detail: Some("low-bitrate scrub transcodes".to_owned()),
+            budget_bytes: i64::try_from(cfg.segment_low_cache_max_bytes).ok(),
+        });
+    }
+    if thumbs_bytes > 0 {
+        crumb_data.push(CrumbDataStoreDto {
+            key: "thumbnails".to_owned(),
+            label: "Thumbnail cache".to_owned(),
+            bytes: thumbs_bytes,
+            location: format!("{}/.thumbs", cfg.export_dir),
+            detail: Some("filmstrip scrub frames".to_owned()),
+            budget_bytes: i64::try_from(cfg.thumb_cache_max_bytes).ok(),
+        });
+    }
+    if exports_bytes > 0 {
+        crumb_data.push(CrumbDataStoreDto {
+            key: "exports".to_owned(),
+            label: "Exports".to_owned(),
+            bytes: exports_bytes,
+            location: cfg.export_dir.clone(),
+            detail: Some("saved video exports".to_owned()),
+            budget_bytes: None,
+        });
+    }
+    crumb_data.push(CrumbDataStoreDto {
+        key: "database".to_owned(),
+        label: "Database".to_owned(),
+        bytes: db_meta_bytes,
+        location: "Postgres".to_owned(),
+        detail: Some("events, segment index, config".to_owned()),
+        budget_bytes: None,
+    });
+    crumb_data.sort_by_key(|d| std::cmp::Reverse(d.bytes));
+    let crumb_data_total_bytes: i64 = crumb_data.iter().map(|d| d.bytes).sum();
+
     Ok(Json(StorageAdvisorResponse {
         storages: out,
-        generated_at: Utc::now(),
+        crumb_data,
+        crumb_data_total_bytes,
+        generated_at: now,
     }))
+}
+
+/// Recursively sum the size of every regular file under `path`. Symlinks are not
+/// followed (metadata via `DirEntry::metadata`, which does not traverse). Any
+/// unreadable entry is skipped rather than propagated — the footprint is
+/// best-effort informational data, never worth failing the advisor over. Runs
+/// inside `spawn_blocking` (synchronous `std::fs`).
+fn dir_size(path: &std::path::Path) -> i64 {
+    let Ok(rd) = std::fs::read_dir(path) else {
+        return 0;
+    };
+    let mut total: i64 = 0;
+    for entry in rd.flatten() {
+        let Ok(ft) = entry.file_type() else { continue };
+        if ft.is_dir() {
+            total = total.saturating_add(dir_size(&entry.path()));
+        } else if ft.is_file() {
+            if let Ok(meta) = entry.metadata() {
+                total = total.saturating_add(i64::try_from(meta.len()).unwrap_or(i64::MAX));
+            }
+        }
+    }
+    total
+}
+
+/// Measure the Crumb-managed subtrees under `export_dir`, returning
+/// `(clips, segcache, thumbs, export_total)` in bytes. `export_total` is the
+/// whole `export_dir` (so user-export bytes = total − the three caches). Missing
+/// dirs read as 0.
+fn measure_export_dirs(export_dir: &str) -> (i64, i64, i64, i64) {
+    let root = std::path::Path::new(export_dir);
+    let clips = dir_size(&root.join("clips"));
+    let segcache = dir_size(&root.join("segcache"));
+    let thumbs = dir_size(&root.join(".thumbs"));
+    let total = dir_size(root);
+    (clips, segcache, thumbs, total)
+}
+
+/// Format a non-negative integer with thousands separators (e.g. `1240` →
+/// `"1,240"`) for count details, independent of locale crates.
+fn fmt_count(n: i64) -> String {
+    let s = n.abs().to_string();
+    let bytes = s.as_bytes();
+    let mut out = String::with_capacity(s.len() + s.len() / 3);
+    if n < 0 {
+        out.push('-');
+    }
+    for (i, ch) in bytes.iter().enumerate() {
+        if i > 0 && (bytes.len() - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(*ch as char);
+    }
+    out
 }
 
 /// Query `(total_bytes, free_bytes)` for the filesystem containing `path` via

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -8507,9 +8507,31 @@ pub async fn update_camera_lpr(
     Ok(())
 }
 
-/// Aggregate storage footprint of the `plate_reads` table, for the retention
-/// hint under the admin console's plate-read-retention field: total stored
-/// reads, total bytes of stored crop JPEGs, and the oldest read's timestamp.
+/// Total on-disk size of the Crumb Postgres database (`pg_database_size`), in
+/// bytes. This is the whole database — events, the segment index, config,
+/// bookmarks, and the LPR `plate_reads` table (whose `crop` bytea images
+/// dominate when LPR is on). The storage advisor subtracts the LPR crop bytes
+/// (via [`lpr_storage_stats`]) to attribute the two separately.
+///
+/// # Errors
+///
+/// Returns an error if the query fails.
+pub async fn database_size_bytes(pool: &Pool) -> Result<i64> {
+    let client = get_conn(pool).await?;
+    let row = client
+        .query_one(
+            "SELECT pg_database_size(current_database())::bigint AS bytes",
+            &[],
+        )
+        .await
+        .context("database_size_bytes")?;
+    Ok(row.get("bytes"))
+}
+
+/// Aggregate storage footprint of the `plate_reads` table: total stored reads,
+/// total bytes of stored crop JPEGs, and the oldest read's timestamp. Feeds both
+/// the admin console's plate-read-retention hint and the storage advisor's LPR
+/// footprint line.
 ///
 /// # Errors
 ///


### PR DESCRIPTION
The Storage Advisor showed per-disk recording usage but nothing about the *other* things Crumb stores — LPR plate images, the clip/playback/thumbnail caches, exports, the database. This adds a server-wide **Crumb data footprint** card: a color-coded stacked bar + one row per store, with size, share of the total, the physical location it lives on, and a budget meter for the capped caches.

Verified live on prod:
```
Recordings          6,305,777,734,133  2 recording locations
Database                3,070,114,374  Postgres    events, segment index, config
Thumbnail cache            37,374,561  /data/exports/.thumbs    filmstrip scrub frames
Playback cache             20,869,303  /data/exports/segcache   low-bitrate scrub transcodes
LPR plate images           14,975,441  Postgres    403 reads · oldest 4d
Clips cache                 2,088,568  /data/exports/clips
```

## Why a separate card, not segments on the disk bars
Each per-disk bar is sized by `statvfs` of that real filesystem. On a typical deployment the LPR images live in Postgres and the caches/exports under `export_dir` — different volumes from the recording disks — so folding them into a disk's bar would be factually wrong. The footprint card is volume-agnostic and honest: every store shows *where* it lives. Stores that happen to share a disk still read correctly.

## Backend
- `GET /stats/storage` gains `crumb_data[]` + `crumb_data_total_bytes`.
- On-disk sizes (clips / segcache / .thumbs / exports) via a best-effort recursive walk in `spawn_blocking`; Postgres sizes via new `db::database_size_bytes` (`pg_database_size`) + existing `lpr_storage_stats`. Database line = total − LPR crop bytes, so the two read distinctly.
- Failures degrade to 0 — the footprint never fails the advisor. LPR line only appears when there are reads; empty caches/exports are omitted; recordings + database always shown.

## Frontend (admin.html)
- `advFootprintPanel()` rendered once below the per-device cards; stable per-store colours (recordings = the Default blue), budget meters, responsive collapse. `node --check` clean.

## Notes
- Depends on `lpr_storage_stats` (also in #214); this branch carries it so it builds standalone — merges cleanly whichever lands first.
- Gate green: fmt + clippy (-D warnings) on the main base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)