### PR TITLE
fix(desktop): actually freeze a maximized carousel/hotspot slot (#269)

### DIFF
--- a/apps/desktop-flutter/lib/ui/special_tiles/special_tile_controller.dart
+++ b/apps/desktop-flutter/lib/ui/special_tiles/special_tile_controller.dart
@@ -95,6 +95,9 @@ class SpecialTileController extends ChangeNotifier {
   /// — they carry no resolved camera. Starts/stops carousel timers as needed.
   void applySpecs(Map<int, SpecialTileSpec> specs) {
     _specs = specs;
+    // Slot indices mean something else in the incoming view — a stale frozen
+    // index could freeze an arbitrary slot of the new layout (#269).
+    frozenSlot = null;
 
     // Stop + drop carousels for slots no longer carrying a carousel spec.
     for (final slot in _carousels.keys.toList()) {

--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -378,7 +378,13 @@ class _WallScreenState extends State<WallScreen> {
   }
 
   /// Maximize a camera + make it the audio-active pane.
-  void _maximize(Camera cam) {
+  ///
+  /// [specialSlot]: when the maximize originated from a carousel/hotspot slot,
+  /// its slot index — the controller freezes that slot so the rotation doesn't
+  /// keep advancing (and, with seamless switching, warm-swapping streams)
+  /// underneath the maximized overlay (#269). Null for plain-camera maximizes,
+  /// which also UNfreezes any previously frozen slot.
+  void _maximize(Camera cam, {int? specialSlot}) {
     // Maximizing a different camera mid panel-edit ends (and persists) the
     // edit — the editor chrome must not follow the wrong camera. The session
     // teardown is synchronous inside endEditAndSave (only the store write is
@@ -400,6 +406,9 @@ class _WallScreenState extends State<WallScreen> {
       // it shows live video (upscaled sub stream) instead of black while its
       // own main-stream player waits ~a GOP for its first keyframe.
       _maximizeWarmCtrl = _tileKeys[cam.id]?.currentState?.warmController;
+      // Freeze the originating carousel/hotspot slot (or unfreeze on a
+      // plain-camera maximize) — see the doc above (#269).
+      _special.frozenSlot = specialSlot;
       _maximized = cam;
       // Fresh key per maximize — lets the wall reach this pane's State later
       // (e.g. to push refreshed HA links after an edit saves) while keeping
@@ -419,6 +428,8 @@ class _WallScreenState extends State<WallScreen> {
     setState(() {
       _maximizeWarmCtrl = null;
       _maximized = null;
+      // Let a frozen carousel/hotspot slot resume rotating (#269).
+      _special.frozenSlot = null;
     });
   }
 
@@ -773,7 +784,9 @@ class _WallScreenState extends State<WallScreen> {
                     onTap: () {
                       // Clicking a camera retargets classic (click) hotspots.
                       _special.routeHotspotClick(i, cam.id);
-                      _maximize(cam);
+                      // A maximize FROM a carousel/hotspot slot freezes that
+                      // slot's rotation until restore (#269).
+                      _maximize(cam, specialSlot: spec == null ? null : i);
                     },
                     onEditPtzPanel: () => unawaited(_beginPtzPanelEdit(cam)),
                     onEditHaOverlay: () =>


### PR DESCRIPTION
Fixes #269 (found during the #254 review).

`SpecialTileController.frozenSlot` existed and all three advance/motion guards read it — but **no host ever set it**, so the guard was dead code: a carousel kept rotating (and, now that seamless switching is live, kept warm-swapping streams) underneath a maximized overlay.

## Fix
- `_maximize` takes an optional `specialSlot`; the carousel/hotspot tile's tap passes its slot index → the controller freezes that slot. All other maximize paths (default grid, edit funnels, hotkeys) pass nothing, which also **un**freezes any stale freeze.
- `_restore` unfreezes.
- `applySpecs` clears it — slot indices mean something else in the incoming view; a stale index could freeze an arbitrary slot of the new layout.

Two files, +18/−2. `flutter analyze` clean (1 pre-existing info lint).

## Verify (on the wall)
Maximize a carousel tile → it holds its camera (and the go2rtc consumer set stays put) until you restore; restore → rotation resumes on the next tick. Maximizing a plain camera or switching views never leaves anything frozen.