### PR TITLE
fix(recorder): quarantine prune ages from entry time + exempts -rN collision losers (#277)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -735,6 +735,15 @@ confirmed absent immediately beforehand, so it can never delete good footage.
 cameras (would justify the monotonic-counter filename scheme), or a decision to
 support sub-second segment resolution (would change the collision surface).
 
+**Addendum (2026-07-20, issue #277):** the "stays an on-disk orphan (never
+deleted)" promise was silently broken when the quarantine-retention prune
+(#203) landed: an unparseable `-rN` name is exactly the orphan pass's
+`NotIndexable` → quarantine path, and the prune then deleted the file after
+the retention window. Restored: `prune_quarantine` now exempts `-rN`
+disambiguated files at any age (`is_collision_disambiguated`), so quarantine
+is their terminal parking spot and deletion remains a manual operator action —
+the ratified outcome above holds again. See RECORDER-CORRECTNESS item 29.
+
 ---
 
 ## 2026-07-13, Fuzzy plate matching: length-scaled character tolerance (edit distance), superseding pg_trgm trigram similarity

--- a/docs/RECORDER-CORRECTNESS.md
+++ b/docs/RECORDER-CORRECTNESS.md
@@ -210,3 +210,17 @@ recorder, and later the API) must satisfy these *by construction*.
     re-check `pg_stat_progress_create_index` for that index — skip a real manual
     `CREATE INDEX CONCURRENTLY`, but RETRY transient/foreign contention rather than
     permanently skipping (which would silently leave a broken catalog entry).
+
+## quarantine (review-then-purge)
+29. **The quarantine prune ages by quarantine-ENTRY time, and only ever deletes
+    inside `_quarantine/`.** `quarantine_file` stamps mtime to NOW on arrival
+    (a same-fs rename would otherwise preserve the RECORDING-time mtime,
+    silently shrinking the review window to `retention − age-at-entry`,
+    clamped at zero — issue #277: a deleted camera's history was orphaned,
+    quarantined, and purged within one reconcile pass). The prune deletes only
+    regular files, inside the canonicalized `_quarantine/` subtree, strictly
+    older than `quarantine_retention_days` counted from entry; `0` disables it;
+    `walk_storage` never descends `_quarantine/`. **`-rN` collision-loser
+    files are exempt at any age** — they are real footage ratified "never
+    deleted" (2026-07-14 decision); quarantine is their terminal parking spot
+    and deleting them stays a manual operator action.

--- a/services/recorder/src/reconcile.rs
+++ b/services/recorder/src/reconcile.rs
@@ -1190,6 +1190,7 @@ pub async fn quarantine_file(file_path: &Path, storage_root: &Path) -> Result<()
                 dst = %dst.display(),
                 "quarantined file via rename"
             );
+            stamp_quarantine_entry_time(&dst);
             Ok(())
         }
         Err(e) if e.raw_os_error() == Some(libc_cross_device_error()) => {
@@ -1208,6 +1209,7 @@ pub async fn quarantine_file(file_path: &Path, storage_root: &Path) -> Result<()
                 dst = %dst.display(),
                 "quarantined file via copy+delete (cross-device)"
             );
+            stamp_quarantine_entry_time(&dst);
             Ok(())
         }
         Err(e) => Err(anyhow::anyhow!(
@@ -1215,6 +1217,49 @@ pub async fn quarantine_file(file_path: &Path, storage_root: &Path) -> Result<()
             file_path.display(),
             dst.display()
         )),
+    }
+}
+
+/// Stamp a just-quarantined file's mtime to NOW — the quarantine-ENTRY time.
+///
+/// The prune's age gate reads mtime, and a same-filesystem `rename` preserves
+/// the original RECORDING-time mtime — which silently turned the
+/// "review-then-purge grace window" into `retention − (age at quarantine)`,
+/// clamped at zero (issue #277): a file already older than the window at entry
+/// was deleted by the very next prune, possibly in the SAME reconcile pass
+/// (e.g. a deleted camera's entire history, orphaned → quarantined → purged
+/// within ~15 minutes, no review window at all). Touching mtime on arrival
+/// gives every quarantined file the FULL window from the moment an operator
+/// could first see it in `_quarantine/`.
+///
+/// Best-effort: on a filesystem where this fails, the old mtime remains and
+/// that file falls back to recording-age pruning — logged loudly so the
+/// degradation is visible, and never a reason to fail the quarantine itself
+/// (parking the file safely still comes first).
+fn stamp_quarantine_entry_time(path: &Path) {
+    let touch = || -> std::io::Result<()> {
+        let f = std::fs::File::options().append(true).open(path)?;
+        f.set_times(std::fs::FileTimes::new().set_modified(std::time::SystemTime::now()))
+    };
+    if let Err(e) = touch() {
+        warn!(
+            path = %path.display(),
+            error = %e,
+            "quarantine: could not stamp entry-time mtime; prune will age this file by its RECORDING time"
+        );
+    }
+}
+
+/// True when `filename` carries the backward-clock `-rN` disambiguator
+/// (`recording.rs::disambiguated_name`, issue #144 item 2): stem ends in
+/// `-r<digits>`. Those files are the losers of a wall-clock collision — real
+/// footage ratified as "never deleted" (DECISIONS 2026-07-14) — and the
+/// quarantine prune exempts them (issue #277). Pure + unit-tested.
+fn is_collision_disambiguated(filename: &str) -> bool {
+    let stem = filename.rsplit_once('.').map_or(filename, |(s, _)| s);
+    match stem.rsplit_once("-r") {
+        Some((_, digits)) => !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit()),
+        None => false,
     }
 }
 
@@ -1328,8 +1373,27 @@ async fn prune_quarantine(storage_root: &Path, retention_days: i64) -> (u64, u64
                 continue;
             }
 
+            // COLLISION-LOSER EXEMPTION (issue #277): `-rN` disambiguated
+            // files are the losers of a backward wall-clock collision — real
+            // footage the 2026-07-14 decision promises is "never deleted".
+            // Their stems deliberately don't parse, so the orphan pass parks
+            // them here; quarantine is their TERMINAL home, and deleting them
+            // stays a manual operator action.
+            if entry
+                .file_name()
+                .to_str()
+                .is_some_and(is_collision_disambiguated)
+            {
+                debug!(path = %path.display(),
+                    "prune_quarantine: -rN collision-loser footage; never auto-deleted");
+                continue;
+            }
+
             // AGE GATE: only files strictly older than the retention cutoff. A
             // missing/unreadable mtime fails SAFE toward keeping the file.
+            // NOTE the epoch: `quarantine_file` stamps mtime to the
+            // quarantine-ENTRY time on arrival, so this window counts from
+            // when the file became reviewable — not from when it was recorded.
             let mtime = match meta.modified() {
                 Ok(m) => m,
                 Err(e) => {
@@ -1653,6 +1717,104 @@ mod tests {
             aged2.exists(),
             "retention 0 must keep even a 30-day-old file"
         );
+    }
+
+    /// Issue #277 part (a): the prune's grace window must count from
+    /// quarantine ENTRY, not from recording time. A file 30 days old at the
+    /// moment it is quarantined must still get the FULL review window —
+    /// pre-fix, `rename` preserved the recording mtime and the very next
+    /// prune (same reconcile pass) deleted it, so e.g. deleting a camera
+    /// silently destroyed its whole history with zero review window.
+    #[tokio::test]
+    async fn quarantine_entry_restarts_the_prune_clock() {
+        const DAY: u64 = 86_400;
+        let root = tempfile::Builder::new()
+            .prefix("crumb-qclock")
+            .tempdir()
+            .expect("tempdir");
+        let root_path = root.path();
+
+        // An "orphaned segment" already 30 days old at quarantine time.
+        let cam = Uuid::new_v4().to_string();
+        let rec_dir = root_path.join(&cam).join("2026").join("06");
+        tokio::fs::create_dir_all(&rec_dir).await.expect("mkdir");
+        let old_file = rec_dir.join("20260620T000000Z.mp4");
+        tokio::fs::write(&old_file, vec![0u8; 4096])
+            .await
+            .expect("write");
+        backdate(&old_file, 30 * DAY).await;
+
+        quarantine_file(&old_file, root_path)
+            .await
+            .expect("quarantine");
+        // Layout: `_quarantine/<camera_id>/<filename>` (camera dir preserved,
+        // date tree flattened — see quarantine_file's doc).
+        let quarantined = root_path
+            .join("_quarantine")
+            .join(&cam)
+            .join("20260620T000000Z.mp4");
+        assert!(quarantined.exists(), "file parked under _quarantine");
+
+        // Entry stamp: mtime is ~now, not the 30-day-old recording time.
+        let mtime: DateTime<Utc> = tokio::fs::metadata(&quarantined)
+            .await
+            .expect("meta")
+            .modified()
+            .expect("mtime")
+            .into();
+        assert!(
+            Utc::now() - mtime < Duration::minutes(5),
+            "quarantine entry must stamp mtime to NOW (got {mtime})"
+        );
+
+        // The very next prune (14d window) must KEEP it — the full review
+        // window starts at entry.
+        let (files, _) = prune_quarantine(root_path, 14).await;
+        assert_eq!(files, 0, "freshly quarantined file must survive the prune");
+        assert!(quarantined.exists());
+    }
+
+    /// Issue #277 part (b): `-rN` collision-loser files are ratified "never
+    /// deleted" (DECISIONS 2026-07-14) — the prune must exempt them at ANY
+    /// age, while a plain aged neighbor is still pruned.
+    #[tokio::test]
+    async fn prune_quarantine_exempts_collision_losers() {
+        const DAY: u64 = 86_400;
+        let root = tempfile::Builder::new()
+            .prefix("crumb-qrn")
+            .tempdir()
+            .expect("tempdir");
+        let q = root.path().join("_quarantine").join("cam");
+        tokio::fs::create_dir_all(&q).await.expect("mkdir");
+
+        let loser = q.join("20260101T000000Z-r1.mp4");
+        tokio::fs::write(&loser, vec![0u8; 1024]).await.expect("w");
+        backdate(&loser, 90 * DAY).await;
+
+        let plain = q.join("20260101T000000Z.mp4");
+        tokio::fs::write(&plain, vec![0u8; 2048]).await.expect("w");
+        backdate(&plain, 90 * DAY).await;
+
+        let (files, bytes) = prune_quarantine(root.path(), 14).await;
+        assert_eq!(files, 1, "only the plain aged file is pruned");
+        assert_eq!(bytes, 2048);
+        assert!(
+            loser.exists(),
+            "-rN collision-loser footage must NEVER be auto-deleted"
+        );
+        assert!(!plain.exists());
+    }
+
+    /// The `-rN` detector: exact suffix shape only (stem ends `-r<digits>`).
+    #[test]
+    fn collision_disambiguated_detector() {
+        assert!(is_collision_disambiguated("20260101T000000Z-r1.mp4"));
+        assert!(is_collision_disambiguated("20260101T000000Z-r64.mp4"));
+        assert!(is_collision_disambiguated("seg-r7")); // no extension
+        assert!(!is_collision_disambiguated("20260101T000000Z.mp4"));
+        assert!(!is_collision_disambiguated("clip-r.mp4")); // no digits
+        assert!(!is_collision_disambiguated("clip-r1x.mp4")); // trailing junk
+        assert!(!is_collision_disambiguated("rear-video.mp4"));
     }
 
     /// Prefers `CRUMB_TEST_DATABASE_URL`, falling back to the workspace-wide


### PR DESCRIPTION
Fixes #277 — **P1 footage-loss finding (F2)** from the 2026-07-19 adversarial recorder audit.

## The bug
The #203 quarantine prune ages files by **mtime** — but `quarantine_file` moves files with a same-fs `rename`, which **preserves the recording-time mtime**. So the "review-then-purge grace window" was really `retention − (age at quarantine)`, clamped at zero:

- **Deleting a camera** (or delete-and-re-add to fix a flaky stream) cascaded its `segments` rows away; within one reconcile interval the orphan pass quarantined its entire on-disk history, and the prune **in the same pass** permanently deleted everything older than 14 days. Camera delete = silent deferred destruction, zero review window.
- The `-rN` **collision-loser** files that the ratified 2026-07-14 decision promises are "**never deleted**" route into quarantine via their deliberately-unparseable names — and were deleted 14 days later. The decision was silently broken when #203 landed.

## The fix
- **`quarantine_file` stamps mtime to NOW on arrival** (rename + cross-device paths) → every quarantined file gets the *full* review window from the moment an operator could first see it. Best-effort with a loud warn where `set_times` fails.
- **`prune_quarantine` exempts `-rN` files at any age** (`is_collision_disambiguated`) → quarantine is their terminal parking spot; deletion stays manual. The ratified promise holds again.
- **Docs**: dated addendum on the 2026-07-14 DECISIONS entry recording the break + restoration; RECORDER-CORRECTNESS gains **item 29** (prune preconditions + the age-clock epoch).

## Verification
- `quarantine_entry_restarts_the_prune_clock`: a 30-day-old file is quarantined → mtime ≈ now → survives the next prune.
- `prune_quarantine_exempts_collision_losers`: a 90-day-old `-rN` file survives while a plain aged neighbor is pruned.
- Unit test pinning the `-rN` detector shape (incl. negatives like `rear-video.mp4`).
- Existing prune/boundary/orphan tests green; full gate: fmt ✅ clippy -D warnings ✅ `cargo test --workspace` ✅ (261 recorder tests).