### PR TITLE
chore(recorder): remove the stale lint blanket entirely (dead code resolved, closes #244)

### DIFF
--- a/services/recorder/src/archive.rs
+++ b/services/recorder/src/archive.rs
@@ -222,6 +222,8 @@ fn fs_free_and_total(path: &str) -> Option<(i64, i64)> {
 ///     exceed the whole disk and perma-trigger eviction), so we fall back to the
 ///     fractional floor alone. This keeps the default 50GB headroom meaningful on
 ///     real multi-TB live tiers while never wedging a small/test filesystem.
+#[cfg(test)] // production always goes through the per-policy variant; the tests
+             // exercise the env-default floor path through this thin wrapper
 fn below_free_floor(path: &str) -> Option<(bool, i64)> {
     below_free_floor_for_policy(path, None, None)
 }

--- a/services/recorder/src/frigate_motion.rs
+++ b/services/recorder/src/frigate_motion.rs
@@ -22,12 +22,11 @@
 //! [`CameraTracker`]) are pure and unit-tested; only the thin MQTT plumbing
 //! needs a live broker.
 //!
-//! ## Selection (Stage 2 vs Stage 4)
+//! ## Selection
 //!
-//! Which cameras use Frigate motion is chosen here by the `FRIGATE_MOTION_CAMERAS`
-//! env allow-list ("all", or a comma list of go2rtc / camera names) so the
-//! feature is deployable and verifiable now. Stage 4 replaces
-//! [`camera_uses_frigate_motion`] with a per-camera `motion_source` DB column.
+//! Which cameras use Frigate motion is chosen by the per-camera `motion_source`
+//! DB column (Stage 4). The interim `FRIGATE_MOTION_CAMERAS` env allow-list and
+//! its `camera_uses_frigate_motion` helper were retired once the column landed.
 
 use std::collections::HashMap;
 use std::time::Duration;
@@ -137,34 +136,6 @@ impl FrigateMotionConfig {
             min_score: s.min_score,
         })
     }
-}
-
-/// Whether `camera` should be driven by Frigate motion rather than pixel-diff.
-///
-/// Authoritative source is the per-camera `motion_source` column
-/// (`"frigate"`); the `FRIGATE_MOTION_CAMERAS` env allow-list (`"all"`, or a
-/// comma list matched against the camera's `go2rtc_name` / display `name`)
-/// remains as a global override for fleet-wide testing and pre-column rollout.
-/// Either being set selects Frigate motion.
-#[must_use]
-pub fn camera_uses_frigate_motion(camera: &Camera) -> bool {
-    if camera.motion_source.eq_ignore_ascii_case("frigate") {
-        return true;
-    }
-    let Ok(list) = std::env::var("FRIGATE_MOTION_CAMERAS") else {
-        return false;
-    };
-    let list = list.trim();
-    if list.is_empty() {
-        return false;
-    }
-    if list.eq_ignore_ascii_case("all") {
-        return true;
-    }
-    list.split(',')
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .any(|name| name == camera.go2rtc_name || name == camera.name)
 }
 
 // ── pure event classification ─────────────────────────────────────────────────

--- a/services/recorder/src/main.rs
+++ b/services/recorder/src/main.rs
@@ -1,11 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Dead-code allowance only: a handful of superseded motion-detector helpers
-// are still in-tree pending a post-0.1.0 cleanup (issue #244). The
-// unused_imports / unused_variables halves of the old contract-phase blanket
-// allow are back on; the todo!() stubs that allow covered are long gone.
-#![allow(dead_code)]
-
 //! Crumb NVR — recorder process entry point.
 //!
 //! # Responsibility

--- a/services/recorder/src/main.rs
+++ b/services/recorder/src/main.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// CONTRACT PHASE — stub modules contain todo!() bodies and not-yet-used
-// imports / functions.  Remove these allows once all stubs are implemented.
-#![allow(dead_code, unused_imports, unused_variables)]
+// Dead-code allowance only: a handful of superseded motion-detector helpers
+// are still in-tree pending a post-0.1.0 cleanup (issue #244). The
+// unused_imports / unused_variables halves of the old contract-phase blanket
+// allow are back on; the todo!() stubs that allow covered are long gone.
+#![allow(dead_code)]
 
 //! Crumb NVR — recorder process entry point.
 //!

--- a/services/recorder/src/motion.rs
+++ b/services/recorder/src/motion.rs
@@ -414,6 +414,11 @@ pub enum MotionAlgorithm {
 
 impl MotionAlgorithm {
     /// Canonical lower-case identifier (DB column / API / tuner).
+    ///
+    /// Test-only today: production writes the identifier at its source (admin
+    /// console / tuner) and the recorder only ever parses; the round-trip
+    /// parity test keeps this in lockstep with [`Self::from_str_lenient`].
+    #[cfg(test)]
     pub fn as_str(self) -> &'static str {
         match self {
             MotionAlgorithm::Census => "census",
@@ -436,14 +441,6 @@ impl MotionAlgorithm {
             _ => MotionAlgorithm::Census,
         }
     }
-}
-
-/// Where a camera's motion comes from. `LocalCv` runs the frame pipeline with a
-/// [`MotionDetector`]; `Frigate` (a later stage) consumes Frigate MQTT object
-/// events and bypasses the frame pipeline entirely.
-pub enum MotionSource {
-    LocalCv(Box<dyn MotionDetector>),
-    // Frigate(..) — added in the Frigate-as-source stage.
 }
 
 /// Shared per-frame state the detector needs when folding a frame into its model.
@@ -485,11 +482,15 @@ pub trait MotionDetector: Send {
     /// be updated — the pixel is masked out and its model state is frozen.
     fn commit(&mut self, frame: &[u8], ctx: FrameContext, active: &[u8]);
 
-    /// Drop all model state (called when the sub-stream reconnects so a stale
-    /// background can't read as motion on resume).
+    /// Drop all model state. Test-only: production never resets in place (a
+    /// reconnect rebuilds the detector via `build_detector`); the unit tests
+    /// use it to verify a cleared model re-seeds correctly.
+    #[cfg(test)]
     fn reset(&mut self);
 
-    /// Which algorithm this is (diagnostics / tuner).
+    /// Which algorithm this is. Test-only: the identity tests assert
+    /// `build_detector` wires each config value to the right detector.
+    #[cfg(test)]
     fn algorithm_id(&self) -> MotionAlgorithm;
 }
 
@@ -543,6 +544,7 @@ impl MotionDetector for CensusDetector {
         update_background_active(&mut self.bg, frame, alpha, active);
     }
 
+    #[cfg(test)]
     fn reset(&mut self) {
         self.bg_init = false;
         for b in self.bg.iter_mut() {
@@ -550,6 +552,7 @@ impl MotionDetector for CensusDetector {
         }
     }
 
+    #[cfg(test)]
     fn algorithm_id(&self) -> MotionAlgorithm {
         MotionAlgorithm::Census
     }
@@ -618,11 +621,13 @@ impl MotionDetector for FrameDiffDetector {
         }
     }
 
+    #[cfg(test)]
     fn reset(&mut self) {
         self.prev_init = false;
         self.prev.iter_mut().for_each(|p| *p = 0);
     }
 
+    #[cfg(test)]
     fn algorithm_id(&self) -> MotionAlgorithm {
         MotionAlgorithm::FrameDiff
     }
@@ -836,6 +841,7 @@ impl MotionDetector for Mog2Detector {
         }
     }
 
+    #[cfg(test)]
     fn reset(&mut self) {
         self.init = false;
         self.means.iter_mut().for_each(|v| *v = 0.0);
@@ -843,6 +849,7 @@ impl MotionDetector for Mog2Detector {
         self.weights.iter_mut().for_each(|v| *v = 0.0);
     }
 
+    #[cfg(test)]
     fn algorithm_id(&self) -> MotionAlgorithm {
         MotionAlgorithm::Mog2
     }
@@ -995,11 +1002,13 @@ impl MotionDetector for OpticalFlowDetector {
         }
     }
 
+    #[cfg(test)]
     fn reset(&mut self) {
         self.prev_init = false;
         self.prev.iter_mut().for_each(|p| *p = 0);
     }
 
+    #[cfg(test)]
     fn algorithm_id(&self) -> MotionAlgorithm {
         MotionAlgorithm::OpticalFlow
     }
@@ -1099,11 +1108,13 @@ impl MotionDetector for EnsembleDetector {
         self.mog2.commit(frame, ctx, active);
     }
 
+    #[cfg(test)]
     fn reset(&mut self) {
         self.census.reset();
         self.mog2.reset();
     }
 
+    #[cfg(test)]
     fn algorithm_id(&self) -> MotionAlgorithm {
         MotionAlgorithm::Ensemble
     }
@@ -3232,6 +3243,7 @@ async fn emit_pixel_signal(tx: &MotionTx, pool: &Pool, signal: MotionSignal) {
 /// frame_absdiff(&prev, &curr, &mut dst);
 /// assert_eq!(dst, vec![50, 50, 50, 50]);
 /// ```
+#[cfg(test)] // legacy-parity / boundary reference, exercised only by the unit tests
 pub fn frame_absdiff(prev: &[u8], curr: &[u8], dst: &mut [u8]) {
     let n = prev.len().min(curr.len()).min(dst.len());
     for i in 0..n {
@@ -3247,6 +3259,7 @@ pub fn frame_absdiff(prev: &[u8], curr: &[u8], dst: &mut [u8]) {
 /// let diff = vec![0u8, 50, 100, 200];
 /// assert_eq!(count_above_threshold(&diff, 75), 2);
 /// ```
+#[cfg(test)] // legacy-parity / boundary reference, exercised only by the unit tests
 pub fn count_above_threshold(diff: &[u8], threshold: u8) -> usize {
     diff.iter().filter(|&&p| p > threshold).count()
 }
@@ -3277,6 +3290,7 @@ const MIN_NEIGHBOURS_ON: u32 = 4;
 ///
 /// Border pixels (no full 3×3 neighbourhood) are never counted; on tiny frames it
 /// falls back to the un-denoised count.
+#[cfg(test)] // legacy-parity / boundary reference, exercised only by the unit tests
 pub fn count_eroded_above_threshold(diff: &[u8], width: u32, height: u32, threshold: u8) -> usize {
     let w = width as usize;
     let h = height as usize;
@@ -3328,6 +3342,7 @@ fn manual_floor(motion_threshold: Option<f32>) -> f32 {
 }
 
 /// EMA-update the background model in place: `bg = bg·(1−α) + curr·α`.
+#[cfg(test)] // legacy-parity / boundary reference, exercised only by the unit tests
 fn update_background(bg: &mut [f32], curr: &[u8], alpha: f32) {
     let keep = 1.0 - alpha;
     for (b, &c) in bg.iter_mut().zip(curr.iter()) {
@@ -3352,6 +3367,7 @@ fn update_background_active(bg: &mut [f32], curr: &[u8], alpha: f32, active: &[u
 /// Threshold `|curr − bg|` into a binary foreground mask (0 or 255). Every output
 /// byte is assigned, so the caller may reuse `mask` across frames. Retained for
 /// the census dark-region fallback's semantics and the unit tests.
+#[cfg(test)] // legacy-parity / boundary reference, exercised only by the unit tests
 fn threshold_mask_vs_bg(curr: &[u8], bg: &[f32], thr: f32, mask: &mut [u8]) {
     for ((m, &c), &b) in mask.iter_mut().zip(curr.iter()).zip(bg.iter()) {
         *m = if (c as f32 - b).abs() > thr { 255 } else { 0 };
@@ -4117,6 +4133,7 @@ pub(crate) fn should_process_frame(
 ///
 /// Mirrors the condition in the frame loop so boundary behavior is testable
 /// without spawning ffmpeg or touching real timers.
+#[cfg(test)] // legacy-parity / boundary reference, exercised only by the unit tests
 pub(crate) fn frame_receipt_deadline_exceeded(elapsed_secs: u64) -> bool {
     elapsed_secs >= FRAME_RECEIPT_TIMEOUT_SECS
 }

--- a/services/recorder/src/motion.rs
+++ b/services/recorder/src/motion.rs
@@ -39,7 +39,7 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use chrono::{DateTime, Datelike, Timelike, Utc};
+use chrono::{DateTime, Timelike, Utc};
 use crumb_common::{
     config::{Config, HwAccel},
     db::MotionBaselineState,


### PR DESCRIPTION
From the v0.1.0 code audit, now taken all the way. `services/recorder/src/main.rs` carried a crate-wide `#![allow(dead_code, unused_imports, unused_variables)]` justified by a "CONTRACT PHASE" comment about `todo!()` stubs that no longer exist anywhere. Rather than narrowing it (the first commit) and deferring the rest, this PR resolves every flagged item and **removes the blanket entirely** — the recorder now compiles under the full `-D warnings` gate with zero crate-level allows.

## What was actually dead
- **Deleted:** `camera_uses_frigate_motion` and the legacy `FRIGATE_MOTION_CAMERAS` env allow-list it implemented (the per-camera `motion_source` DB column has been authoritative since it landed; module docs updated), and the unused `MotionSource` enum (scaffolding for a design the Frigate integration didn't take).
- **`#[cfg(test)]`, not deleted:** investigation showed the rest are *test infrastructure*, not garbage — `MotionDetector::reset`/`algorithm_id` (production rebuilds detectors on reconnect, so in-place reset is redundant, but the tests use them to verify model-clearing and `build_detector` wiring), the five legacy-parity reference functions (the proofs that the detector-seam refactor preserved behavior byte-for-byte), the watchdog boundary mirror, and the retention-floor test wrapper. They're now compiled only for tests and excluded from release binaries.
- Also fixed the one unused import the blanket was hiding (`chrono::Datelike`).

## Safety notes (golden rule 2)
One item got extra scrutiny: `reset`'s doc claimed it runs "when the sub-stream reconnects", but nothing called it — verified this is **not** a latent stale-background bug: the detector is constructed inside the per-connection run and the supervisor restarts the whole function on reconnect, so every reconnect gets a fresh model by construction.

## Verified (full gate)
- `cargo fmt --all --check` clean
- `cargo clippy -p crumb-recorder --all-targets -- -D warnings` clean, **zero allows**
- Recorder test suite against Postgres: **258 passed, 0 failed** (all parity and invariant tests intact)

Fixes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)