### PR TITLE
fix(desktop): harden diagnostics log scrubbing to redact URL credentials

### DIFF
--- a/apps/desktop-flutter/lib/services/diagnostics_service.dart
+++ b/apps/desktop-flutter/lib/services/diagnostics_service.dart
@@ -123,16 +123,25 @@ class DiagnosticsService extends ChangeNotifier {
   /// Wire a media_kit [player]'s error/log streams into the buffer. Errors
   /// always; mpv's own log lines only in verbose (they're chatty). The
   /// subscriptions die with the player's streams on dispose — fire-and-forget.
+  ///
+  /// mpv/ffmpeg error and log text routinely echoes back the full URL it was
+  /// opening (a go2rtc/RTSP restream, possibly `user:pass@`-embedded) — [log]
+  /// already runs every message through [scrub], but these two call sites
+  /// pre-scrub the raw text too, belt-and-suspenders, since it's the one place
+  /// credential-bearing URLs are most likely to appear verbatim.
   void attachPlayer(String tag, Player player) {
     player.stream.error.listen(
-      (e) => log('player:$tag', e, level: 'warn'),
+      (e) => log('player:$tag', scrub(e), level: 'warn'),
       onError: (_) {},
     );
     player.stream.log.listen(
       (l) {
         if (!_verbose) return;
-        log('player:$tag', '[${l.level}] ${l.prefix}: ${l.text}',
-            level: 'debug');
+        log(
+          'player:$tag',
+          scrub('[${l.level}] ${l.prefix}: ${l.text}'),
+          level: 'debug',
+        );
       },
       onError: (_) {},
     );
@@ -167,6 +176,15 @@ class DiagnosticsService extends ChangeNotifier {
         caseSensitive: false,
       ),
       (m) => '"${m[1]}":"[REDACTED]"',
+    );
+    // URL userinfo (`scheme://user:pass@host`) — go2rtc/RTSP restream URLs can
+    // embed basic-auth-style credentials, and mpv/ffmpeg error + log lines
+    // routinely echo back the full URL being opened. Strip the userinfo
+    // regardless of scheme so a restream credential never survives into an
+    // exported diagnostics file.
+    out = out.replaceAllMapped(
+      RegExp(r'([a-z][a-z0-9+.-]*://)[^/@\s]+@'),
+      (m) => '${m[1]}[REDACTED]@',
     );
     return out;
   }


### PR DESCRIPTION
## Summary

Hardens the desktop diagnostics log scrubber (`apps/desktop-flutter/lib/services/diagnostics_service.dart`) so URL-embedded credentials are always redacted before capture:

- `scrub()` gains a userinfo-redaction pattern (`scheme://user:pass@host` -> `scheme://[REDACTED]@host`).
- `attachPlayer`'s two capture sites (player error stream, verbose mpv log stream) now pre-scrub the raw text before handing it to `log()`, belt-and-suspenders alongside the scrub `log()` already applies to every message.

This closes a gap where a media-player error or verbose log line that echoes back the URL it was opening could carry an unredacted credential into the bounded diagnostics buffer and, from there, into an exported diagnostics file.

Addresses a privately-reported security advisory (GHSA-rpqp-22wr-p5gh) rather than a public issue — see the repo's private security-advisory process in `SECURITY.md`.

## Verification

Not build-verified — the Flutter desktop client is built on a separate Windows host (winbuild) this session did not have access to; no `flutter analyze`/`flutter test` was run. The change is a self-contained, minimal edit to one file (a new regex-based `String -> String` transform plus two call sites now routing through it) with no new imports or API surface. Please run `flutter analyze` / the desktop test suite on winbuild before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)