### PR TITLE
fix(android): minor correctness cleanups (clip-player guard, stale comments)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/data/MediaTokenCache.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/MediaTokenCache.kt
@@ -140,8 +140,11 @@ class MediaTokenCache(
         /** Refresh a cached token once it's within this long of expiring. */
         const val REFRESH_SKEW_MS = 10_000L
 
-        /** Fallback assumed lifetime if `expires_at` fails to parse — matches the
-         *  server's documented ~15 min scoped-token validity. */
+        /** Fallback assumed lifetime if `expires_at` fails to parse: a conservative
+         *  60 s, deliberately well under the server's actual ~15 min scoped-token
+         *  validity (`MEDIA_TOKEN_EXPIRY_SECONDS` in `services/api/src/auth.rs`) —
+         *  if we couldn't determine the real expiry, refresh sooner rather than
+         *  risk serving a URL built from an already-expired token. */
         const val DEFAULT_TTL_MS = 60_000L
     }
 }

--- a/apps/android/app/src/main/java/video/crumb/app/data/Network.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/Network.kt
@@ -91,8 +91,9 @@ object Network {
             // connection before send is transparently retried on a fresh socket.
             .retryOnConnectionFailure(true)
         if (callTimeoutSeconds != null) builder.callTimeout(callTimeoutSeconds, TimeUnit.SECONDS)
-        // Log ONLY in debug builds: BASIC logs request URLs, and media URLs carry the
-        // JWT as ?token= — never write that to logcat in a release build.
+        // Log ONLY in debug builds: BASIC logs request URLs, and media URLs carry a
+        // short-lived scoped media token (see MediaTokenCache) as ?token= — never
+        // write that to logcat in a release build.
         if (BuildConfig.DEBUG) {
             builder.addInterceptor(
                 HttpLoggingInterceptor().apply { level = HttpLoggingInterceptor.Level.BASIC },

--- a/apps/android/app/src/main/java/video/crumb/app/feature/clips/ClipsScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/clips/ClipsScreen.kt
@@ -420,9 +420,16 @@ private fun ClipPlayerDialog(
     LaunchedEffect(clip.id) {
         val url = runCatching { mediaUrls.clipVideoUrl(clip.cameraId, clip.id, "preview") }.getOrNull()
             ?: return@LaunchedEffect
-        exo.setMediaItem(MediaItem.fromUri(url))
-        exo.prepare()
-        exo.playWhenReady = true
+        // The token resolve above is a network round-trip; if the dialog was
+        // dismissed (and exo released) while it was in flight, there's no further
+        // suspension point before touching exo below for Compose's cooperative
+        // cancellation to catch — guard against IllegalStateException from an
+        // already-released player instead of crashing.
+        runCatching {
+            exo.setMediaItem(MediaItem.fromUri(url))
+            exo.prepare()
+            exo.playWhenReady = true
+        }
     }
 
     // Gate the motion auto-zoom on the FIRST rendered frame. Without this, the
@@ -492,10 +499,13 @@ private fun ClipPlayerDialog(
                     scope.launch {
                         val url = runCatching { mediaUrls.clipVideoUrl(clip.cameraId, clip.id, quality) }.getOrNull()
                             ?: return@launch
-                        exo.setMediaItem(MediaItem.fromUri(url))
-                        exo.prepare()
-                        exo.seekTo(at)
-                        exo.playWhenReady = true
+                        // Same disposed-mid-load guard as the initial load above.
+                        runCatching {
+                            exo.setMediaItem(MediaItem.fromUri(url))
+                            exo.prepare()
+                            exo.seekTo(at)
+                            exo.playWhenReady = true
+                        }
                     }
                 }) {
                     Icon(


### PR DESCRIPTION
## Summary

Three small, low-risk cleanups from a correctness audit of the Android client:

1. **Unguarded ExoPlayer touch after a possible dispose in the clip dialog.** `ClipsScreen.kt`'s `ClipPlayerDialog` resolves the clip's scoped-token URL (a network round-trip) before touching its `ExoPlayer`, both on initial load (`LaunchedEffect(clip.id)`) and on the HD quality toggle. If the dialog is dismissed (and `exo.release()` runs) while that resolve is in flight, there's no remaining suspension point before the `exo.*` calls for Kotlin's cooperative cancellation to catch — so a disposed-mid-load player throws `IllegalStateException` instead of failing silently. Wrapped both post-resolve `exo.*` blocks in `runCatching`.
2. **Stale comment in `Network.kt`.** Said media URLs carry "the JWT as `?token=`" — the app actually uses short-lived scoped media tokens (`MediaTokenCache`), not the login JWT.
3. **Wrong TTL claim in `MediaTokenCache.kt`.** `DEFAULT_TTL_MS`'s comment claimed the 60s fallback "matches the server's documented ~15 min scoped-token validity" — it doesn't. I checked the server side (`services/api/src/auth.rs`, `MEDIA_TOKEN_EXPIRY_SECONDS = 900`) to confirm the real TTL is in fact 15 min; `DEFAULT_TTL_MS = 60_000L` is a deliberately conservative fallback used only when `expires_at` fails to parse. Fixed the comment to say so (left the value unchanged, per the audit's own framing of this as a comment fix).

## Not fixed / citation mismatch

The audit's other citation for the clip-player guard item, `PlatesScreen.kt:2315-2317`, does not match reality — that file is only 1704 lines long at `6248a38` and contains no `ExoPlayer`/`open()`-style player code at all (Android's `PlatesScreen.kt` doesn't play video). This citation appears to have been conflated with the desktop Flutter client's `player.open()` pattern, which was audited separately. No change made there.

## Test plan

- [x] Confirmed `PlatesScreen.kt` has no matching code before skipping that citation (`grep` for `ExoPlayer`/`.open(`/`ExoPlayer.Builder` returned nothing).
- [x] Confirmed the server's actual scoped-token TTL (`MEDIA_TOKEN_EXPIRY_SECONDS = 900` in `services/api/src/auth.rs`) before wording the comment fix.
- [ ] CI Android build.
- Not manually built/run locally — relying on CI's Android build step; did not reproduce the dispose-mid-load race on-device.

Fixes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)