### PR TITLE
fix(desktop): restore from maximize when the maximized camera drops out of _shown

### DIFF
--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -276,6 +276,20 @@ class _WallScreenState extends State<WallScreen> {
     if (idsChanged) {
       _liveStatus.cameraIds = _shown.map((c) => c.id).toList();
     }
+    // A config-driven refresh can remove OR disable the currently-maximized
+    // camera — disabling alone doesn't flip `idsChanged` above (the raw id
+    // list is unchanged; only that camera's `enabled` flag is), but it does
+    // drop the camera from `_shown`, which unmounts its wall tile. That tile
+    // detach-disposes its player while `_maximizeWarmCtrl` may still
+    // reference the now-invalid `VideoController` — and the maximized pane
+    // paints it as its warm-start stand-in whenever its own main-stream
+    // player hasn't decoded a first frame yet (issue #319: black pane, or a
+    // media_kit texture exception). Leave the maximized view — which also
+    // clears `_maximizeWarmCtrl` — before that stale controller can be painted.
+    final maxCam = _maximized;
+    if (maxCam != null && !_shown.any((c) => c.id == maxCam.id)) {
+      _restore();
+    }
   }
 
   /// The wall's config-change signal: re-fetch the camera list via the host.


### PR DESCRIPTION
## Summary

Fixes #319 — the maximized live-wall pane could end up painting a disposed tile's warm-start `VideoController` after a camera-list refresh removed or disabled the maximized camera.

`WallScreen.didUpdateWidget` only cleared `_maximizeWarmCtrl` (the tile's warm-start handoff controller) on an applied-view change, not on a camera-list change. If a `config_version`-triggered refresh (an admin edit reflected live, #146) removes or disables the currently-maximized camera, its wall tile unmounts — detach-disposing its player — while `_maximizeWarmCtrl` still references that now-invalid controller. `_MaximizedPane` renders `warmController` whenever its own main-stream player hasn't decoded a first frame yet, so it can end up painting a disposed controller: a black pane, or a media_kit texture exception.

## Change

In `didUpdateWidget`, after the existing `idsChanged` handling: if `_maximized` is non-null and its camera id is no longer present in `_shown` (the enabled-camera list), call the existing `_restore()` — which already clears `_maximizeWarmCtrl` among its other teardown, rather than duplicating that logic inline.

Note the check has to be independent of the existing `idsChanged` comparison: disabling a camera (vs. removing it from the list) doesn't change the raw camera-id list `idsChanged` compares, only that camera's `enabled` flag — but it does drop the camera from `_shown` (the enabled-only view), which is what actually unmounts its tile.

## Verification

Not build-verified — the Flutter desktop client builds on a separate Windows host (winbuild) not available this session; no `flutter analyze`/`flutter test` was run. Confirmed `_restore()` already nulls `_maximizeWarmCtrl` (so no duplicate assignment needed) and that `didUpdateWidget` is a normal place to call `setState`-triggering methods (the existing code already does so in the same method for the view-change branch). Please exercise a maximize -> config-triggered camera removal/disable on winbuild before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
