### PR TITLE
fix(android): lifecycle-gate HA-states poll and pause clip player on background

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/clips/ClipsScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/clips/ClipsScreen.kt
@@ -80,6 +80,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewmodel.initializer
@@ -412,6 +415,25 @@ private fun ClipPlayerDialog(
     var playerView by remember { mutableStateOf<PlayerView?>(null) }
     val exo = remember { ExoPlayer.Builder(context).build() }
     DisposableEffect(Unit) { onDispose { exo.release() } }
+
+    // Pause when backgrounded (matches PlaybackScreen) — otherwise this dialog's
+    // audio/video keeps playing after the user leaves the app.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner, exo) {
+        var wasPlaying = false
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_PAUSE -> {
+                    wasPlaying = exo.playWhenReady
+                    exo.pause()
+                }
+                Lifecycle.Event.ON_RESUME -> if (wasPlaying) exo.play()
+                else -> Unit
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     // The clip URL carries a per-camera scoped token (see MediaTokenCache), so
     // resolving it is a suspend call — prepare the player once the FIRST

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
@@ -140,12 +140,20 @@ fun LiveFullscreenScreen(
     }
     // Poll HA states while this camera has linked entities (to keep the on-video
     // badges live) or the sheet is open. Server demand-caches with a ~2s TTL.
+    // Gate on lifecycle so it doesn't poll while backgrounded, and back off under
+    // failure (matches the motion poll below).
     val haHasPlaced = haLinks.any { it.hasPlacement }
     LaunchedEffect(currentCameraId, haHasPlaced, haSheetOpen) {
         if (!haHasPlaced && !haSheetOpen) return@LaunchedEffect
-        while (true) {
-            repo.haStates().onSuccess { haStates = it }
-            kotlinx.coroutines.delay(2000)
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            var failStreak = 0
+            while (true) {
+                val res = repo.haStates().onSuccess { haStates = it }
+                failStreak = if (res.isSuccess) 0 else failStreak + 1
+                kotlinx.coroutines.delay(
+                    if (failStreak == 0) 2000L else (2000L shl (failStreak - 1)).coerceAtMost(30000L),
+                )
+            }
         }
     }
     // Decoded video pixel size (for contain-fit badge placement) and the current


### PR DESCRIPTION
## Summary

Two lifecycle-gating gaps found by an Android correctness audit:

**#298 — HA-states poll runs forever in the background with no backoff.** `LiveFullscreenScreen.kt`'s HA-states poll ran as a bare `while(true) { repo.haStates()...; delay(2000) }` with no `repeatOnLifecycle` gate and no failure backoff, unlike the motion poll in the same file (`LiveFullscreenScreen.kt`, ~100 lines below) which already does both correctly. Backgrounding the app while a fullscreen camera with placed HA badges is up kept hitting `GET /ha/states` every 2s indefinitely.

**#302 — clip player keeps playing (with audio) after the app is backgrounded.** `ClipPlayerDialog` in `ClipsScreen.kt` builds its own `ExoPlayer` but had no lifecycle observer, unlike `PlaybackScreen`'s player. Pressing Home mid-clip left audio/video running.

## Changes

- `LiveFullscreenScreen.kt`: wrapped the HA-states loop in `lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED)` and added the same failure-streak exponential backoff (`2s → ... → cap 30s`) the motion poll uses.
- `ClipsScreen.kt`: added a `LifecycleEventObserver` to `ClipPlayerDialog` mirroring `PlaybackScreen.kt`'s pause-on-`ON_PAUSE`/resume-on-`ON_RESUME` pattern. Since the clip dialog (unlike `PlaybackScreen`) has no separate "playing" view-model state to key resume off, it captures `exo.playWhenReady` at the moment of pausing and restores it on resume. Player `release()` stays in its existing separate `DisposableEffect(Unit)` — unchanged.

## Test plan

- [x] Diff checked against the cited sibling patterns (motion poll in the same file; `PlaybackScreen.kt:585-598`) for idiomatic match.
- [ ] CI Android build.
- Not manually built/run locally — relying on CI's Android build step; no emulator/device test was performed for the backoff timing or the pause/resume behavior.

Fixes #298
Fixes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)