### PR TITLE
fix(api): empty-safe parse_env (fresh installs crash-loop) + smoke gates PRs (#249)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -3,8 +3,14 @@
 # follows). Kept OUT of ci.yml because it builds both Rust images from source and
 # boots the full 6-service stack (~10 min), which shouldn't tax every push.
 #
-# Runs: nightly, on manual dispatch, and on pushes to main that touch the
-# install surface (compose / migrations / services / setup script).
+# Runs: nightly, on manual dispatch, on pushes to main, AND on pull requests
+# that touch the install surface (compose / migrations / services / setup
+# script). The PR trigger was added after #249: a compose+config change merged
+# green through ci.yml and crash-looped the api on every fresh install; this
+# smoke caught it, but only post-merge where nobody was watching. ~10 min on
+# the few PRs that touch these paths is the right price for gating that class.
+# (The path lists are duplicated because GitHub Actions does not support YAML
+# anchors; keep them in sync.)
 name: fresh-install-smoke
 
 on:
@@ -13,6 +19,18 @@ on:
   workflow_dispatch: {}
   push:
     branches: [main]
+    paths:
+      - "docker-compose*.yml"
+      - "db/migrations/**"
+      - "services/**"
+      - "scripts/setup-env.sh"
+      - "scripts/test/fresh-install-smoke.sh"
+      - "scripts/test/smoke-testsrc-go2rtc.yaml"
+      - "caddy/**"
+      - "go2rtc/**"
+      - "mosquitto/**"
+      - "VERSION"
+  pull_request:
     paths:
       - "docker-compose*.yml"
       - "db/migrations/**"

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -520,9 +520,9 @@ mod tests {
     use super::parse_env;
 
     /// #249: compose forwards keys as `${VAR:-}`, so an unset key arrives as an
-    /// empty string. The api's parse_env must treat that as "use the default",
+    /// empty string. The api's `parse_env` must treat that as "use the default",
     /// not a fatal error, or a fresh install crash-loops at boot (the exact
-    /// regression: DB_POOL_SIZE = "" from the stock docker-compose.yml).
+    /// regression: `DB_POOL_SIZE` = "" from the stock `docker-compose.yml`).
     #[test]
     fn parse_env_treats_empty_as_default() {
         std::env::set_var("CRUMB_API_TEST_EMPTY_NUM", "");

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -462,6 +462,11 @@ where
     T::Err: std::fmt::Display,
 {
     match env::var(key) {
+        // Empty (or whitespace-only) means "not configured": compose forwards
+        // keys as `${VAR:-}`, so an unset key still arrives as "". Treat it as
+        // the default rather than a fatal parse error that would crash-loop the
+        // api on a fresh install (#249; mirrors crumb-common's parse_env).
+        Ok(val) if val.trim().is_empty() => Ok(default),
         Ok(val) => val
             .parse::<T>()
             .map_err(|e| anyhow::anyhow!("env var '{key}' = '{val}' could not be parsed: {e}")),
@@ -507,5 +512,31 @@ fn parse_onvif_config() -> Result<HashMap<String, OnvifCameraConfig>> {
                 "ONVIF config is not valid JSON; expected an object keyed by go2rtc_name, \
                  e.g. {\"lpr\":{\"host\":\"198.51.100.6\",\"port\":80,\"user\":\"admin\",\"password\":\"...\"}}"
             }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_env;
+
+    /// #249: compose forwards keys as `${VAR:-}`, so an unset key arrives as an
+    /// empty string. The api's parse_env must treat that as "use the default",
+    /// not a fatal error, or a fresh install crash-loops at boot (the exact
+    /// regression: DB_POOL_SIZE = "" from the stock docker-compose.yml).
+    #[test]
+    fn parse_env_treats_empty_as_default() {
+        std::env::set_var("CRUMB_API_TEST_EMPTY_NUM", "");
+        assert_eq!(
+            parse_env::<u32>("CRUMB_API_TEST_EMPTY_NUM", 32).unwrap(),
+            32,
+            "an empty env value must fall back to the default, not error"
+        );
+        std::env::set_var("CRUMB_API_TEST_WS_NUM", "   ");
+        assert_eq!(parse_env::<u32>("CRUMB_API_TEST_WS_NUM", 32).unwrap(), 32);
+        std::env::set_var("CRUMB_API_TEST_SET_NUM", "8");
+        assert_eq!(parse_env::<u32>("CRUMB_API_TEST_SET_NUM", 32).unwrap(), 8);
+        std::env::remove_var("CRUMB_API_TEST_EMPTY_NUM");
+        std::env::remove_var("CRUMB_API_TEST_WS_NUM");
+        std::env::remove_var("CRUMB_API_TEST_SET_NUM");
     }
 }


### PR DESCRIPTION
**Fixes #249 — a fresh-install boot blocker, found live by the v0.1.0 install verification on a clean host.**

Every fresh install pulling `:latest` crash-loops the api:
```
Error: env var 'DB_POOL_SIZE' = '' could not be parsed: cannot parse integer from empty string
```

**Root cause:** #234 made env parsing empty-safe in `crumb-common` so compose could forward keys as `${VAR:-}`, but `services/api/src/config.rs` has its **own duplicate `parse_env`** that still treated `""` as fatal. The recorder (which uses common's fixed helper) boots fine, which is exactly why the regression was invisible in unit CI.

**The fix:** mirror the empty-as-unset behavior into the api's helper + the same regression test (green across all test harness targets).

**The process fix:** the fresh-install smoke workflow *did* catch this — on the post-merge push to `main`, where nobody was watching. It now also triggers on **pull requests** touching the install surface (compose, migrations, services, setup script), so this class gates before merge. ~10 min on the few PRs that touch those paths.

Deduplicating the two `parse_env` copies (re-export common's) is a reasonable follow-up; kept out of this PR to stay minimal for the release.

Verified: fmt/clippy clean, regression test passes on all harness targets; the live install-test instance boots healthy with these semantics (reproduced via an env-null override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)