### PR TITLE
feat(desktop): surface server auto-discovery in the login screen (#235)

### DIFF
--- a/apps/desktop-flutter/lib/ui/login_screen.dart
+++ b/apps/desktop-flutter/lib/ui/login_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 
 import 'package:crumb_desktop/api/crumb_api.dart';
 import 'package:crumb_desktop/api/models.dart';
+import 'package:crumb_desktop/ui/discovery/server_discovery_panel.dart';
 
 /// Optional prefill for the server field, e.g.
 /// `--dart-define=SERVER_URL=http://host:port`. Never committed with a real
@@ -27,6 +28,7 @@ class _LoginScreenState extends State<LoginScreen> {
   final _server = TextEditingController(text: _prefillServer);
   final _user = TextEditingController();
   final _pass = TextEditingController();
+  final _userFocus = FocusNode();
   bool _busy = false;
   String? _error;
 
@@ -61,6 +63,7 @@ class _LoginScreenState extends State<LoginScreen> {
     _server.dispose();
     _user.dispose();
     _pass.dispose();
+    _userFocus.dispose();
     super.dispose();
   }
 
@@ -96,9 +99,20 @@ class _LoginScreenState extends State<LoginScreen> {
                 keyboardType: TextInputType.url,
                 enabled: !_busy,
               ),
+              const SizedBox(height: 8),
+              // "Find my server": scans the LAN and fills the field above. The
+              // panel is self-contained and reports the chosen URL back here.
+              ServerDiscoveryPanel(
+                api: widget.api,
+                onServerSelected: (url) {
+                  setState(() => _server.text = url);
+                  _userFocus.requestFocus();
+                },
+              ),
               const SizedBox(height: 12),
               TextField(
                 controller: _user,
+                focusNode: _userFocus,
                 decoration: const InputDecoration(
                   labelText: 'Username',
                   border: OutlineInputBorder(),


### PR DESCRIPTION
**Closes #235.**

The `ServerDiscoveryPanel` widget and the `DiscoveryApi` extension (`discoverServers`, `localSubnetCidr`, LAN scan on the default 8080/8443 pair, subnet rescan, single-hit autofill / multi-hit pick list) already existed but were wired into **no screen**, so desktop users could only type the server URL by hand.

This mounts the panel under the **Server URL** field on the login screen: a "Find my server" button scans the LAN; a single hit (or a picked result) fills the field and moves focus to the username. Wiring only, no change to the discovery API or the panel widget.

**Verified:** `flutter analyze lib/ui/login_screen.dart lib/ui/discovery` on the winbuild box (Flutter 3.44.6) → *No issues found!* (There is no Flutter CI job, so desktop changes are build-verified on winbuild.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)