### PR TITLE
fix(desktop): per-camera intensity fallback when the server lacks the batch endpoint (#270)

### DIFF
--- a/apps/desktop-flutter/lib/api/motion_timeline_api.dart
+++ b/apps/desktop-flutter/lib/api/motion_timeline_api.dart
@@ -108,6 +108,12 @@ class DetectionEvent {
 // `http.Client()` construction, just not shared with it.
 final http.Client _client = TimeoutClient();
 
+/// Server bases whose API 404'd `/timeline/intensity/batch` — i.e. servers
+/// older than the batch endpoint (#270). Keyed by base (not a lone bool) so a
+/// same-process switch to a different, newer server isn't wrongly demoted to
+/// the per-camera fallback.
+final Set<String> _batchUnsupportedBases = <String>{};
+
 extension MotionTimelineApi on CrumbApi {
   /// GET /timeline/intensity?camera_id=<id>&start=<iso>&end=<iso>&buckets=<n>
   ///
@@ -162,6 +168,14 @@ extension MotionTimelineApi on CrumbApi {
   /// instead of one per camera (#256). Returns a map keyed by camera id; every
   /// requested camera is present (all-zero buckets for one with no footage or
   /// outside the caller's scope), so the caller can rely on a complete map.
+  ///
+  /// Version tolerance (#270): a server older than the batch endpoint 404s the
+  /// route. Client/server skew is normal for a self-hosted VMS, so on a 404
+  /// this falls back to the per-camera [fetchIntensity] fan-out every older
+  /// server supports — same complete-map result, just N requests — and
+  /// remembers batch-unsupported for that server so later refreshes skip the
+  /// doomed batch attempt. (A server upgraded mid-session picks the batch path
+  /// back up on next app start; skew in that direction is rare and harmless.)
   Future<Map<String, IntensityBuckets>> fetchIntensityBatch(
     Session s,
     List<String> cameraIds,
@@ -169,6 +183,43 @@ extension MotionTimelineApi on CrumbApi {
     DateTime end, {
     int buckets = 240,
   }) async {
+    if (_batchUnsupportedBases.contains(s.base)) {
+      return _fetchIntensityPerCamera(s, cameraIds, start, end, buckets);
+    }
+    try {
+      return await _fetchIntensityBatchRaw(s, cameraIds, start, end, buckets);
+    } on CrumbApiException catch (e) {
+      if (e.statusCode != 404) rethrow;
+      _batchUnsupportedBases.add(s.base);
+      return _fetchIntensityPerCamera(s, cameraIds, start, end, buckets);
+    }
+  }
+
+  /// The pre-batch per-camera fan-out (the #270 fallback path). Mirrors the
+  /// batch guarantee: one entry per requested camera ([fetchIntensity] returns
+  /// all-zero buckets rather than erroring for scope/no-footage cameras).
+  Future<Map<String, IntensityBuckets>> _fetchIntensityPerCamera(
+    Session s,
+    List<String> cameraIds,
+    DateTime start,
+    DateTime end,
+    int buckets,
+  ) async {
+    final results = await Future.wait(
+      cameraIds.map(
+        (id) => fetchIntensity(s, id, start, end, buckets: buckets),
+      ),
+    );
+    return {for (final r in results) r.cameraId: r};
+  }
+
+  Future<Map<String, IntensityBuckets>> _fetchIntensityBatchRaw(
+    Session s,
+    List<String> cameraIds,
+    DateTime start,
+    DateTime end,
+    int buckets,
+  ) async {
     final uri = Uri.parse('${s.base}/timeline/intensity/batch').replace(
       queryParameters: {
         'camera_ids': cameraIds.join(','),


### PR DESCRIPTION
Fixes #270. Found live: a client built from current main against a server still on pre-#264 images showed `CrumbApiException(404): Failed to load motion intensity` on the motion strip, permanently — the batched `/timeline/intensity/batch` route doesn't exist there and the client had no fallback.

## Fix
Version tolerance in `fetchIntensityBatch`:
- Try the batch route as designed.
- On **404**, fall back to the per-camera `GET /timeline/intensity` fan-out every older server supports — same complete-map result, just N requests (i.e. exactly the pre-#264 behavior).
- Remember batch-unsupported **per server base** so subsequent refreshes go straight to the fallback instead of paying a doomed request each time. Keyed by base, not a global bool, so switching to a newer server in the same process isn't wrongly demoted. A server upgraded mid-session picks the batch path back up on next app start.

Only non-404 errors still surface as before (real failures should be visible, not silently retried down a slower path).

One file, client-only. `flutter analyze` clean (0 errors/warnings; the file's pre-existing info doc-comment lints are unchanged at 15).

## Verify
- Current client → pre-#264 server: motion strip renders via the fallback (no 404 banner).
- Current client → current server: single batch request as designed (fallback never engages).