### PR TITLE
fix(android): move snapshot JPEG compress + MediaStore I/O off the main thread

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/Snapshot.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/Snapshot.kt
@@ -11,6 +11,8 @@ import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
 import androidx.core.content.FileProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
 
@@ -34,41 +36,47 @@ data class SavedSnapshot(val displayPath: String, val shareUri: Uri)
  * - Q+ (API 29+): MediaStore with RELATIVE_PATH — lands in the gallery, no
  *   storage permission required.
  * - Pre-Q: the app's external Pictures dir (no permission; not gallery-indexed).
+ *
+ * Runs the JPEG compress and MediaStore/file I/O off the main thread (same
+ * `withContext(Dispatchers.IO)` pattern as `PlatesPdf.generatePlateReportPdf`)
+ * — callers only need to grab the [Bitmap] (e.g. `TextureView.getBitmap`) on
+ * Main before calling in.
  */
-fun saveFrameToGallery(context: Context, bitmap: Bitmap, camName: String): SavedSnapshot? {
-    val safeCam = camName.replace(Regex("[^A-Za-z0-9_-]"), "_").ifBlank { "camera" }
-    val stamp = android.text.format.DateFormat.format("yyyyMMdd_HHmmss", System.currentTimeMillis())
-    val fileName = "crumb_${safeCam}_$stamp.jpg"
-    return try {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            val values = ContentValues().apply {
-                put(MediaStore.Images.Media.DISPLAY_NAME, fileName)
-                put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
-                put(MediaStore.Images.Media.RELATIVE_PATH, "Pictures/Crumb")
+suspend fun saveFrameToGallery(context: Context, bitmap: Bitmap, camName: String): SavedSnapshot? =
+    withContext(Dispatchers.IO) {
+        val safeCam = camName.replace(Regex("[^A-Za-z0-9_-]"), "_").ifBlank { "camera" }
+        val stamp = android.text.format.DateFormat.format("yyyyMMdd_HHmmss", System.currentTimeMillis())
+        val fileName = "crumb_${safeCam}_$stamp.jpg"
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                val values = ContentValues().apply {
+                    put(MediaStore.Images.Media.DISPLAY_NAME, fileName)
+                    put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+                    put(MediaStore.Images.Media.RELATIVE_PATH, "Pictures/Crumb")
+                }
+                val uri = context.contentResolver.insert(
+                    MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values,
+                ) ?: return@withContext null
+                context.contentResolver.openOutputStream(uri)?.use { out ->
+                    bitmap.compress(Bitmap.CompressFormat.JPEG, 92, out)
+                } ?: return@withContext null
+                // The MediaStore entry is itself a shareable content:// Uri.
+                SavedSnapshot(displayPath = "Pictures/Crumb/$fileName", shareUri = uri)
+            } else {
+                val dir = File(context.getExternalFilesDir(Environment.DIRECTORY_PICTURES), "Crumb")
+                dir.mkdirs()
+                val f = File(dir, fileName)
+                FileOutputStream(f).use { out -> bitmap.compress(Bitmap.CompressFormat.JPEG, 92, out) }
+                val shareUri = FileProvider.getUriForFile(
+                    context, "${context.packageName}.fileprovider", f,
+                )
+                SavedSnapshot(displayPath = f.absolutePath, shareUri = shareUri)
             }
-            val uri = context.contentResolver.insert(
-                MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values,
-            ) ?: return null
-            context.contentResolver.openOutputStream(uri)?.use { out ->
-                bitmap.compress(Bitmap.CompressFormat.JPEG, 92, out)
-            } ?: return null
-            // The MediaStore entry is itself a shareable content:// Uri.
-            SavedSnapshot(displayPath = "Pictures/Crumb/$fileName", shareUri = uri)
-        } else {
-            val dir = File(context.getExternalFilesDir(Environment.DIRECTORY_PICTURES), "Crumb")
-            dir.mkdirs()
-            val f = File(dir, fileName)
-            FileOutputStream(f).use { out -> bitmap.compress(Bitmap.CompressFormat.JPEG, 92, out) }
-            val shareUri = FileProvider.getUriForFile(
-                context, "${context.packageName}.fileprovider", f,
-            )
-            SavedSnapshot(displayPath = f.absolutePath, shareUri = shareUri)
+        } catch (e: Exception) {
+            android.util.Log.w("Snapshot", "snapshot save failed", e)
+            null
         }
-    } catch (e: Exception) {
-        android.util.Log.w("Snapshot", "snapshot save failed", e)
-        null
     }
-}
 
 /**
  * Open the Android system share sheet for a saved snapshot [uri] (a JPEG image).


### PR DESCRIPTION
## Summary

`saveFrameToGallery()` (`apps/android/app/src/main/java/video/crumb/app/feature/playback/Snapshot.kt`) was a plain function doing `contentResolver.insert`/`openOutputStream` and a full-resolution `bitmap.compress(JPEG, 92, out)` synchronously. All three callers (`PlaybackScreen.kt`, `ClipsScreen.kt`, `LiveScreen.kt`) invoke it from a coroutine with no dispatcher override, i.e. on Main — causing a visible multi-hundred-ms freeze on snapshot with ANR risk on slower storage.

`PlatesPdf.generatePlateReportPdf` (`apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesPdf.kt:123`) already does the right thing for comparable work.

## Changes

Made `saveFrameToGallery` a `suspend fun` and wrapped its body in `withContext(Dispatchers.IO)`. All three call sites already invoke it from a coroutine (`scope.launch`, or `LiveScreen`'s existing `suspend fun captureCameraSnapshot` wrapper), so no caller-side signature changes were needed beyond Kotlin implicitly threading the suspend call. Only the initial `TextureView.getBitmap` capture (done by callers *before* calling in) stays on Main, as before.

## Test plan

- [x] Confirmed all three call sites (`PlaybackScreen.kt:631`, `ClipsScreen.kt:447`, `LiveScreen.kt:776`) already run inside a coroutine, so this is a drop-in change.
- [ ] CI Android build.
- Not manually built/run locally — relying on CI's Android build step; did not verify the absence of a UI freeze on-device.

Fixes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)