### PR TITLE
chore(release): add pr-changelog.sh (per-PR bulleted change list) + document it

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -63,12 +63,21 @@ between releases.
 ## Cutting a release
 
 1. Land changes on `main` (CI green: fmt, clippy, build, test, images build).
-2. Tag and push:
+2. Generate the change list for the release notes, one bullet per merged PR
+   since the last tag:
+   ```bash
+   scripts/release/pr-changelog.sh              # since the most recent tag
+   # or an explicit range: scripts/release/pr-changelog.sh v1.1.0 v1.2.0
+   ```
+   The repo squash-merges, so this is every merged PR (each subject ends in
+   `(#N)`); drop it into the GitHub Release notes / `CHANGELOG.md` alongside the
+   curated Added/Changed/Fixed prose.
+3. Tag and push:
    ```bash
    git tag -a v1.2.0 -m "Crumb v1.2.0"
    git push origin v1.2.0
    ```
-3. CI builds `recorder` and `api` and tags them `v1.2.0` (+ short SHA). If a
+4. CI builds `recorder` and `api` and tags them `v1.2.0` (+ short SHA). If a
    registry is configured (below), they're pushed; otherwise they're built and
    validated but not pushed.
 

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -43,6 +43,9 @@ API is live before the clients ship. A failed gate aborts the deploy.
 - `ios.sh`, `xcodebuild` over SSH (unsigned compile check).
 - `desktop-linux.sh` / `desktop-windows.sh`, **retired** Tauri builds; each
   prints a pointer to `windows-release-flutter.yml` and exits.
+- `pr-changelog.sh`, one bullet per merged PR in a range (default: since the
+  last tag). Standalone, no SSH/hosts; feeds the release notes (see
+  `docs/RELEASE.md`).
 - `lib.sh`, shared host/path config (set hosts via `CRUMB_BUILD_HOST`/`CRUMB_PROD_HOST`/`CRUMB_MAC_HOST`).
 
 ## Prerequisites

--- a/scripts/release/pr-changelog.sh
+++ b/scripts/release/pr-changelog.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Crumb release changelog — a flat bulleted list of every merged PR in a range.
+#
+# The repo squash-merges, so every merged PR is exactly one commit whose subject
+# ends in "(#N)". This prints one bullet per such commit, which is the
+# "every single change" list to drop into the release notes / CHANGELOG.
+#
+# Usage:
+#   scripts/release/pr-changelog.sh                 # since the most recent tag → HEAD
+#   scripts/release/pr-changelog.sh v0.1.0          # since v0.1.0 → HEAD
+#   scripts/release/pr-changelog.sh v0.1.0 v0.2.0   # exactly the v0.1.0..v0.2.0 range
+#
+# Notes:
+# - Runs a `git fetch --tags` first so tags/main are current (skippable with
+#   CRUMB_NO_FETCH=1, e.g. offline).
+# - Scoping is git-range based ON PURPOSE. `gh pr list --search "merged:>DATE"`
+#   is date-granular and wrongly sweeps in same-day PRs merged *before* the tag;
+#   a commit range is exact.
+set -euo pipefail
+
+REMOTE="${CRUMB_REMOTE:-origin}"
+BRANCH="${CRUMB_BRANCH:-main}"
+
+if [[ "${CRUMB_NO_FETCH:-}" != "1" ]]; then
+  git fetch --quiet --tags "${REMOTE}" "${BRANCH}"
+fi
+
+head_ref="${REMOTE}/${BRANCH}"
+
+case "$#" in
+  0) from="$(git describe --tags --abbrev=0 "${head_ref}")"; to="${head_ref}" ;;
+  1) from="$1"; to="${head_ref}" ;;
+  2) from="$1"; to="$2" ;;
+  *) echo "usage: $0 [FROM_TAG [TO_REF]]" >&2; exit 2 ;;
+esac
+
+# One bullet per squash-merged PR (subject ends in "(#N)"), newest first.
+count="$(git log "${from}..${to}" --format='%s' | grep -cE '\(#[0-9]+\)$' || true)"
+git log "${from}..${to}" --format='- %s' | grep -aE '\(#[0-9]+\)$' || true
+
+echo >&2
+echo "${count} merged PR(s) in ${from}..${to}" >&2


### PR DESCRIPTION
Adds `scripts/release/pr-changelog.sh` so cutting a release includes a flat, one-bullet-per-PR change list without hand-maintaining anything.

## What it does
```bash
scripts/release/pr-changelog.sh              # since the most recent tag → HEAD
scripts/release/pr-changelog.sh v0.1.0       # since a given tag → HEAD
scripts/release/pr-changelog.sh v0.1.0 v0.2.0  # an explicit range
```
Prints `- <subject>` for every commit in the range whose subject ends in `(#N)`. Since the repo squash-merges, that's exactly one line per merged PR.

## Why git-range, not `gh --search`
`gh pr list --search "merged:>DATE"` is date-granular and wrongly sweeps in same-day PRs merged *before* the tag (it reported 15 "since v0.1.0" when the answer was 0). A commit range (`lasttag..main`) is exact.

## Wiring
- `docs/RELEASE.md`: new step 2 of "Cutting a release".
- `scripts/release/README.md`: listed under Scripts (standalone, no SSH/hosts).

## Verified
`bash -n` clean; `v0.0.1..v0.1.0` produces the full 30-PR v0.1.0 list; no-args since-`v0.1.0` correctly prints 0. Tracked with mode 100755.

🤖 Generated with [Claude Code](https://claude.com/claude-code)