### PR TITLE
fix(android): make Time.parseToMillis lenient instead of crashing on parse failure

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/ui/Time.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/ui/Time.kt
@@ -3,6 +3,7 @@
 package video.crumb.app.ui
 
 import java.time.Instant
+import java.time.OffsetDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -25,7 +26,20 @@ object Time {
     /** Parse an RFC-3339 string (handles fractional seconds + 'Z'). */
     fun parse(iso: String): Instant = Instant.parse(iso)
 
-    fun parseToMillis(iso: String): Long = Instant.parse(iso).toEpochMilli()
+    /**
+     * Parse an RFC-3339 string to epoch-millis, leniently: recorded-span and
+     * segment timestamps come straight from the server and are trusted
+     * unconditionally by many hot paths (playback resolve, the centered
+     * timeline), so a single malformed/oddly-formatted value (e.g. an explicit
+     * offset like `+00:00` instead of a `Z` suffix) must not crash composition
+     * or a ViewModel coroutine. Falls back to [OffsetDateTime.parse] for
+     * offset-style timestamps [Instant.parse] rejects, and to `0L` (epoch) if
+     * neither parses.
+     */
+    fun parseToMillis(iso: String): Long =
+        runCatching { Instant.parse(iso).toEpochMilli() }
+            .recoverCatching { OffsetDateTime.parse(iso).toInstant().toEpochMilli() }
+            .getOrDefault(0L)
 
     fun clock(instant: Instant): String = clockFmt.format(instant.atZone(zone))
     fun clock(iso: String): String = clock(parse(iso))


### PR DESCRIPTION
## Summary

`Time.parseToMillis()` (`apps/android/app/src/main/java/video/crumb/app/ui/Time.kt:26-28`) called `Instant.parse(iso)` unguarded, throwing `DateTimeParseException` on anything `Instant.parse` can't handle (e.g. an offset-formatted timestamp like `+00:00` instead of a `Z` suffix). It's used unguarded across many hot paths (`PlaybackViewModel`'s segment resolve/prefetch/scrub/filmstrip, `CenteredTimeline`'s span parsing inside a `remember` block, `PlaybackWallScreen`, `PlaybackScreen`), so a single malformed server timestamp crashes composition or a ViewModel coroutine. Detection/HA/bookmark/clip timestamp paths elsewhere already guard their own parses (`runCatching { Instant.parse(...) }`); only the recorded-span/segment paths trusted the server unconditionally.

## Changes

`parseToMillis` now:
1. Tries `Instant.parse`.
2. Falls back to `OffsetDateTime.parse` for offset-style timestamps `Instant.parse` rejects.
3. Returns `0L` if neither parses, instead of throwing.

Kept the `Long` (non-nullable) return type to avoid touching the ~10+ call sites that funnel through this one function — this is scoped to exactly the fix the audit called "the smallest, highest-leverage fix" (only `parseToMillis`; `Time.parse`/`Time.clock`/`Time.dateTime` were not in scope for this finding and are unchanged).

## Test plan

- [x] Read all cited call sites to confirm they only consume the `Long` return value (no signature changes required anywhere).
- [ ] CI Android build.
- Not manually built/run locally — relying on CI's Android build step; did not verify behavior against a live malformed-timestamp server response.

Fixes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)