### PR TITLE
fix(desktop): honor stream-override menu on the maximized live pane

### DIFF
--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -2123,16 +2123,37 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
         setState(() {}); // affects PTZ affordances/menu gating
       case 'main':
         prefs?.setOverride(widget.camera.id, StreamQuality.main);
+        await _load();
       case 'sub':
         prefs?.setOverride(widget.camera.id, StreamQuality.sub);
+        await _load();
       case 'data-saver':
         prefs?.setOverride(widget.camera.id, StreamQuality.dataSaver);
+        await _load();
       case 'reset':
         prefs?.setOverride(widget.camera.id, null);
+        await _load();
     }
   }
 
   Future<void> _load() async {
+    // A reload (the right-click stream-override menu now calls _load() again
+    // after setOverride — issue #322) must retire any already-playing player
+    // + watchdog first: this method originally only ran once from initState,
+    // so a second call would otherwise leak the outgoing player and run two
+    // decoders/watchdogs at once. Resetting _firstFrame re-arms the width
+    // listener below and briefly shows the warm-start stand-in (if any) /
+    // loading spinner while the new tier buffers — expected for an explicit
+    // quality change. No-op on the very first call (_player is still null).
+    final previous = _player;
+    if (previous != null) {
+      _watchdog?.dispose();
+      _watchdog = null;
+      _player = null;
+      _controller = null;
+      if (mounted) setState(() => _firstFrame = false);
+      _disposePlayerDetached(previous);
+    }
     // Track a Player created below so the catch can dispose it if open() throws
     // before this pane adopts it — a failed initial load otherwise leaks the
     // player and its native mpv handle (#132). Cleared once ownership passes to
@@ -2144,8 +2165,17 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
         widget.camera.id,
       );
       _streams = streams; // gate the right-click Data-saver item
-      // Prefer MAIN for the maximized view; fall back to sub.
-      final url = streams.rtspMain ?? streams.preferredForWall;
+      // Honor an explicit per-camera stream override from the right-click
+      // menu (Main/Sub/Data saver) — issue #322, this pane used to ignore
+      // `streamPrefs` entirely. `isMaximized: false` here means "don't force
+      // main the way a wall-tile zoom-to-main does" — an override is a
+      // deliberate, persistent choice for this camera, not a transient zoom.
+      // With no override, keep today's default: prefer MAIN for the
+      // maximized view, falling back to sub.
+      final prefs = widget.streamPrefs;
+      final url = (prefs != null && prefs.hasOverride(widget.camera.id))
+          ? prefs.liveStreamUrl(widget.camera.id, streams, isMaximized: false)
+          : (streams.rtspMain ?? streams.preferredForWall);
       if (url == null) {
         setState(() => _error = 'no stream');
         return;


### PR DESCRIPTION
## Summary

Fixes #322 — the maximized live-wall pane's right-click stream-override menu (Main / Sub / Data saver) visibly did nothing.

`_MaximizedPaneState`'s menu handler only wrote the per-camera `StreamPrefsStore` override, never reloading the stream; `_load()` ignored `streamPrefs` entirely (`streams.rtspMain ?? streams.preferredForWall`, unconditionally). Contrast the wall tile's own menu, which already `await`s `_reloadStream()` after setting an override.

## Changes

- `_load()` now resolves the URL via `streamPrefs.liveStreamUrl(camera.id, streams, isMaximized: false)` when this camera has an explicit override, keeping today's main-preferring default (`rtspMain ?? preferredForWall`) when there's no override. `isMaximized: false` is deliberate here: `StreamPrefsStore.resolvedQuality`'s `isMaximized && maximizeUsesMain` branch (default `maximizeUsesMain: true`) *forces* main regardless of any override — that's the right behavior for a wall tile's transient zoom-to-main, but wrong for this menu, where the override is a deliberate, persistent per-camera choice.
- The menu's `main`/`sub`/`data-saver`/`reset` cases now `await _load()` after `setOverride`, mirroring the wall tile's own menu.
- Since `_load()` previously only ran once (from `initState`), making it reloadable needed one more piece: it now retires the already-playing player + watchdog first (detached dispose, #105) when called with one already active, or the reload would leak the outgoing player and run two decoders/watchdogs concurrently. No-op on the original first-call path.

## Verification

Not build-verified — the Flutter desktop client builds on a separate Windows host (winbuild) not available this session; no `flutter analyze`/`flutter test` was run. Read `StreamPrefsStore.resolvedQuality`/`liveStreamUrl` in full to confirm the `isMaximized: false` choice actually respects the override rather than accidentally re-forcing main, and traced the wall tile's analogous menu/`_reloadStream` pattern to mirror it. Please exercise the maximized-pane Main/Sub/Data-saver menu on winbuild before merging (and confirm no double-player leak across repeated overrides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
