### PR TITLE
fix(desktop): gate post-open seeks on file-loaded — no-motion frame-step 4s jump (#186)

### DIFF
--- a/apps/desktop-flutter/lib/ui/playback/gapless_segment_pane_controller.dart
+++ b/apps/desktop-flutter/lib/ui/playback/gapless_segment_pane_controller.dart
@@ -595,6 +595,15 @@ class GaplessSegmentPaneController extends ChangeNotifier {
         } catch (_) {
           /* non-fatal — the transport owner reasserts speed on its next change */
         }
+        // The offset seek below MUST wait for the file to finish loading:
+        // media_kit's open() returns before mpv's file-loaded, and mpv
+        // silently REJECTS seeks issued mid-load (media_kit logs, never
+        // throws). Without this gate the pane lands on the segment's FIRST
+        // frame while the playhead shows the clicked time — invisible on a
+        // static scene, then "exposed" by the first frame-step truthfully
+        // mapping mpv's real position and snapping the playhead a whole
+        // segment (the #186 no-motion ~4s jump).
+        await _awaitFileLoaded();
       }
       final offsetMs = (ts.millisecondsSinceEpoch - seg.startMs)
           .clamp(0, seg.durationMs)
@@ -625,6 +634,26 @@ class GaplessSegmentPaneController extends ChangeNotifier {
     } finally {
       _resolving = false;
       _replayPendingResolve();
+    }
+  }
+
+  /// Wait (bounded) for a just-`open()`ed file to actually finish loading
+  /// before issuing its offset seek. mpv rejects seeks while a file is still
+  /// loading, and media_kit's `open()` returns as soon as the load *begins* —
+  /// so an immediate seek is silently dropped (media_kit only logs the mpv
+  /// error) and the pane sits on the file's first frame while the app thinks
+  /// it seeked (#186). mpv's `duration` flips 0 → real exactly at
+  /// file-loaded (`open()` resets it to 0 first), so that's the gate.
+  /// Timeout → proceed and seek anyway: the worst case is today's behavior,
+  /// never a new hang.
+  Future<void> _awaitFileLoaded() async {
+    if (_player.state.duration > Duration.zero) return;
+    try {
+      await _player.stream.duration
+          .firstWhere((d) => d > Duration.zero)
+          .timeout(const Duration(seconds: 3));
+    } catch (_) {
+      /* best-effort — see doc */
     }
   }
 
@@ -854,6 +883,12 @@ class GaplessSegmentPaneController extends ChangeNotifier {
       } catch (_) {
         /* non-fatal — the transport owner reasserts speed on its next change */
       }
+      // Same dropped-seek gate as resolveAt (#186): without it the backward
+      // cross's `durationMs - 200` seek is rejected mid-load and the pane
+      // lands on the previous segment's FIRST frame — whose position ≈ 0 the
+      // next back-press reads as "at the file start" and crosses ANOTHER
+      // segment (the repeated whole-segment back-jump #192 only softened).
+      await _awaitFileLoaded();
       // Landing offset: first frame going forward. Going backward, aim a few
       // frames shy of the end (200 ms) rather than the exact last frame —
       // the indexed duration can slightly overshoot the real file, and a


### PR DESCRIPTION
Fixes #186 — the long-standing "frame-step is perfect in motion but jumps ~4s in quiet footage" bug that #192 only partially addressed.

## Root cause (experimentally verified against mpv, not just code-read)
1. media_kit's `open()` **returns before mpv finishes loading the file**; the pane's post-open offset seek fires ~1–2 ms later — *inside* the load window.
2. **mpv rejects seeks issued mid-load**, and the failure is invisible twice over: media_kit logs-but-never-throws, and the controller's catch swallows it. Verified with mpv IPC on recorder-identical fragmented HEVC over HTTP: seek at 2 ms → `error running command`, position stays 0.000; at 10 ms → success.
3. Net state after a cold timeline click: mpv paused on the segment's **first frame**, playhead showing your clicked mid-segment time.
4. The first frame-step then works *correctly* — steps frame 0 → +50 ms and truthfully maps mpv's real position — snapping the playhead to the segment boundary. **The "4s jump" is the desync being revealed, not a bad step.**

**Why motion-dependent** (same footage steps identically — verified): motion regions are reached by playing-into or re-seeking within an already-loaded file (`sameFile` path — no fresh open, no race), and a visibly-wrong frame there gets re-clicked before stepping. A quiet region is reached by a cold click, and its static first frame is **indistinguishable** from the requested frame — the desync silently survives until you step.

## Fix
`_awaitFileLoaded()`: after each fresh `open()`, wait (bounded 3 s) for mpv's `duration` to flip 0 → real — the file-loaded signal — before issuing the offset seek. Timeout falls through to seeking anyway: worst case is exactly today's behavior, never a new hang. Applied at the only two open→offset-seek sites:
- `resolveAt` (cold click / scrub-commit / bookmark / goto-time), and
- `_openAdjacentForStep` (boundary-crossing steps) — which also kills the **residual repeated whole-segment back-jump**: the backward cross's `duration−200ms` seek was being dropped the same way, landing on frame 0, which the next back-press read as "at the file start" and crossed another segment. #192's settle-wait attributed that position-0 to a stale stream; it was real.

Free bonus: bookmarks/plate-jumps/goto-time now land on the requested frame instead of silently starting at the segment boundary on quiet scenes.

One file, client-only, +35 lines. `flutter analyze` clean.

## Verify (on hardware)
- Pause, click a **quiet** timeline spot mid-segment, press frame-forward once — before: playhead snaps to the 4 s boundary; after: +~50 ms.
- Step backward across a segment boundary — lands ~200 ms shy of the previous segment's end, not at its start, and repeated back-presses walk frames instead of segments.
- Regression: in-motion stepping, scrubbing, bookmark jumps, gapless boundary playback.