### PR TITLE
fix(desktop): carry camera identity with the pending player, not widget.camera

### DIFF
--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -1056,6 +1056,14 @@ class _WallTileState extends State<_WallTile> {
   Timer? _pendingTimeout;
   static const _pendingSwapTimeout = Duration(seconds: 15);
 
+  /// The camera [_pending] was actually opened for, captured at the same time
+  /// as [_pending] itself. Under seamless carousel/hotspot switching a rapid
+  /// double flip (A -> B -> C) can retarget `widget.camera` to C while B's
+  /// player is still the one parked in [_pending] — [_onFirstFrame] must
+  /// promote `_shown` from THIS captured identity, not from `widget.camera`,
+  /// or the tile paints B's footage labelled as C (issue #321).
+  Camera? _pendingCamera;
+
   String? _error;
   bool _firstFrame = false;
 
@@ -1278,6 +1286,15 @@ class _WallTileState extends State<_WallTile> {
         // so the native mpv wind-down never stalls the swap (#105 contract).
         final superseded = _pending;
         _pending = player;
+        // Capture the camera THIS player was actually opened for, right now —
+        // the `gen == _loadGen` check just above guarantees no newer _load()
+        // has started (and thus `widget.camera` hasn't moved on) since this
+        // call began. Under seamless double-flip retargeting (A -> B -> C),
+        // `widget.camera` can already read C by the time B's player is the
+        // one promoted in [_onFirstFrame] — that promotion must label the
+        // pane from THIS captured identity, not from `widget.camera` at
+        // promote time (issue #321).
+        _pendingCamera = widget.camera;
         // Arm the wedged-swap recovery timeout (#318) — cancels+re-arms if a
         // second swap starts before the first ever resolved.
         _pendingTimeout?.cancel();
@@ -1403,10 +1420,16 @@ class _WallTileState extends State<_WallTile> {
     _pending = null;
     _pendingTimeout?.cancel();
     _pendingTimeout = null;
+    // The camera THIS player was opened for (captured alongside _pending) —
+    // NOT widget.camera, which can already have moved on under a rapid
+    // double flip (issue #321: promoting B's player while widget.camera
+    // reads C must still label the tile "B", not "C").
+    final promotedCamera = _pendingCamera ?? widget.camera;
+    _pendingCamera = null;
     _firstFrame = true;
     // The incoming feed is now the painted one — promote the name label to it
     // (it lagged the pending switch on purpose, #254); _adopt's setState repaints.
-    _shown = widget.camera;
+    _shown = promotedCamera;
     _adopt(player, controller);
     // Retire the outgoing player OFF the UI isolate — libmpv dispose() can block
     // for seconds (#105), and under a carousel this now fires on every switch.
@@ -1425,6 +1448,7 @@ class _WallTileState extends State<_WallTile> {
     final pending = _pending;
     if (pending == null) return;
     _pending = null;
+    _pendingCamera = null;
     _disposePlayerDetached(pending);
   }
 
@@ -1616,6 +1640,7 @@ class _WallTileState extends State<_WallTile> {
     final pending = _pending;
     final player = _player;
     _pending = null;
+    _pendingCamera = null;
     _player = null;
     _disposePlayerDetached(pending);
     _disposePlayerDetached(player);


### PR DESCRIPTION
## Summary

Fixes #321 — a seamless carousel/hotspot tile could paint one camera's video labelled with a different camera's name/identity after a rapid double flip.

`_WallTileState._onFirstFrame` promoted a pending stream-swap player's identity from `widget.camera` at *promote* time:

```dart
_shown = widget.camera;
```

Under seamless switching (#254), `widget.camera` retargets the instant a slot flips, independent of when the in-flight player for the *previous* target actually decodes its first frame. On a rapid double flip A -> B -> C, `widget.camera` can already read C by the time B's player (parked in `_pending`) is the one being promoted — so the tile ends up painting B's live footage while its name pill and snapshot target say "C". On a security product, misattributed footage is a meaningful correctness bug.

## Change

- New `Camera? _pendingCamera` field, captured alongside `_pending` at the exact point a player is parked there (right after the `gen == _loadGen` freshness check, which guarantees `widget.camera` hasn't moved on since this specific `_load()` call started).
- `_onFirstFrame` now promotes `_shown` from the captured `_pendingCamera` (falling back to `widget.camera` only if somehow unset, which shouldn't happen on the promoted path) instead of from `widget.camera` directly.
- `_pendingCamera` is cleared everywhere `_pending` already is (on promotion and on tile `dispose()`), so it never outlives its player.

## Verification

Not build-verified — the Flutter desktop client builds on a separate Windows host (winbuild) not available this session; no `flutter analyze`/`flutter test` was run, and the exact double-flip timing window was not independently reproduced against live hardware. The fix directly targets the documented mechanism (promotion using a stale `widget.camera` read) regardless of the precise interleaving that triggers it. Please exercise a rapid seamless double flip on a carousel/hotspot tile on winbuild before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
