### PR TITLE
fix(api): security hardening batch — log redaction, XSS, and export/events authz

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,41 @@ revisit.
 
 ---
 
+## 2026-07-20, Admin-only outbound probes (stream-test / ONVIF discovery) are not SSRF-guarded; risk accepted under the LAN-only, single-operator trust model
+
+**Context.** An API reliability/security audit flagged that `POST
+/config/test-stream`, `/config/test-frame`, `/config/discover`, and
+`/config/discover/probe` let the caller point Crumb's outbound request at an
+arbitrary host — including `169.254.169.254` (cloud metadata), `localhost:<port>`,
+or other internal hosts — a classic SSRF surface. Error text can echo a snippet
+of the upstream response.
+
+**Decision — accept the risk; do not add a URL allowlist or private-IP denylist
+right now.** Every one of these endpoints is `AdminUser`-gated, and in Crumb's
+ratified posture the admin **is** the trust root and owns the LAN. Crumb's whole
+job is to reach arbitrary RTSP/ONVIF hosts on the operator's own network that the
+admin types in — a private-IP denylist would break the primary use case (LAN
+cameras live on exactly the private ranges an SSRF guard blocks). There is **no
+viewer-reachable outbound path**: the audit confirmed the only non-admin outbound
+(PTZ) targets a DB/admin-set host the viewer cannot influence. So this is admin
+self-targeting, not a privilege-boundary break.
+
+**Rejected:** an allowlist/denylist on these outbound targets — it fights the LAN
+camera use case and adds config surface for a threat the trust model already
+covers. Also rejected: suppressing upstream error snippets — they are genuinely
+useful for diagnosing why a camera URL failed, and the reader is the admin.
+
+**Revisit triggers (any one):**
+- Crumb grows a **hosted / multi-tenant** deployment mode, or any path where a
+  non-admin (or a lower-trust admin) can influence these outbound targets — then a
+  metadata-endpoint / link-local (`169.254.0.0/16`) denylist and error-snippet
+  suppression become warranted.
+- These probe endpoints are ever exposed to an untrusted network or moved off the
+  `AdminUser` gate.
+- A credible report of admin-context SSRF being chained with another finding.
+
+Tracked privately as advisory GHSA-v7q8-gj2q-gffw.
+
 ## 2026-07-19, iOS/macOS v0.1.0 parity: HA overlays + LPR are read-only on mobile; client-side logic ported verbatim from the server
 
 **Context.** The iOS/macOS SwiftUI client was catching up to a large batch of

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -8935,7 +8935,7 @@ function renderUser(id) {
   const roleObj = ROLES.find(r => r.id === u.role_id);
   const roleSub = u.role === 'admin'
     ? 'Administrator · Full access including this console'
-    : (roleObj ? `Role: ${roleObj.name}` : 'No role assigned');
+    : (roleObj ? `Role: ${esc(roleObj.name)}` : 'No role assigned');
   $('right-pane').innerHTML = `
     <div class="rp-head">
       <div class="rp-head-left">

--- a/services/api/src/discover.rs
+++ b/services/api/src/discover.rs
@@ -1291,8 +1291,12 @@ pub(crate) async fn redetect_camera_streams(
     .is_ok_and(|r| r.is_ok());
 
     if !reachable {
+        // Redact the RTSP userinfo before logging — the URL embeds the camera's
+        // `user:pass@`, and percent-encoding is not redaction. Same treatment
+        // the go2rtc apply path gives this class of URL.
+        let redacted_url = crumb_common::redact::redact_url_credentials(&source_url);
         tracing::warn!(
-            rtsp_url = %source_url,
+            rtsp_url = %redacted_url,
             onvif_host = %host,
             probe_host = %probe_host_str,
             probe_port,

--- a/services/api/src/events.rs
+++ b/services/api/src/events.rs
@@ -244,12 +244,21 @@ async fn get_event_snapshot(
     State(state): State<AppState>,
     Path(event_id): Path<Uuid>,
 ) -> Result<Response, ApiError> {
-    // Enforce camera scope when the event's camera is known.
-    if let Some(camera_id) = db::get_event_camera_id(state.pool(), event_id)
+    // Enforce camera scope, failing CLOSED. A NULL-camera event has no scope to
+    // check, so previously it was served to any authenticated user; treat "no
+    // owning camera" as a denial instead — event media must always be behind a
+    // camera the caller can access. (No current path inserts a NULL-camera event
+    // with media, so this denies nothing legitimate.)
+    match db::get_event_camera_id(state.pool(), event_id)
         .await
         .map_err(ApiError::Internal)?
     {
-        user.assert_camera_access(camera_id)?;
+        Some(camera_id) => user.assert_camera_access(camera_id)?,
+        None => {
+            return Err(ApiError::Forbidden(
+                "event has no accessible camera scope".to_owned(),
+            ));
+        }
     }
 
     // Look up the stored snapshot URL. When there is none, fall back to the
@@ -266,6 +275,11 @@ async fn get_event_snapshot(
         .await
         .map_err(ApiError::Internal)?
     {
+        // This fallback serves a license-plate crop — plate data. Gate it behind
+        // the same `view_plates` capability the dedicated GET /plates/{id}/crop
+        // enforces, so a viewer without it can't reach the crop bytes through the
+        // snapshot path.
+        user.require_view_plates()?;
         return Ok(([(axum::http::header::CONTENT_TYPE, "image/jpeg")], crop).into_response());
     } else {
         return Err(ApiError::NotFound(format!(

--- a/services/api/src/export.rs
+++ b/services/api/src/export.rs
@@ -259,6 +259,18 @@ async fn get_export_status(
         ));
     }
 
+    // Return only what the caller can see: strip out-of-scope camera UUIDs and
+    // their per-camera download URLs, so polling a job you have only partial
+    // access to doesn't disclose cameras outside your scope. The job's creator
+    // and admins hold every camera in the job, so they see it unchanged. The
+    // single nil-camera ZIP-archive entry names no specific camera, so it is
+    // left in place (the archive download handler enforces its own scope).
+    let visible_set: std::collections::HashSet<Uuid> = visible.iter().copied().collect();
+    let mut job = job;
+    job.camera_ids.retain(|c| visible_set.contains(c));
+    job.output_files
+        .retain(|f| f.camera_id.is_nil() || visible_set.contains(&f.camera_id));
+
     Ok(Json(job))
 }
 
@@ -278,16 +290,20 @@ async fn cancel_export(
     State(state): State<AppState>,
     Path(job_id): Path<Uuid>,
 ) -> Result<StatusCode, ApiError> {
-    // Same gate as get_export_status: export capability + access to ≥1 job camera.
     user.require_export()?;
     let job = state
         .export_jobs()
         .get(&job_id)
         .map(|r| r.clone())
         .ok_or_else(|| ApiError::NotFound(format!("export job {job_id} not found")))?;
-    if user.filter_camera_ids(&job.camera_ids).is_empty() {
+    // Cancelling aborts the WHOLE job, so require access to EVERY camera in it —
+    // not just one. The creator and admins hold them all; a viewer with partial
+    // access must not be able to kill someone else's multi-camera export.
+    // filter_camera_ids drops only out-of-scope cameras, so an equal length
+    // means every camera is in the caller's scope.
+    if user.filter_camera_ids(&job.camera_ids).len() != job.camera_ids.len() {
         return Err(ApiError::Forbidden(
-            "you do not have access to this export job".to_owned(),
+            "you do not have access to all cameras in this export job".to_owned(),
         ));
     }
 


### PR DESCRIPTION
Batches the smaller findings from the API security audit. Details are in **private advisories** (kept off the public tracker per `SECURITY.md`): GHSA-fpq9-qjx3-mmr8, GHSA-wjr9-vqqh-37wr, GHSA-wmgp-66mm-g3pr, and GHSA-v7q8-gj2q-gffw. Each item below is stated as the behavioural fix.

- **`discover.rs`** — the ONVIF re-detect reachability warning logged the camera's RTSP URL verbatim (embedding `user:pass@`). Now redacts the userinfo before logging, matching the go2rtc apply path.
- **`admin.html`** — the user-detail pane interpolated the role name into `innerHTML` without `esc()`. Now escaped (every sibling render already did). Verified with `node --check` on the extracted script.
- **`export.rs`** — `cancel_export` required access to only **one** of a job's cameras to abort the whole job; now requires access to **every** camera in it. `get_export_status` returned the full job to a caller with partial access (disclosing out-of-scope camera UUIDs + per-camera download URLs); now filters `camera_ids` and per-camera output files to the caller's scope (the nil-camera ZIP-archive entry is kept — its download handler enforces scope). Creators and admins hold all cameras, so they see the job unchanged.
- **`events.rs`** — `GET /events/{id}/snapshot` skipped the camera-scope check for a NULL-camera event (fail-open) → now fails **closed**. Its plate-crop fallback served crop bytes without the `view_plates` capability the dedicated `/plates/{id}/crop` enforces → now gated the same way.
- **`docs/DECISIONS.md`** — records accepting the admin-only stream-test / discovery **SSRF** surface under the LAN-only single-operator trust model, with a hosted/multi-tenant revisit trigger (rather than an allowlist that would break LAN cameras).

## Gate
`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace` all green against a throwaway Postgres; `node --check` clean on the admin console script. The export/events authz changes are covered by the existing integration suite (no regression); the creator/admin common path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)