### PR TITLE
fix(desktop): detach playback pane player disposal from the UI isolate

### DIFF
--- a/apps/desktop-flutter/lib/ui/playback/gapless_segment_pane_controller.dart
+++ b/apps/desktop-flutter/lib/ui/playback/gapless_segment_pane_controller.dart
@@ -957,7 +957,17 @@ class GaplessSegmentPaneController extends ChangeNotifier {
     // touch a disposed Player from [_onPlaylistChanged].
     unawaited(_playlistSub?.cancel());
     _playlistSub = null;
-    _player.dispose();
+    // Detach the (potentially seconds-long) libmpv teardown from the calling
+    // isolate — media_kit/libmpv's Player.dispose() can block for seconds
+    // while the native mpv handle winds down, and PlaybackScreen.dispose()
+    // tears down every pane's controller in a tight synchronous loop. On a
+    // 9-16 camera playback wall that reproduces the same multi-second UI
+    // freeze the live wall already worked around (its
+    // `_disposePlayerDetached` helper, wall_screen.dart — issue #105).
+    // Nothing reads `_player` after this ChangeNotifier is disposed, so it's
+    // safe to let the native teardown finish on its own after this returns.
+    final player = _player;
+    unawaited(Future(() => player.dispose()));
     super.dispose();
   }
 }


### PR DESCRIPTION
## Summary

Fixes #320 — `GaplessSegmentPaneController.dispose()` called `Player.dispose()` inline, and `PlaybackScreen.dispose()` loops over every camera pane's controller disposing them one after another, synchronously, on the UI isolate. media_kit/libmpv's `Player.dispose()` can block the calling isolate for seconds while the native mpv handle winds down — the live wall already worked around exactly this (issue #105, `wall_screen.dart`'s `_disposePlayerDetached` helper), but the playback screen's per-pane controller never got the same treatment. On a 9-16 camera playback wall, closing/leaving Playback hits the same multi-second UI freeze class.

## Change

`GaplessSegmentPaneController.dispose()` now defers the native `Player.dispose()` call to a fresh microtask/event (`unawaited(Future(() => player.dispose()))`), same fix shape as the wall's `_disposePlayerDetached`. One difference from that helper: `_player` here is `late final` (not nullable), so it can't be nulled before deferring — but nothing reads `_player` after this `ChangeNotifier` is disposed (any further use would already be a contract violation against `ChangeNotifier` itself), so capturing it into a local and deferring the dispose call alone is sufficient; no race window opens up.

## Verification

Not build-verified — the Flutter desktop client builds on a separate Windows host (winbuild) not available this session; no `flutter analyze`/`flutter test` was run, and this was not independently profiled on a 9-16 camera playback wall. Confirmed by reading `PlaybackScreen.dispose()`'s pane-disposal loop and the referenced `wall_screen.dart` helper that this is the same code shape as the already-confirmed #105 freeze. Please profile a full-grid Playback close on winbuild before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
