### PR TITLE
fix(desktop): bound wedged stream-swaps with a timeout + recover a missed first-frame race

### DIFF
--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -1014,6 +1014,17 @@ class _WallTileState extends State<_WallTile> {
   /// the pane while the fresh player waits ~a GOP for its first keyframe.
   Player? _pending;
 
+  /// Bounded-timeout recovery for [_pending] (issue #318): if the replacement
+  /// never reaches its first keyframe (e.g. the newly-selected stream's URL
+  /// is dead), the swap must not wedge the tile on the stale outgoing feed
+  /// forever — and, since [_reconnectStalled] refuses to run at all while
+  /// [_pending] is non-null (a real swap is assumed to be resolving on its
+  /// own), a wedged swap would also permanently disable this tile's stall
+  /// watchdog. Armed whenever a player is parked in [_pending]; cancelled
+  /// the moment it clears (promoted or disposed).
+  Timer? _pendingTimeout;
+  static const _pendingSwapTimeout = Duration(seconds: 15);
+
   String? _error;
   bool _firstFrame = false;
 
@@ -1233,7 +1244,18 @@ class _WallTileState extends State<_WallTile> {
         // so the native mpv wind-down never stalls the swap (#105 contract).
         final superseded = _pending;
         _pending = player;
+        // Arm the wedged-swap recovery timeout (#318) — cancels+re-arms if a
+        // second swap starts before the first ever resolved.
+        _pendingTimeout?.cancel();
+        _pendingTimeout = Timer(_pendingSwapTimeout, _onPendingSwapTimedOut);
         _disposePlayerDetached(superseded);
+        // The width event can fire during the `await player.open()` above,
+        // before `_pending` was assigned — the stream listener's
+        // `identical(player, _pending)` check would have silently dropped
+        // that signal (#318). Re-check once now that `_pending` is set so an
+        // already-arrived first frame isn't lost.
+        final w = player.state.width;
+        if (w != null && w > 0) _onFirstFrame(player, controller);
       }
       spawned = null; // ownership handed off — the catch must not dispose it
     } catch (_) {
@@ -1343,6 +1365,8 @@ class _WallTileState extends State<_WallTile> {
     if (!identical(player, _pending)) return; // superseded swap — ignore
     final old = _player;
     _pending = null;
+    _pendingTimeout?.cancel();
+    _pendingTimeout = null;
     _firstFrame = true;
     // The incoming feed is now the painted one — promote the name label to it
     // (it lagged the pending switch on purpose, #254); _adopt's setState repaints.
@@ -1353,6 +1377,19 @@ class _WallTileState extends State<_WallTile> {
     // Safe: warmController is null whenever _pending != null, so nothing external
     // was painting `old` at promote time.
     _disposePlayerDetached(old);
+  }
+
+  /// [_pendingTimeout] fired: the pending swap never reached a first frame.
+  /// Retire the wedged player (detached, #105) and clear [_pending] so
+  /// [_reconnectStalled] — which refuses to run at all while a swap looks
+  /// "in flight" — resumes normal stall recovery on the still-painting
+  /// outgoing player (issue #318).
+  void _onPendingSwapTimedOut() {
+    _pendingTimeout = null;
+    final pending = _pending;
+    if (pending == null) return;
+    _pending = null;
+    _disposePlayerDetached(pending);
   }
 
   String get _paneId => widget.paneIdOverride ?? 'wall:${widget.camera.id}';
@@ -1536,6 +1573,8 @@ class _WallTileState extends State<_WallTile> {
     widget.onHaLinksLoaded?.call(widget.camera.id, const []);
     // Detach the (potentially seconds-long) libmpv teardown from the teardown
     // path so restore/close doesn't freeze the UI (#105). Null first.
+    _pendingTimeout?.cancel();
+    _pendingTimeout = null;
     final pending = _pending;
     final player = _player;
     _pending = null;


### PR DESCRIPTION
## Summary

Fixes #318 — a wall tile's stream-swap (main/sub override, zoom-to-main) could wedge forever with no recovery, and permanently disable that tile's stall watchdog in the process.

`_WallTileState._load` keeps the old player painting while the replacement ("pending") player decodes toward its first keyframe, promoting it once `_onFirstFrame` sees a real frame. There was no timeout: if the newly-selected stream's URL never decodes, `_pending` is never cleared. Since `_reconnectStalled` (the stall watchdog's recovery path) refuses to run at all whenever `_pending != null` — reasoning that a user-initiated swap must be resolving on its own — a wedged swap also silently disabled the watchdog for any *later, unrelated* real freeze on that same tile.

Separately: if the replacement player's `width` stream event fires very early — during the `await player.open()` call, before `_pending` is assigned — `_onFirstFrame`'s `identical(player, _pending)` check drops it, since `_pending` isn't set yet. That first-frame signal is then lost, leaving the swap dependent on a second signal that may never come.

## Changes

- New `Timer? _pendingTimeout` field + `_pendingSwapTimeout` (15s) constant. Armed whenever a player is parked in `_pending`; on expiry, `_onPendingSwapTimedOut` retires the wedged player (detached, per the existing `_disposePlayerDetached`/#105 discipline) and clears `_pending`, re-enabling the stall watchdog.
- The timer is cancelled wherever `_pending` is otherwise cleared: `_onFirstFrame` (successful promotion) and `dispose()` (tile teardown).
- Right after `_pending = player` is assigned, re-check `player.state.width` once and call `_onFirstFrame` synchronously if it's already positive — recovers the race where the first-frame signal arrived during the preceding `open()` await.

## Verification

Not build-verified — the Flutter desktop client builds on a separate Windows host (winbuild) not available this session; no `flutter analyze`/`flutter test` was run. Read the full `_WallTileState` swap/promote/dispose lifecycle by hand to confirm the timer is armed/cancelled on every path that sets or clears `_pending` (swap-start, promote, timeout, and tile dispose) with no double-dispose or leaked timer. Please run `flutter analyze` and exercise a stream-swap to a dead URL on winbuild before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
