### PR TITLE
fix(console): schedule times use the server's timezone, not hardcoded LA (#237)

### DIFF
--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -3452,26 +3452,44 @@ function fmtClock(h24, m) {
 /* Plain-English schedule summary (for the schedule control preview note). */
 function describeSchedule(s) {
   if (s.type === 'none')   return 'No automatic archiving. Footage still moves to archive when the live storage size cap is reached, set a size cap to control this.';
-  if (s.type === 'hourly') return 'Archive runs every hour, at the top of the hour, Pacific.';
+  if (s.type === 'hourly') return `Archive runs every hour, at the top of the hour, ${serverTzLabel()}.`;
   if (s.type === 'every-n') {
-    if (s.n === 1) return 'Archive runs every hour, at the top of the hour, Pacific.';
+    if (s.n === 1) return `Archive runs every hour, at the top of the hour, ${serverTzLabel()}.`;
     const hrs = []; for (let h = 0; h < 24; h += s.n) hrs.push(fmtClock(h, 0));
-    return `Archive runs every ${s.n} hours (${hrs.join(', ')}) Pacific.`;
+    return `Archive runs every ${s.n} hours (${hrs.join(', ')}) ${serverTzLabel()}.`;
   }
-  if (s.type === 'daily')  return `Archive runs daily at ${fmtClock(s.hour24, s.minute)} Pacific.`;
+  if (s.type === 'daily')  return `Archive runs daily at ${fmtClock(s.hour24, s.minute)} ${serverTzLabel()}.`;
   if (s.type === 'weekly') {
     const full = s.days.map(d => ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'][d]);
-    return `Archive runs every ${full.join(' and ')} at ${fmtClock(s.hour24, s.minute)} Pacific.`;
+    return `Archive runs every ${full.join(' and ')} at ${fmtClock(s.hour24, s.minute)} ${serverTzLabel()}.`;
   }
   return 'Custom schedule.';
 }
 
-/* "Next run" preview computed in America/Los_Angeles wall-clock time. */
+/* The IANA zone the SERVER evaluates schedules in, reported by GET /config/server
+   (#237). Falls back to America/Los_Angeles for an old backend that doesn't send
+   it, matching the server's own default. */
+function serverTz() {
+  const tz = WZ.server && WZ.server.tz;
+  return (typeof tz === 'string' && tz) ? tz : 'America/Los_Angeles';
+}
+/* Short human label for the server's zone (e.g. "PST", "CET", "GMT+9") for
+   inline schedule copy; falls back to the IANA name if the browser can't. */
+function serverTzLabel() {
+  const tz = serverTz();
+  try {
+    const p = new Intl.DateTimeFormat('en-US', { timeZone: tz, timeZoneName: 'short' })
+      .formatToParts(new Date());
+    return p.find(x => x.type === 'timeZoneName')?.value || tz;
+  } catch { return tz; }
+}
+
+/* "Next run" preview computed in the server's schedule timezone. */
 function nextRunPreview(s) {
   if (!s || s.type === 'none' || s.type === 'custom') return '';
-  // Current Pacific wall-clock components.
+  // Current wall-clock components in the server's zone.
   const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone: 'America/Los_Angeles', hour12: false,
+    timeZone: serverTz(), hour12: false,
     weekday: 'short', hour: '2-digit', minute: '2-digit'
   }).formatToParts(new Date());
   const get = t => parts.find(p => p.type === t)?.value;
@@ -3507,7 +3525,7 @@ function nextRunPreview(s) {
   if (best.offset === 0) when = 'today';
   else if (best.offset === 1) when = 'tomorrow';
   else { const d = (dow + best.offset) % 7; when = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'][d]; }
-  return `Next run: ${when} at ${fmtClock(best.h, best.m)} Pacific.`;
+  return `Next run: ${when} at ${fmtClock(best.h, best.m)} ${serverTzLabel()}.`;
 }
 
 /* ── Schedule control: render + wire + read ───────────────────────────────── */
@@ -3591,7 +3609,7 @@ function renderSchedControl(pfx, cron) {
       ${customRow}
     </div>
     <div class="sched-preview" id="${pfx}-sched-preview"></div>
-    <div class="sched-tz">Schedules run in America/Los_Angeles time.</div>`;
+    <div class="sched-tz">Schedules run in ${esc(serverTz())} time (set by the server's TZ).</div>`;
 
   schedChanged(pfx);
 }
@@ -7340,7 +7358,7 @@ function bannerHTML(p, borderCls, srcText, camId) {
   const liveStHl  = hl(esc(liveName), 'accent2');
   const capHl     = p.live_max_bytes ? `, up to ${hl(fmtBytes(p.live_max_bytes), 'warn')}` : '';
   const archiveLine = p.archive_enabled
-    ? `Archive to ${hl(esc(archName), 'accent2')} for ${hl(fmtDur(p.archive_retention_hours), 'warn')}, <span style="color:var(--dim)">${esc(fmtSchedule(p.archive_schedule).toLowerCase())} Pacific</span>.`
+    ? `Archive to ${hl(esc(archName), 'accent2')} for ${hl(fmtDur(p.archive_retention_hours), 'warn')}, <span style="color:var(--dim)">${esc(fmtSchedule(p.archive_schedule).toLowerCase())} ${esc(serverTzLabel())}</span>.`
     : `<span style="color:var(--dim2)">No archiving configured.</span>`;
   return `<div class="inherit-banner ${borderCls}">
     <div class="inherit-banner-title">Using "${esc(p.name || 'Default')}" policy</div>
@@ -8193,7 +8211,7 @@ function bannerHTMLForGroup(p, inheriting) {
   const modeHl   = p.mode === 'motion' ? hl('Motion-triggered', 'danger') : hl('Continuous', 'ok');
   const streamHl = hl(p.record_stream === 'sub' ? 'sub' : 'main', 'accent2');
   const archiveLine = p.archive_enabled
-    ? `Archive to ${hl(archName, 'accent2')} for ${hl(fmtDur(p.archive_retention_hours), 'warn')}, <span style="color:var(--dim)">${esc(fmtSchedule(p.archive_schedule).toLowerCase())} Pacific</span>.`
+    ? `Archive to ${hl(archName, 'accent2')} for ${hl(fmtDur(p.archive_retention_hours), 'warn')}, <span style="color:var(--dim)">${esc(fmtSchedule(p.archive_schedule).toLowerCase())} ${esc(serverTzLabel())}</span>.`
     : `<span style="color:var(--dim2)">No archiving configured.</span>`;
   return `<div class="inherit-banner ${inheriting?'default-profile':''}">
     <div class="inherit-banner-title">Using "${esc(p.name || 'Default')}" profile</div>
@@ -8385,7 +8403,7 @@ function renderProfile(id) {
           ${capForStorage(p.archive_storage_id)}
           <div class="tier-field"><div class="tier-field-name">Keep for</div><div class="tier-field-value">${p.archive_retention_hours==null?'No expiry':fmtDur(p.archive_retention_hours)}</div></div>
           <div class="tier-field"><div class="tier-field-name">Size cap</div><div class="tier-field-value">${p.archive_max_bytes?fmtBytes(p.archive_max_bytes):'No cap'}</div></div>
-          <div class="tier-field"><div class="tier-field-name">Schedule</div><div class="tier-field-value">${esc(fmtSchedule(p.archive_schedule))} Pacific</div></div>`
+          <div class="tier-field"><div class="tier-field-name">Schedule</div><div class="tier-field-value">${esc(fmtSchedule(p.archive_schedule))} ${esc(serverTzLabel())}</div></div>`
           : '<div style="font-size:13px;color:var(--dim);padding:8px 0">Archiving is disabled for this profile.</div>'}
         </div>
       </div>

--- a/services/api/src/config_routes.rs
+++ b/services/api/src/config_routes.rs
@@ -3835,6 +3835,10 @@ fn server_settings_to_dto(s: ServerSettings) -> ServerSettingsDto {
         motion_hwaccel: s.motion_hwaccel,
         motion_vaapi_device: s.motion_vaapi_device,
         version: s.version,
+        // Derived from the TZ env (not the DB row), so the console can show
+        // schedule times in the server's real zone instead of a hardcoded
+        // one (#237). A PUT to /config/server never changes it.
+        tz: crate::db_backup::schedule_tz().name().to_string(),
     }
 }
 

--- a/services/api/src/db_backup.rs
+++ b/services/api/src/db_backup.rs
@@ -98,7 +98,11 @@ fn env_keep(key: &str, default: usize) -> usize {
 /// Timezone the schedule is evaluated in: `TZ` env (IANA name), default
 /// `America/Los_Angeles`. `chrono-tz` embeds the IANA db, so no system tzdata
 /// is needed in the image.
-fn schedule_tz() -> Tz {
+///
+/// `pub(crate)` so `/config/server` can report the same resolved zone to the
+/// console (#237), keeping the displayed schedule TZ in lockstep with the zone
+/// the backup scheduler actually uses.
+pub(crate) fn schedule_tz() -> Tz {
     let Ok(v) = std::env::var("TZ") else {
         return Tz::America__Los_Angeles;
     };

--- a/services/api/src/dto.rs
+++ b/services/api/src/dto.rs
@@ -916,6 +916,12 @@ pub struct ServerSettingsDto {
     /// Monotonically increasing version counter; bumped on every PUT. Clients
     /// poll this (via `/status`) to detect changes and reload stream URLs.
     pub version: i64,
+    /// Resolved IANA timezone the server evaluates its schedules in (from the
+    /// `TZ` env; `America/Los_Angeles` if unset/invalid). Read-only, derived from
+    /// the environment (not the `server_settings` row, so a PUT never changes
+    /// it). The console shows schedule "next run" times in this zone instead of a
+    /// hardcoded one (#237).
+    pub tz: String,
 }
 
 /// `PUT /config/server` request body.

--- a/services/api/tests/support/mod.rs
+++ b/services/api/tests/support/mod.rs
@@ -55,6 +55,8 @@ pub mod clips;
 pub mod config;
 #[path = "../../src/config_routes.rs"]
 pub mod config_routes;
+#[path = "../../src/db_backup.rs"]
+pub mod db_backup;
 #[path = "../../src/discover.rs"]
 pub mod discover;
 #[path = "../../src/dto.rs"]


### PR DESCRIPTION
**Fixes #237.**

The admin console hardcoded `America/Los_Angeles` in the schedule UI, so a non-LA operator saw backup/archive schedule times in Pacific and a label claiming Pacific, even though the schedules actually run in the server's `TZ`. It was in more places than I first saw: `describeSchedule`, `nextRunPreview`, **and three** policy/tier card descriptions.

## Changes
- **`GET /config/server`** gains a read-only **`tz`** field: the API's resolved schedule timezone, from the same `db_backup::schedule_tz()` the backup scheduler uses (now `pub(crate)`). Derived from the `TZ` env, not the `server_settings` row, so a PUT never changes it.
- **`admin.html`**: `serverTz()` reads it; `serverTzLabel()` renders a short zone (PST/CET/GMT+9) via `Intl`. Every hardcoded Pacific/LA string now uses these, falling back to `America/Los_Angeles` only for an old backend that omits the field (matches the server's own default).

## Not in scope (already correct / handled elsewhere)
- `setup-env.sh` **already** detects the host IANA zone and writes `TZ` to `.env` (UTC fallback); `.env.example` documents it. My first read said otherwise, it was a stale local checkout; corrected in #237.
- Recorder `RECORDER_TZ` inheriting `TZ` is #228 / PR #234.

## Verified
`cargo check -p crumb-api` clean; extracted-script `node --check` passes. (fmt/clippy/test via the CI `rust` gate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)