### PR TITLE
fix(config): seed the default recording policy at boot — fresh installs cannot complete setup (#251)

### DIFF
--- a/scripts/test/fresh-install-smoke.sh
+++ b/scripts/test/fresh-install-smoke.sh
@@ -151,6 +151,29 @@ if [ -n "${TOKEN}" ]; then
 
   CAMS="$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer ${TOKEN}" "${API_URL}/config/cameras" 2>/dev/null || true)"
   [ "${CAMS}" = "200" ] && pass "/config/cameras = 200 (admin API responds)" || fail "/config/cameras = ${CAMS} (expected 200)"
+
+  # ── 4c1. first-run setup actually works (#251 regression) ──────────────────
+  # A fresh DB has no default recording policy unless boot seeds it; without
+  # the row, the wizard's storage step, PUT /config/policy/default, and camera
+  # creation ALL 500. Exercise the real first-run sequence, not just reads.
+  info "first-run setup path (default policy + camera add)"
+  DP="$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer ${TOKEN}" "${API_URL}/config/policy/default" 2>/dev/null || true)"
+  [ "${DP}" = "200" ] && pass "GET /config/policy/default = 200 (default policy seeded)" || fail "GET /config/policy/default = ${DP} (expected 200 — default policy row missing?)"
+
+  DPUT="$(curl -s -o /dev/null -w '%{http_code}' -X PUT -H "Authorization: Bearer ${TOKEN}" -H 'Content-Type: application/json' \
+    -d '{"live_max_bytes":10000000000,"live_retention_hours":168}' \
+    "${API_URL}/config/policy/default" 2>/dev/null || true)"
+  [ "${DPUT}" = "200" ] && pass "PUT /config/policy/default = 200 (wizard storage step works)" || fail "PUT /config/policy/default = ${DPUT} (expected 200)"
+
+  # Camera add clones the default policy; the RTSP URL points at the smoke's
+  # go2rtc testsrc so the recorder can actually ingest it.
+  CADD="$(curl -s -o /dev/null -w '%{http_code}' -X POST -H "Authorization: Bearer ${TOKEN}" -H 'Content-Type: application/json' \
+    -d '{"name":"Smoke Cam","source_url":"rtsp://localhost:8554/testsrc"}' \
+    "${API_URL}/config/cameras" 2>/dev/null || true)"
+  case "${CADD}" in
+    200|201) pass "POST /config/cameras = ${CADD} (camera add works on a fresh install)" ;;
+    *) fail "POST /config/cameras = ${CADD} (expected 200/201 — default-policy clone broken?)" ;;
+  esac
 fi
 
 # ── 4c2. built-in DB backup: boot catch-up dump landed ───────────────────────

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -63,10 +63,8 @@ pub struct ApiConfig {
     ///
     /// No longer read by request handlers: a segment's file is now resolved SOLELY
     /// by its `storage_id` (→ `storages.path`), never by a stage→mount guess (A1).
-    /// Retained as the documented operational mount contract (the compose bind
-    /// still mounts this path read-only); kept in the struct so the env var stays
-    /// part of the config surface.
-    #[allow(dead_code)]
+    /// Read at boot by `ensure_default_policy` (#251) to wire the default
+    /// policy's `live_storage_id` to the storage row matching this path.
     pub live_storage_path: String,
 
     /// `ARCHIVE_STORAGE_PATH` -- in-container mount point for archive footage.

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -294,6 +294,13 @@ async fn main() -> anyhow::Result<()> {
     if let Err(e) = crumb_common::db::ensure_segments_storage_index(&pool).await {
         tracing::warn!(error = %e, "ensure_segments_storage_index failed (Change-storage drain SELECT may full-scan until recorder runs)");
     }
+    // Default recording policy row (#251): no migration seeds it, and without it
+    // the first-run wizard's storage step, PUT /config/policy/default, and
+    // camera creation all 500 on a fresh database. Idempotent; the recorder
+    // ensures it too right after seeding the storage rows.
+    if let Err(e) = crumb_common::db::ensure_default_policy(&pool, &cfg.live_storage_path).await {
+        tracing::warn!(error = %e, "ensure_default_policy failed (first-run setup will fail until the default policy exists)");
+    }
     // Frigate/MQTT settings singleton (seeded from env on first create) — backs
     // the admin Integrations page + the hot-reloadable detection provider.
     if let Err(e) = crumb_common::db::ensure_frigate_config_table(&pool).await {

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -2599,6 +2599,61 @@ pub async fn config_version(pool: &Pool) -> Result<String> {
     Ok(row.get("version"))
 }
 
+/// Ensure the single default recording policy row exists (idempotent).
+///
+/// No migration seeds this row (#251): on a truly fresh database
+/// `recording_policies` is empty, and everything that assumes the default row
+/// (the wizard's storage step, `PUT /config/policy/default`, camera creation's
+/// policy clone) got a 500 from [`get_default_policy`]. Called at api boot
+/// (beside the other ensures) and by the recorder right after it seeds the
+/// storage rows, so whichever service boots first creates it.
+///
+/// Two idempotent statements:
+/// 1. Insert a `Default` (`is_default = true`) row only when no default row
+///    exists. Every other column takes its schema default (continuous mode,
+///    48 h live retention, audio on) — the same baseline a fresh wizard run
+///    starts from. `ON CONFLICT DO NOTHING` guards both the partial-unique
+///    `is_default` index and the unique `name` index, so a legacy DB with a
+///    non-default policy literally named `Default` degrades to a no-op rather
+///    than an error (the operator's row wins; the loud failure then stays
+///    [`get_default_policy`]'s, exactly as before).
+/// 2. Backfill `live_storage_id` from the configured live-storage path when it
+///    is NULL, so the row points at real storage as soon as the recorder has
+///    seeded the storages table (first-boot ordering is race-free: whichever
+///    service runs this last wires it).
+pub async fn ensure_default_policy(pool: &Pool, live_storage_path: &str) -> Result<()> {
+    let client = get_conn(pool).await?;
+    client
+        .execute(
+            r"
+            INSERT INTO recording_policies (is_default, name)
+            SELECT true, 'Default'
+            WHERE NOT EXISTS (
+                SELECT 1 FROM recording_policies WHERE is_default
+            )
+            ON CONFLICT DO NOTHING
+            ",
+            &[],
+        )
+        .await
+        .context("ensure_default_policy: insert")?;
+    client
+        .execute(
+            r"
+            UPDATE recording_policies
+            SET live_storage_id = s.id
+            FROM storages s
+            WHERE recording_policies.is_default
+              AND recording_policies.live_storage_id IS NULL
+              AND s.path = $1
+            ",
+            &[&live_storage_path],
+        )
+        .await
+        .context("ensure_default_policy: backfill live_storage_id")?;
+    Ok(())
+}
+
 /// Return the single default recording policy row (`is_default = true`).
 ///
 /// There is exactly one such row (enforced by a partial unique index in the

--- a/services/recorder/src/main.rs
+++ b/services/recorder/src/main.rs
@@ -1089,6 +1089,14 @@ impl RecorderSupervisor {
             archive = %self.config.archive_storage_name,
             "storage rows seeded"
         );
+
+        // Default recording policy row (#251): no migration seeds it, and
+        // camera creation / the wizard's storage step 500 without it. Runs
+        // right after the storage upsert so live_storage_id wires correctly
+        // on the very first boot; the api ensures it too (idempotent).
+        db::ensure_default_policy(&self.pool, &self.config.live_storage_path)
+            .await
+            .context("ensuring default recording policy")?;
         Ok(())
     }
 }


### PR DESCRIPTION
**Fixes #251 — the worst find of the v0.1.0 fresh-install verification.**

On a truly fresh database, `recording_policies` is **empty**: no migration seeds the default row and the runtime path that once created it no longer exists. Every consumer of `get_default_policy` then 500s: the **first-run wizard's storage step**, **`PUT /config/policy/default`** (the documented AI-INSTALL §6b path), and **`POST /config/cameras`** (the policy clone). A fresh install cannot complete setup by any path. Existing installs never noticed because their row predates the policy-collapse migrations.

## Fix
- **`crumb-common`:** `ensure_default_policy(pool, live_storage_path)` — idempotent; inserts the `Default` (`is_default = true`) row when absent (schema defaults supply the rest: continuous, 48 h, audio on) and backfills `live_storage_id` from the storage row matching the configured live path. `ON CONFLICT DO NOTHING` degrades gracefully on the legacy edge case of a non-default policy literally named `Default`.
- **api boot:** called beside the other ensures (warn-only, like its siblings).
- **recorder boot:** called right after `seed_storages`, so `live_storage_id` wires deterministically on the very first boot.
- **smoke:** now exercises the real first-run sequence after login — `GET`+`PUT /config/policy/default` and `POST /config/cameras` — instead of read-only probes (this is why the nightly smoke never saw it).

## Verified
- Full gate: fmt + workspace clippy `-D warnings` clean; **494 workspace tests green** against Postgres.
- **Live end-to-end on the fresh-install test host:** rebuilt both images from this branch against the still-empty database → the `Default` row appeared wired on boot → the previously-500 `PUT /config/policy/default` returns 200 → 3 cameras added (201) → setup-complete → **segments recording to disk and indexed within seconds** (`/health` 200).

Third find of the fresh-install run (#247 heredoc, #249 parse_env, #251 this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)