### PR TITLE
fix(admin): never silently downgrade a camera's LPR engine to 'frigate'

### DIFF
--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -5324,8 +5324,17 @@ async function saveLprZones() {
   }
   const camId = LZ.camId;
   const cfg = LPR_CAMS[camId] || {};
+  // Never let a zone save rewrite the engine to a guessed value: preserve the
+  // camera's stored engine, and abort if it's unknown rather than downgrading
+  // it to 'frigate' (which would silently turn off a 'both' camera's crumb-alpr
+  // half). Editing zones must not change which engine reads the camera.
+  const engine = lprResolveEngine(cfg.engine, cfg);
+  if (engine === null) {
+    setMsg('lz-msg', 'Engine unknown for this camera — reopen the LPR table before saving zones.', 'err');
+    return;
+  }
   const body = {
-    engine: cfg.engine || 'frigate',
+    engine: engine,
     min_confidence: cfg.min_confidence ?? 0.8,
     zones: zones,
   };
@@ -9342,7 +9351,7 @@ async function loadLprCamTable() {
   if (!$('lpr-cam-table')) return; // navigated away
   LPR_CAMS = {};
   cams.forEach((c, i) => { LPR_CAMS[c.id] = cfgs[i]; });
-  const engOpt = (cfg, v, label) => `<option value="${v}" ${(cfg.engine||'frigate')===v?'selected':''}>${label}</option>`;
+  const engOpt = (cfg, v, label) => `<option value="${v}" ${cfg.engine===v?'selected':''}>${label}</option>`;
   const rows = cams.map(c => {
     const cfg = LPR_CAMS[c.id] || {};
     return `<tr>
@@ -9363,12 +9372,34 @@ async function loadLprCamTable() {
     <tbody>${rows}</tbody></table></div>`;
 }
 
+/* The four valid per-camera LPR engines. A save must NEVER invent one the
+   operator didn't choose: silently defaulting a missing/unknown value to
+   'frigate' would downgrade a 'both' camera — turning off half its LPR and
+   dropping it from the dual-engine A/B benchmark (the Benchmark button then
+   vanishes). Callers use [lprResolveEngine] to get a known engine or null. */
+const LPR_ENGINES = ['none', 'frigate', 'crumb-alpr', 'both'];
+/* Resolve the engine to persist: the operator's explicit choice [preferred] if
+   it is a known engine, else the camera's stored engine, else null (→ the
+   caller aborts and reloads rather than writing a guessed engine). */
+function lprResolveEngine(preferred, cfg) {
+  if (LPR_ENGINES.includes(preferred)) return preferred;
+  if (cfg && LPR_ENGINES.includes(cfg.engine)) return cfg.engine;
+  return null;
+}
+
 /* Save one row (engine and/or min-conf changed): merge over the cached config
    so zones survive, PUT, then refresh the row's status pill. On failure,
    reload the table so the controls snap back to stored reality. */
 async function lprCamSave(camId) {
   const cfg = LPR_CAMS[camId] || {};
-  const engine = ($('lpr-eng-' + camId) || {}).value || cfg.engine || 'frigate';
+  const engine = lprResolveEngine(($('lpr-eng-' + camId) || {}).value, cfg);
+  if (engine === null) {
+    // Stored engine unknown (config didn't load) — reload rather than write a
+    // guessed value that could downgrade the camera.
+    toast('Engine unknown for this camera — reloaded; try again.');
+    loadLprCamTable();
+    return;
+  }
   const rawConf = parseFloat(($('lpr-conf-' + camId) || {}).value);
   const minConf = Number.isFinite(rawConf) ? Math.max(0, Math.min(1, rawConf)) : (cfg.min_confidence ?? 0.8);
   const body = { engine, min_confidence: minConf, zones: cfg.zones || null };


### PR DESCRIPTION
Fixes #225

The LPR admin table saved `cfg.engine || 'frigate'` in two places (row save at ~9371, zone save at ~5328). When a camera's per-camera LPR config was missing/unknown at render time, the engine dropdown showed — and a save wrote — `'frigate'`, **silently downgrading a `'both'` camera**. That turns off its crumb-alpr half and drops it from the dual-engine A/B benchmark, so the desktop **Benchmark button disappears**.

This is the most plausible mechanism behind a "Benchmark button vanished" report after the #214 LPR-admin rework (which consolidated the engine dropdown into the new LPR section).

## Fix
- Add `LPR_ENGINES` + `lprResolveEngine(preferred, cfg)`: resolve to the operator's explicit choice if it's a known engine, else the stored engine, else `null`.
- Both save paths (`lprCamSave`, `saveLprZones`) now **abort-and-reload** instead of writing a guessed engine.
- `engOpt` no longer pre-selects `'frigate'` for an unknown engine — it renders the true stored engine only.
- Normal saves (engine is always one of the four valid values) are unchanged.

JS validated with `node --check` on the extracted `<script>` block. No new endpoints/config/ports, so no install-guide changes.

Also worth flagging separately: there is **no Flutter build job in CI** (the gate is Rust-only), so desktop-flutter compile breaks aren't caught by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)