### PR TITLE
fix(api): serialize go2rtc reconcile against stream teardown (delete race)

### DIFF
--- a/services/api/src/go2rtc.rs
+++ b/services/api/src/go2rtc.rs
@@ -317,6 +317,14 @@ fn is_patch_alias_collision(src: &str, managed_names: &HashSet<String>) -> bool 
 /// [`patch_stream`]. To force a real producer re-dial after a source change, use
 /// [`reconnect`] (DELETE + `PUT`), not this pass.
 pub async fn reconcile(state: &AppState) -> Result<()> {
+    // Hold the reconcile/teardown lock for the whole read-then-apply pass. This
+    // pass is additive (PUT every DB stream, never prune), so without this a
+    // camera delete's stream teardown could land *between* our stream-list read
+    // and our PUTs and be undone — resurrecting the deleted camera's stream
+    // permanently (#294). `remove()` takes the same lock.
+    let lock = state.go2rtc_reconcile_lock();
+    let _guard = lock.lock().await;
+
     let api_base = &state.config().crumb_go2rtc_api_base;
     let auth = (
         state.config().go2rtc_user.as_str(),
@@ -438,6 +446,14 @@ async fn apply_stream(
 
 /// Remove a camera's go2rtc streams (main + sub) — call after deleting a camera.
 pub async fn remove(state: &AppState, go2rtc_name: &str) -> Result<()> {
+    // Serialize teardown against a reconcile pass (#294): a pass that snapshotted
+    // this camera before the delete must not re-PUT its stream after we tear it
+    // down. Holding the same lock reconcile() takes means the two never
+    // interleave — the pass either finishes before we delete, or reads the
+    // post-delete camera set and never re-adds us.
+    let lock = state.go2rtc_reconcile_lock();
+    let _guard = lock.lock().await;
+
     let api_base = &state.config().crumb_go2rtc_api_base;
     let auth = (
         state.config().go2rtc_user.as_str(),

--- a/services/api/src/state.rs
+++ b/services/api/src/state.rs
@@ -147,6 +147,16 @@ struct Inner {
     /// pattern and lifecycle as `thumb_inflight`.
     clip_inflight: DashMap<std::path::PathBuf, Arc<tokio::sync::Mutex<()>>>,
 
+    /// Serializes go2rtc reconcile passes against camera-stream teardown. A
+    /// reconcile pass is additive (it PUTs every DB stream but never prunes), so
+    /// a periodic pass that snapshots the camera list *before* a camera delete
+    /// but applies its PUTs *after* the delete tore the stream down would
+    /// resurrect the deleted camera's go2rtc stream permanently. `reconcile()`
+    /// and `remove()` both hold this for their duration so the teardown can
+    /// never interleave with a pass's read-then-apply. Low-frequency operations,
+    /// so a single global lock is fine.
+    go2rtc_reconcile_lock: Arc<tokio::sync::Mutex<()>>,
+
     /// In-memory cache of permission [`Role`]s keyed by id. The `AuthUser`
     /// extractor resolves a token's `role_id` to its effective capabilities +
     /// cameras through this, so per-request auth costs no DB round-trip after the
@@ -258,6 +268,7 @@ impl AppState {
             play_semaphore,
             clip_gen_semaphore,
             clip_inflight: DashMap::new(),
+            go2rtc_reconcile_lock: Arc::new(tokio::sync::Mutex::new(())),
             thumb_semaphore,
             thumb_inflight: DashMap::new(),
             roles_cache: DashMap::new(),
@@ -448,6 +459,15 @@ impl AppState {
             .entry(path.to_path_buf())
             .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
             .clone()
+    }
+
+    /// Clone the shared go2rtc reconcile/teardown lock. A go2rtc `reconcile()`
+    /// pass and a stream `remove()` both hold this for their duration so a
+    /// camera delete can never interleave with a pass's read-then-apply and
+    /// resurrect the deleted camera's stream. See the field docs on
+    /// [`go2rtc_reconcile_lock`](Inner::go2rtc_reconcile_lock).
+    pub fn go2rtc_reconcile_lock(&self) -> Arc<tokio::sync::Mutex<()>> {
+        Arc::clone(&self.0.go2rtc_reconcile_lock)
     }
 
     // ── health-alert maintenance window (issue #46) ───────────────────────────


### PR DESCRIPTION
Fixes #294.

`reconcile` is deliberately **additive** — it PUTs every camera stream in the DB but never prunes go2rtc streams absent from the DB. Stream removal is done only by the delete/update handlers via `go2rtc::remove`. There was **no serialization** between the two, so this interleaving was possible:

1. a periodic `reconcile` reads the camera-stream list (camera X present)
2. `DELETE /config/cameras/X` commits and `go2rtc::remove` tears X down
3. the same reconcile pass, still acting on its pre-delete snapshot, PUTs X's stream back

Because reconcile never prunes, the resurrected stream then **persists until a go2rtc restart** — a deleted security camera staying restreamable.

## Fix

A single global `AppState` mutex (`go2rtc_reconcile_lock`) held for the whole duration of both `reconcile()` and `remove()`. The teardown can no longer land between a pass's stream-list read and its PUTs: the pass either finishes before the delete, or reads the post-delete camera set and never re-adds the stream. Both operations are low-frequency (reconcile every ~60 s; camera CRUD is rare), so a global lock is fine; neither function calls the other, so there's no re-entrancy/deadlock. Reconcile's additive-only design is unchanged (this does **not** turn it into a pruning pass).

No unit test: the fix is mutual exclusion **by construction** (a genuine interleaving race), which a unit test can't meaningfully exercise without a live go2rtc and precise scheduling.

## Gate
`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace` all green against a throwaway Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)