### PR TITLE
fix(wizard): storage-cap prefill floors at 80% of free, never unlimited (#227)

### DIFF
--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -1795,11 +1795,18 @@ function wizardStorageBody() {
       <div style="height:100%;width:${usedPct}%;background:var(--accent)"></div>
     </div>
     <div class="login-sub" style="margin-top:6px">${fmtBytes(free)} free of ${fmtBytes(total)}${total ? ` · ${usedPct}% used` : ''}</div>` : '';
-  // Cap prefill: min(80% of fs_total, free − 50 GiB) so a novice disk can't fill.
+  // Cap prefill: leave 50 GiB headroom (free − 50 GiB), but never below 80% of
+  // free and never above 80% of total, so a novice disk can't fill. The floor
+  // matters most on a nearly-full disk: when free < 50 GiB the headroom term
+  // goes negative, and without the 80%-of-free floor it clamped to 0, which
+  // renders as a blank field = UNLIMITED, the least-safe cap exactly when the
+  // disk is smallest (#227).
   const dp = WZ.defaultPolicy || {};
   const HEADROOM = 50 * 1024 * 1024 * 1024;
   const capDefaultBytes = total
-    ? Math.max(0, Math.min(Math.floor(total * 0.8), (free != null ? free - HEADROOM : Math.floor(total * 0.8))))
+    ? (free != null
+        ? Math.min(Math.floor(total * 0.8), Math.max(free - HEADROOM, Math.floor(free * 0.8)))
+        : Math.floor(total * 0.8))
     : 0;
   const capBytes = (dp.live_max_bytes != null) ? dp.live_max_bytes : capDefaultBytes;
   const capGb = capBytes ? Math.round(capBytes / 1e9) : '';


### PR DESCRIPTION
**Fixes #227.**

The first-run wizard's storage step prefilled the keep-at-most cap as `min(80% of total, free − 50 GiB)`. When free space is under 50 GiB the headroom term goes negative, the old `Math.max(0, …)` clamped it to **0**, and a 0 cap renders as a **blank field, which the wizard treats as unlimited**. So the least-safe cap was prefilled exactly when the disk is smallest and most needs one, a disk-fill / footage-loss hazard.

**Fix:** floor the prefill at 80% of *free* (still ceilinged at 80% of *total*), so it is always a sane positive cap. `admin.html` only, no API or schema change. Extracted-script `node --check` passes.

| free space | old prefill | new prefill |
|---|---|---|
| 2 TB free / 4 TB disk | ~1.95 TB (free − 50 G) | ~1.95 TB (unchanged) |
| 40 GiB free | **0 → unlimited** | **32 GiB (80% of free)** |
| 10 GiB free | **0 → unlimited** | **8 GiB (80% of free)** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)