### PR TITLE
perf(timeline): batch the per-camera intensity fan-out into one request (#256)

### DIFF
--- a/apps/desktop-flutter/lib/api/motion_timeline_api.dart
+++ b/apps/desktop-flutter/lib/api/motion_timeline_api.dart
@@ -156,6 +156,59 @@ extension MotionTimelineApi on CrumbApi {
     );
   }
 
+  /// GET /timeline/intensity/batch?camera_ids=<csv>&start=<iso>&end=<iso>&buckets=<n>
+  ///
+  /// The batched form of [fetchIntensity]: one request for the whole wall
+  /// instead of one per camera (#256). Returns a map keyed by camera id; every
+  /// requested camera is present (all-zero buckets for one with no footage or
+  /// outside the caller's scope), so the caller can rely on a complete map.
+  Future<Map<String, IntensityBuckets>> fetchIntensityBatch(
+    Session s,
+    List<String> cameraIds,
+    DateTime start,
+    DateTime end, {
+    int buckets = 240,
+  }) async {
+    final uri = Uri.parse('${s.base}/timeline/intensity/batch').replace(
+      queryParameters: {
+        'camera_ids': cameraIds.join(','),
+        'start': start.toUtc().toIso8601String(),
+        'end': end.toUtc().toIso8601String(),
+        'buckets': '$buckets',
+      },
+    );
+    final resp = await _client.get(
+      uri,
+      headers: {'authorization': 'Bearer ${s.token}'},
+    );
+    if (resp.statusCode != 200) {
+      throw CrumbApiException(
+        'Failed to load motion intensity (HTTP ${resp.statusCode}).',
+        statusCode: resp.statusCode,
+      );
+    }
+    final j = jsonDecode(resp.body) as Map<String, dynamic>;
+    final cameras = (j['cameras'] as Map<String, dynamic>? ?? const {});
+    final startMs = start.toUtc().millisecondsSinceEpoch;
+    final endMs = end.toUtc().millisecondsSinceEpoch;
+    final out = <String, IntensityBuckets>{};
+    cameras.forEach((cameraId, v) {
+      final list = (v as List<dynamic>? ?? const [])
+          .map((e) => (e as num).toDouble())
+          .toList(growable: false);
+      final n = list.isEmpty ? 1 : list.length;
+      final bucketMs = ((endMs - startMs) / n).round();
+      out[cameraId] = IntensityBuckets(
+        cameraId: cameraId,
+        startMs: startMs,
+        endMs: endMs,
+        bucketMs: bucketMs,
+        buckets: list,
+      );
+    });
+    return out;
+  }
+
   /// GET /timeline/motion?camera_id=<id>&from=<iso>&dir=next|prev
   ///
   /// The start of the next/previous motion EVENT relative to `from`, searched

--- a/apps/desktop-flutter/lib/ui/motion_timeline/motion_timeline_controller.dart
+++ b/apps/desktop-flutter/lib/ui/motion_timeline/motion_timeline_controller.dart
@@ -145,27 +145,20 @@ class MotionTimelineController extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final results = await Future.wait(
-        camIds.map((id) async {
-          try {
-            final r = await api.fetchIntensity(
-              session,
-              id,
-              DateTime.fromMillisecondsSinceEpoch(fetchStart, isUtc: true),
-              DateTime.fromMillisecondsSinceEpoch(fetchEnd, isUtc: true),
-              buckets: bucketCount,
-            );
-            return MapEntry(id, r);
-          } catch (_) {
-            return null; // per-camera failure shouldn't sink the whole fetch
-          }
-        }),
+      // One batched request for the whole wall (#256) instead of a per-camera
+      // fan-out: one HTTP round-trip, one server DB scan, one rate-limit token.
+      // The server returns a complete map (all-zero buckets for a camera with no
+      // footage or outside scope), so every requested camera is covered.
+      final intensity = await api.fetchIntensityBatch(
+        session,
+        camIds,
+        DateTime.fromMillisecondsSinceEpoch(fetchStart, isUtc: true),
+        DateTime.fromMillisecondsSinceEpoch(fetchEnd, isUtc: true),
+        buckets: bucketCount,
       );
       if (mySeq != _seq) return; // superseded by a newer refresh
 
-      for (final e in results) {
-        if (e != null) intensityByCam[e.key] = e.value;
-      }
+      intensityByCam.addAll(intensity);
 
       final events = await api.fetchEvents(
         session,

--- a/services/api/src/timeline.rs
+++ b/services/api/src/timeline.rs
@@ -70,6 +70,10 @@ const MAX_SPAN_LIMIT: usize = 10_000;
 /// windowing or future SQL-side bucketing.
 const SCAN_WARN_SEGMENTS: usize = 100_000;
 
+/// Max cameras accepted by `GET /timeline/intensity/batch`. A wall is a handful
+/// of cameras; this just bounds a pathological request.
+const MAX_INTENSITY_BATCH: usize = 64;
+
 /// Mount timeline routes.
 ///
 /// Caller (`main.rs`) merges this at the router root.
@@ -77,6 +81,7 @@ pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/timeline", get(get_timeline))
         .route("/timeline/intensity", get(get_intensity))
+        .route("/timeline/intensity/batch", get(get_intensity_batch))
         .route("/timeline/motion", get(get_motion_edge))
 }
 
@@ -163,6 +168,75 @@ async fn get_intensity(
         .await
         .map_err(ApiError::Internal)?;
     Ok(Json(IntensityResponse { buckets }))
+}
+
+/// Query for `GET /timeline/intensity/batch` — the multi-camera form.
+#[derive(Debug, Deserialize)]
+struct IntensityBatchQuery {
+    /// Comma-separated camera UUIDs.
+    camera_ids: String,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    /// Number of time buckets across the window (default 240, clamped 1..4096).
+    buckets: Option<usize>,
+}
+
+/// Response for `GET /timeline/intensity/batch` — a bucket array per requested
+/// camera (keyed by UUID string). Every requested camera is present; a camera
+/// with no footage (or outside the caller's scope) gets an all-zero array, so
+/// the client gets a complete map in one request instead of N.
+#[derive(Debug, Serialize)]
+struct IntensityBatchResponse {
+    cameras: std::collections::HashMap<String, Vec<f32>>,
+}
+
+/// `GET /timeline/intensity/batch?camera_ids=<csv>&start=<iso>&end=<iso>&buckets=<n>`
+///
+/// The batched form of [`get_intensity`]: one request + one DB scan for the
+/// whole wall instead of one per camera (#256). Scope is enforced like the
+/// per-camera endpoint — a camera the caller can't access gets all-zeros rather
+/// than a 403.
+async fn get_intensity_batch(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Query(q): Query<IntensityBatchQuery>,
+) -> Result<Json<IntensityBatchResponse>, ApiError> {
+    user.require_playback()?;
+    if q.start >= q.end {
+        return Err(ApiError::BadRequest(
+            "start must be strictly before end".to_owned(),
+        ));
+    }
+    let requested = parse_uuid_csv(&q.camera_ids)?;
+    if requested.is_empty() {
+        return Err(ApiError::BadRequest(
+            "camera_ids must contain at least one UUID".to_owned(),
+        ));
+    }
+    // Bound the fan-in — a wall is a handful of cameras, not hundreds.
+    if requested.len() > MAX_INTENSITY_BATCH {
+        return Err(ApiError::BadRequest(format!(
+            "camera_ids: at most {MAX_INTENSITY_BATCH} cameras per request"
+        )));
+    }
+    let n = q.buckets.unwrap_or(240).clamp(1, 4096);
+
+    // Fetch only the accessible cameras; inaccessible ones fall through to the
+    // all-zeros default below (matching the per-camera endpoint's behaviour).
+    let accessible = user.filter_camera_ids(&requested);
+    let mut data = db::motion_intensity_buckets_multi(state.pool(), &accessible, q.start, q.end, n)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    // Build the response over EVERY requested camera so the client always gets a
+    // complete map (accessible-with-data, accessible-empty, and inaccessible all
+    // resolve to an array; only inaccessible are silently zeroed).
+    let mut cameras = std::collections::HashMap::with_capacity(requested.len());
+    for id in &requested {
+        let buckets = data.remove(id).unwrap_or_else(|| vec![0.0; n]);
+        cameras.insert(id.to_string(), buckets);
+    }
+    Ok(Json(IntensityBatchResponse { cameras }))
 }
 
 // ─── handler ──────────────────────────────────────────────────────────────────

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -6690,6 +6690,81 @@ pub async fn motion_intensity_buckets(
     Ok(buckets)
 }
 
+/// Batched [`motion_intensity_buckets`] for many cameras in ONE query (#256).
+///
+/// The playback timeline needs the intensity histogram for every camera on the
+/// wall at once. Doing that as one request/pool-checkout per camera multiplies
+/// load; this fetches all of them with a single `camera_id = ANY(...)` scan and
+/// buckets each camera's segments in Rust with the identical math as the
+/// single-camera function (asserted equal by a test).
+///
+/// Returns a bucket array (length `n`, clamped 1..=4096) for EVERY requested
+/// camera — an all-zero array for a camera with no segments in the window, so
+/// callers can rely on a complete map.
+pub async fn motion_intensity_buckets_multi(
+    pool: &Pool,
+    camera_ids: &[Uuid],
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    n: usize,
+) -> Result<std::collections::HashMap<Uuid, Vec<f32>>> {
+    let n = n.clamp(1, 4096);
+    // Every requested camera gets an entry up front (all-zeros), so a camera
+    // with no footage still returns a bucket array — same as the per-camera
+    // endpoint, which returns zeros rather than omitting the camera.
+    let mut out: std::collections::HashMap<Uuid, Vec<f32>> = camera_ids
+        .iter()
+        .map(|id| (*id, vec![0.0_f32; n]))
+        .collect();
+    if end <= start || camera_ids.is_empty() {
+        return Ok(out);
+    }
+    let span_ms = (end - start).num_milliseconds().max(1) as f64;
+    // Same sargable lower bound as the single-camera query (audit P2 #11) —
+    // O(window) not O(retention). See `motion_intensity_buckets`.
+    let lower_bound = start - MAX_SEGMENT_LEN;
+    let client = get_conn(pool).await?;
+    let rows = client
+        .query(
+            r"
+            SELECT camera_id, start_ts, end_ts, COALESCE(motion_score, 0.0) AS motion_score
+            FROM segments
+            WHERE camera_id = ANY($1)
+              AND start_ts >= $4
+              AND start_ts < $3
+              AND end_ts   > $2
+            ",
+            &[&camera_ids, &start, &end, &lower_bound],
+        )
+        .await
+        .context("motion_intensity_buckets_multi")?;
+
+    for row in &rows {
+        let cam: Uuid = row.get("camera_id");
+        let Some(buckets) = out.get_mut(&cam) else {
+            continue;
+        };
+        let s: DateTime<Utc> = row.get("start_ts");
+        let e: DateTime<Utc> = row.get("end_ts");
+        let score: f32 = row.get("motion_score");
+        // Identical bucketing to `motion_intensity_buckets`: map the segment's
+        // overlap with [start,end) onto bucket indices and keep the MAX score.
+        let s_off = ((s - start).num_milliseconds() as f64).max(0.0);
+        let e_off = ((e - start).num_milliseconds() as f64).min(span_ms);
+        if e_off <= s_off {
+            continue;
+        }
+        let b0 = ((s_off / span_ms) * n as f64).floor() as usize;
+        let b1 = (((e_off / span_ms) * n as f64).ceil() as usize).min(n);
+        for bucket in &mut buckets[b0..b1] {
+            if score > *bucket {
+                *bucket = score;
+            }
+        }
+    }
+    Ok(out)
+}
+
 /// Ensure the `motion_grid` table exists (idempotent — the recorder calls this
 /// at startup so the tuner works without a manual migration).
 pub async fn ensure_motion_grid_table(pool: &Pool) -> Result<()> {
@@ -13144,6 +13219,91 @@ mod tests {
                 .expect("backfill again"),
             0,
             "backfill must not touch already-populated hosts"
+        );
+    }
+
+    /// The batched `motion_intensity_buckets_multi` must return, for every
+    /// camera, EXACTLY what the per-camera `motion_intensity_buckets` returns —
+    /// that equality is what lets the client replace the N-request fan-out with
+    /// one request without changing the rendered bars (#256).
+    #[tokio::test]
+    async fn motion_intensity_multi_matches_per_camera() {
+        let Some(url) = test_db_url() else {
+            eprintln!("skipping: TEST_DATABASE_URL not set");
+            return;
+        };
+        let pool = migrated_public_pool(&url).await;
+        let policy_id = insert_nondefault_policy(&pool).await;
+        let cam_a = seed_camera_for_test(&pool, policy_id).await;
+        let cam_b = seed_camera_for_test(&pool, policy_id).await;
+        let cam_empty = seed_camera_for_test(&pool, policy_id).await; // no segments
+        let storage_name = format!("test-storage-{}", Uuid::new_v4().simple());
+        let storage_id = create_storage(&pool, &storage_name, "/does/not/matter", None, None)
+            .await
+            .expect("create_storage")
+            .id;
+
+        let base = Utc
+            .timestamp_millis_opt(1_700_000_000_000)
+            .single()
+            .unwrap();
+        let sec = |n: i64| base + chrono::Duration::seconds(n);
+        let (start, end) = (sec(0), sec(120));
+
+        // Inline scored-segment insert (no shared helper — keeps this branch
+        // independent of the one that adds `insert_scored_segment`).
+        async fn seed(
+            pool: &Pool,
+            camera_id: Uuid,
+            storage_id: Uuid,
+            start_ts: DateTime<Utc>,
+            end_ts: DateTime<Utc>,
+            score: f32,
+        ) {
+            let client = get_conn(pool).await.expect("conn");
+            #[allow(clippy::cast_possible_truncation)]
+            let dur = (end_ts - start_ts).num_milliseconds() as i32;
+            client
+                .execute(
+                    r"
+                    INSERT INTO segments
+                        (camera_id, storage_id, stage, path, stream, start_ts, end_ts,
+                         duration_ms, has_motion, size_bytes, motion_score)
+                    VALUES ($1,$2,'live','s.mp4','main',$3,$4,$5,true,64,$6)
+                    ",
+                    &[&camera_id, &storage_id, &start_ts, &end_ts, &dur, &score],
+                )
+                .await
+                .expect("insert scored segment");
+        }
+        // cam A: one segment overlapping the window start from before, one mid.
+        seed(&pool, cam_a, storage_id, sec(-5), sec(5), 0.8).await;
+        seed(&pool, cam_a, storage_id, sec(60), sec(66), 0.5).await;
+        // cam B: one segment.
+        seed(&pool, cam_b, storage_id, sec(30), sec(36), 0.3).await;
+
+        let n = 120;
+        let batch =
+            motion_intensity_buckets_multi(&pool, &[cam_a, cam_b, cam_empty], start, end, n)
+                .await
+                .expect("motion_intensity_buckets_multi");
+
+        for cam in [cam_a, cam_b, cam_empty] {
+            let single = motion_intensity_buckets(&pool, cam, start, end, n)
+                .await
+                .expect("motion_intensity_buckets");
+            assert_eq!(
+                batch.get(&cam).cloned().unwrap_or_default(),
+                single,
+                "batched buckets must equal the per-camera buckets for {cam}"
+            );
+        }
+        // A camera with no footage still gets a full-length zero array (so the
+        // client can rely on a complete map).
+        assert_eq!(
+            batch.get(&cam_empty).map(Vec::len),
+            Some(n),
+            "no-footage camera must still return an n-length array"
         );
     }
 }

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -12810,9 +12810,13 @@ mod tests {
     /// non-default policy sidesteps the `one_default_policy` partial-unique
     /// constraint entirely (this test never needs the global default), and the
     /// explicit column set mirrors `services/api/tests/support/mod.rs`'s seed so
-    /// it stays valid as the schema grows.
+    /// it stays valid as the schema grows. The name carries a UUID suffix: the
+    /// shared CI database runs the whole suite in parallel, and `name` is
+    /// globally unique (`recording_policies_name_uidx`), so a fixed name would
+    /// collide the moment two tests seed a policy at once.
     async fn insert_nondefault_policy(pool: &Pool) -> Uuid {
         let client = get_conn(pool).await.expect("get_conn (insert_policy)");
+        let name = format!("Test Non-Default Policy {}", Uuid::new_v4().simple());
         let row = client
             .query_one(
                 r"
@@ -12823,14 +12827,14 @@ mod tests {
                     motion_keyframes_only, record_stream
                 )
                 VALUES (
-                    'Test Non-Default Policy', false, 'continuous', NULL, 48,
+                    $1, false, 'continuous', NULL, 48,
                     false, NULL, NULL, NULL,
                     5, 10, 'dynamic',
                     false, 'main'
                 )
                 RETURNING id
                 ",
-                &[],
+                &[&name],
             )
             .await
             .expect("insert non-default recording_policies row");


### PR DESCRIPTION
Third and last of the three timeline load-perf fixes from #256 (after #259 sargable bound, #260 client loop hygiene). Where those two cut per-query cost and stopped refreshes from stacking, this one cuts the **request multiplier**: a wall of N cameras was firing N separate `/timeline/intensity` requests every refresh — N HTTP round-trips, N DB scans, N rate-limit tokens. This collapses them into one.

## What

**New batched endpoint** `GET /timeline/intensity/batch?camera_ids=<csv>&start=&end=&buckets=`
- One `camera_id = ANY($1)` DB query (carrying the same sargable `start_ts >= start - MAX_SEGMENT_LEN` bound landed in #259), then per-camera bucketing in Rust — byte-identical output to calling the single-camera path per id.
- Auth/scope preserved: `require_playback`, then `filter_camera_ids` drops any id the caller can't see. The response is a **complete map** over every requested id — a camera with no footage, or one filtered out by scope, comes back as all-zero buckets, so the client can rely on the map being total and never has to special-case a missing key.
- Capped at `MAX_INTENSITY_BATCH = 64` camera ids per request.

**Client** (`apps/desktop-flutter`)
- `motion_timeline_api.dart`: new `fetchIntensityBatch(...)`.
- `motion_timeline_controller.dart`: the per-camera `Future.wait` fan-out is replaced by a single `fetchIntensityBatch` call; results merged with `intensityByCam.addAll(...)`. The latest-wins `_seq` guard is unchanged.

## Correctness

`motion_intensity_buckets_multi` is a pure refactor of the existing single-camera `motion_intensity_buckets` — same lower-bound, same window predicate, same bucketing math. New test `motion_intensity_multi_matches_per_camera` asserts the batched result is identical to the per-camera result for a multi-camera seed. Recorder untouched.

## Gate

- `cargo fmt --all --check`, `cargo clippy --all-targets -D warnings`, `cargo test --workspace` (Postgres) — all green; the new test passes.
- Desktop client `flutter analyze` — 0 errors, 0 warnings.

Part of #256.