### PR TITLE
fix(config): forward TRUST_PROXY + retention low-disk floor env keys (#241)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,6 +118,22 @@ ALERT_WEBHOOK_URL=
 # CAMERA_OFFLINE_BOOT_GRACE_SECS=180      # grace after a restart before camera-offline alerts
 # MAINTENANCE_UNTIL=                       # unix-seconds; suppress all health alerts until then
 
+# --- Retention low-disk safety floor (optional) ---
+# Eviction always keeps at least this much free on the physical disk holding the
+# footage, whichever of the two is larger. Unset = 5% / 50 GiB defaults.
+# MIN_FREE_FRACTION=0.05                   # fraction of the disk kept free
+# MIN_FREE_BYTES=53687091200               # absolute floor in bytes (50 GiB)
+
+# --- Reverse proxy / TLS (optional) ---
+# Behind the bundled Caddy (:8443) or your own reverse proxy, set TRUST_PROXY=1
+# so the API rate limiter keys on the real client IP from X-Forwarded-For
+# instead of the proxy's address. Leave unset when clients hit :8080 directly.
+# TRUST_PROXY=1
+# CRUMB_HTTPS_PORT=8443                    # the bundled Caddy's HTTPS port (docs/TLS.md)
+
+# --- Hardware decode (optional; used with docker-compose.vaapi.example.yml) ---
+# RENDER_GID=993                           # GID of /dev/dri/renderD128 on the host (scripts/enable-hwaccel.sh sets this)
+
 # --- Update-available check (optional, issue #7; OFF by default) ---
 # When enabled, the api periodically asks github.com for the latest CrumbVMS
 # release tag (version number only, nothing sent) so clients can show an
@@ -146,7 +162,7 @@ ONVIF_CONFIG_B64=
 # Unset → pulls ghcr.io/badbread/crumbvms/{api,recorder}:latest. Pin a version for
 # reproducible upgrades. Build from source: add -f docker-compose.build.yml. docs/IMAGES.md
 # CRUMB_IMAGE_PREFIX=ghcr.io/badbread/crumbvms
-# CRUMB_VERSION=v0.0.1
+# CRUMB_VERSION=v0.1.0
 
 # --- Frigate detection (ALL OPTIONAL; bring your own Frigate) ---
 # Crumb bundles no detection. Point at your own Frigate's MQTT broker and set each

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,10 @@ services:
       HA_TOKEN: ${HA_TOKEN:-}
       HA_TOKEN_FILE: ${HA_TOKEN_FILE:-}
       DB_POOL_SIZE: ${DB_POOL_SIZE:-}                   # sqlx pool size (empty = default 32)
+      # Retention low-disk safety floor: eviction keeps at least this much free
+      # on the physical disk. Empty = defaults (5% / 50 GiB). (#241)
+      MIN_FREE_FRACTION: ${MIN_FREE_FRACTION:-}
+      MIN_FREE_BYTES: ${MIN_FREE_BYTES:-}
     volumes:
       - ${MEDIA_HOST_PATH:-./_data}:/data              # one broad media root, RW (recorder owns all writes)
       - /proc:/host/proc:ro                            # NSpid translation for per-camera GPU% (optional)
@@ -191,6 +195,11 @@ services:
       THUMB_PREGEN_LOOKBACK_HOURS: ${THUMB_PREGEN_LOOKBACK_HOURS:-}
       THUMB_PREGEN_SCAN_SECS: ${THUMB_PREGEN_SCAN_SECS:-}
       THUMB_PREGEN_WIDTH: ${THUMB_PREGEN_WIDTH:-}
+      # Behind the bundled Caddy (or any reverse proxy), set TRUST_PROXY=1 so the
+      # rate limiter keys on the client IP from X-Forwarded-For instead of the
+      # proxy's own address (one bucket for ALL HTTPS users otherwise). Leave
+      # empty when clients hit :8080 directly. (#241, docs/TLS.md)
+      TRUST_PROXY: ${TRUST_PROXY:-}
     volumes:
       - ${MEDIA_HOST_PATH:-./_data}:/data:ro            # same media root as recorder, READ-ONLY (api never writes footage)
       - crumb_exports:/exports
@@ -235,7 +244,7 @@ services:
     volumes:
       - ./mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
     ports:
-      - "127.0.0.1:1883:1883"   # LAN-local only; not forwarded to WAN
+      - "127.0.0.1:1883:1883"   # host-local only (a Frigate on ANOTHER host can't reach it; widen the bind deliberately if needed, docs/COMPOSE.md)
     environment:
       - TZ=${TZ:-UTC}
 

--- a/docs/TLS.md
+++ b/docs/TLS.md
@@ -86,6 +86,12 @@ warning above only applies if you point a **browser** at the HTTPS port.
   autosaved config. If you don't want it, delete the `caddy:` block (and the
   two volumes) from `docker-compose.yml`, the rest of the stack is
   unaffected.
+- **Rate limiting behind the proxy:** with clients coming through Caddy, the
+  API sees every request from Caddy's container IP, so the login rate limiter
+  shares one bucket across all HTTPS users. Set `TRUST_PROXY=1` in `.env` and
+  the limiter keys on the client IP from `X-Forwarded-For` (which Caddy sets)
+  instead. Leave it unset when clients hit `:8080` directly, trusting a header
+  that any direct client can forge would let an attacker dodge the limiter.
 
 ## Going HTTPS-only
 


### PR DESCRIPTION
**Fixes #241.** Second sweep of the #229 silent-no-op class, found by the full v0.1.0 audit.

- **`TRUST_PROXY`** (api): the rate limiter reads it to key on `X-Forwarded-For` behind a proxy, but compose never forwarded it, so the stock Caddy stack put **every HTTPS user in one rate-limit bucket** keyed to Caddy's container IP, and the knob to fix it silently did nothing. Now forwarded + documented in `.env.example` and `docs/TLS.md` (including the security note: leave unset without a proxy, since a direct client can forge the header).
- **`MIN_FREE_FRACTION` / `MIN_FREE_BYTES`** (recorder): the retention low-disk safety floor, advertised by the admin UI's own help text, was not forwardable, a silent no-op **on the eviction path**. Now forwarded + documented.
- `.env.example`: stale `CRUMB_VERSION=v0.0.1` example bumped to `v0.1.0`; added the documented-elsewhere-but-missing `CRUMB_HTTPS_PORT` and `RENDER_GID` entries.
- Compose comment fix: mosquitto's `127.0.0.1:1883` is **host**-local, not "LAN-local".

Empty-safe env parsing landed in #234, so `${VAR:-}` forwarding cannot break boot. Compose YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)