### PR TITLE
fix(desktop): guard disposed-mid-load players, detach error-path dispose

### DIFF
--- a/apps/desktop-flutter/lib/ui/clips/clips_screen.dart
+++ b/apps/desktop-flutter/lib/ui/clips/clips_screen.dart
@@ -943,6 +943,11 @@ class _ClipPlayerState extends State<_ClipPlayer> {
         _controller = controller;
       });
     }
+    // The property-setting loop above awaits — the overlay can be closed
+    // (dispose() synchronously disposes _player) during that gap. Calling
+    // open()/play() on the now-disposed player would throw an uncaught async
+    // error (issue #323).
+    if (!mounted) return;
     await player.open(Media(url));
     await player.play();
     _armWatchdog();

--- a/apps/desktop-flutter/lib/ui/plates/plates_screen.dart
+++ b/apps/desktop-flutter/lib/ui/plates/plates_screen.dart
@@ -2312,6 +2312,11 @@ class _PlateClipPlayerState extends State<_PlateClipPlayer> {
         _controller = controller;
       });
     }
+    // The property-setting loop above awaits — the overlay can be closed
+    // (dispose() synchronously disposes _player) during that gap. Calling
+    // open()/play() on the now-disposed player would throw an uncaught async
+    // error (issue #323).
+    if (!mounted) return;
     await player.open(Media(url));
     await player.play();
     _armWatchdog();

--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -1241,8 +1241,10 @@ class _WallTileState extends State<_WallTile> {
       // native mpv handle isn't leaked on a failed initial load (#132). On the
       // success path spawned is nulled above once the pane adopts the player
       // (or hands it to _pending), so the stall-watchdog/reconnect handling is
-      // untouched and a live player is never disposed here.
-      spawned?.dispose();
+      // untouched and a live player is never disposed here. Detached (#105,
+      // issue #323) — same discipline as every other player teardown in this
+      // file, rather than a synchronous dispose on this error path.
+      _disposePlayerDetached(spawned);
       if (mounted) {
         setState(() => _error = 'load failed');
       }
@@ -2226,8 +2228,9 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
       // A Player created before open() failed is orphaned; dispose it so its
       // native mpv handle isn't leaked on a failed initial load (#132). On the
       // success path spawned is nulled above (after _player/_controller adopt
-      // it), so a live/reconnecting player is never disposed here.
-      spawned?.dispose();
+      // it), so a live/reconnecting player is never disposed here. Detached
+      // (#105, issue #323) rather than a synchronous dispose on this error path.
+      _disposePlayerDetached(spawned);
       if (mounted) setState(() => _error = 'load failed');
     }
   }


### PR DESCRIPTION
## Summary

Fixes #323 — two small correctness cleanups from the 2026-07-19 desktop audit; the other two items in that issue are intentionally left untouched (see below).

## Changes

**1. Unguarded `player.open()`/`.play()` after a disposed-mid-load overlay.**

`ClipsScreen`'s clip player `_open()` and `PlatesScreen`'s plate-read player `_open()` both create a `Player`, `await` a property-setting loop (an await gap), then call `await player.open(Media(url)); await player.play();` with no further `mounted` check. If the overlay is closed during that gap, `dispose()` has already synchronously disposed `_player`, and the coroutine then throws an uncaught async error calling `.open()`/`.play()` on it. Added a `mounted` check immediately before the final `open()` call in both `_open()` methods — verified both cited line ranges match a real `player.open()`/`.play()` call site.

**2. Error-path `spawned?.dispose()` was synchronous, against the file's own #105 posture.**

`_WallTileState._load` and `_MaximizedPaneState._load` (`wall_screen.dart`) both disposed an orphaned `Player` synchronously in their catch blocks when `open()` throws during initial load — inconsistent with every other player teardown in the same file, which already routes through the `_disposePlayerDetached` helper (the #105 fix). Both now use `_disposePlayerDetached(spawned)`.

## Not touched (documented in #323)

- `playback_screen.dart`'s `_frameStep` steps every pane sequentially — but the code has an explicit in-line rationale ("Sequential on purpose: ... the boundary-crossing path does its own `/play/` resolve — no need to fan out"). Parallelizing without addressing that stated boundary-crossing contention risks recreating the exact problem the sequential design avoids; left for a dedicated perf discussion.
- `admin_console_api.dart`'s JWT-in-URL-fragment is a deliberate, documented design choice, not a bug.

## Verification

Not build-verified — the Flutter desktop client builds on a separate Windows host (winbuild) not available this session; no `flutter analyze`/`flutter test` was run. Read all four touched call sites directly to confirm the line citations matched real code before editing. Please run `flutter analyze` on winbuild before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
