### PR TITLE
ci(release): macOS attach race + Windows zip sha256 (#253)

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -74,7 +74,15 @@ jobs:
           if-no-files-found: error
 
       - name: Attach app + sha256 to the Release (tag builds only)
+        # softprops/action-gh-release CREATES the Release if it doesn't exist
+        # yet — same action the Windows/Android workflows use. The previous
+        # `gh release upload` failed with "release not found" whenever this
+        # build finished before any sibling workflow had created the Release
+        # for the tag (bit v0.1.0; fixed by hand). Issue #253.
         if: startsWith(github.ref, 'refs/tags/')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${GITHUB_REF_NAME}" CrumbVMS-macos-*.zip CrumbVMS-macos-*.zip.sha256 --clobber --repo "${GITHUB_REPOSITORY}"
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            apps/ios/CrumbVMS-macos-*.zip
+            apps/ios/CrumbVMS-macos-*.zip.sha256
+          fail_on_unmatched_files: true

--- a/.github/workflows/windows-release-flutter.yml
+++ b/.github/workflows/windows-release-flutter.yml
@@ -87,21 +87,31 @@ jobs:
           $out = "CrumbVMS-windows-$ref.zip"
           Compress-Archive -Path build/windows/x64/runner/Release/* -DestinationPath $out -Force
           Write-Host "wrote $out ($([math]::Round((Get-Item $out).Length/1MB,1)) MB)"
+          # SHA-256 companion, same `<hash>  <file>` format as the macOS and
+          # Android assets, so every published binary is verifiable with
+          # `sha256sum -c` / `Get-FileHash`. Issue #253.
+          $hash = (Get-FileHash $out -Algorithm SHA256).Hash.ToLower()
+          "$hash  $out" | Out-File -Encoding ascii -NoNewline "$out.sha256"
+          Get-Content "$out.sha256"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: crumbvms-windows-flutter
-          path: apps/desktop-flutter/CrumbVMS-windows-*.zip
+          path: |
+            apps/desktop-flutter/CrumbVMS-windows-*.zip
+            apps/desktop-flutter/CrumbVMS-windows-*.zip.sha256
 
-      - name: Attach zip to the GitHub Release (tag builds only)
+      - name: Attach zip + sha256 to the GitHub Release (tag builds only)
         # Only fires on a v* tag push; workflow_dispatch runs skip this and just
         # leave the artifact above for iteration. Glob is repo-root-relative
         # (defaults.run working-directory does not apply to action inputs).
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
-          files: apps/desktop-flutter/CrumbVMS-windows-*.zip
+          files: |
+            apps/desktop-flutter/CrumbVMS-windows-*.zip
+            apps/desktop-flutter/CrumbVMS-windows-*.zip.sha256
           fail_on_unmatched_files: true
 
       # Remaining polish (post-0.1.0, tracked in DECISIONS.md):

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -9,8 +9,12 @@ How Crumb goes from a git commit to a known, versioned, deployable, and
 
 > **Windows desktop:** the desktop release is built by
 > `.github/workflows/windows-release-flutter.yml` on the `v*` tag, which
-> attaches `CrumbVMS-windows-<tag>.zip` to the GitHub Release. The
-> `scripts/release/` desktop targets (the old Tauri builds) are retired.
+> attaches `CrumbVMS-windows-<tag>.zip` **and its `.sha256` companion** to the
+> GitHub Release (every published binary — Windows, macOS, Android — ships a
+> checksum). The `scripts/release/` desktop targets (the old Tauri builds) are
+> retired. All three release workflows attach via `softprops/action-gh-release`,
+> which creates the Release if it doesn't exist yet — no workflow depends on
+> another having run first (#253).
 
 ---
 


### PR DESCRIPTION
Fixes #253 — the two release-pipeline gaps observed shipping v0.1.0.

## 1. macOS attach race
`macos-release.yml` attached with `gh release upload`, which fails with `release not found` if no Release object exists for the tag yet — exactly what happened on v0.1.0 when the macOS build finished first (hand-fixed at the time). Switched to **`softprops/action-gh-release@v2`** (create-if-missing) — the same action the Windows and Android workflows already use. Invariant now: **no release workflow depends on another having run first**; whichever finishes first creates the Release.

## 2. Windows zip checksum
`CrumbVMS-windows-<tag>.zip` shipped bare while macOS/Android carry `.sha256` companions. Added one in the same `<hash>  <file>` format, attached to both the workflow artifact and the Release — every published binary is now verifiable.

`docs/RELEASE.md` updated to document both invariants.

## Verification
- Both workflows parse (YAML validated).
- **Live dispatch run** of `windows-release-flutter.yml` on this branch is exercising the new packaging + checksum step end-to-end (attach steps are tag-only; the macOS attach is a copy of the proven Windows/Android usage): [run 29720689682](https://github.com/badbread/crumbvms/actions/runs/29720689682). Will confirm the `.sha256` lands in the artifact before merge.
- Full tag-path proof comes free with the next `v*` tag.