### PR TITLE
feat(desktop): draggable HA edit panel + Dot badges show their label (#255)

### DIFF
--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_badge_style_editor.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_badge_style_editor.dart
@@ -48,9 +48,14 @@ String overlayColorToHex(Color c) =>
 /// form (bottom). Rendered by the maximized pane while an HA overlay edit
 /// session is active.
 class HaOverlayEditPanel extends StatelessWidget {
-  const HaOverlayEditPanel({super.key, required this.host});
+  const HaOverlayEditPanel({super.key, required this.host, this.onDragHeader});
 
   final HaOverlayController host;
+
+  /// Drag delta from the panel's header strip — the host repositions the panel
+  /// (#255) so it can be moved off a spot the operator wants to place a badge
+  /// on. Null leaves the panel fixed.
+  final void Function(Offset delta)? onDragHeader;
 
   @override
   Widget build(BuildContext context) {
@@ -74,6 +79,35 @@ class HaOverlayEditPanel extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              // Drag handle: grab this strip to move the panel out of the way.
+              MouseRegion(
+                cursor: onDragHeader == null
+                    ? MouseCursor.defer
+                    : SystemMouseCursors.move,
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onPanUpdate: onDragHeader == null
+                      ? null
+                      : (d) => onDragHeader!(d.delta),
+                  child: const Padding(
+                    padding: EdgeInsets.only(bottom: 8),
+                    child: Row(
+                      children: [
+                        Icon(Icons.drag_indicator, color: Colors.white38, size: 16),
+                        SizedBox(width: 4),
+                        Text(
+                          'Home Assistant',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 12.5,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
               const Text(
                 'Entities',
                 style: TextStyle(

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_layer.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_layer.dart
@@ -353,7 +353,16 @@ class HaBadgeCaptions extends StatelessWidget {
 
     final showState = item.showState || hovered;
     final showAge = (item.showAge || hovered) && state?.lastChanged != null;
-    if (!showState && !showAge && !hovered) return null;
+    // A Dot renders icon-only (unlike a Pill, which shows its label inline), so
+    // when the operator has given a Dot an explicit label, surface it as a
+    // caption line — the compact-Dot analogue of the Pill's inline label
+    // (#255). Gated on a non-empty operator label so unlabeled Dots stay
+    // icon-only, and suppressed while hovering (the hover line already shows the
+    // name). Rides the link's existing `label` — no new persisted field.
+    final showLabel = !item.isPill &&
+        !hovered &&
+        (item.labelText?.trim().isNotEmpty ?? false);
+    if (!showState && !showAge && !hovered && !showLabel) return null;
 
     // Scale text with the badge so captions stay proportional on small tiles.
     final fState = (h * 0.42).clamp(8.0, 13.0).toDouble();
@@ -364,6 +373,17 @@ class HaBadgeCaptions extends StatelessWidget {
       if (hovered)
         Text(
           item.displayLabel,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: TextStyle(
+            color: Colors.white,
+            fontSize: fState,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      if (showLabel)
+        Text(
+          item.pillLabel,
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
           style: TextStyle(

--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -1852,6 +1852,12 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
   /// `AnimatedBuilder` for that).
   bool _haEditing = false;
 
+  /// Top-left position of the draggable HA edit panel (#255). Null = its default
+  /// top-right anchor; a drag pins an explicit offset for the rest of the edit
+  /// session so the operator can move it off a spot they want to place a badge
+  /// on. Clamped to the pane in `build`; reset when the session ends.
+  Offset? _haPanelOffset;
+
   void _onHaOverlayChanged() {
     if (!mounted) return;
     final editing = widget.haOverlay?.editor.editMode ?? false;
@@ -1860,7 +1866,12 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
     // style lives in the right-side panel now), so a badge drag can't hide
     // under it (issue #13).
     widget.haOverlay?.editor.setEditBottomInset(editing ? 78 : 0);
-    setState(() => _haEditing = editing);
+    setState(() {
+      _haEditing = editing;
+      // Fresh session starts at the default anchor (a stale drag position from a
+      // previous camera's edit could land off-pane after a resize).
+      if (!editing) _haPanelOffset = null;
+    });
     // NOTE (issue #3): this pane deliberately does NOT re-fetch links when the
     // edit session ends. `editor.endEdit()` flips editMode false SYNCHRONOUSLY
     // — before `endEditAndSave` has awaited its placement PUTs — so a reload
@@ -2702,11 +2713,35 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
                 // generic multi-select geometry ops (align/group/match/undo).
                 // Mutually exclusive with the PTZ chrome above by construction.
                 if (widget.haOverlay != null && _haEditing) ...[
-                  Positioned(
-                    right: 14,
-                    top: 64,
-                    child: HaOverlayEditPanel(host: widget.haOverlay!),
-                  ),
+                  () {
+                    // Draggable (#255): default to the top-right anchor, but once
+                    // the operator drags the panel's header, honor that offset —
+                    // clamped so the header can never leave the pane.
+                    const panelW = 300.0;
+                    final defaultLeft =
+                        (pane.width - panelW - 14).clamp(0.0, pane.width);
+                    final maxLeft = (pane.width - panelW).clamp(0.0, pane.width);
+                    final maxTop = (pane.height - 44).clamp(0.0, pane.height);
+                    final pos = _haPanelOffset ?? Offset(defaultLeft, 64);
+                    return Positioned(
+                      left: pos.dx.clamp(0.0, maxLeft),
+                      top: pos.dy.clamp(0.0, maxTop),
+                      child: HaOverlayEditPanel(
+                        host: widget.haOverlay!,
+                        onDragHeader: (delta) {
+                          setState(() {
+                            final base = _haPanelOffset ?? Offset(defaultLeft, 64);
+                            // Clamp here (not just at render) so dragging past an
+                            // edge can't bank up phantom offset to unwind later.
+                            _haPanelOffset = Offset(
+                              (base.dx + delta.dx).clamp(0.0, maxLeft),
+                              (base.dy + delta.dy).clamp(0.0, maxTop),
+                            );
+                          });
+                        },
+                      ),
+                    );
+                  }(),
                   Positioned(
                     left: 0,
                     right: 0,


### PR DESCRIPTION
Fixes #255. Two small UX gaps in the HA badge editor, both desktop-only.

## 1. The edit panel is now draggable
It was pinned top-right and could sit over the exact spot you wanted to drop a badge. Added a **drag-handle header** ("⠿ Home Assistant" strip) — grab it to move the panel anywhere, clamped to the pane. The position is remembered for the edit session and resets to the default anchor when the session ends (so a stale offset can't land off-pane on the next camera).

- `wall_screen.dart`: `Offset? _haPanelOffset` on the maximized-pane state; the panel `Positioned` uses it (default = top-right), clamped to the pane in both the drag setter and at render.
- `ha_badge_style_editor.dart`: `onDragHeader` callback + the header strip (`MouseRegion` move cursor + `GestureDetector.onPanUpdate`).

## 2. Dot badges show their label
A **Dot** rendered icon-only, so a label typed for a Dot appeared nowhere (only **Pill** shows a label inline). Surface it through the **existing caption system** as a label line — gated on a non-empty operator label so unlabeled Dots stay compact, and suppressed while hovering (the hover line already shows the name).

- `ha_overlay_layer.dart` `HaBadgeCaptions._captionFor`: one derived caption line.

**No new persisted field / migration / server / Android change** — the label is the link's existing `label` column, already edited and saved through the placement PUT. (Derived over a new `overlay_show_label` toggle deliberately: a persisted toggle would be a ~10-surface change to store one bool, and "let a Dot show its label" is exactly the derive-when-labeled behavior.)

## Verify
`flutter analyze` clean on the build box (only pre-existing info lints in an untouched file). On-device: in the HA overlay editor, drag the panel over a busy scene and drop a badge where it used to sit; add a Dot with a label and confirm the name renders as a caption under it.