### PR TITLE
chore(release): v0.1.0 release prep (client version bumps, CHANGELOG cut, security-link fix)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/crumbvms/crumb/security/advisories/new
+    url: https://github.com/badbread/crumbvms/security/advisories/new
     about: Do NOT open a public issue for security vulnerabilities. Report them privately — see SECURITY.md.
   - name: Question or discussion
-    url: https://github.com/crumbvms/crumb/issues
+    url: https://github.com/badbread/crumbvms/issues
     about: For usage questions, please search existing issues first; open a bug report or feature request if nothing fits.

--- a/.github/workflows/windows-release-flutter.yml
+++ b/.github/workflows/windows-release-flutter.yml
@@ -109,4 +109,3 @@ jobs:
       #    the old Tauri NSIS UX. For the 0.1.0 alpha the docs say "unzip and run
       #    crumb_desktop.exe", which is honest.
       #  - code signing (Windows SmartScreen shows "unknown publisher" otherwise).
-      #    from windows-release.yml, then retire that file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ landed on `main`.
 Crumb is **alpha**. Versions before 1.0 make no compatibility promises, read the
 [Alpha Tester Terms](docs/ALPHA-TESTER-TERMS.md) before you rely on it.
 
-## [Unreleased] (heading toward v0.1.0)
+## [0.1.0] - 2026-07-18
 
 The week after the first public cut. The theme: turn a working recorder into a
 seat you'd actually want to sit in: a native desktop rewrite, license-plate
@@ -123,6 +123,23 @@ sheet for a saved snapshot or export.
 - Timeline shows the date when scrubbed off "today"; wall scrub tiles show
   "no footage" instead of freezing; thumbnail extraction forced to MJPEG (fixed a
   100%-scrub 404); Android Edit-view layout; and a long tail of client polish.
+- **Timezones actually work now.** The recorder's archive/retention cron
+  inherits the container `TZ` instead of hardcoding America/Los_Angeles, and the
+  admin console shows schedule times in the server's real timezone instead of a
+  hardcoded "Pacific" label (#228, #237).
+- **`.env` keys stopped being silent no-ops.** Compose now forwards the
+  code-read keys it previously dropped (`RECORDER_TZ`, `HA_BASE_URL`/`HA_TOKEN`/
+  `HA_TOKEN_FILE`, `DB_POOL_SIZE`, `MAINTENANCE_UNTIL`,
+  `CAMERA_OFFLINE_BOOT_GRACE_SECS`, the `THUMB_*` set), and the env parsers
+  treat an empty value as unset instead of failing boot (#229).
+- **First-run wizard storage cap.** On a nearly-full disk the prefilled
+  keep-at-most cap could invert to *unlimited*; it now floors at 80% of free
+  space (#227).
+- **The Windows desktop release ships the Flutter client.** The `v*` tag
+  workflow was still building the retired Tauri app; it now builds
+  `apps/desktop-flutter` and attaches an unzip-and-run
+  `CrumbVMS-windows-<tag>.zip` to the Release, with a real Crumb app icon
+  instead of the Flutter placeholder.
 
 ### Hardened (recorder correctness)
 
@@ -147,5 +164,5 @@ wizard with generated secrets, LAN-only by default; and native desktop
 (then Tauri), Android, and web-admin clients. Runs entirely on your own hardware,
 no cloud, no account, no telemetry.
 
-[Unreleased]: https://github.com/badbread/crumbvms/compare/v0.0.1...HEAD
+[0.1.0]: https://github.com/badbread/crumbvms/compare/v0.0.1...v0.1.0
 [0.0.1]: https://github.com/badbread/crumbvms/releases/tag/v0.0.1

--- a/apps/android/version.properties
+++ b/apps/android/version.properties
@@ -12,5 +12,5 @@
 # These are read by app/build.gradle.kts; if this file is missing or a key is
 # absent, sane debug-friendly defaults are used instead (versionCode=1,
 # versionName="0.0.1-dev") so local builds never hard-fail.
-VERSION_CODE=2
-VERSION_NAME=0.0.1
+VERSION_CODE=3
+VERSION_NAME=0.1.0

--- a/apps/desktop-flutter/pubspec.yaml
+++ b/apps/desktop-flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 0.1.0+1
 
 environment:
   sdk: ^3.12.2

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -13,8 +13,8 @@ settings:
     SWIFT_VERSION: "5.9"
     # Keep in lockstep with the rest of the project (android version.properties,
     # tauri.conf.json) — the first public tag must mean one version everywhere.
-    MARKETING_VERSION: "0.0.1"
-    CURRENT_PROJECT_VERSION: "1"
+    MARKETING_VERSION: "0.1.0"
+    CURRENT_PROJECT_VERSION: "2"
     # Swift-6 readiness for the macOS port. `targeted` checks concurrency-adopting
     # code for Sendable / actor-isolation violations (warnings, not errors).
     SWIFT_STRICT_CONCURRENCY: targeted


### PR DESCRIPTION
Release-prep blockers from the full v0.1.0 audit (four parallel auditors over code, repo docs, docs-site, marketing site).

## Why these block the tag
- **All three client apps self-reported wrong versions.** Android `0.0.1` (and a non-bumped VERSION_CODE, which poisons the in-app update check), macOS `0.0.1`, and the Windows Flutter exe `1.0.0` (stock placeholder, *ahead* of the release). All three release workflows fire on the `v*` tag, so tagging would have shipped mis-versioned artifacts on every platform. Now: Android `0.1.0`/code 3, iOS/macOS `0.1.0`/build 2, Windows `0.1.0+1`.
- **CHANGELOG still said `[Unreleased]`.** Cut to `[0.1.0] - 2026-07-18` with a fixed compare link, plus the Fixed entries that post-dated the last docs sweep (#227, #228/#237, #229, and the Flutter Windows release cutover + real app icon).
- **Private vulnerability reporting pointed at the wrong GitHub namespace** (`crumbvms/crumb`): the issue-template contact links now point at `badbread/crumbvms`, so SECURITY.md's reporting path actually works.
- Minor: removed a dangling leftover comment line in `windows-release-flutter.yml`.

Server-side versions were already coherent (`VERSION` = 0.1.0, all three service crates 0.1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)