### PR TITLE
fix(api): bound the filmstrip window so one request can't OOM the api

### DIFF
--- a/services/api/src/filmstrip.rs
+++ b/services/api/src/filmstrip.rs
@@ -81,6 +81,13 @@ pub(crate) const DEFAULT_THUMB_INTERVAL_SECS: i64 = 4;
 const THUMB_MIN_WIDTH: u32 = 48;
 const THUMB_MAX_WIDTH: u32 = 640;
 
+/// Hard ceiling on a single filmstrip window. The endpoint builds one grid
+/// entry per `DEFAULT_THUMB_INTERVAL_SECS`, so an unbounded range would
+/// allocate an enormous Vec (and OOM the process — filmstrip lives on the
+/// no-timeout, no-rate-limit media router). No real scrub window is anywhere
+/// near a week; past this we reject with 400 rather than allocate.
+const FILMSTRIP_MAX_RANGE_SECS: i64 = 7 * 24 * 60 * 60;
+
 /// Monotonic counter for unique temp-file suffixes during atomic thumbnail
 /// writes (ffmpeg renders to `<final>.tmpN`, then we rename into place).
 static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
@@ -132,6 +139,17 @@ async fn list_filmstrip(
         return Err(ApiError::BadRequest(
             "start must be strictly before end".to_owned(),
         ));
+    }
+
+    // Bound the window before it reaches the grid builder. An unbounded range
+    // (e.g. year 1000 → 9999) would synthesise tens of billions of slots and
+    // OOM the api on this no-timeout router; reject it up front with a clear
+    // 400 instead. `thumbnail_grid_slots` also caps the allocation as a
+    // defense-in-depth backstop for any other caller.
+    if (q.end - q.start).num_seconds() > FILMSTRIP_MAX_RANGE_SECS {
+        return Err(ApiError::BadRequest(format!(
+            "filmstrip window too large: max {FILMSTRIP_MAX_RANGE_SECS} seconds"
+        )));
     }
 
     // Query coverage-filtered thumbnail slot timestamps from the DB.

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -4727,6 +4727,19 @@ pub fn thumbnail_grid_slots(
     if end_ms <= start_ms {
         return vec![];
     }
+    // Defense-in-depth allocation bound. Without this, a caller that fails to
+    // bound its `[start, end)` window (or passes a far-past/future range) would
+    // have us allocate a Vec of `count` timestamps — and callers a second Vec
+    // of the same size — which for a multi-millennium span is tens of billions
+    // of entries and OOM-kills the process. This is the single choke point for
+    // both the synthetic filmstrip grid and the coverage-filtered
+    // `list_thumbnail_times` (which calls us first), so bounding it here caps
+    // every path. No legitimate scrub/filmstrip grid is anywhere near this
+    // ceiling; past it we return nothing rather than allocate.
+    const MAX_GRID_SLOTS: i64 = 250_000; // at 4 s spacing, ~11.5 days
+    if (end_ms - start_ms) / step_ms >= MAX_GRID_SLOTS {
+        return vec![];
+    }
     // start_ms < end_ms and step_ms > 0 here; the quotient fits usize on all
     // targets we care about (Linux x86_64 with 48-bit virtual address space).
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
@@ -12782,6 +12795,24 @@ mod tests {
             .unwrap();
         assert!(thumbnail_grid_slots(t, t, 5).is_empty());
         assert!(thumbnail_grid_slots(t + chrono::Duration::seconds(5), t, 5).is_empty());
+    }
+
+    #[test]
+    fn thumbnail_grid_slots_caps_absurd_range_instead_of_allocating() {
+        // Regression guard for the filmstrip OOM (issue #288): an unbounded
+        // window (here ~9000 years) at 4 s spacing would ask for ~7e10 slots and
+        // OOM the process. The allocation bound must return empty rather than
+        // build the Vec. A just-under-the-cap range must still produce slots.
+        let start = Utc.timestamp_millis_opt(0).single().unwrap();
+        let far_future = Utc.with_ymd_and_hms(9999, 1, 1, 0, 0, 0).single().unwrap();
+        assert!(
+            thumbnail_grid_slots(start, far_future, 4).is_empty(),
+            "an absurd range must be refused, not allocated"
+        );
+
+        // Sanity: a modest range still returns the expected grid.
+        let end = start + chrono::Duration::seconds(40);
+        assert_eq!(thumbnail_grid_slots(start, end, 4).len(), 10);
     }
 
     // ── list_thumbnail_times — coverage-aware grid, throwaway-DB integration test ──


### PR DESCRIPTION
Fixes #288.

`GET /filmstrip/{camera_id}` validated only `start < end` and put **no cap on the window size**. When the range has no recorded coverage it falls through to the synthetic grid (`generate_synthetic_timestamps` → `db::thumbnail_grid_slots`), which builds a `Vec` of `(end-start)/4s` entries. A range spanning millennia asks for ~10¹⁰–10¹¹ slots → multi-GB allocation → **OOM-kill of the api process**. Filmstrip is mounted on the media router, which has **neither the 30 s `TimeoutLayer` nor the rate-limit layer**, so nothing aborts it.

## Fix (two layers)

- **`list_filmstrip`** rejects a window wider than 7 days with a clear `400`, before the grid is built. No real scrub window is anywhere near a week.
- **`thumbnail_grid_slots`** — the single choke point for *both* the synthetic grid and the coverage-filtered `list_thumbnail_times` (which calls it first, even `with_capacity(grid.len())`) — returns empty past a hard `MAX_GRID_SLOTS` (250k, ~11.5 days at 4 s) cap, as a defense-in-depth backstop for any other caller.

## Test

Adds `thumbnail_grid_slots_caps_absurd_range_instead_of_allocating`: a ~9000-year range at 4 s returns empty (refused, not allocated), while a modest range still returns the expected grid.

## Gate

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --workspace` (267 passed) all green against a throwaway Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)