### PR TITLE
fix(android): let CenteredTimeline's pinch-zoom span clamp match the host's own range

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/CenteredTimeline.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/CenteredTimeline.kt
@@ -90,6 +90,12 @@ private val ICON_DISC = Color(0xF21A1C22)   // near-opaque dark disc directly be
  *   rendering is identical to having no events. Additive and non-fatal.
  * @param playheadMs Current playback position (rendered at the center).
  * @param spanMs Visible time span across the full width (pinch-to-zoom).
+ * @param minSpanMs Minimum pinch-zoomed-in span (max zoom-in), clamped inside the
+ *   gesture itself so [onSpanChange] never sees a value outside the host's range.
+ * @param maxSpanMs Maximum pinch-zoomed-out span (max zoom-out) — must match the
+ *   host's own data-window width (e.g. the playback wall's 12 h vs. single-camera
+ *   playback's 6 h), or pinch-out silently stops working before the host's actual
+ *   range is reached.
  * @param onScrubStart Called once when a gesture begins.
  * @param onScrub Called continuously with the new playhead time.
  * @param onScrubEnd Called once on release with the final playhead time.
@@ -105,6 +111,8 @@ fun CenteredTimeline(
     bookmarks: List<Long>,
     playheadMs: Long,
     spanMs: Long,
+    minSpanMs: Long = 60_000L,
+    maxSpanMs: Long = 6L * 3600_000L,
     onScrubStart: () -> Unit,
     onScrub: (Long) -> Unit,
     onScrubEnd: (Long) -> Unit,
@@ -173,7 +181,7 @@ fun CenteredTimeline(
                             val zoom = event.calculateZoom()
                             if (zoom != 1f && zoom > 0f) {
                                 sp = (sp / zoom).roundToLong()
-                                    .coerceIn(60_000L, 6L * 3600_000L)
+                                    .coerceIn(minSpanMs, maxSpanMs)
                                 onSpanChange(sp)
                             }
                             // Only a single-finger drag scrubs. While PINCHING (two

--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackWallScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackWallScreen.kt
@@ -492,6 +492,8 @@ fun PlaybackWallScreen(
                     bookmarks = emptyList(),
                     playheadMs = cursorMs,
                     spanMs = visibleSpanMs,
+                    minSpanMs = WALL_MIN_SPAN_MS,
+                    maxSpanMs = WALL_MAX_SPAN_MS,
                     onScrubStart = {},
                     onScrub = { ts -> cursorMs = ts; atLatest = false; previewMs = ts },
                     onScrubEnd = { ts ->


### PR DESCRIPTION
## Summary

`CenteredTimeline.kt`'s pinch-zoom gesture clamped the span to a hardcoded 1 min-6 h range (`coerceIn(60_000L, 6L * 3600_000L)`) inside its own gesture-loop accumulator, regardless of the host screen's range. `PlaybackWallScreen.kt` defines a 12 h `WALL_MAX_SPAN_MS` and re-clamps again in its `onSpanChange` callback — but by the time `onSpanChange` runs, the value has already been capped at 6 h inside `CenteredTimeline`'s own accumulator, so the wall could never pinch out past 6 h even though its own data window covers 12 h.

## Changes

- Added `minSpanMs`/`maxSpanMs` parameters to `CenteredTimeline`, defaulting to the existing `60_000L`/`6L * 3600_000L` (so `PlaybackScreen.kt`'s call site, which uses those exact bounds via `PlaybackViewModel`'s `MIN_SPAN_MS`/`MAX_SPAN_MS`, needed no changes).
- The pinch gesture's `coerceIn` now uses the parameters instead of the hardcoded constants.
- `PlaybackWallScreen.kt` now passes `minSpanMs = WALL_MIN_SPAN_MS, maxSpanMs = WALL_MAX_SPAN_MS` at its `CenteredTimeline(...)` call site, so the wall can pinch out to its full 12 h window.

## Test plan

- [x] Confirmed both call sites (`PlaybackScreen.kt`, `PlaybackWallScreen.kt`) use named arguments throughout, so inserting the new parameters ahead of the required lambda parameters doesn't break either call.
- [ ] CI Android build.
- Not manually built/run locally — relying on CI's Android build step; did not verify the pinch-zoom behavior on-device.

Fixes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)