### PR TITLE
fix(install): escape backticks in the setup-env .env heredoc (#247)

### DIFF
--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -255,7 +255,7 @@ API_BIND=0.0.0.0:8080
 # Exports live at a TOP-LEVEL /exports (own named volume), NOT under the API's
 # read-only /data mount — a nested mountpoint under a read-only bind can't be
 # created on a fresh install and stalls the api container. Must match the compose
-# `crumb_exports:/exports` mount + its ${EXPORT_DIR:-/exports} default.
+# \`crumb_exports:/exports\` mount + its \${EXPORT_DIR:-/exports} default.
 EXPORT_DIR=/exports
 EXPORT_TTL_SECONDS=86400
 


### PR DESCRIPTION
**Fixes #247.** Found live during the v0.1.0 fresh-install verification (clean clone on a clean host).

The `.env` template heredoc is deliberately unquoted (secret + date substitutions), so the EXPORT_DIR comment's unescaped backticks executed `` `crumb_exports:/exports` `` as a command substitution: every fresh install printed `line 164: crumb_exports:/exports: No such file or directory` as the setup script's first visible output, and the generated `.env` comment came out mangled. Values were unaffected.

One-line fix (escape `` \` `` and `\${...}`, matching the correctly-escaped lines a few paragraphs down). Verified: `bash -n` clean, and a fresh generation run produces zero stderr and the literal comment in `.env`. Swept the whole heredoc; this was the only unescaped line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)