### PR TITLE
fix(android): close export Create button's double-submit window

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportScreen.kt
@@ -161,7 +161,7 @@ fun ExportScreen(onBack: () -> Unit) {
                 endMs = state.endMs,
                 onStartChange = vm::setStart,
                 onEndChange = vm::setEnd,
-                disabled = state.polling,
+                disabled = state.polling || state.submitting,
             )
 
             HorizontalDivider(color = NavySurfaceVariant)
@@ -171,19 +171,22 @@ fun ExportScreen(onBack: () -> Unit) {
             BurnTimestampRow(
                 enabled = state.burn,
                 onChange = vm::setBurn,
-                disabled = state.polling,
+                disabled = state.polling || state.submitting,
             )
 
             HorizontalDivider(color = NavySurfaceVariant)
 
             // ─── submit button ───────────────────────────────────────────────
-            val canSubmit = state.selectedCameraIds.isNotEmpty() && !state.polling
+            // state.submitting covers the gap between tapping Create and the POST
+            // round-trip resolving (before state.polling itself flips true) — closes
+            // a fast-double-tap window that could otherwise submit two export jobs.
+            val canSubmit = state.selectedCameraIds.isNotEmpty() && !state.polling && !state.submitting
             Button(
                 onClick = vm::createExport,
                 enabled = canSubmit,
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                Text(if (state.polling) "Exporting..." else "Create Export")
+                Text(if (state.polling || state.submitting) "Exporting..." else "Create Export")
             }
 
             // ─── job progress + results ──────────────────────────────────────

--- a/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportViewModel.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportViewModel.kt
@@ -33,6 +33,12 @@ import java.time.Instant
  * @property job The most recent [ExportJob] returned by the server (null until created).
  * @property jobError Human-readable error string when the job itself fails.
  * @property polling True while we are actively polling exportStatus.
+ * @property submitting True from the moment [ExportViewModel.createExport] is called
+ *   until its `POST /export` round-trip resolves (success or failure). Distinct from
+ *   [polling], which only flips true AFTER that round-trip completes — without this,
+ *   a fast double-tap on Create before the first response lands could submit two
+ *   export jobs (the guard in [ExportViewModel.createExport] checked [polling] too
+ *   late to catch it).
  */
 data class ExportUiState(
     val loadingCameras: Boolean = true,
@@ -45,6 +51,7 @@ data class ExportUiState(
     val job: ExportJob? = null,
     val jobError: String? = null,
     val polling: Boolean = false,
+    val submitting: Boolean = false,
 )
 
 /**
@@ -123,7 +130,11 @@ class ExportViewModel(private val repo: CrumbRepository) : ViewModel() {
     fun createExport() {
         val s = _state.value
         if (s.selectedCameraIds.isEmpty()) return
-        if (s.polling) return // already running
+        if (s.polling || s.submitting) return // already running or already in flight
+        // Set synchronously, BEFORE the coroutine launch, so a fast double-tap on
+        // Create can't slip a second submit in during the POST round-trip (polling
+        // alone doesn't flip true until that round-trip completes).
+        _state.update { it.copy(submitting = true) }
 
         val startIso = Time.iso(Instant.ofEpochMilli(s.startMs))
         val endIso = Time.iso(Instant.ofEpochMilli(s.endMs))
@@ -138,10 +149,10 @@ class ExportViewModel(private val repo: CrumbRepository) : ViewModel() {
                 endIso = endIso,
                 burn = s.burn,
             ).onSuccess { response ->
-                _state.update { it.copy(polling = true) }
+                _state.update { it.copy(polling = true, submitting = false) }
                 startPolling(response.jobId)
             }.onFailure { t ->
-                _state.update { it.copy(jobError = t.toUserMessage()) }
+                _state.update { it.copy(jobError = t.toUserMessage(), submitting = false) }
             }
         }
     }


### PR DESCRIPTION
## Summary

`ExportViewModel.createExport()` guarded re-entrancy on `s.polling`, but `polling` only flips to `true` after the `createExport` POST round-trip completes — so a fast double-tap on the Create button before the first response lands could submit two export jobs. `ExportScreen.kt` disables the Create button based on the same `state.polling` field, so the button doesn't protect against this either.

## Changes

- Added `submitting: Boolean = false` to `ExportUiState`, documented alongside `polling`.
- `createExport()` now checks `s.polling || s.submitting` and sets `submitting = true` synchronously, before the coroutine launch — closing the window between the tap and the POST resolving.
- `submitting` clears on both the success and failure branches of the `createExport` call.
- `ExportScreen.kt`'s Create-button `canSubmit`/label and the two other export-form controls it already disables while `polling` (`TimeRangeSection`, `BurnTimestampRow`) now also gate on `submitting`.

## Test plan

- [x] Read the full before/after flow to confirm `submitting` is always cleared on every exit path (`onSuccess`, `onFailure`) so the button can never get stuck disabled.
- [ ] CI Android build.
- Not manually built/run locally — relying on CI's Android build step; did not verify the double-tap race on-device.

Fixes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)