### PR TITLE
feat(desktop): in-app Diagnostics — bounded log capture, verbose toggle, scrubbed export (#180)

### DIFF
--- a/apps/desktop-flutter/lib/api/http_client.dart
+++ b/apps/desktop-flutter/lib/api/http_client.dart
@@ -14,6 +14,8 @@ import 'dart:async';
 
 import 'package:http/http.dart' as http;
 
+import '../services/diagnostics_service.dart';
+
 /// Per-request budget for every desktop API call. Long enough to ride out a
 /// briefly slow LAN server, short enough that a wedged request fails fast
 /// instead of freezing the UI.
@@ -31,14 +33,37 @@ class TimeoutClient extends http.BaseClient {
   final Duration timeout;
 
   @override
-  Future<http.StreamedResponse> send(http.BaseRequest request) {
-    return _inner.send(request).timeout(
-      timeout,
-      onTimeout: () => throw TimeoutException(
-        'Request to ${request.url} timed out',
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    // Diagnostics (#180): every API call funnels through this one method, so
+    // it's the single choke point for the HTTP trace. ONLY method + bare path
+    // + status + duration are ever recorded — never the query string (media
+    // URLs carry `?token=`), never headers (`authorization: Bearer`), never
+    // bodies (login credentials).
+    final sw = Stopwatch()..start();
+    try {
+      final resp = await _inner.send(request).timeout(
         timeout,
-      ),
-    );
+        onTimeout: () => throw TimeoutException(
+          'Request to ${request.url} timed out',
+          timeout,
+        ),
+      );
+      DiagnosticsService.instance.httpTrace(
+        request.method,
+        request.url.path,
+        resp.statusCode,
+        sw.elapsedMilliseconds,
+      );
+      return resp;
+    } catch (e) {
+      DiagnosticsService.instance.httpTrace(
+        request.method,
+        request.url.path,
+        null,
+        sw.elapsedMilliseconds,
+      );
+      rethrow;
+    }
   }
 
   @override

--- a/apps/desktop-flutter/lib/main.dart
+++ b/apps/desktop-flutter/lib/main.dart
@@ -10,6 +10,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:math' as math;
+import 'dart:ui' show PlatformDispatcher;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';

--- a/apps/desktop-flutter/lib/main.dart
+++ b/apps/desktop-flutter/lib/main.dart
@@ -27,6 +27,7 @@ import 'package:crumb_desktop/api/models.dart';
 import 'package:crumb_desktop/api/playback_api.dart' show PlaybackApi;
 import 'package:crumb_desktop/api/views_api.dart';
 import 'package:crumb_desktop/services/audio_follow_controller.dart';
+import 'package:crumb_desktop/services/diagnostics_service.dart';
 import 'package:crumb_desktop/services/snapshot_service.dart';
 import 'package:crumb_desktop/perf_grid.dart';
 import 'package:crumb_desktop/session/session_controller.dart';
@@ -108,6 +109,24 @@ ThemeData _desktopTheme() {
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  // Diagnostics (#180): stand up the bounded log capture and funnel every
+  // framework/platform error into it — before anything else can fail. The
+  // handlers CHAIN to Flutter's defaults so console behavior is unchanged;
+  // the buffer is just an additional, exportable witness.
+  await DiagnosticsService.instance.init();
+  final prevFlutterError = FlutterError.onError;
+  FlutterError.onError = (details) {
+    DiagnosticsService.instance.log(
+      'flutter',
+      details.exceptionAsString(),
+      level: 'error',
+    );
+    prevFlutterError?.call(details);
+  };
+  PlatformDispatcher.instance.onError = (error, stack) {
+    DiagnosticsService.instance.log('uncaught', '$error', level: 'error');
+    return false; // not handled — keep the default crash/log behavior
+  };
   // media_kit native surface + libmpv init.
   MediaKit.ensureInitialized();
   // flutter_rust_bridge — loads the cargokit-built rust_lib_crumb_desktop dylib.
@@ -281,6 +300,8 @@ class _CrumbClientAppState extends State<CrumbClientApp> {
     _updateCheck = UpdateCheckController(api: _api, session: session)..start();
     _session = session;
     _cameras = cameras;
+    // Diagnostics breadcrumb (#180): record host:port only, never creds.
+    DiagnosticsService.instance.setServerBase(session.base);
     // Apply "launch into fullscreen wall" only after the initial camera load —
     // same ordering as the old client's applyLaunchPreferences().
     unawaited(applyLaunchFullscreenPreference(_fullscreen));

--- a/apps/desktop-flutter/lib/services/diagnostics_service.dart
+++ b/apps/desktop-flutter/lib/services/diagnostics_service.dart
@@ -1,0 +1,198 @@
+// In-app diagnostics (issue #180): a bounded, always-on capture of the
+// client's warnings/errors plus an opt-in verbose trace (HTTP, player logs),
+// exportable as a scrubbed text file a tester can hand to the maintainer.
+//
+// Design constraints, in order:
+//  1. SCRUB EVERYTHING SENSITIVE. Bearer/JWT/media tokens, `?token=` query
+//     params, and password/token JSON fields are redacted AT CAPTURE TIME —
+//     nothing token-shaped is ever even held in the buffer, so no later
+//     export path can leak what was never stored. Server identity is recorded
+//     as host:port only, never the full base URL with credentials-bearing
+//     paths. (A leaky "share my logs" button would be worse than none.)
+//  2. Bounded by construction: a fixed-capacity ring buffer with a per-line
+//     length cap. Verbose mode is safe to leave on indefinitely — it can't
+//     grow memory or disk (nothing is written to disk until an export).
+//  3. Zero cost when quiet: normal (non-verbose) capture only records
+//     warnings, errors, and a handful of lifecycle breadcrumbs.
+//
+// Singleton (mirrors `SnapshotRegistry.instance`) so the HTTP layer, player
+// hooks, and error handlers can log without threading a reference through
+// every constructor in the app.
+
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+import 'package:media_kit/media_kit.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const String _kVerboseKey = 'crumb.verboseLogging';
+
+/// Ring capacity (records) and per-message length cap. ~4k trimmed lines is
+/// hours of verbose capture and well under a megabyte of memory.
+const int _kCapacity = 4000;
+const int _kMaxMsgLen = 2000;
+
+class _Rec {
+  _Rec(this.ts, this.level, this.tag, this.msg);
+  final DateTime ts;
+  final String level; // 'error' | 'warn' | 'info' | 'debug'
+  final String tag;
+  final String msg;
+}
+
+class DiagnosticsService extends ChangeNotifier {
+  DiagnosticsService._();
+
+  static final DiagnosticsService instance = DiagnosticsService._();
+
+  final ListQueue<_Rec> _buf = ListQueue<_Rec>();
+  SharedPreferences? _prefs;
+  String? _appVersion; // "1.2.3+45" once resolved
+  String? _serverHost; // host:port only — never the full base URL
+
+  /// Verbose capture on/off (persisted; off by default). Off = only
+  /// warnings/errors/lifecycle are kept; on = HTTP traces + player logs too.
+  bool get verbose => _verbose;
+  bool _verbose = false;
+  set verbose(bool v) {
+    if (v == _verbose) return;
+    _verbose = v;
+    // Bracket the change in the log itself so an exported file shows exactly
+    // which stretch was captured verbose.
+    log('diag', 'verbose logging ${v ? 'enabled' : 'disabled'}');
+    _prefs?.setBool(_kVerboseKey, v);
+    notifyListeners();
+  }
+
+  /// Buffered record count (drives the pane's "N lines captured" hint).
+  int get length => _buf.length;
+
+  /// Load the persisted verbose flag + resolve the app version. Best-effort:
+  /// diagnostics must never be the thing that breaks startup.
+  Future<void> init() async {
+    try {
+      _prefs = await SharedPreferences.getInstance();
+      _verbose = _prefs?.getBool(_kVerboseKey) ?? false;
+    } catch (_) {
+      /* plugin unavailable — session-only toggle */
+    }
+    try {
+      final info = await PackageInfo.fromPlatform();
+      _appVersion = info.buildNumber.isEmpty
+          ? info.version
+          : '${info.version}+${info.buildNumber}';
+    } catch (_) {
+      /* dev build — version stays unknown */
+    }
+    log('diag', 'diagnostics started (app ${_appVersion ?? 'dev'})');
+  }
+
+  /// Record the connected server as HOST:PORT only (from `Session.base`).
+  /// Called on login/restore; deliberately never stores the full URL.
+  void setServerBase(String base) {
+    _serverHost = Uri.tryParse(base)?.authority ?? '(unparsed)';
+    log('session', 'connected to $_serverHost');
+  }
+
+  /// Append one record. `debug` is kept only in verbose mode; `info` and up
+  /// always. Message is scrubbed and length-capped before storage.
+  void log(String tag, String message, {String level = 'info'}) {
+    if (level == 'debug' && !_verbose) return;
+    var msg = scrub(message);
+    if (msg.length > _kMaxMsgLen) msg = '${msg.substring(0, _kMaxMsgLen)}…';
+    _buf.addLast(_Rec(DateTime.now().toUtc(), level, tag, msg));
+    while (_buf.length > _kCapacity) {
+      _buf.removeFirst();
+    }
+  }
+
+  /// HTTP trace hook for [TimeoutClient]: failures always captured, routine
+  /// traffic only in verbose. `path` must be a bare path — callers never pass
+  /// the query string (it can carry `?token=`).
+  void httpTrace(String method, String path, int? status, int ms) {
+    final failed = status == null || status >= 400;
+    if (!failed && !_verbose) return;
+    log(
+      'http',
+      '$method $path → ${status ?? 'timeout/error'} (${ms}ms)',
+      level: failed ? 'warn' : 'debug',
+    );
+  }
+
+  /// Wire a media_kit [player]'s error/log streams into the buffer. Errors
+  /// always; mpv's own log lines only in verbose (they're chatty). The
+  /// subscriptions die with the player's streams on dispose — fire-and-forget.
+  void attachPlayer(String tag, Player player) {
+    player.stream.error.listen(
+      (e) => log('player:$tag', e, level: 'warn'),
+      onError: (_) {},
+    );
+    player.stream.log.listen(
+      (l) {
+        if (!_verbose) return;
+        log('player:$tag', '[${l.level}] ${l.prefix}: ${l.text}',
+            level: 'debug');
+      },
+      onError: (_) {},
+    );
+  }
+
+  /// Redact anything secret-shaped. Applied at capture; applied again over
+  /// the assembled export as a belt-and-suspenders pass (headers included).
+  static String scrub(String s) {
+    var out = s;
+    // JWT-shaped triplets (session bearer tokens, media claims).
+    out = out.replaceAll(
+      RegExp(r'eyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}'),
+      '[REDACTED-JWT]',
+    );
+    // Authorization header values.
+    out = out.replaceAll(
+      RegExp('Bearer [A-Za-z0-9._~+/=-]+'),
+      'Bearer [REDACTED]',
+    );
+    // token/password/secret-ish query params or key=value fragments.
+    out = out.replaceAllMapped(
+      RegExp(
+        r'''(token|password|secret|api_key|apikey)=[^&\s"']+''',
+        caseSensitive: false,
+      ),
+      (m) => '${m[1]}=[REDACTED]',
+    );
+    // JSON fields: "password": "...", "token": "...", "secret": "..."
+    out = out.replaceAllMapped(
+      RegExp(
+        r'"(password|token|secret|api_key)"\s*:\s*"[^"]*"',
+        caseSensitive: false,
+      ),
+      (m) => '"${m[1]}":"[REDACTED]"',
+    );
+    return out;
+  }
+
+  /// Assemble the scrubbed export text: environment header + buffered lines.
+  String buildExport() {
+    final b = StringBuffer()
+      ..writeln('CrumbVMS desktop diagnostics')
+      ..writeln('exported: ${DateTime.now().toUtc().toIso8601String()}')
+      ..writeln('app: ${_appVersion ?? 'unknown (dev build)'}')
+      ..writeln(
+        'os: ${defaultTargetPlatform.name} '
+        '(debug=${kDebugMode ? 'yes' : 'no'})',
+      )
+      ..writeln('server: ${_serverHost ?? '(not connected)'}')
+      ..writeln('verbose: ${_verbose ? 'on' : 'off'}')
+      ..writeln('lines: ${_buf.length} (cap $_kCapacity)')
+      ..writeln('---');
+    for (final r in _buf) {
+      b.writeln(
+        '${r.ts.toIso8601String()} ${r.level.padRight(5)} '
+        '[${r.tag}] ${r.msg}',
+      );
+    }
+    // Second scrub pass over the whole assembly — catches anything a header
+    // or a future field addition might have carried through.
+    return scrub(b.toString());
+  }
+}

--- a/apps/desktop-flutter/lib/ui/playback/gapless_segment_pane_controller.dart
+++ b/apps/desktop-flutter/lib/ui/playback/gapless_segment_pane_controller.dart
@@ -92,6 +92,7 @@ import 'package:media_kit_video/media_kit_video.dart';
 import '../../api/crumb_api.dart';
 import '../../api/models.dart';
 import '../../api/playback_api.dart';
+import '../../services/diagnostics_service.dart';
 
 /// How long before a segment's end to kick off the prefetch of the next one.
 /// Mirrors app.js's `seg.segEndMs - 1000` check in `pbTick`.
@@ -136,6 +137,8 @@ class GaplessSegmentPaneController extends ChangeNotifier {
   }) : _session = session {
     _player = Player();
     _videoController = VideoController(_player);
+    // Diagnostics (#180): player errors always captured; mpv log in verbose.
+    DiagnosticsService.instance.attachPlayer('playback:$cameraId', _player);
     // Watch mpv's playlist pointer: with `prefetch-playlist=yes` and the next
     // segment appended, mpv auto-advances the playlist at the REAL end of the
     // current file. In the single-pane mpv-driven mode that auto-advance IS

--- a/apps/desktop-flutter/lib/ui/settings/diagnostics_pane.dart
+++ b/apps/desktop-flutter/lib/ui/settings/diagnostics_pane.dart
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Settings → Diagnostics (issue #180): the verbose-logging toggle and the
+// scrubbed log export. The capture itself lives in
+// `services/diagnostics_service.dart`; this pane is just its controls.
+
+import 'dart:convert';
+
+import 'package:file_selector/file_selector.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../services/diagnostics_service.dart';
+import '../fullscreen/native_picker_guard.dart';
+
+class DiagnosticsPane extends StatefulWidget {
+  const DiagnosticsPane({super.key});
+
+  @override
+  State<DiagnosticsPane> createState() => _DiagnosticsPaneState();
+}
+
+class _DiagnosticsPaneState extends State<DiagnosticsPane> {
+  String? _status; // transient "Saved to…" / "Copied" feedback
+
+  Future<void> _export() async {
+    final diag = DiagnosticsService.instance;
+    final stamp = DateTime.now()
+        .toUtc()
+        .toIso8601String()
+        .replaceAll(':', '')
+        .split('.')
+        .first;
+    final loc = await runNativePicker(
+      () => getSaveLocation(suggestedName: 'crumb-diagnostics-$stamp.txt'),
+    );
+    if (loc == null) return; // cancelled
+    try {
+      final bytes = utf8.encode(diag.buildExport());
+      final file = XFile.fromData(
+        bytes,
+        mimeType: 'text/plain',
+        name: 'crumb-diagnostics.txt',
+      );
+      await file.saveTo(loc.path);
+      setState(() => _status = 'Saved to ${loc.path}');
+    } catch (e) {
+      setState(() => _status = 'Export failed: $e');
+    }
+  }
+
+  Future<void> _copy() async {
+    await Clipboard.setData(
+      ClipboardData(text: DiagnosticsService.instance.buildExport()),
+    );
+    setState(() => _status = 'Copied to clipboard');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final diag = DiagnosticsService.instance;
+    return AnimatedBuilder(
+      animation: diag,
+      builder: (context, _) => ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const Text(
+            'Diagnostics',
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(height: 4),
+          const Text(
+            'The client always keeps a small rolling log of warnings and '
+            'errors. Turn on verbose logging while reproducing a problem, '
+            'then export the log and attach it to your bug report. Exports '
+            'are scrubbed — tokens, passwords, and credentials are never '
+            'included.',
+            style: TextStyle(color: Colors.white70, fontSize: 12.5),
+          ),
+          const SizedBox(height: 16),
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            dense: true,
+            title: const Text('Verbose logging'),
+            subtitle: const Text(
+              'Also capture HTTP request traces and video-player (mpv) logs. '
+              'Bounded — safe to leave on while reproducing an issue.',
+              style: TextStyle(fontSize: 11.5),
+            ),
+            value: diag.verbose,
+            onChanged: (v) => diag.verbose = v,
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              FilledButton.icon(
+                onPressed: _export,
+                icon: const Icon(Icons.save_alt, size: 18),
+                label: const Text('Export logs…'),
+              ),
+              const SizedBox(width: 10),
+              OutlinedButton.icon(
+                onPressed: _copy,
+                icon: const Icon(Icons.copy, size: 18),
+                label: const Text('Copy to clipboard'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Text(
+            '${diag.length} lines captured',
+            style: const TextStyle(color: Colors.white54, fontSize: 11.5),
+          ),
+          if (_status != null) ...[
+            const SizedBox(height: 6),
+            Text(
+              _status!,
+              style: const TextStyle(color: Colors.white70, fontSize: 12),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/apps/desktop-flutter/lib/ui/settings/settings_window.dart
+++ b/apps/desktop-flutter/lib/ui/settings/settings_window.dart
@@ -27,6 +27,7 @@ import 'package:crumb_desktop/ui/client_options/client_options_screen.dart';
 import 'package:crumb_desktop/ui/hotkeys/hotkey_remap_screen.dart';
 import 'package:crumb_desktop/ui/hotkeys/keyboard_shortcuts_screen.dart';
 import 'package:crumb_desktop/ui/server/server_dashboard_screen.dart';
+import 'package:crumb_desktop/ui/settings/diagnostics_pane.dart';
 import 'package:crumb_desktop/ui/settings/ha_settings_screen.dart';
 import 'package:crumb_desktop/ui/updates/about_panel.dart';
 import 'package:crumb_desktop/ui/updates/update_check_controller.dart';
@@ -43,6 +44,7 @@ enum SettingsSection {
   // entry entirely for non-admins (see `_leftNav`); `PUT/POST /config/ha*`
   // are admin-enforced server-side regardless.
   homeAssistant(Icons.home_outlined, 'Home Assistant', pane: true),
+  diagnostics(Icons.bug_report_outlined, 'Diagnostics', pane: true),
   about(Icons.info_outline, 'About', pane: true),
   serverConsole(Icons.admin_panel_settings_outlined, 'Server console',
       pane: false),
@@ -335,6 +337,8 @@ class _SettingsWindowState extends State<SettingsWindow> {
         // this value some other way.
         if (!widget.isAdmin) return const _Unavailable('Home Assistant');
         return HaSettingsScreen(api: widget.api, session: widget.session);
+      case SettingsSection.diagnostics:
+        return const DiagnosticsPane();
       case SettingsSection.about:
         return AboutPanel(controller: widget.updateCheck);
       case SettingsSection.serverConsole:

--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -18,6 +18,7 @@ import 'package:crumb_desktop/api/ha_models.dart';
 import 'package:crumb_desktop/api/models.dart';
 import 'package:crumb_desktop/api/ptz_panel_store.dart';
 import 'package:crumb_desktop/services/audio_follow_controller.dart';
+import 'package:crumb_desktop/services/diagnostics_service.dart';
 import 'package:crumb_desktop/services/snapshot_registry.dart';
 import 'package:crumb_desktop/src/rust/api/host.dart';
 import 'package:crumb_desktop/state/client_options.dart';
@@ -1165,6 +1166,11 @@ class _WallTileState extends State<_WallTile> {
       final player = Player();
       final controller = VideoController(player);
       spawned = player;
+      // Diagnostics (#180): player errors always captured; mpv log in verbose.
+      DiagnosticsService.instance.attachPlayer(
+        'live:${widget.camera.name}',
+        player,
+      );
       final p = player.platform;
       if (p is NativePlayer) {
         for (final kv in const [
@@ -2133,6 +2139,11 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
       }
       final player = Player();
       final controller = VideoController(player);
+      // Diagnostics (#180): player errors always captured; mpv log in verbose.
+      DiagnosticsService.instance.attachPlayer(
+        'max:${widget.camera.name}',
+        player,
+      );
       spawned = player;
       final p = player.platform;
       if (p is NativePlayer) {

--- a/apps/desktop-flutter/test/diagnostics_scrub_test.dart
+++ b/apps/desktop-flutter/test/diagnostics_scrub_test.dart
@@ -1,0 +1,51 @@
+// The scrub is the load-bearing part of Diagnostics (#180): a leaky "share my
+// logs" button would be worse than none. These tests pin every redaction shape.
+
+import 'package:crumb_desktop/services/diagnostics_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const scrub = DiagnosticsService.scrub;
+
+  test('JWT-shaped triplets are redacted wherever they appear', () {
+    const jwt =
+        'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiIsImV4cCI6MTcwMDAwMDAwMH0.'
+        'sZ4x8jkeeQm1qX0dPLYc2vT5nJH3wQ9yUabcdEfGhIj';
+    final out = scrub('opened http://host:8080/media/x.mp4 with $jwt trailing');
+    expect(out, isNot(contains('eyJ')));
+    expect(out, contains('[REDACTED-JWT]'));
+  });
+
+  test('Authorization bearer values are redacted', () {
+    final out = scrub('header authorization: Bearer abc.def-123_456 sent');
+    expect(out, isNot(contains('abc.def-123_456')));
+    expect(out, contains('Bearer [REDACTED]'));
+  });
+
+  test('token/password/secret query params are redacted, key preserved', () {
+    final out = scrub(
+      'GET /media/seg.mp4?token=sekrit123&start=5 and password=hunter2 done',
+    );
+    expect(out, isNot(contains('sekrit123')));
+    expect(out, isNot(contains('hunter2')));
+    expect(out, contains('token=[REDACTED]'));
+    expect(out, contains('password=[REDACTED]'));
+    expect(out, contains('start=5'), reason: 'non-secret params survive');
+  });
+
+  test('JSON secret fields are redacted, key preserved', () {
+    final out = scrub(
+      '{"username":"admin","password":"pw123","token":"tok456"}',
+    );
+    expect(out, isNot(contains('pw123')));
+    expect(out, isNot(contains('tok456')));
+    expect(out, contains('"password":"[REDACTED]"'));
+    expect(out, contains('"token":"[REDACTED]"'));
+    expect(out, contains('"username":"admin"'), reason: 'non-secrets survive');
+  });
+
+  test('ordinary log lines pass through untouched', () {
+    const line = 'GET /cameras → 200 (41ms)';
+    expect(scrub(line), line);
+  });
+}


### PR DESCRIPTION
Desktop half of #180. Context that motivated doing this now: today's LPR black-screen mystery died unexplained *precisely because* the client keeps no logs — recon confirmed the desktop app had **zero logging**: no seam, no `FlutterError.onError`, empty `catch (_) {}` everywhere. This turns "something broke, no idea why" into an attachable file.

## What
- **`DiagnosticsService`** (new): app-scoped **bounded ring buffer** (4k lines, capped message length, memory-only until export — nothing written to disk unasked). Warnings/errors/lifecycle always captured; a persisted **verbose** toggle (off by default) adds HTTP traces + mpv player logs. Bounded by construction, so it's safe to leave on while reproducing.
- **Scrubbing at capture time** (the issue's hard constraint): JWT shapes, `Bearer` values, `token/password/secret/api_key` query params and JSON fields are redacted **before storage** — nothing token-shaped ever even sits in the buffer — plus a second pass over the assembled export. Server identity is recorded as `host:port` only. **Every redaction shape is pinned by unit tests** (`test/diagnostics_scrub_test.dart`, 5/5 green on the build box).
- **Global error funnels** in `main()`: `FlutterError.onError` (chained to the default) + `PlatformDispatcher.onError`.
- **HTTP trace** at the single choke point (`TimeoutClient.send`): method + **bare path** + status + duration only — never query strings (`?token=`), headers, or bodies. Failures always; routine traffic verbose-only.
- **Player hooks** (live tile, maximized pane, playback panes): `stream.error` always; mpv's own log stream verbose-only. This is exactly the evidence that was missing for the LPR incident.
- **Settings → Diagnostics** pane: verbose toggle, **Export logs…** (native save dialog via the fullscreen picker guard), **Copy to clipboard**, live line count. Export header carries app version (package_info), OS, server host, verbose state.

## Scope
Desktop only. The Android share-sheet export and the server-side admin diagnostics bundle from #180 are follow-ups — the issue stays open to track them.

## Verify
- `flutter analyze` clean; `flutter test test/diagnostics_scrub_test.dart` 5/5.
- On the wall: Settings → Diagnostics → flip verbose, browse a bit, Export — the file opens with the header + scrubbed lines; grep it for `eyJ`/`Bearer `/`token=` and find only `[REDACTED]`.

Part of #180 (leave open for Android + server bundle).