### PR TITLE
fix(android): quality label no longer wraps 'AUTO' to two lines (#262)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -738,16 +739,24 @@ fun PlaybackScreen(
                 actions = {
                     // Quality selector (Auto / Full / Data saver) — always visible so
                     // the operator can pick a cellular-friendly stream before playing.
+                    // A TextButton (sizes to its content), NOT an IconButton: the
+                    // latter is a fixed ~48dp single-glyph box, so a 4-char label
+                    // like "AUTO" wrapped to two lines ("AUT"/"O"). maxLines/softWrap
+                    // are a belt-and-suspenders guard against wrap when the bar is
+                    // crowded. (#262)
                     HintTooltip(PlaybackQuality.label(quality)) {
-                        IconButton(
+                        TextButton(
                             onClick = {
                                 quality = PlaybackQuality.next(quality)
                                 store.playbackQuality = quality
                             },
+                            contentPadding = PaddingValues(horizontal = 12.dp),
                         ) {
                             Text(
                                 text = PlaybackQuality.short(quality),
                                 color = if (quality == PlaybackQuality.AUTO) Color.White else TealAccent,
+                                maxLines = 1,
+                                softWrap = false,
                             )
                         }
                     }


### PR DESCRIPTION
Fixes #262.

## Problem
The Android fullscreen-playback top-bar quality selector showed **"AUTO" broken across two lines** ("AUT" / "O"). The label was a `Text` inside a Material3 `IconButton` — a fixed ~48dp box sized for a single glyph — with no wrap guard. "HD"/"SD" (2 chars) fit; the 4-char "AUTO" didn't.

## Fix
- Swap the `IconButton` for a **`TextButton`**, which sizes to its content, with a compact `contentPadding` so it stays tidy in the bar.
- Guard the `Text` with `maxLines = 1, softWrap = false` so it can't wrap even when the bar is crowded (long camera name + mute button — the aggravating case called out in the issue).

One file, `feature/playback/PlaybackScreen.kt`. No behavior change beyond layout — same tap-to-cycle (Auto → Full → Data saver), same color treatment.

## Verify
`android (debug build)` CI compiles it. On-device: the label shows on one line for all three tiers (AUTO / HD / SD), including with a long camera title in the bar.