### PR TITLE
fix(desktop): plate-crop aspect (real pixels, not 16:9) + persist watchlist open state

### DIFF
--- a/apps/desktop-flutter/lib/ui/plates/plate_crop.dart
+++ b/apps/desktop-flutter/lib/ui/plates/plate_crop.dart
@@ -12,21 +12,34 @@ import 'dart:typed_data';
 import 'package:image/image.dart' as img;
 
 /// Crop [fullBytes] to the normalized `[x, y, w, h]` [bbox] (fractions 0..1 of
-/// the snapshot). Returns re-encoded JPEG bytes, or null if the image can't be
-/// decoded (callers then fall back to the full frame).
+/// the snapshot). Returns a `(jpegBytes, width, height)` record — the re-encoded
+/// crop plus its true pixel dimensions — or null if the image can't be decoded
+/// (callers then fall back to the full frame).
+///
+/// The width/height are the crop's ACTUAL pixels (`bbox.w · frameW` by
+/// `bbox.h · frameH`), so `width / height` is the crop's real display aspect.
+/// This is the authoritative aspect: the bbox fractions alone can't give it
+/// without the snapshot's real dimensions (which vary by camera — never assume
+/// 16:9), and callers must not re-derive it from a hard-coded frame aspect.
 ///
 /// The decode/crop/encode (all `package:image`, which is isolate-safe) runs on
 /// a background isolate via [Isolate.run] so a full-frame JPEG doesn't freeze
 /// the UI isolate. The closure captures only sendable data (the byte list + the
 /// bbox doubles) and calls a top-level function.
-Future<Uint8List?> cropPlateToBbox(Uint8List fullBytes, List<double> bbox) {
+Future<(Uint8List, int, int)?> cropPlateToBbox(
+  Uint8List fullBytes,
+  List<double> bbox,
+) {
   return Isolate.run(() => cropPlateToBboxSync(fullBytes, bbox));
 }
 
 /// The synchronous crop, safe to run inside a background isolate. The rect is
 /// clamped into the image so an out-of-range or degenerate box still yields a
-/// crop.
-Uint8List? cropPlateToBboxSync(Uint8List fullBytes, List<double> bbox) {
+/// crop. Returns `(jpegBytes, width, height)` — see [cropPlateToBbox].
+(Uint8List, int, int)? cropPlateToBboxSync(
+  Uint8List fullBytes,
+  List<double> bbox,
+) {
   final decoded = img.decodeImage(fullBytes);
   if (decoded == null) return null;
   final w = decoded.width;
@@ -43,7 +56,7 @@ Uint8List? cropPlateToBboxSync(Uint8List fullBytes, List<double> bbox) {
   // primary guard; this catches any residual bad box. Non-destructive — the
   // full frame still contains the plate somewhere.
   if (_isNearlyBlack(cropped)) return null;
-  return img.encodeJpg(cropped, quality: 90);
+  return (img.encodeJpg(cropped, quality: 90), cropped.width, cropped.height);
 }
 
 /// True when [im] is almost entirely black — the signature of a crop box that
@@ -76,6 +89,12 @@ final Map<String, Uint8List> _plateCropCache = {};
 final List<String> _plateCropOrder = []; // oldest first
 const _plateCropCacheMax = 256;
 
+/// The crop's true display aspect (`width / height`), keyed by the same read id
+/// as [_plateCropCache] and evicted in lockstep with it. Populated by
+/// [cachedPlateCrop] from the crop's real pixel dimensions so display code can
+/// size the crop's slot to its OWN aspect without guessing the frame aspect.
+final Map<String, double> _plateCropAspect = {};
+
 /// Sentinel cached against a key when a crop was attempted but failed (bad
 /// bytes / undecodable), so a doomed decode isn't retried on every rebuild.
 /// Distinct from "not computed yet" (absent from the map).
@@ -91,9 +110,15 @@ Future<Uint8List?> cachedPlateCrop(
 ) async {
   final hit = _plateCropCache[key];
   if (hit != null) return identical(hit, _cropFailed) ? null : hit;
-  final cropped = await cropPlateToBbox(fullBytes, bbox);
-  _cachePut(key, cropped ?? _cropFailed);
-  return cropped;
+  final result = await cropPlateToBbox(fullBytes, bbox);
+  if (result == null) {
+    _cachePut(key, _cropFailed);
+    return null;
+  }
+  final (bytes, cw, ch) = result;
+  _cachePut(key, bytes);
+  if (ch > 0) _plateCropAspect[key] = cw / ch;
+  return bytes;
 }
 
 /// Read a previously computed crop synchronously, without computing one.
@@ -104,6 +129,11 @@ Uint8List? peekPlateCrop(String key) {
   return hit;
 }
 
+/// The crop's real display aspect (`width / height`) for [key], or null if the
+/// crop hasn't been computed yet or failed. Frame-aspect-independent — derived
+/// from the crop's own pixels, so it is correct for any camera resolution.
+double? peekPlateCropAspect(String key) => _plateCropAspect[key];
+
 void _cachePut(String key, Uint8List bytes) {
   if (_plateCropCache.containsKey(key)) {
     _plateCropOrder.remove(key);
@@ -113,5 +143,6 @@ void _cachePut(String key, Uint8List bytes) {
   while (_plateCropOrder.length > _plateCropCacheMax) {
     final evicted = _plateCropOrder.removeAt(0);
     _plateCropCache.remove(evicted);
+    _plateCropAspect.remove(evicted);
   }
 }

--- a/apps/desktop-flutter/lib/ui/plates/plate_report_dialog.dart
+++ b/apps/desktop-flutter/lib/ui/plates/plate_report_dialog.dart
@@ -113,7 +113,7 @@ class _PlateReportDialogState extends State<_PlateReportDialog> {
       if (fullSnapshot != null && read.bbox != null) {
         final cropped = await cropPlateToBbox(fullSnapshot, read.bbox!);
         if (cropped != null) {
-          plateCrop = cropped;
+          plateCrop = cropped.$1;
           cropIsFallback = false;
         }
       }

--- a/apps/desktop-flutter/lib/ui/plates/plates_prefs.dart
+++ b/apps/desktop-flutter/lib/ui/plates/plates_prefs.dart
@@ -43,6 +43,7 @@ class PlatesPrefs {
   static const String _kCropCorner = 'crumb_plates_crop_corner';
   static const String _kCropSize = 'crumb_plates_crop_size';
   static const String _kCollapse = 'crumb_plates_collapse_dupes';
+  static const String _kShowWatchlist = 'crumb_plates_show_watchlist';
 
   /// The last-used view mode, or [PlatesViewMode.list] when the operator has
   /// never changed it (or persistence is unavailable).
@@ -155,6 +156,29 @@ class PlatesPrefs {
     try {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool(_kCollapse, on);
+    } catch (_) {
+      /* best-effort persistence */
+    }
+  }
+
+  /// Whether the watchlist side panel is open. Defaults to true (open) the
+  /// first time, matching the panel's original default; thereafter it remembers
+  /// the operator's last choice, so closing it and switching tabs (which rebuilds
+  /// the Plates screen from scratch — there is no keep-alive) no longer springs
+  /// the panel back open. Purely local UI state, like the other plate prefs.
+  static Future<bool> getShowWatchlist() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      return prefs.getBool(_kShowWatchlist) ?? true;
+    } catch (_) {
+      return true;
+    }
+  }
+
+  static Future<void> setShowWatchlist(bool show) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_kShowWatchlist, show);
     } catch (_) {
       /* best-effort persistence */
     }

--- a/apps/desktop-flutter/lib/ui/plates/plates_screen.dart
+++ b/apps/desktop-flutter/lib/ui/plates/plates_screen.dart
@@ -179,6 +179,7 @@ class _PlatesScreenState extends State<PlatesScreen> {
     final corner = await PlatesPrefs.getCropCorner();
     final size = await PlatesPrefs.getCropSize();
     final collapse = await PlatesPrefs.getCollapseDuplicates();
+    final showWatchlist = await PlatesPrefs.getShowWatchlist();
     if (!mounted) return;
     setState(() {
       _viewMode = mode;
@@ -186,6 +187,7 @@ class _PlatesScreenState extends State<PlatesScreen> {
       _cropCorner = corner;
       _cropSize = size;
       _collapse = collapse;
+      _showWatchlist = showWatchlist;
     });
   }
 
@@ -518,8 +520,10 @@ class _PlatesScreenState extends State<PlatesScreen> {
                           onAdd: _addToWatchlist,
                           onRemove: _removeFromWatchlist,
                           onRefresh: _loadWatchlist,
-                          onClose: () =>
-                              setState(() => _showWatchlist = false),
+                          onClose: () => setState(() {
+                            _showWatchlist = false;
+                            PlatesPrefs.setShowWatchlist(false);
+                          }),
                         ),
                     ],
                   ),
@@ -688,8 +692,10 @@ class _PlatesScreenState extends State<PlatesScreen> {
               ),
             ),
           TextButton.icon(
-            onPressed: () =>
-                setState(() => _showWatchlist = !_showWatchlist),
+            onPressed: () => setState(() {
+              _showWatchlist = !_showWatchlist;
+              PlatesPrefs.setShowWatchlist(_showWatchlist);
+            }),
             icon: Icon(
               _showWatchlist
                   ? Icons.playlist_add_check
@@ -1461,18 +1467,18 @@ class _PlateThumbState extends State<_PlateThumb> {
     return Container(color: Colors.black, child: image);
   }
 
-  /// Display aspect (w/h) of the plate crop, derived from the read's
-  /// normalized bbox. The bbox is in frame FRACTIONS, so its w/h must be
-  /// scaled by the frame's own aspect (snapshots are 16:9 — the same
-  /// assumption [_sideBySide] makes for the full frame) to get the crop's
-  /// pixel aspect. Clamped to a sane band so a degenerate box can't produce
-  /// an absurd slot. Null when the read has no usable bbox.
+  /// Display aspect (w/h) of the plate crop, taken from the crop image's OWN
+  /// decoded pixels (surfaced by the crop cache via [peekPlateCropAspect]) — not
+  /// re-derived from the bbox. The bbox is in frame FRACTIONS, so turning it
+  /// into a pixel aspect needs the snapshot's real dimensions, which vary by
+  /// camera; a hard-coded 16:9 assumption there mis-shaped the slot on any
+  /// non-16:9 camera (that was the bug). Clamped to a sane band so a degenerate
+  /// crop can't produce an absurd slot. Null until the crop is computed (the
+  /// caller then falls back to a plain letterboxed render).
   double? get _cropAspect {
-    final bb = widget.read.bbox;
-    if (bb == null || bb.length < 4) return null;
-    final bw = bb[2], bh = bb[3];
-    if (bw <= 0 || bh <= 0) return null;
-    return ((bw / bh) * (16 / 9)).clamp(1.0, 8.0).toDouble();
+    final a = peekPlateCropAspect(widget.read.id);
+    if (a == null || a <= 0) return null;
+    return a.clamp(1.0, 8.0).toDouble();
   }
 
   /// The crop centered in its (fixed) slot with the black backing sized to

--- a/apps/desktop-flutter/test/plate_crop_aspect_test.dart
+++ b/apps/desktop-flutter/test/plate_crop_aspect_test.dart
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Regression lock for the plate-crop DISPLAY ASPECT.
+//
+// This has been re-broken repeatedly by deriving the crop's on-screen aspect
+// from the read's normalized bbox times a hard-coded frame aspect (16:9):
+//
+//     aspect = (bbox.w / bbox.h) * (16 / 9)   // WRONG
+//
+// The bbox is in frame FRACTIONS, so that is only right when the snapshot really
+// is 16:9. On a 4:3 or square camera the crop slot is the wrong shape and the
+// plate stretches / floats between letterbox bars — the recurring "plate crops
+// don't scale right" bug.
+//
+// The durable rule: the crop's aspect MUST come from the crop image's OWN
+// pixels. cropPlateToBboxSync returns the true (width, height); cachedPlateCrop
+// caches width/height and exposes it via peekPlateCropAspect. These tests pin
+// that invariant on deliberately NON-16:9 frames, so any reintroduced
+// frame-aspect guess (16:9 or otherwise) fails here instead of shipping.
+
+import 'dart:typed_data';
+
+import 'package:crumb_desktop/ui/plates/plate_crop.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+
+/// A solid mid-gray JPEG of [w]x[h] — non-black so the crop isn't rejected by
+/// plate_crop's near-black guard, uniform so JPEG re-encode preserves the exact
+/// dimensions the aspect math depends on.
+Uint8List _solidJpeg(int w, int h) {
+  final im = img.Image(width: w, height: h);
+  img.fill(im, color: img.ColorRgb8(180, 180, 180));
+  return img.encodeJpg(im, quality: 95);
+}
+
+/// The aspect the OLD, buggy code produced from the bbox fractions alone.
+double _legacy16x9Guess(double bw, double bh) => (bw / bh) * (16 / 9);
+
+void main() {
+  test('crop dims come from real pixels on a square (non-16:9) frame', () {
+    final frame = _solidJpeg(400, 400); // 1:1 — nothing like 16:9
+    // Plate region: half the frame width, a quarter of its height.
+    final res = cropPlateToBboxSync(frame, const [0.25, 0.25, 0.5, 0.25]);
+    expect(res, isNotNull);
+    final (bytes, w, h) = res!;
+    expect(bytes, isNotEmpty);
+    expect(w, 200); // 0.5 * 400
+    expect(h, 100); // 0.25 * 400
+    final realAspect = w / h; // 2.0
+    expect(realAspect, closeTo(2.0, 0.001));
+    // The regression guard: the legacy 16:9-derived guess would be ~3.56, and
+    // would mis-shape the slot. The real pixel aspect must NOT equal it.
+    expect(realAspect, isNot(closeTo(_legacy16x9Guess(0.5, 0.25), 0.05)));
+  });
+
+  test('crop aspect is frame-correct on a 4:3 frame', () {
+    final frame = _solidJpeg(800, 600); // 4:3
+    final res = cropPlateToBboxSync(frame, const [0.1, 0.4, 0.4, 0.1]);
+    expect(res, isNotNull);
+    final (_, w, h) = res!;
+    expect(w, 320); // 0.4 * 800
+    expect(h, 60); //  0.1 * 600
+    expect(w / h, closeTo(320 / 60, 0.001)); // 5.333, the true pixel aspect
+    // Legacy guess would be (0.4/0.1)*(16/9) = 7.11 — must NOT match.
+    expect(w / h, isNot(closeTo(_legacy16x9Guess(0.4, 0.1), 0.1)));
+  });
+
+  test('cachedPlateCrop populates peekPlateCropAspect with the real aspect',
+      () async {
+    final frame = _solidJpeg(400, 400);
+    const key = 'test-read-square';
+    expect(peekPlateCropAspect(key), isNull); // nothing computed yet
+    final crop = await cachedPlateCrop(key, frame, const [0.25, 0.25, 0.5, 0.25]);
+    expect(crop, isNotNull);
+    final aspect = peekPlateCropAspect(key);
+    expect(aspect, isNotNull);
+    // Real pixels (2.0), not the 16:9 guess (~3.56).
+    expect(aspect!, closeTo(2.0, 0.001));
+  });
+}


### PR DESCRIPTION
Fixes #224

Two Plates-screen (LPR tab) fixes in the Flutter desktop client. Build-verified with `flutter analyze` on the winbuild box (zero errors/warnings from these changes; only pre-existing cargokit `build_tool` analyzer noise remains).

## 1. Plate crop scaling — regression from #218
`_cropAspect` derived each crop's display aspect as `(bw/bh) × (16/9)`, hard-coding a 16:9 snapshot. The bbox values are frame *fractions*, so the true aspect needs the camera's real resolution — on any non-16:9 camera the crop slot was mis-shaped (stretched / wrong letterbox). This is the recurring "crops don't scale right" bug.

**Fix:** the crop pipeline already computes the crop's true pixel dimensions, so cache the real aspect (`width/height`) and drive the slot from it — never from a frame assumption. `cropPlateToBbox` now returns `(bytes, w, h)`; `plates_screen` reads the cached aspect via `peekPlateCropAspect`. Keeps #218's edge-to-edge fill, correct at any resolution.

## 2. Watchlist panel re-opens on every tab switch — long-standing (since #138), not this batch
`_showWatchlist` defaulted to `true` and was never persisted; the tab shell rebuilds each tab on switch (no keep-alive), so returning to the LPR tab always re-opened the panel even after the user closed it.

**Fix:** persist open/closed via `PlatesPrefs` like the other plate toggles — hydrate on load, save on toggle and on close. Remembers the last choice across tab switches and restarts.

Files: `plate_crop.dart`, `plates_screen.dart`, `plates_prefs.dart`, `plate_report_dialog.dart`.

Note: not visually verified (winbuild is headless) — the crop change is layout logic, analyze-verified and reasoned, but a human should eyeball the crop rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)