### PR TITLE
fix(config): forward code-read env keys via compose + empty-safe helpers + TZ inherit (#228, #229)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ POSTGRES_DB=crumb
 # api + recorder read this. For a REMOTE Postgres, change the host and use
 # docker-compose.override.example.yml. Host 'postgres' = the compose service name.
 DATABASE_URL=postgresql://crumb:change-me@postgres:5432/crumb
-# DB_POOL_SIZE=42                         # optional; unset = code default (32). Raising it also needs a compose override (see docs)
+# DB_POOL_SIZE=42                         # optional; unset = code default (32). Forwarded by compose to api + recorder
 
 # --- Streaming (fallbacks; the admin "Server & streaming" settings win) ---
 # Leave both blank: Crumb's go2rtc runs embedded in the recorder and the compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,16 @@ services:
       SEED_DEFAULT_CAMERAS: ${SEED_DEFAULT_CAMERAS:-false}   # dev-only prototype cameras; keep false in real deploys
       RUST_LOG: ${RUST_LOG:-info}
       LOG_FORMAT: ${LOG_FORMAT:-json}
+      # Timezone for the archive/retention cron. Unset = inherit TZ above so the
+      # schedule matches the container wall clock; set only to run it in a
+      # different zone. (#228)
+      RECORDER_TZ: ${RECORDER_TZ:-}
+      # Home Assistant as a motion source (optional; per-camera links live in the
+      # DB, these are the env fallback). Empty = use DB settings / disabled. (#229)
+      HA_BASE_URL: ${HA_BASE_URL:-}
+      HA_TOKEN: ${HA_TOKEN:-}
+      HA_TOKEN_FILE: ${HA_TOKEN_FILE:-}
+      DB_POOL_SIZE: ${DB_POOL_SIZE:-}                   # sqlx pool size (empty = default 32)
     volumes:
       - ${MEDIA_HOST_PATH:-./_data}:/data              # one broad media root, RW (recorder owns all writes)
       - /proc:/host/proc:ro                            # NSpid translation for per-camera GPU% (optional)
@@ -158,6 +168,29 @@ services:
       DB_BACKUP_KEEP_WEEKS: ${DB_BACKUP_KEEP_WEEKS:-4}
       DB_BACKUP_KEEP_MONTHS: ${DB_BACKUP_KEEP_MONTHS:-0}
       DB_BACKUP_ENABLED: ${DB_BACKUP_ENABLED:-true}
+      # Home Assistant entity overlay / control (optional; DB settings win, these
+      # are the env fallback). Empty = use DB settings / disabled. (#229)
+      HA_BASE_URL: ${HA_BASE_URL:-}
+      HA_TOKEN: ${HA_TOKEN:-}
+      HA_TOKEN_FILE: ${HA_TOKEN_FILE:-}
+      DB_POOL_SIZE: ${DB_POOL_SIZE:-}                   # sqlx pool size (empty = default 32)
+      MAINTENANCE_UNTIL: ${MAINTENANCE_UNTIL:-}         # unix seconds; suppress low-disk/offline alerts during planned maintenance
+      CAMERA_OFFLINE_BOOT_GRACE_SECS: ${CAMERA_OFFLINE_BOOT_GRACE_SECS:-}   # grace before offline alerts after boot (empty = default 180)
+      # Thumbnail cache + pregen tuning (all optional; empty = built-in default). (#229)
+      THUMB_CACHE_DIR: ${THUMB_CACHE_DIR:-}
+      THUMB_CACHE_MAX_BYTES: ${THUMB_CACHE_MAX_BYTES:-}
+      THUMB_CACHE_TTL_SECONDS: ${THUMB_CACHE_TTL_SECONDS:-}
+      THUMB_EXTRACT_MAX_CONCURRENCY: ${THUMB_EXTRACT_MAX_CONCURRENCY:-}
+      THUMB_EXTRACT_TIMEOUT_SECS: ${THUMB_EXTRACT_TIMEOUT_SECS:-}
+      THUMB_INTERVAL_SECS: ${THUMB_INTERVAL_SECS:-}
+      THUMB_MAX_ATTEMPTS: ${THUMB_MAX_ATTEMPTS:-}
+      THUMB_MAX_WIDTH: ${THUMB_MAX_WIDTH:-}
+      THUMB_MIN_WIDTH: ${THUMB_MIN_WIDTH:-}
+      THUMB_NEAR_BLACK_LUMA: ${THUMB_NEAR_BLACK_LUMA:-}
+      THUMB_PREGEN_ENABLED: ${THUMB_PREGEN_ENABLED:-}
+      THUMB_PREGEN_LOOKBACK_HOURS: ${THUMB_PREGEN_LOOKBACK_HOURS:-}
+      THUMB_PREGEN_SCAN_SECS: ${THUMB_PREGEN_SCAN_SECS:-}
+      THUMB_PREGEN_WIDTH: ${THUMB_PREGEN_WIDTH:-}
     volumes:
       - ${MEDIA_HOST_PATH:-./_data}:/data:ro            # same media root as recorder, READ-ONLY (api never writes footage)
       - crumb_exports:/exports

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,41 @@ revisit.
 
 ---
 
+## 2026-07-18, Compose forwards code-read env keys explicitly; helpers treat empty as unset
+
+**Status.** Implemented. `docker-compose.yml` now forwards the previously
+silently-dropped keys (`RECORDER_TZ`, `HA_BASE_URL`/`HA_TOKEN`/`HA_TOKEN_FILE`,
+`DB_POOL_SIZE`, `MAINTENANCE_UNTIL`, `CAMERA_OFFLINE_BOOT_GRACE_SECS`, the
+`THUMB_*` set) into the api and recorder as `${VAR:-}`, and `parse_env` /
+`parse_tz_env` treat an empty-or-whitespace value as "unset → default" (fixes
+#228, #229).
+
+**Context.** These keys are read via `std::env` but the stock compose never
+forwarded them, so setting them in `.env` was a silent no-op. Compose
+materializes a forwarded key even when unset (`${VAR:-}` → `""`), and
+`parse_env` previously treated `""` as a fatal parse error, so a naive
+passthrough would have failed boot. Separately, `RECORDER_TZ` hard-defaulted to
+`America/Los_Angeles` for every operator regardless of `TZ`.
+
+**Chosen.** Explicit per-service passthrough of the documented keys, plus making
+the numeric/timezone env helpers empty-safe (mirroring the existing
+`parse_bool_env`). `RECORDER_TZ` now inherits `TZ` when unset. This keeps the
+env contract explicit and secure-by-default while making every documented key
+actually work from `.env`.
+**Rejected.** `env_file: .env` on the api/recorder services (would pull the
+*entire* `.env`, including secrets meant only for other services, into every
+container, widening exposure, against golden rule 1). Per-key compose defaults
+duplicating each code default (e.g. `${DB_POOL_SIZE:-32}`) drift from the code
+defaults over time; the empty-as-unset helper fix removes the need. Leaving the
+docs to say "add a compose override" (the keys are meant to work from `.env`).
+**Trade-offs accepted.** The api env block grew by the `THUMB_*` tuning set,
+which most operators never touch, in exchange for no silent no-ops. An operator
+who explicitly sets a key to an empty string now gets the default rather than an
+empty value; for these keys that is the intended reading of "blank = unset".
+**Revisit.** If the forwarded-key list grows unwieldy, reconsider a scoped
+`env_file` split (a non-secret `.env.app` forwarded wholesale, secrets kept
+per-service).
+
 ## 2026-07-18, Desktop release ships the Flutter client, not the retired Tauri app
 
 **Status.** Decided during the v0.1.0 readiness audit; NOT yet implemented. The

--- a/services/common/src/config.rs
+++ b/services/common/src/config.rs
@@ -411,7 +411,12 @@ impl Config {
             live_storage_name: optional_env("LIVE_STORAGE_NAME", "NVMe-Live"),
             archive_storage_path: optional_env("ARCHIVE_STORAGE_PATH", "/data/archive"),
             archive_storage_name: optional_env("ARCHIVE_STORAGE_NAME", "Bulk-Archive"),
-            archive_cron_tz: parse_tz_env("RECORDER_TZ", "America/Los_Angeles"),
+            // RECORDER_TZ wins; otherwise inherit the container's TZ (compose
+            // forwards it, and setup-env.sh sets it to the host zone) so a
+            // non-US operator's archive/retention cron matches their wall clock
+            // instead of always running in LA. America/Los_Angeles only if
+            // neither is set (bare-metal with no TZ at all). (#228)
+            archive_cron_tz: parse_tz_env("RECORDER_TZ", &optional_env("TZ", "America/Los_Angeles")),
             motion_hwaccel,
             motion_vaapi_device: optional_env("MOTION_VAAPI_DEVICE", "/dev/dri/renderD128"),
             max_gpu_decode_sessions: parse_env("MAX_GPU_DECODE_SESSIONS", 4)?,
@@ -460,7 +465,15 @@ fn require_secret(key: &str) -> Result<String> {
 /// it runs the archive cron in the wrong timezone with no clue why (audit
 /// #84).
 fn parse_tz_env(key: &str, default: &str) -> chrono_tz::Tz {
+    // An env var set to an empty string (compose forwards keys as `${VAR:-}`, so
+    // an unset key still materializes as "") means "not configured": use the
+    // default, don't treat "" as an invalid-zone error. (#228/#229)
     let raw = optional_env(key, default);
+    let raw = if raw.trim().is_empty() {
+        default.to_owned()
+    } else {
+        raw
+    };
     match raw.parse::<chrono_tz::Tz>() {
         Ok(tz) => tz,
         Err(_) => {
@@ -487,6 +500,11 @@ where
     T::Err: std::fmt::Display,
 {
     match env::var(key) {
+        // Empty (or whitespace-only) means "not configured": compose forwards
+        // keys as `${VAR:-}`, so an unset key still arrives as "". Treat it as
+        // the default rather than a fatal parse error that would fail boot.
+        // (#229; mirrors parse_bool_env's empty handling.)
+        Ok(val) if val.trim().is_empty() => Ok(default),
         Ok(val) => val
             .parse::<T>()
             .map_err(|e| anyhow::anyhow!("env var '{key}' = '{val}' could not be parsed: {e}")),
@@ -523,7 +541,7 @@ fn parse_bool_env(key: &str, default: bool) -> Result<bool> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_tz_env;
+    use super::{optional_env, parse_env, parse_tz_env};
 
     /// Audit #84: an invalid TZ value must fall back (non-fatal, now loudly
     /// logged) to the caller's default when that parses — never panic, never
@@ -553,5 +571,58 @@ mod tests {
             parse_tz_env("CRUMB_TEST_TZ_UNSET", "America/Los_Angeles"),
             chrono_tz::Tz::America__Los_Angeles
         );
+    }
+
+    /// #229: compose forwards keys as `${VAR:-}`, so an unset key arrives as an
+    /// empty string. parse_env must treat that as "use the default", not a fatal
+    /// parse error that would fail boot.
+    #[test]
+    fn parse_env_treats_empty_as_default() {
+        std::env::set_var("CRUMB_TEST_EMPTY_NUM", "");
+        assert_eq!(
+            parse_env::<u32>("CRUMB_TEST_EMPTY_NUM", 32).unwrap(),
+            32,
+            "an empty env value must fall back to the default, not error"
+        );
+        std::env::set_var("CRUMB_TEST_WS_NUM", "   ");
+        assert_eq!(
+            parse_env::<u32>("CRUMB_TEST_WS_NUM", 32).unwrap(),
+            32,
+            "a whitespace-only env value must fall back to the default"
+        );
+        std::env::set_var("CRUMB_TEST_SET_NUM", "8");
+        assert_eq!(parse_env::<u32>("CRUMB_TEST_SET_NUM", 32).unwrap(), 8);
+        std::env::remove_var("CRUMB_TEST_EMPTY_NUM");
+        std::env::remove_var("CRUMB_TEST_WS_NUM");
+        std::env::remove_var("CRUMB_TEST_SET_NUM");
+    }
+
+    /// #228: with RECORDER_TZ unset, the archive cron inherits TZ (this is how
+    /// the recorder resolves it: `parse_tz_env("RECORDER_TZ", optional_env("TZ", …))`),
+    /// and an empty RECORDER_TZ (the `${VAR:-}` case) is treated as unset.
+    #[test]
+    fn archive_tz_inherits_tz_when_recorder_tz_absent() {
+        // RECORDER_TZ unset -> inherit TZ.
+        std::env::set_var("CRUMB_TEST_TZ_INHERIT", "Europe/Berlin");
+        assert_eq!(
+            parse_tz_env(
+                "CRUMB_TEST_RECORDER_TZ_UNSET",
+                &optional_env("CRUMB_TEST_TZ_INHERIT", "America/Los_Angeles")
+            ),
+            chrono_tz::Tz::Europe__Berlin,
+            "an unset RECORDER_TZ must inherit TZ"
+        );
+        // RECORDER_TZ present but empty -> still treated as unset, inherit TZ.
+        std::env::set_var("CRUMB_TEST_RECORDER_TZ_EMPTY", "");
+        assert_eq!(
+            parse_tz_env(
+                "CRUMB_TEST_RECORDER_TZ_EMPTY",
+                &optional_env("CRUMB_TEST_TZ_INHERIT", "America/Los_Angeles")
+            ),
+            chrono_tz::Tz::Europe__Berlin,
+            "an empty RECORDER_TZ must be treated as unset and inherit TZ"
+        );
+        std::env::remove_var("CRUMB_TEST_TZ_INHERIT");
+        std::env::remove_var("CRUMB_TEST_RECORDER_TZ_EMPTY");
     }
 }

--- a/services/common/src/config.rs
+++ b/services/common/src/config.rs
@@ -416,7 +416,10 @@ impl Config {
             // non-US operator's archive/retention cron matches their wall clock
             // instead of always running in LA. America/Los_Angeles only if
             // neither is set (bare-metal with no TZ at all). (#228)
-            archive_cron_tz: parse_tz_env("RECORDER_TZ", &optional_env("TZ", "America/Los_Angeles")),
+            archive_cron_tz: parse_tz_env(
+                "RECORDER_TZ",
+                &optional_env("TZ", "America/Los_Angeles"),
+            ),
             motion_hwaccel,
             motion_vaapi_device: optional_env("MOTION_VAAPI_DEVICE", "/dev/dri/renderD128"),
             max_gpu_decode_sessions: parse_env("MAX_GPU_DECODE_SESSIONS", 4)?,


### PR DESCRIPTION
**Fixes #228 and #229.** Both live in the same two files (`config.rs` + `docker-compose.yml`), so they share one branch; splitting would just conflict.

## #229 — code-read env keys were silent no-ops
`HA_BASE_URL`/`HA_TOKEN`/`HA_TOKEN_FILE`, `DB_POOL_SIZE`, `MAINTENANCE_UNTIL`, `CAMERA_OFFLINE_BOOT_GRACE_SECS`, and the `THUMB_*` set are read via `std::env` but the stock compose never forwarded them, so setting them in `.env` did nothing. Now forwarded to the api and recorder (per which service reads each) as `${VAR:-}`.

**The subtlety:** compose materializes a forwarded key even when unset (`${VAR:-}` → `""`), and `parse_env` previously treated `""` as a **fatal parse error** — a naive passthrough would have failed boot. So `parse_env`/`parse_tz_env` now treat empty/whitespace as "unset → default", mirroring the existing `parse_bool_env`.

## #228 — RECORDER_TZ forced LA on everyone
`RECORDER_TZ` hard-defaulted to `America/Los_Angeles` regardless of `TZ`, so archive/retention ran in LA time for every operator. Now it **inherits `TZ`** when unset (and `RECORDER_TZ` is also forwarded for an explicit override); `America/Los_Angeles` only if neither is set.

## Tests
- `parse_env_treats_empty_as_default` — empty/whitespace → default, not a boot error.
- `archive_tz_inherits_tz_when_recorder_tz_absent` — unset/empty `RECORDER_TZ` inherits `TZ`.

## Docs / decisions
- `.env.example`: `DB_POOL_SIZE` no longer says "needs a compose override".
- `docs/DECISIONS.md`: records why explicit per-service forwarding + empty-as-unset (rejected `env_file` for secure-by-default; rejected per-key compose defaults for drift).

Recorder-correctness note (golden rule 2): the only recorder-path change is the archive-cron timezone *source* (RECORDER_TZ → TZ → LA); no change to recording, indexing, retention logic, or migrations. Compose YAML validated; the pinned-toolchain `rust` CI job runs the full fmt/clippy/test gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)