### PR TITLE
perf(timeline): stop the motion-strip refresh from stacking under load (#256)

### DIFF
--- a/apps/desktop-flutter/lib/ui/motion_timeline/motion_timeline_controller.dart
+++ b/apps/desktop-flutter/lib/ui/motion_timeline/motion_timeline_controller.dart
@@ -92,6 +92,16 @@ class MotionTimelineController extends ChangeNotifier {
 
   int _seq = 0;
 
+  // Loop-hygiene state (#256): the playback screen re-fires refresh() every 5s
+  // on an idle timer, and the scrubber fires it on every move. Without these
+  // guards, a slow fetch (e.g. under recording load) lets identical-window
+  // fetches stack into dozens of concurrent server scans. `_fetchingSig` is the
+  // signature of the in-flight fetch (null when idle); `_loadedSig` is the
+  // signature of the last COMPLETED fetch. A signature is (fetchStart, fetchEnd,
+  // sorted-camera-ids) — the actual data range on screen.
+  String? _fetchingSig;
+  String? _loadedSig;
+
   /// Update window/selection/camera-set; caller still must call [refresh].
   void configure({
     int? windowStartMs,
@@ -115,7 +125,11 @@ class MotionTimelineController extends ChangeNotifier {
   /// Fetch the intensity histogram for every camera in the wall grid (fanned
   /// out, latest-wins) plus object-detection events for the loaded window.
   /// Ported from pbReloadTimeline -> pbFetchIntensity / pbFetchDetections.
-  Future<void> refresh() async {
+  ///
+  /// Pass [force] to bypass the "same window already loaded / in flight" guards
+  /// (the playback screen uses it for the periodic full re-fetch that picks up
+  /// footage evicted by retention).
+  Future<void> refresh({bool force = false}) async {
     final winDur = (windowEndMs - windowStartMs) > 0
         ? (windowEndMs - windowStartMs)
         : 3600000;
@@ -132,14 +146,30 @@ class MotionTimelineController extends ChangeNotifier {
     if (camIds.isEmpty) {
       intensityByCam.clear();
       detections = const [];
+      _fetchingSig = null;
+      _loadedSig = null;
       notifyListeners();
       return;
+    }
+
+    // Loop hygiene (#256): the data range currently requested. The epoch-snapped
+    // fetch bounds already keep small pans within one loaded range, so an
+    // unchanged sig means "the bars on screen already cover this".
+    final sig = '$fetchStart|$fetchEnd|${(camIds.toList()..sort()).join(',')}';
+    if (!force) {
+      // An identical fetch is already running — coalesce (the idle timer
+      // re-firing the same window is what stacks concurrent server scans).
+      if (_fetchingSig == sig) return;
+      // This exact range is already loaded and nothing is in flight — nothing
+      // to do. Scrubbing to a new window changes `sig` and proceeds normally.
+      if (_fetchingSig == null && _loadedSig == sig) return;
     }
 
     // Drop cached intensity for cameras no longer in the grid.
     intensityByCam.removeWhere((id, _) => !camIds.contains(id));
 
     final mySeq = ++_seq;
+    _fetchingSig = sig;
     loading = true;
     error = null;
     notifyListeners();
@@ -179,10 +209,17 @@ class MotionTimelineController extends ChangeNotifier {
       // each as a glyph too would flood the row. Object detections only.
       detections = events.where((e) => e.iconKey.isNotEmpty && e.iconKey != 'motion').toList();
 
+      // Record what's now loaded and clear the in-flight marker. Superseded
+      // fetches returned above without touching these, so the newest fetch owns
+      // them (single isolate — no race).
+      _loadedSig = sig;
+      _fetchingSig = null;
       loading = false;
       notifyListeners();
     } catch (e) {
       if (mySeq != _seq) return;
+      // Failed: clear in-flight (but not _loadedSig) so a retry can proceed.
+      _fetchingSig = null;
       loading = false;
       error = '$e';
       notifyListeners();

--- a/apps/desktop-flutter/lib/ui/playback/playback_screen.dart
+++ b/apps/desktop-flutter/lib/ui/playback/playback_screen.dart
@@ -286,9 +286,13 @@ class _PlaybackScreenState extends State<PlaybackScreen> {
       if (!mounted) return;
       _idleTicks++;
       // Live-edge top-up most ticks; a full re-fetch every ~5 min so coverage
-      // evicted by retention eventually drops off the line.
-      unawaited(_syncCoverage(force: _idleTicks % 60 == 0));
-      _scheduleMotionRefresh();
+      // evicted by retention eventually drops off the line. The motion refresh
+      // is forced on the same cadence: on the other ticks an unchanged window
+      // is a no-op (the controller skips it), which is what stops idle ticks
+      // from stacking concurrent server scans (#256).
+      final full = _idleTicks % 60 == 0;
+      unawaited(_syncCoverage(force: full));
+      _scheduleMotionRefresh(force: full);
     });
   }
 
@@ -315,8 +319,10 @@ class _PlaybackScreenState extends State<PlaybackScreen> {
   }
 
   /// Keep the motion controller's window/selection in step with the scrubber,
-  /// then (debounced) refetch intensity + detections.
-  void _scheduleMotionRefresh() {
+  /// then (debounced) refetch intensity + detections. [force] bypasses the
+  /// controller's "same window already loaded" skip (used by the periodic
+  /// full re-fetch).
+  void _scheduleMotionRefresh({bool force = false}) {
     _motion.configure(
       windowStartMs: _timeline.windowStart.millisecondsSinceEpoch,
       windowEndMs: _timeline.windowEnd.millisecondsSinceEpoch,
@@ -326,7 +332,7 @@ class _PlaybackScreenState extends State<PlaybackScreen> {
     _motionDebounce?.cancel();
     _motionDebounce = Timer(
       const Duration(milliseconds: 350),
-      () => _motion.refresh(),
+      () => _motion.refresh(force: force),
     );
   }
 


### PR DESCRIPTION
Fix #2 of 3 for #256. Where #1 makes each query cheap, this stops the **client** from multiplying and stacking them.

## The problem
The playback screen re-fires the per-camera intensity fan-out **every 5s on an idle timer** (plus on every scrubber move), and `MotionTimelineController.refresh()` had no guard against overlapping or redundant runs. When a fetch is slow (e.g. under recording load), identical-window fetches stack — up to ~6 generations × 11 cameras ≈ dozens of concurrent server scans — whose 2s pool-checkout failures are silently swallowed into blank bars. Metastable collapse: the slower it gets, the more work the client creates.

## The fix
Loop hygiene keyed on a **fetch signature** = `(fetchStart, fetchEnd, sorted-camera-ids)` — the actual data range on screen:
- **coalesce:** if an identical fetch is already in flight, skip it.
- **skip-unchanged:** if that exact range is already loaded and nothing is in flight, do nothing. This is what neutralizes the idle timer on a stationary window.
- **`refresh(force: true)`** bypasses both; the idle timer forces a full re-fetch every ~5 min (unchanged cadence) so retention-evicted coverage still drops off the line.

Behavior is otherwise identical: a moving window (scrub or playback) changes the signature and refetches exactly as before; only redundant same-window idle re-fetches and same-window overlaps are dropped. The fetch bounds are already epoch-snapped, so small pans within a loaded range were already stable — this just stops re-fetching them.

## Verified
`flutter analyze` clean on `lib/ui/motion_timeline` + `playback_screen.dart` (winbuild, Flutter 3.44.6). No Flutter CI exists, so desktop changes are analyzed on the build box. Runtime behavior (bars still update on scrub, stationary window quiesces) is best confirmed on a live install with recording load; the change is conservative (worst case: a paused, stationary window waits up to 5 min for the forced eviction refresh).

Part of #256; #1 = the sargable SQL bound (#259), #3 = batching the fan-out into one request (follows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)