### PR TITLE
docs(v0.1.0): fix every remaining finding from the full release audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ the code is.
 CrumbVMS is a **self-hosted, operator-grade** network video recorder: a Rust
 backend (`services/`) + Postgres + a Crumb-managed go2rtc restreamer (embedded
 in the recorder container, supervised by the recorder process), native
-desktop (Tauri/libmpv) and Android (Kotlin/Compose) clients, and a web admin
+desktop (Flutter/libmpv) and Android (Kotlin/Compose) clients, and a web admin
 console served by the API at `/admin`. The UX bar is a leading commercial VMS,
 not a hobby dashboard.
 
@@ -104,9 +104,12 @@ not a hobby dashboard.
   exist), `esc()` for interpolation, `api()` helper for authed fetches,
   semantic colors `var(--ok)`/`var(--warn)`/`var(--danger)`. Sanity-check with
   `node --check` on the extracted script block.
-- `apps/desktop`, Tauri + WebView2 over native libmpv. Windows note:
-  `libmpv-2.dll` must sit next to the built exe or video panes render black.
-- `apps/android`, Kotlin/Compose/Media3, Gradle (JDK 21, SDK 34).
+- `apps/desktop-flutter`, the live desktop client: Flutter over a Rust core
+  via `flutter_rust_bridge`, video through `media_kit`/libmpv. Windows note:
+  `libmpv-2.dll` must sit next to the built exe or video panes render black
+  (media_kit bundles it into the Release folder). `apps/desktop` is the
+  retired Tauri client, kept for reference; not built by CI or releases.
+- `apps/android`, Kotlin/Compose/Media3, Gradle (JDK 17, SDK 34).
 - `db/migrations/`, numbered SQL (see golden rule 4).
 - `docs/`, design docs and runbooks; `docs/ROADMAP.md` for larger initiatives.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,24 +30,26 @@ CrumbVMS is a Rust workspace plus native clients and a web console:
 
 ```
 services/   # Rust workspace: common, api, recorder (api also serves /admin)
-apps/       # desktop (Tauri + libmpv), android (Kotlin/Compose), ios
+apps/       # desktop-flutter (Flutter + libmpv; apps/desktop is the retired Tauri client), android (Kotlin/Compose), ios
 db/         # numbered SQL migrations, applied on boot
 docs/       # design specs and runbooks
 ```
 
 To stand up a working instance, follow **[docs/AI-INSTALL.md](docs/AI-INSTALL.md)**
 (the agent-runnable, secure-by-default install runbook) or the manual path in
-the [README](README.md#run): `scripts/setup-env.sh` → `docker compose up -d` →
+the [README](README.md#install): `scripts/setup-env.sh` → `docker compose up -d` →
 `http://<host>:8080/admin`. We don't duplicate install steps here, that
 runbook is the single source of truth.
 
 ### Client build notes (high level)
 
-- **Desktop** (`apps/desktop`): Tauri + WebView2 shell over native libmpv. On
-  Windows, `libmpv-2.dll` must sit next to the built exe or the video panes
-  render black.
+- **Desktop** (`apps/desktop-flutter`): Flutter over a Rust core via
+  `flutter_rust_bridge`, video through `media_kit`/libmpv. Needs the Flutter
+  3.44+ toolchain plus Rust and LLVM/libclang (for the bridge codegen); build
+  with `flutter build windows --release`. libmpv is bundled by media_kit.
+  (`apps/desktop` is the retired Tauri client, kept for reference.)
 - **Android** (`apps/android`): Kotlin / Jetpack Compose / Media3, built with
-  Gradle (JDK 21, SDK 34).
+  Gradle (JDK 17, SDK 34).
 - **iOS** (`apps/ios`): Swift; still partial and gated on further work.
 
 Each client's manifests (`Cargo.toml`, `build.gradle.kts`, Swift package files)

--- a/NOTICE
+++ b/NOTICE
@@ -49,9 +49,17 @@ licenses govern those components; this NOTICE is informational.
 The Rust backend (axum, tokio, tower-http, sqlx/tokio-postgres, jsonwebtoken,
 argon2, and others), the Android client (AndroidX, Jetpack Compose, Media3,
 Retrofit, OkHttp, Coil), the iOS client (Apple frameworks; WebRTC under BSD-3),
-and the desktop shell (Tauri) are all licensed under permissive terms
-(MIT / Apache-2.0 / BSD). See each project's Cargo.toml, build.gradle.kts, and
-Swift package manifests for the authoritative dependency lists.
+and the desktop client (Flutter under BSD-3-Clause; media_kit and
+flutter_rust_bridge under MIT/Apache-2.0) are all licensed under permissive
+terms (MIT / Apache-2.0 / BSD). See each project's Cargo.toml,
+build.gradle.kts, pubspec.yaml, and Swift package manifests for the
+authoritative dependency lists.
+
+The optional crumb-alpr worker (services/alpr-worker, opt-in `alpr` compose
+profile) builds on the fast-alpr wrappers (MIT) and ONNX Runtime (MIT). Its
+default detector weights are YOLOv9-derived models licensed GPL-3.0-or-later
+(compatible with AGPL-3.0); they are downloaded by the worker at first run and
+are never redistributed by CrumbVMS.
 
 ================================================================================
 Trademarks

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@
 
 It is a side project. One maintainer, built on my own time, running at home in production
 today: eleven cameras, multiple storage volumes, recording day in and day out for months.
-**It is about 90% of where I want v1 to be, and the next milestone is the first tagged release,
-v0.1.0.** The recorder, the Windows desktop client, and the Android app are the polished daily
+**It is about 90% of where I want v1 to be, and the next milestone is v0.1.0, the first minor
+release.** The recorder, the Windows desktop client, and the Android app are the polished daily
 drivers. The macOS app works but sits behind Android and Windows until demand says otherwise,
 and the iOS app is built and actively developed but not yet distributable (Apple wants a paid
 developer account, see [License](#license)). Both macOS and iOS get kept up to date, they just
@@ -55,7 +55,7 @@ are not as hammered on as the desktop and Android. Client details are in the
 - **A customizable on-video PTZ panel**: build your own control layout over the live feed, drag on a pan/tilt wheel, zoom, focus, iris, and your camera's presets, then size and place them how you like, per camera. Full ONVIF control
 - A per-camera **Data saver** stream (on-demand low-res transcode) for cheap remote or bandwidth-limited viewing
 - **Home Assistant entities on the live video, with live status.** Link a camera to its HA entities and drag each badge onto the frame where the thing actually is: the contact sensor on the front door, the light badge on the porch, the motion sensor over the driveway. Every badge shows live state right on the wall, updating as HA does
-- **Real native clients, not a browser in a wrapper.** A Windows/macOS desktop app on libmpv and a native Android app, both purpose-built, which is what makes the live wall and frame-accurate H.265 scrubbing feel instant instead of a laggy web tab. The web admin console is there for when you just want a browser
+- **Real native clients, not a browser in a wrapper.** A Windows desktop app on libmpv, a native SwiftUI macOS app, and a native Android app, all purpose-built, which is what makes the live wall and frame-accurate H.265 scrubbing feel instant instead of a laggy web tab. The web admin console is there for when you just want a browser
 
 **Keep**
 - Rust recorder. The Postgres segment index is the single source of truth
@@ -68,7 +68,7 @@ are not as hammered on as the desktop and Android. Client details are in the
 - First-run wizard, generated secrets, LAN-only by default
 - Custom roles with per-camera and per-group access
 - Batch export list to MP4 or AES-256 encrypted ZIP, optional timestamp burn-in
-- Clients: Windows/macOS desktop (Flutter/libmpv), Android (Compose/Media3), web admin console. macOS and iOS are built and kept current, less battle-tested for now
+- Clients: Windows desktop (Flutter/libmpv), macOS (native SwiftUI), Android (Compose/Media3), web admin console. macOS and iOS are built and kept current, less battle-tested for now
 
 > Crumb records and lets you investigate. Frigate detects. They compose over MQTT.
 
@@ -231,7 +231,7 @@ so if you have thoughts on how it should work,
 | Primary focus | Operator/timeline layer + recording | Object-detection NVR | Integration hub + NVR | All-in-one NVR | Classic NVR |
 | Object detection | **BYO Frigate** (composes) | ✅ built-in | ✅ plugins | ✅ (DeepStack / CodeProject) | Basic / add-ons |
 | Scrubbable timeline | ✅ frame-level, native (libmpv) | ✅ web-based | ✅ web-based | ✅ native | Basic |
-| Native desktop client | ✅ Flutter/libmpv | ❌ (web) | ❌ (web) | ✅ Windows | ❌ (web) |
+| Native desktop client | ✅ Windows (Flutter/libmpv), macOS (SwiftUI) | ❌ (web) | ❌ (web) | ✅ Windows | ❌ (web) |
 | Mobile app | ✅ Android (iOS in progress) | via HA / 3rd-party | ✅ | ✅ | 3rd-party |
 | Multi-cam saveable wall | ✅ | ✅ camera groups | limited | ✅ | limited |
 | Batch export | ✅ list → MP4 / AES-256 zip | manual | limited | ✅ | limited |
@@ -398,7 +398,7 @@ For contributors working in this repo:
 
 ```
 services/   # Rust backend: common (types, DB, migrations), api (axum + web admin at /admin), recorder
-apps/       # desktop (Flutter + libmpv), android (Kotlin/Compose), ios
+apps/       # desktop-flutter (Flutter + libmpv), android (Kotlin/Compose), ios; desktop = retired Tauri client
 db/         # PostgreSQL migrations; the segment index is the single source of truth
 site/       # crumbvms.com source (static, zero-dep build)
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,7 @@ When you report, please include as much of the following as you can:
 
 - The **server API** (`services/api`).
 - The **recorder** (`services/recorder`) and shared backend (`services/common`).
-- The **clients**: desktop (`apps/desktop`), Android (`apps/android`), iOS
+- The **clients**: desktop (`apps/desktop-flutter`), Android (`apps/android`), iOS
   (`apps/ios`), and the web admin console (served by the API at `/admin`).
 - The Docker Compose deployment, first-run setup flow, and the auth/token model.
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,7 +1,8 @@
-# Tauri + Vanilla
+# RETIRED: Tauri desktop client
 
-This template should help get you started developing with Tauri in vanilla HTML, CSS and Javascript.
+This Tauri client is **retired**. It is not built by CI or releases, and it is
+not the desktop app users get from the Releases page.
 
-## Recommended IDE Setup
-
-- [VS Code](https://code.visualstudio.com/) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
+The live desktop client is **`apps/desktop-flutter`** (Flutter, Rust core over
+`flutter_rust_bridge`, video via `media_kit`/libmpv). This tree is kept for
+reference only.

--- a/docs-site/docs/admin-console/index.md
+++ b/docs-site/docs/admin-console/index.md
@@ -7,31 +7,28 @@ slug: /admin-console/
 # Admin Console
 
 The admin console is Crumb's web interface, served directly by the server
-at `/admin`. It is a full management console, not just a viewer: everything
-from first-run setup through day-to-day live viewing, playback, camera
-management, and user administration happens here, and it's also the most
-production-ready of Crumb's clients today.
+at `/admin`. It is a management console, not a video player: everything
+from first-run setup through camera and recording configuration, motion
+tuning, and user administration happens here, and it's also the most
+production-ready of Crumb's clients today. Watching live video, scrubbing
+playback, and exporting clips are what the native desktop and Android
+clients are for, see [Clients](/clients/).
 
 ## What it covers
 
-- **Live view.** A multi-camera wall with saveable, per-device layouts:
-  carousels, an auto-hotspot tile that follows recent motion, PTZ tiles,
-  clocks, and web panes, alongside individual camera tiles with on-video
-  PTZ, focus, and iris control where a camera supports it.
-- **Playback.** A frame-level, scrubbable timeline per camera, jump to the
-  next or previous motion event, and digital zoom into a clip without
-  needing camera-side PTZ.
-- **Clips and export.** Review motion events as a filmstrip, then build a
-  batch export list across a review session and export it as MP4 or an
-  encrypted archive.
+- **First-run setup.** On a fresh install the
+  [first-run wizard](/getting-started/first-run-wizard) runs here:
+  confirming the server address, choosing storage and retention, and
+  finding cameras on your network.
 - **Cameras.** Discovery, adding, editing, grouping, and stream testing.
   See [Cameras & Streams](/cameras/).
 - **Recording and storage.** Recording profiles (each camera is pinned to a
   named profile), size caps, storage tiers, and the storage advisor's
   per-profile fill-rate and retention cards. See
   [Recording & Storage](/recording/).
-- **Motion tuning.** Per-camera detector choice, exclusion zones drawn
-  directly on the live image. See [Motion & Detection](/motion/).
+- **Motion tuning.** The motion tuner: per-camera detector choice, and
+  exclusion zones drawn over a still-frame preview of the camera. See
+  [Motion & Detection](/motion/).
 - **Detection and clips.** The Frigate detection integration, Home Assistant
   connection settings (link a camera's HA motion, sensor, and actuator
   entities, and use HA sensors as a recording trigger), and clip options.

--- a/docs-site/docs/clients/android.md
+++ b/docs-site/docs/clients/android.md
@@ -30,9 +30,10 @@ compares to the other clients.
 
 ## Verifying the download (optional but recommended)
 
-Since the alpha APK isn't distributed through a code-signing or Play Store
-channel, each release also publishes an `app-release.apk.sha256` checksum file
-next to the APK. Download both into the same folder and confirm they match
+The APK is signed with the project's release keystore in CI, but it isn't
+distributed through the Play Store, so no store vouches for the download
+itself. Each release therefore also publishes an `app-release.apk.sha256`
+checksum file next to the APK. Download both into the same folder and confirm they match
 before installing:
 
 ```bash

--- a/docs-site/docs/clients/web-console.md
+++ b/docs-site/docs/clients/web-console.md
@@ -7,8 +7,10 @@ slug: /clients/web-console
 # Web console
 
 No install needed. Open `http://<server-host>:8080/admin` in any modern
-browser. On first server run, this is where you create the administrator
-account (see [First-run wizard](/getting-started/first-run-wizard)).
+browser. On first server run you sign in with the seeded admin credentials
+`setup-env.sh` printed (they're also saved in `.env`); the browser
+create-admin bootstrap only appears if you deliberately blanked the seed
+before first boot (see [First-run wizard](/getting-started/first-run-wizard)).
 
 The web console is Crumb's administration surface, and it's the most
 production-ready piece Crumb has today. It's where you add and configure

--- a/docs-site/docs/configuration/environment-reference.md
+++ b/docs-site/docs/configuration/environment-reference.md
@@ -6,22 +6,25 @@ slug: /configuration/environment-reference
 
 # Environment reference
 
-Every key Crumb reads from `.env`, grouped by area. The authoritative copy
+The keys Crumb reads from `.env`, grouped by area (a few generic ones like
+`RUST_LOG` and `LOG_FORMAT` are omitted). The authoritative copy
 lives in `.env.example` in the repository; this page mirrors it for
 browsing. Most installs never need to touch most of these, `setup-env.sh`
 fills in the values that matter for a first boot.
 
-A few keys further down are read by the code but are **not** wired into
-`docker-compose.yml`. Those are flagged inline as "compose override needed",
-meaning setting them in `.env` alone does nothing, you have to pass them into
-the container yourself with a `docker-compose.override.yml`. I'd rather call
-that out honestly than let you set a key that silently never takes effect.
+Every key below is wired into the stock `docker-compose.yml` (the GPU keys
+ride in via their opt-in overlay files), so the workflow is uniform: set the
+key in `.env`, restart the affected container, done. No
+`docker-compose.override.yml` is needed. Where a value is also editable in
+the admin console, the console value (stored in the database) wins over the
+env default; that's flagged in the notes.
 
 ## Time zone
 
 | Key | Default | Notes |
 |---|---|---|
 | `TZ` | `UTC` | Local wall-clock for the whole stack: quiet hours, the nightly DB backup schedule (`DB_BACKUP_SCHEDULE`), the offsite-sync cron, and every log timestamp. Set an IANA name like `America/Los_Angeles` or `Europe/Berlin`. `setup-env.sh` detects the host's zone and writes it; if it can't, the compose default is `UTC` (not any local zone), so the clock is at least predictable. |
+| `RECORDER_TZ` | inherits `TZ` | IANA zone the recorder's per-camera archive-schedule cron runs in. Unset or empty means it inherits `TZ` above, which is what you want; set it only to run archive schedules in a different zone than the rest of the stack. A value that fails to parse is logged loudly and falls back rather than stopping the recorder. |
 
 ## PostgreSQL
 
@@ -31,7 +34,7 @@ that out honestly than let you set a key that silently never takes effect.
 | `POSTGRES_PASSWORD` | generated | strong random value from `setup-env.sh` |
 | `POSTGRES_DB` | `crumb` | |
 | `DATABASE_URL` | derived | full connection string used by api + recorder |
-| `DB_POOL_SIZE` | `32` | connection pool size. Fixed default of 32, not a per-camera formula. Raise it past ~16 cameras (rule of thumb `2 * cameras + 10`), and raise Postgres `max_connections` to match. **Compose override needed:** the base compose file doesn't forward this, so set it in a `docker-compose.override.yml`, not just `.env`. |
+| `DB_POOL_SIZE` | `32` | connection pool size. Fixed default of 32, not a per-camera formula. Raise it past ~16 cameras (rule of thumb `2 * cameras + 10`), and raise Postgres `max_connections` to match. Forwarded by the stock `docker-compose.yml` to both api and recorder; set it in `.env` and restart both containers. |
 
 ## WebRTC live (iOS / browser)
 
@@ -60,6 +63,18 @@ console's Server & streaming settings, that value wins.
 |---|---|---|
 | `SEGMENT_SECONDS` | `4` | 2 to 6 seconds; short segments mean near-instant seek |
 
+## Recorder internals
+
+Tuning knobs for the recorder's supervision loops. The defaults are right
+for almost everyone; `RECONCILE_PAUSED` is the only one an operator normally
+touches, and only during a deliberate storage migration.
+
+| Key | Default | Notes |
+|---|---|---|
+| `CONFIG_POLL_SECONDS` | `30` | how often the recorder diffs the database camera list against its running workers to pick up config changes |
+| `RECONCILE_INTERVAL_SECONDS` | `900` | how often the reconcile pass re-runs (adopt orphan files on disk, repair size drift, prune dangling index rows); floored to 60 |
+| `RECONCILE_PAUSED` | `false` | maintenance switch: `true` runs no reconcile passes at all. Set it while deliberately moving footage files out-of-band (storage migration, disk swap), since reconcile would race the move. Recording, motion, and retention continue normally. |
+
 ## Motion-mode RAM cache
 
 See [Motion & Detection](/motion/) for the mechanism this configures.
@@ -78,17 +93,21 @@ Five of these are also editable live from the admin console (**Server →
 Scrub previews**): the env value below is only the *default* until an
 operator sets it in the console, at which point the console value wins (no
 restart needed, takes effect within one scan interval / cache-sweep tick).
-The other two (`THUMB_CACHE_DIR`, `THUMB_PREGEN_WIDTH`) are env/compose-only,
-see the Notes column.
+The other three (`THUMB_CACHE_DIR`, `THUMB_PREGEN_WIDTH`,
+`THUMB_EXTRACT_MAX_CONCURRENCY`) are env-only, see the Notes column.
 
-**Compose override needed for the env side.** The base `docker-compose.yml`
-doesn't forward any `THUMB_*` key into the api container, so the env
-*defaults* below only change if you pass them in via a
-`docker-compose.override.yml`. The five console-editable knobs are the
-exception: those take effect through the database regardless, because the
-console writes them to `server_settings` (which the api reads at runtime),
-not to the environment. In short: edit these in the console, not `.env`,
-unless you're comfortable wiring a compose override for the two env-only ones.
+All of these are forwarded by the stock `docker-compose.yml` into the api
+container: set them in `.env` and restart the api. For the five
+console-editable knobs, prefer the console anyway; once an operator sets a
+value there, the database copy wins and the env value is just the default.
+
+One honest footnote: the compose file also forwards a few more `THUMB_*`
+names (`THUMB_INTERVAL_SECS`, `THUMB_MAX_ATTEMPTS`, `THUMB_MAX_WIDTH`,
+`THUMB_MIN_WIDTH`, `THUMB_NEAR_BLACK_LUMA`, `THUMB_EXTRACT_TIMEOUT_SECS`)
+that the current release treats as fixed built-in constants (a 4-second
+preview grid, widths clamped 48-640, a 12-second extract timeout, and the
+black-frame retry logic). Setting those in `.env` today has no effect;
+they're plumbed through for a future release, so they don't get rows here.
 
 | Key | Default | Console-editable? | Notes |
 |---|---|---|---|
@@ -114,7 +133,10 @@ unless you're comfortable wiring a compose override for the two env-only ones.
 
 | Key | Default | Notes |
 |---|---|---|
-| `MOTION_HWACCEL` | `auto` | `auto` probes for NVDEC and falls back to CPU; `cuda` forces NVDEC, `cpu` forces software decode |
+| `MOTION_HWACCEL` | `auto` | `auto` probes for NVDEC and falls back to CPU; `cuda` forces NVDEC, `vaapi` forces an Intel/AMD iGPU, `cpu` forces software decode |
+| `MAX_GPU_DECODE_SESSIONS` | `4` | global cap on concurrent NVDEC decode sessions; a camera past the cap decodes on CPU instead of failing |
+| `MOTION_VAAPI_DEVICE` | `/dev/dri/renderD128` | DRI render node used when `MOTION_HWACCEL=vaapi`; wired in by the `docker-compose.vaapi.example.yml` overlay, ignored otherwise |
+| `RENDER_GID` | `993` | host `render` group GID, read by the VAAPI overlay's `group_add` (not by Crumb itself) so the uid-1001 container user can open the render node; find yours with `getent group render` |
 
 See [Hardware decode](/configuration/hardware-decode) for enabling this.
 
@@ -164,8 +186,9 @@ See [Backups](/configuration/backups) for the full picture.
 | Key | Default | Notes |
 |---|---|---|
 | `ALERT_WEBHOOK_URL` | empty | a generic JSON webhook (Discord/Slack-compatible) for recorder-death paging; empty means silent |
-| `CAMERA_OFFLINE_BOOT_GRACE_SECS` | `180` | holds camera-offline alerts for this long after a recorder restart. **Compose override needed:** not forwarded by the base compose file, set it in a `docker-compose.override.yml`. |
-| `MAINTENANCE_UNTIL` | empty | unix-seconds timestamp to pre-arm a maintenance window at boot. **Compose override needed:** not forwarded by the base compose file, set it in a `docker-compose.override.yml`. |
+| `CAMERA_OFFLINE_BOOT_GRACE_SECS` | `180` | holds camera-offline alerts for this long after a recorder restart. Forwarded by the stock `docker-compose.yml`; set it in `.env` and restart the api container. |
+| `MAINTENANCE_UNTIL` | empty | unix-seconds timestamp to pre-arm a maintenance window at boot. Forwarded by the stock `docker-compose.yml`; set it in `.env` and restart the api container. |
+| `MOTION_UNHEALTHY_ALERT_SECS` | `180` | how long a camera's motion detector must stay *continuously* unhealthy before the recorder raises a system alert. This is alert hysteresis for flaky cameras that blip and self-heal; it delays only the alert, never the fail-open recording safety rail. |
 
 ## Update-available check (issue #7)
 
@@ -240,8 +263,7 @@ token from a dedicated **non-admin** HA user.
 | `HA_TOKEN` | empty | a long-lived access token; a secret. Prefer `HA_TOKEN_FILE` in production. |
 | `HA_TOKEN_FILE` | empty | path to a Docker-secret file holding the token, e.g. `/run/secrets/ha_token`; read in preference to `HA_TOKEN` |
 
-**Compose override needed.** The base `docker-compose.yml` doesn't forward
-`HA_BASE_URL` / `HA_TOKEN` / `HA_TOKEN_FILE` into the api container, so these
-env fallbacks only take effect through a `docker-compose.override.yml`. The
-console path (which writes to the database) is the supported way to configure
-Home Assistant and needs no compose changes.
+All three are forwarded by the stock `docker-compose.yml` into both the api
+and recorder containers: set them in `.env` and restart both. The console
+path (which writes to the database) is still the supported way to configure
+Home Assistant, and the DB value wins whenever both are set.

--- a/docs-site/docs/configuration/secrets.md
+++ b/docs-site/docs/configuration/secrets.md
@@ -46,12 +46,10 @@ If you missed the printout, read it straight out of the file:
 grep SEED_ADMIN_PASSWORD .env
 ```
 
-You can also re-print it at generation time with `--print`, but only in the
-**same** run that writes `.env`. `--print` shows what that run generated; it
-does not, and cannot, recover a value from an `.env` that already exists
-(re-running the script without `--force` just refuses to touch the existing
-file). Once `.env` exists, the `grep` above is the way to read the password
-back.
+There is no script flag that recovers it later: the password prints on the
+run that generates it, and re-running the script without `--force` just
+refuses to touch the existing file. Once `.env` exists, the `grep` above is
+the way to read the password back.
 
 **Prefer the browser create-admin wizard instead?** Blank out
 `SEED_ADMIN_PASSWORD` in `.env` (and leave `SEED_ADMIN_PASSWORD_HASH` empty)

--- a/docs-site/docs/contributing/index.md
+++ b/docs-site/docs/contributing/index.md
@@ -28,7 +28,7 @@ The codebase is a Rust workspace plus native clients and a web console:
 
 ```
 services/   # Rust workspace: common, api, recorder (api also serves /admin)
-apps/       # desktop (Tauri + native video), Android (Kotlin/Compose), iOS
+apps/       # desktop-flutter (Flutter + Rust core, media_kit/libmpv), Android (Kotlin/Compose), iOS/macOS (SwiftUI)
 db/         # numbered SQL migrations, applied automatically on boot
 docs/       # design specs and runbooks
 ```

--- a/docs-site/docs/getting-started/install-docker-compose.md
+++ b/docs-site/docs/getting-started/install-docker-compose.md
@@ -85,7 +85,8 @@ values.
 curl -fsS http://localhost:8080/health
 ```
 
-returns `200 OK`. A `503` for the first few seconds is normal while
+prints the health response and exits 0 (`curl -fsS` prints the body, not
+a status line). A `503` for the first few seconds is normal while
 Postgres and migrations finish; retry.
 
 ## What's running

--- a/docs-site/docs/getting-started/install-with-ai-agent.md
+++ b/docs-site/docs/getting-started/install-with-ai-agent.md
@@ -38,8 +38,8 @@ worth knowing either way:
 - **Never invents or prints secrets.** Secrets come from
   `scripts/setup-env.sh`, which generates strong random values. An agent
   should never hardcode a password or secret, and should avoid echoing
-  them into chat history if you ask for the admin password back; the
-  script's `--print` flag is the intended path for that.
+  them into chat history; if you need the seeded admin password back
+  later, read it on the server yourself with `grep SEED_ADMIN_PASSWORD .env`.
 - **Confirms before privileged or destructive actions.** Installing system
   packages, changing firewall rules, deleting data, or overwriting an
   existing `.env` are all things the runbook asks the agent to show you and

--- a/docs-site/docs/getting-started/quickstart.md
+++ b/docs-site/docs/getting-started/quickstart.md
@@ -53,7 +53,7 @@ docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
 curl -fsS http://localhost:8080/health
 ```
 
-Should return `200 OK`. A `503` for the first few seconds is normal while the database finishes migrations.
+Should print the health response and exit 0 (`curl -fsS` prints the body, not a status line). A `503` for the first few seconds is normal while the database finishes migrations.
 
 ## 5. Open the browser
 

--- a/docs-site/docs/getting-started/upgrade-and-rollback.md
+++ b/docs-site/docs/getting-started/upgrade-and-rollback.md
@@ -53,7 +53,7 @@ Versioned images make rollback symmetrical with upgrade:
 ```bash
 cd /opt/crumb/app
 
-# In .env, set CRUMB_VERSION back to the previous tag, e.g. v0.1.0
+# In .env, set CRUMB_VERSION back to the previous tag, e.g. v0.0.1
 
 docker compose pull
 docker compose up -d

--- a/docs-site/docs/integrations/frigate.md
+++ b/docs-site/docs/integrations/frigate.md
@@ -63,7 +63,7 @@ When you drag across the timeline you want a thumbnail under the cursor the whol
 way. You can't get that by decoding the full-resolution H.265 stream on every
 scrub tick: that's hundreds of full-frame decodes a second, and 4K H.265 is
 exactly what browsers already choke on. So Crumb pre-generates a low-res JPEG
-preview proxy (a small frame roughly every 10 seconds), lands the drag on the
+preview proxy (a small frame every few seconds, 4 s by default), lands the drag on the
 nearest proxy frame instantly, and only decodes the real frame from the actual
 video when you let go (see [Timeline scrubbing](/playback/scrubbing)). That proxy
 is derived from Crumb's own segment index by a background worker. Reading

--- a/docs-site/docs/integrations/license-plate-recognition.md
+++ b/docs-site/docs/integrations/license-plate-recognition.md
@@ -112,7 +112,7 @@ draw them in the LPR section's per-camera zone editor over a live snapshot.
 
 ## Watchlist, ignore list, and fuzzy matching
 
-- **Watchlist:** add plates you care about (`GET`/`POST`/`DELETE /lpr/watchlist`;
+- **Watchlist:** add plates you care about (`GET`/`POST /lpr/watchlist`, `DELETE /lpr/watchlist/:id`;
   reads are `view_plates`-gated, writes are admin). A watchlist hit fans out as a
   `plate_watchlist_hit` alert with the crop attached.
 - **Ignore list:** plates Crumb drops entirely at ingest: an ignored plate is

--- a/docs-site/docs/notifications/index.md
+++ b/docs-site/docs/notifications/index.md
@@ -12,8 +12,8 @@ Notifications panel.
 
 ## Channels
 
-A channel is a destination: ntfy, Pushover, a generic webhook, or one of
-several chat integrations. Add a channel, then send a test notification to
+A channel is a destination: Discord, Slack, Telegram, ntfy, Pushover, or a
+plain webhook. Add a channel, then send a test notification to
 confirm it delivers before relying on it.
 
 ## Rules

--- a/docs-site/docs/responsible-use.md
+++ b/docs-site/docs/responsible-use.md
@@ -78,8 +78,9 @@ controller under GDPR or UK GDPR, with real obligations. A few highlights:
   (how long live and archive footage are each kept) and an optional
   maximum retention cap that deletes everything older than N days across
   both tiers at once. The cap is off by default. One caveat: footage you
-  explicitly protect (a protected bookmark) is never auto-deleted, so it
-  can outlive the cap, unpin it once it's no longer needed. Crumb enforces
+  explicitly protect (a protected bookmark) is held past the cap for the
+  protection window you chose (1 to 30 days), then the protection expires
+  on its own; delete the bookmark to end it early. Crumb enforces
   whatever period you choose but can't tell you what the right period is,
   that's your call against your purpose and local law.
 - **Signage:** you generally must tell people they're being recorded,

--- a/docs-site/docusaurus.config.js
+++ b/docs-site/docusaurus.config.js
@@ -1,5 +1,5 @@
 // @ts-check
-// CrumbVMS documentation site — docs.crumbvms.com
+// CrumbVMS documentation site, docs.crumbvms.com
 // No trackers: no gtag, no googleAnalytics, no external fonts/CDNs, no Algolia.
 // Search is local (offline lunr index) via @easyops-cn/docusaurus-search-local.
 

--- a/docs/CLIENTS.md
+++ b/docs/CLIENTS.md
@@ -6,7 +6,7 @@ cameras through a **client**. There are five:
 | Client | Platform | Tech | How you get it |
 |---|---|---|---|
 | **Web admin** | any browser | served by the API at `/admin` | nothing to install |
-| **Desktop** | Windows 10/11 | Flutter + native libmpv | installer from Releases |
+| **Desktop** | Windows 10/11 | Flutter + native libmpv | zip from Releases |
 | **Desktop** | Linux | Flutter + libmpv | build from source |
 | **Apple** | macOS 13+ | native SwiftUI | zip from Releases |
 | **Apple / mobile** | iOS 16+ | native SwiftUI | *TestFlight, not set up yet* |
@@ -26,7 +26,7 @@ cameras through a **client**. There are five:
 You need three things:
 
 1. **A running CrumbVMS server** on your LAN (or reachable over your own VPN /
-   Tailscale). See the [README](../README.md) "Run" section or
+   Tailscale). See the [README](../README.md) "Install" section or
    [docs/AI-INSTALL.md](AI-INSTALL.md).
 2. **An account**, your admin login, or a user the admin created for you.
 3. **The server reachable** on port **8080** (HTTP) or **8443** (HTTPS). Native
@@ -43,8 +43,11 @@ You need three things:
 
 ## Web console (no install)
 
-Open **`http://<server-host>:8080/admin`** in any browser. On first server run
-you create the administrator here. The web console covers admin, live view,
+Open **`http://<server-host>:8080/admin`** in any browser. Sign in with the
+seeded admin account: username `admin` and the `SEED_ADMIN_PASSWORD` that
+`scripts/setup-env.sh` printed once when it generated your `.env`. (A
+create-admin step only appears if you deliberately blanked the seed to use the
+browser wizard instead.) The web console covers admin, live view,
 playback, clips, and export, it's the fastest way to confirm your server works
 before installing anything native.
 
@@ -86,15 +89,17 @@ keeps your saved views and settings).
 **Flutter** app (video renders through `media_kit`/libmpv), no WebView2 or other
 runtime to install.
 
-1. On the **Releases** page, download the Windows installer for CrumbVMS.
-   `libmpv-2.dll` is bundled with it, so there's no separate file to manage and
-   nothing to copy next to the exe by hand.
-2. Run the installer. Windows **SmartScreen** will warn about an unrecognized app
-   (it's unsigned during the alpha): click **More info → Run anyway**, then install.
-3. Launch **CrumbVMS** from the Start Menu.
-4. Use **Find my server** or enter `http://<server-host>:8080`, then log in.
+1. On the **Releases** page, download `CrumbVMS-windows-<version>.zip`.
+2. Unzip it anywhere you like, keeping the extracted files together:
+   `crumb_desktop.exe` needs the bundled `libmpv-2.dll` and the `data/` folder
+   next to it. There is no installer to run.
+3. Run `crumb_desktop.exe`. Windows **SmartScreen** will warn about an
+   unrecognized app (it's unsigned during the alpha): click
+   **More info → Run anyway**.
+4. Optional: right-click the exe to pin it to Start or the taskbar.
+5. Use **Find my server** or enter `http://<server-host>:8080`, then log in.
 
-Updates = run the newer installer over the top.
+Updates = download the newer release zip and unzip it over the top.
 
 ---
 
@@ -166,7 +171,7 @@ at the top).
 |---|---|
 | "Find my server" finds nothing | Wi-Fi **client isolation** (common on guest networks) blocks device-to-device traffic, enter the address manually, or join the same LAN segment as the server. |
 | Connects, lists cameras, live panes black | Server RTSP address not set (**Server & streaming**), or the client can't reach port **18554**. |
-| Windows: video panes black | The bundled `libmpv-2.dll` isn't next to `CrumbVMS.exe`, reinstall with the installer rather than copying the exe out by hand. |
+| Windows: video panes black | The bundled `libmpv-2.dll` isn't next to `crumb_desktop.exe`, re-unzip the release zip rather than copying the exe out on its own. |
 | Windows: "Windows protected your PC" | SmartScreen on the unsigned alpha build, **More info → Run anyway**. |
 | macOS: "CrumbVMS can't be opened" | Gatekeeper on the un-notarized alpha build, **right-click → Open** the first time. |
 | Android: "app not installed" | You already have a build signed with a *different* key, uninstall the old one first (this won't happen for updates of the same alpha build). |

--- a/docs/COMPOSE.md
+++ b/docs/COMPOSE.md
@@ -132,6 +132,12 @@ grants.
 The recorder **healthcheck** verifies the recorder is PID 1 (it has no HTTP
 server; it exec's to become PID 1, so a dead recorder = a dead container).
 
+Forwarded env knobs on this service: `RECORDER_TZ` overrides the recorder's
+timezone independently (it inherits `TZ` when unset);
+`HA_BASE_URL`/`HA_TOKEN`/`HA_TOKEN_FILE` wire the optional Home Assistant
+integration (token inline, or read from a mounted file); `DB_POOL_SIZE` sizes
+the sqlx connection pool (empty = the code default).
+
 ## api
 
 Serves the HTTP API and the web admin console at `/admin` on `:8080`. Every
@@ -154,6 +160,14 @@ page itself, `/auth/login`, and the first-run
   at the broker your own Frigate already publishes to and set each camera's
   Frigate name in the admin UI. Empty `FRIGATE_MQTT_URL` ⇒ the whole detection
   subsystem stays disabled.
+- Other forwarded knobs: the same `HA_BASE_URL`/`HA_TOKEN`/`HA_TOKEN_FILE`
+  (Home Assistant) and `DB_POOL_SIZE` as the recorder; `MAINTENANCE_UNTIL`
+  (unix seconds) suppresses low-disk/camera-offline alerts during planned
+  maintenance; `CAMERA_OFFLINE_BOOT_GRACE_SECS` is the grace period before
+  offline alerts fire after boot (empty = default 180); and the `THUMB_*` set
+  tunes the timeline thumbnail cache and pre-generation (cache dir, size cap,
+  TTL, extract concurrency and timeout, widths, pre-gen toggle and lookback).
+  All default sensibly when unset; see [`.env.example`](../.env.example).
 
 ### Built-in nightly DB backup (P0-BACKUP)
 
@@ -194,6 +208,21 @@ one to the LAN (the localhost bind is deliberate; don't widen it by default).
 ```bash
 docker compose --profile frigate up -d            # stack + bundled broker
 docker compose --profile frigate up -d mosquitto  # just the broker, later
+```
+
+## crumb-alpr (opt-in `alpr` profile)
+
+Crumb's own local license-plate OCR worker (fast-alpr), **profile-gated** so a
+plain `up -d` never starts it. One instance per camera: it pulls that camera's
+go2rtc restream, motion-gates, runs plate recognition, and POSTs reads to the
+api's `POST /lpr/reads`. Enable LPR and mint an ingest token in Admin → LPR
+first, then set the env knobs: `CRUMB_API_BASE` (defaults to the internal
+`http://api:8080`), `LPR_INGEST_TOKEN`, `LPR_CAMERA_ID`, and `LPR_RTSP_URL`.
+Built from source (no published image yet); the full knob table is in
+[services/alpr-worker/README.md](../services/alpr-worker/README.md).
+
+```bash
+docker compose --profile alpr up -d --build crumb-alpr
 ```
 
 ## backup-offsite (opt-in `offsite` profile)

--- a/docs/DETECTION-ICONS.md
+++ b/docs/DETECTION-ICONS.md
@@ -28,8 +28,10 @@ Each client keeps a map `icon_key -> { glyph, colour }`. The lookup is:
 
 Per-client maps (keep in sync with the table below):
 
-- **Desktop** (Tauri): `apps/desktop/src/app.js`, `const DETECTION_ICONS` (raw
-  inline SVG, `currentColor` swapped to the hex for the canvas timeline).
+- **Desktop** (Flutter): `apps/desktop-flutter/lib/ui/live_status/detection_icons.dart`,
+  `kDetectionIcons`, a curated Material-Icons mapping (icon + colour per
+  `icon_key`) with a `kGenericDetectionIcon` fallback, rather than the raw
+  inline-SVG set the retired Tauri client carried.
 - **Web admin console**: `services/api/src/admin.html`, the inline timeline
   renderer's icon map (colour + shape per semantic group).
 - **Android** (Compose): `apps/android/.../data/Models.kt` —

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,6 +7,11 @@ How Crumb goes from a git commit to a known, versioned, deployable, and
 > configured build hosts) is handled by the orchestrator in
 > [../scripts/release/](../scripts/release/README.md): `bash scripts/release/release.sh all`.
 
+> **Windows desktop:** the desktop release is built by
+> `.github/workflows/windows-release-flutter.yml` on the `v*` tag, which
+> attaches `CrumbVMS-windows-<tag>.zip` to the GitHub Release. The
+> `scripts/release/` desktop targets (the old Tauri builds) are retired.
+
 ---
 
 ## TL;DR

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # CrumbVMS Roadmap
 
-This is a living roadmap of "eventually" work for CrumbVMS, the free, open-source (AGPL-3.0-or-later) self-hosted NVR (Rust recorder/API + Tauri/libmpv desktop + Kotlin/Compose Android + go2rtc + optional Frigate). It is not a sprint plan or a commitment; it is the place where larger initiatives are scoped, grounded in the current code, and broken into phases so any future session can pick up an item with full context.
+This is a living roadmap of "eventually" work for CrumbVMS, the free, open-source (AGPL-3.0-or-later) self-hosted NVR (Rust recorder/API + Flutter/libmpv desktop + Kotlin/Compose Android + go2rtc + optional Frigate). It is not a sprint plan or a commitment; it is the place where larger initiatives are scoped, grounded in the current code, and broken into phases so any future session can pick up an item with full context.
 
 Each headline initiative below is written to be actionable cold: it cites the actual files involved, states where the code is today versus where it's going, and carries a phased checklist with effort tags, explicit dependencies, and the open decisions that are the maintainer's to make. The short backlog at the end is tracked elsewhere and listed here only for completeness.
 
@@ -61,7 +61,7 @@ Phase B, In-app Crumb push (Android, no FCM) (M)
 - [ ] `GET /notifications?since=<ts>` (viewer-scoped via `AuthUser.filter_camera_ids`, like `/events`) + optional `GET /notifications/stream` (SSE/long-poll) (M)
 - [ ] Android: foreground service OR WorkManager periodic poll → local notification via the declared `POST_NOTIFICATIONS`; tap deep-links to live/playback at the event time (M)
 - [ ] Android device/subscriber registry table so the server can target/scope (and later carry an ntfy/UnifiedPush endpoint) (S)
-- [ ] Desktop (Tauri): toast on new notification via the same `/notifications` endpoint (S)
+- [ ] Desktop (Flutter): toast on new notification via the same `/notifications` endpoint (S)
 
 Phase C, More channels + richer rules (M)
 
@@ -164,6 +164,11 @@ Phase 3, Snapshots + polish (stretch) (M)
 - Default broker when enabled: bundled mosquitto vs the user's existing HA/Mosquitto add-on broker (most HA users already run one). Default to bundled but document pointing at HA's broker.
 
 ### 3. Prebuilt distribution & signed releases
+
+> **Superseded 2026-07-18:** the Windows desktop release now builds
+> `apps/desktop-flutter` via `windows-release-flutter.yml` (media_kit already
+> bundles `libmpv-2.dll`); see `docs/DECISIONS.md`. The Tauri packaging steps
+> below are historical.
 
 Ship Crumb as prebuilt public Docker images (deploy-by-pull + an offline tarball for air-gapped installs), a code-signed Windows desktop installer, and a signed sideload APK, so nobody has to compile a Rust workspace to run it. Crumb is free and open source (AGPL-3.0-or-later); prebuilt artifacts are about convenience and trust (signatures, provenance, SmartScreen reputation), not secrecy. Building from source stays a first-class path.
 
@@ -610,7 +615,7 @@ Rewrite the Windows/Linux desktop client from Tauri/WebView2 to native Flutter, 
 
 #### Where we are today
 
-**P0 (de-risk spike) is done.** `apps/desktop-flutter/` proves media_kit live video + FRB → the real Windows-native Rust core + native overlay compositing (incl. Flutter-native digital zoom/pan) hold together on real hardware. Two things it settled: FRB bridges the *client/util* core (not the mpv engine, which media_kit replaces), and digital zoom/pan belongs in Flutter, not mpv. The Tauri `apps/desktop` is untouched and still ships.
+**P0 (de-risk spike) is done.** `apps/desktop-flutter/` proves media_kit live video + FRB → the real Windows-native Rust core + native overlay compositing (incl. Flutter-native digital zoom/pan) hold together on real hardware. Two things it settled: FRB bridges the *client/util* core (not the mpv engine, which media_kit replaces), and digital zoom/pan belongs in Flutter, not mpv. The Tauri `apps/desktop` is now retired and no longer ships; the Flutter client is the desktop release.
 
 #### What's next
 

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -8,11 +8,15 @@ workstation (Git Bash). Or just ask the Claude session to "update all clients" /
 > versioning, registries, and rollback, see [../../docs/RELEASE.md](../../docs/RELEASE.md).
 
 ```bash
-bash scripts/release/release.sh all                 # backend + android + ios + both desktops
+bash scripts/release/release.sh all                 # backend + android + ios
 bash scripts/release/release.sh backend android     # pick targets
-bash scripts/release/release.sh desktop             # both desktop builds
 bash scripts/release/release.sh backend --api-only  # api only (no recorder blip)
 ```
+
+> **Desktop is not a target here anymore.** The Windows desktop ships via
+> `.github/workflows/windows-release-flutter.yml` on the `v*` tag; the Tauri
+> `desktop-windows.sh` / `desktop-linux.sh` scripts are retired and exit
+> immediately if invoked.
 
 ## Build hosts
 
@@ -27,12 +31,9 @@ needed:
 | Backend gate | build host | `CRUMB_BUILD_HOST` | tar over SSH → `~/crumb-gate` | `cargo fmt --check` + `clippy -D warnings` + `test` |
 | Android | build host | `CRUMB_BUILD_HOST` | tar over SSH → `~/projects/crumb-android` | `./gradlew assembleDebug` → publish `~/apk-serve/crumb.apk` (http :8088) |
 | iOS | Mac host | `CRUMB_MAC_HOST` | repo at `$CRUMB_MAC_REPO` (mount or checkout on the Mac) | `xcodebuild -scheme Crumb` (unsigned compile) |
-| Desktop (Linux) | build host | `CRUMB_BUILD_HOST` | tar over SSH → `~/projects/crumb-desktop` | `cargo build` in `src-tauri` (gtk/mpv pane backend) |
-| Desktop (Windows) | local workstation |, (local) | synced repo → local run-dir (`CRUMB_DESKTOP_RUN_DIR`) | `cargo build` in the run-dir + libmpv-2.dll next to the exe |
 
 Order is fixed: **backend is gated then deployed first**, so a freshly-deployed
-API is live before the clients ship. A failed gate aborts the deploy. Desktop
-(Windows) is the one target that builds **locally** (it's Windows-native).
+API is live before the clients ship. A failed gate aborts the deploy.
 
 ## Scripts
 
@@ -40,8 +41,8 @@ API is live before the clients ship. A failed gate aborts the deploy. Desktop
 - `backend.sh`, `--gate-only` / `--no-gate` / `--api-only`.
 - `android.sh`, sync + `assembleDebug` + publish APK.
 - `ios.sh`, `xcodebuild` over SSH (unsigned compile check).
-- `desktop-linux.sh`, sync + `cargo build` on the build host.
-- `desktop-windows.sh`, local `cargo build` + place libmpv-2.dll (path via `CRUMB_LIBMPV_DLL`).
+- `desktop-linux.sh` / `desktop-windows.sh`, **retired** Tauri builds; each
+  prints a pointer to `windows-release-flutter.yml` and exits.
 - `lib.sh`, shared host/path config (set hosts via `CRUMB_BUILD_HOST`/`CRUMB_PROD_HOST`/`CRUMB_MAC_HOST`).
 
 ## Prerequisites
@@ -61,10 +62,6 @@ into artifacts others install is separate work:
   needs a signing identity + provisioning (free Apple ID = 7-day on-device; the
   $99 Apple Developer Program = TestFlight/App Store). Add an `--archive`/`--device`
   path once that's set up.
-- **Desktop (Linux) .deb**, `desktop-linux.sh` does `cargo build`; a `.deb` needs
-  `cargo tauri build` (the bundle config already declares the deb deps). Add once
-  tauri-cli is set up on the build host.
-- **Desktop (Windows) installer**, `cargo tauri build` produces an MSI/NSIS, but
-  the bundle config doesn't yet ship `libmpv-2.dll` as a resource, so a packaged
-  installer would be missing it. Add the DLL to bundle resources first.
+- **Desktop**, distributed separately: the Windows Flutter client is built and
+  zipped by `.github/workflows/windows-release-flutter.yml` on the `v*` tag.
 - **Web**, secondary console; no prod deploy target wired.

--- a/scripts/release/desktop-linux.sh
+++ b/scripts/release/desktop-linux.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+echo "RETIRED: the desktop release is the Flutter client, built by .github/workflows/windows-release-flutter.yml" >&2
+exit 1
+
 # Build the Linux desktop client (Tauri, gtk/mpv pane backend) on the build host.
 #
 # the build host doesn't mount the repo, so the sources are tar'd over; the GTK/WebKitGTK

--- a/scripts/release/desktop-windows.sh
+++ b/scripts/release/desktop-windows.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+echo "RETIRED: the desktop release is the Flutter client, built by .github/workflows/windows-release-flutter.yml" >&2
+exit 1
+
 # Build the Windows desktop client (Tauri) NATIVELY on this workstation.
 #
 # This is the one target that builds locally, not over SSH: the desktop crate is

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -17,7 +17,10 @@ HERE="$(dirname "${BASH_SOURCE[0]}")"
 USAGE="usage: release.sh <backend|android|ios|desktop-windows|desktop-linux|desktop|all> [target...] [--api-only|--gate-only|--no-gate]"
 [ $# -gt 0 ] || die "$USAGE"
 
-ALL=(backend android ios desktop-linux desktop-windows)
+# desktop-linux/desktop-windows removed from ALL: the Windows desktop ships via
+# .github/workflows/windows-release-flutter.yml on the v* tag; the Tauri scripts
+# are retired (they exit immediately if invoked directly).
+ALL=(backend android ios)
 TARGETS=(); FLAGS=()
 for a in "$@"; do
   case "$a" in

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -17,7 +17,6 @@
 #   scripts/setup-env.sh                # generate all secrets, write .env
 #   scripts/setup-env.sh --prompt       # prompt for the admin password instead
 #   scripts/setup-env.sh --force        # overwrite an existing .env
-#   scripts/setup-env.sh --print        # print the admin password after writing
 # ─────────────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
@@ -29,12 +28,10 @@ ENV_FILE="${ENV_FILE:-${REPO_ROOT}/.env}"
 
 FORCE=0
 PROMPT=0
-PRINT=0
 for arg in "$@"; do
   case "${arg}" in
     --force)  FORCE=1 ;;
     --prompt) PROMPT=1 ;;
-    --print)  PRINT=1 ;;
     -h|--help)
       grep -E '^#' "$0" | sed 's/^# \{0,1\}//' ; exit 0 ;;
     *) echo "unknown flag: ${arg}" >&2; exit 1 ;;


### PR DESCRIPTION
The documentation half of the four-auditor v0.1.0 sweep (code, repo docs, docs-site, marketing site). ~40 findings, all applied and verified. The code findings landed separately (#242 release-prep, #243 env forwarding, #245 recorder lint gate); the marketing site was fixed and deployed directly (it is not in the repo).

## Highlights
- **Retired-Tauri staleness purged everywhere it was presented as current**: AGENTS.md (the file every agent session loads was steering work at the dead client), CONTRIBUTING.md, NOTICE (legal attribution now names Flutter/media_kit/flutter_rust_bridge and adds the crumb-alpr worker stack), SECURITY.md scope, DETECTION-ICONS.md, ROADMAP.md, the release scripts (now hard-exit RETIRED guards), and apps/desktop/README.md (was the stock Tauri template).
- **docs/CLIENTS.md told Windows users to run an installer that does not exist** in the Flutter release; rewritten for the real unzip-and-run zip flow.
- **docs-site admin-console page claimed the web console plays video** (live wall, playback, clips); it is the management surface. Rewritten to its real capabilities.
- **environment-reference had five false "not forwarded by compose" claims** (stale since #234) pushing operators into unnecessary override files; fixed, with missing knob rows added (defaults verified against code) and one honest footnote: five `THUMB_*` names compose forwards are compile-time constants today, so the docs no longer imply they tune anything.
- Seeded-admin default corrected in three places; the dead `--print` flag removed from `setup-env.sh` and both docs referencing it; protected-bookmark lifecycle corrected (time-boxed 1-30 days, no "unpin"); JDK 17 (not 21); assorted precision fixes (4s filmstrip cadence, `DELETE /lpr/watchlist/:id`, rollback example tag, curl wording, named notification channels).

## Verified
- docs-site production build green on the branch (generators + `onBrokenLinks: throw`)
- `bash -n` on all touched scripts
- zero em-dashes in added lines; zero current-tense Tauri claims outside deliberate retirement notes
- every new factual claim in environment-reference checked against code (file:line in the audit trail)

After merge, docs.crumbvms.com needs its manual redeploy to pick this up (same tar-sync + rebuild as before; I can run it on request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)