### PR TITLE
fix(android): map SSLHandshakeException to a specific message instead of the generic one

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/data/CrumbRepository.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/CrumbRepository.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import retrofit2.HttpException
 import java.io.IOException
+import javax.net.ssl.SSLHandshakeException
 
 /**
  * Like [runCatching] but re-throws [CancellationException] instead of capturing
@@ -524,6 +525,13 @@ fun Throwable.toUserMessage(): String = when (this) {
         404 -> "Not found."
         else -> "Server error (${code()})."
     }
+    // Checked before the generic IOException branch below (SSLHandshakeException
+    // is an IOException) — server discovery can surface an https:// candidate
+    // whose self-signed cert the real (validating) client then refuses; without
+    // this the failure fell through to the generic "can't reach" message with no
+    // hint that the actual problem is an untrusted certificate.
+    is SSLHandshakeException ->
+        "Certificate isn't trusted. Try the http:// address instead, or install the server's CA."
     is IOException -> "Can't reach the server. Check the address and your connection."
     else -> message ?: "Unexpected error."
 }


### PR DESCRIPTION
## Summary

`ServerDiscovery.kt` scans with a trust-all TLS client (deliberately, scoped strictly to the unauthenticated `/health` fingerprint probe) and `collapseDualExposed()` prefers a host's `https://` candidate over its plain `http://` one when both answer. But the real API client (`Network.kt`) validates certificates fully, so if the discovered server's `:8443` cert is self-signed (the common case for a LAN Crumb server behind Caddy), login then fails the TLS handshake. `CrumbRepository.kt`'s `toUserMessage()` mapped that failure (`SSLHandshakeException` extends `IOException`) to the same generic `"Can't reach the server. Check the address and your connection."` message as every other network failure — no hint that the actual problem is an untrusted certificate.

## Changes

Added an `SSLHandshakeException` branch to `toUserMessage()`, checked before the generic `IOException` branch (order matters in a `when` — first match wins), with a message pointing at the `http://` fallback or installing the CA.

This is the smallest of the three fixes the audit suggested (the other two — keeping both http/https discovery entries, or verifying the https candidate with a validating client before preferring it — would change discovery's scan/collapse behavior itself; this instead fixes what the user sees when the mismatch bites).

## Test plan

- [x] Confirmed `SSLHandshakeException` (`javax.net.ssl`) extends `SSLException` which extends `IOException`, so ordering the new `when` branch before the generic `IOException` one is required and correct (Kotlin `when` takes the first matching branch).
- [ ] CI Android build.
- Not manually built/run locally — relying on CI's Android build step; did not reproduce an actual self-signed-cert login failure against a live server.

Fixes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)