### PR TITLE
fix(desktop): funnel live-wall 401s into the re-auth prompt

### DIFF
--- a/apps/desktop-flutter/lib/main.dart
+++ b/apps/desktop-flutter/lib/main.dart
@@ -296,9 +296,18 @@ class _CrumbClientAppState extends State<CrumbClientApp> {
       session: session,
       onUnauthorized: controller.handleUnauthorized,
     );
-    _recordingAlerts = RecordingAlertsController(api: _api, session: session)
-      ..start();
-    _updateCheck = UpdateCheckController(api: _api, session: session)..start();
+    _recordingAlerts =
+        RecordingAlertsController(
+          api: _api,
+          session: session,
+          onUnauthorized: controller.handleUnauthorized,
+        )..start();
+    _updateCheck =
+        UpdateCheckController(
+          api: _api,
+          session: session,
+          onUnauthorized: controller.handleUnauthorized,
+        )..start();
     _session = session;
     _cameras = cameras;
     // Diagnostics breadcrumb (#180): record host:port only, never creds.
@@ -1352,6 +1361,10 @@ class _MainShellState extends State<MainShell> with WindowListener {
           // The wall's /status poller detects config_version bumps; bubble that
           // up so an admin/config edit reloads the camera list live (#146).
           onConfigChanged: widget.onRefreshCameras,
+          // A bearer JWT expiring/being revoked while the user stays on Live
+          // never reached re-auth otherwise — the Live tab never mints a
+          // media token, the only other thing wired to this (issue #316).
+          onUnauthorized: widget.sessionController.handleUnauthorized,
         );
     }
   }

--- a/apps/desktop-flutter/lib/ui/live_status/live_status_controller.dart
+++ b/apps/desktop-flutter/lib/ui/live_status/live_status_controller.dart
@@ -66,9 +66,19 @@ class LiveStatusController extends ChangeNotifier {
     this.detectionLookback = const Duration(seconds: 25),
     this.detectionLookahead = const Duration(seconds: 5),
     this.configReloadDebounce = const Duration(milliseconds: 1500),
+    this.onUnauthorized,
   });
 
   final CrumbApi api;
+
+  /// Called when `/status` comes back 401/403 (the bearer JWT expired or was
+  /// revoked mid-wall) — the Live tab never mints a media token, so without
+  /// this hook a 401 here was invisible to `SessionController.handleUnauthorized`
+  /// and just accumulated as ordinary poll failures, eventually showing a
+  /// permanently-false "Connection lost" banner with no recovery (issue #316).
+  /// The caller is expected to surface a re-auth prompt (mirrors
+  /// `MediaTokenCache.onUnauthorized`); this controller does not know how.
+  final VoidCallback? onUnauthorized;
 
   /// The session whose bearer token authenticates every poll. NOT final: an
   /// in-place re-auth (see `main.dart`'s session-change handler) mints a fresh
@@ -235,6 +245,16 @@ class LiveStatusController extends ChangeNotifier {
       if (_disposed) return;
 
       if (statusError != null || status == null) {
+        // An auth rejection is not a network/server problem — don't lie with
+        // a "connection lost" banner (issue #316); hand it to the re-auth
+        // hook instead so the same in-place re-auth prompt a Playback/Clips
+        // 401 already triggers also covers the Live tab.
+        final err = statusError;
+        if (err is CrumbApiException &&
+            (err.statusCode == 401 || err.statusCode == 403)) {
+          onUnauthorized?.call();
+          return;
+        }
         _failStreak += 1;
         if (_failStreak >= failuresBeforeConnLost && !_connectionLost) {
           _connectionLost = true;

--- a/apps/desktop-flutter/lib/ui/recording_alerts/recording_alerts_controller.dart
+++ b/apps/desktop-flutter/lib/ui/recording_alerts/recording_alerts_controller.dart
@@ -48,7 +48,11 @@ const double _heartbeatStaleSecs = 60;
 /// (e.g. the wall screen) and call [start] once the session is established;
 /// call [dispose] on sign-out / screen teardown.
 class RecordingAlertsController extends ChangeNotifier {
-  RecordingAlertsController({required this.api, required this.session});
+  RecordingAlertsController({
+    required this.api,
+    required this.session,
+    this.onUnauthorized,
+  });
 
   /// Adopt a refreshed session (in-place re-auth) so the next poll uses the live
   /// token instead of the dead one captured at construction. See #131.
@@ -56,6 +60,12 @@ class RecordingAlertsController extends ChangeNotifier {
 
   final CrumbApi api;
   Session session;
+
+  /// Called when a poll comes back 401/403 (the bearer JWT expired or was
+  /// revoked) — mirrors `MediaTokenCache.onUnauthorized` so this poller's
+  /// 401s reach `SessionController.handleUnauthorized` too instead of just
+  /// silently keeping the last-known warnings forever (issue #316).
+  final VoidCallback? onUnauthorized;
 
   Timer? _timer;
   List<RecordingWarning> _warnings = const [];
@@ -99,7 +109,12 @@ class RecordingAlertsController extends ChangeNotifier {
       );
       _warnings = next;
       notifyListeners();
-    } catch (_) {
+    } catch (e) {
+      if (e is CrumbApiException &&
+          (e.statusCode == 401 || e.statusCode == 403)) {
+        onUnauthorized?.call();
+        return;
+      }
       // Transient network error — keep showing the last computed state,
       // exactly like pollRecordingAlerts' empty catch block.
     }

--- a/apps/desktop-flutter/lib/ui/updates/update_check_controller.dart
+++ b/apps/desktop-flutter/lib/ui/updates/update_check_controller.dart
@@ -61,7 +61,11 @@ bool isNewerVersion(String? latest, String? own) {
 /// shell) and call [start] once a session is established; call [stop] on
 /// sign-out and [dispose] on teardown.
 class UpdateCheckController extends ChangeNotifier {
-  UpdateCheckController({required this.api, required this.session});
+  UpdateCheckController({
+    required this.api,
+    required this.session,
+    this.onUnauthorized,
+  });
 
   /// Adopt a refreshed session (in-place re-auth) so the next poll uses the live
   /// token instead of the dead one captured at construction. See #131.
@@ -69,6 +73,12 @@ class UpdateCheckController extends ChangeNotifier {
 
   final CrumbApi api;
   Session session;
+
+  /// Called when a check comes back 401/403 (the bearer JWT expired or was
+  /// revoked) — mirrors `MediaTokenCache.onUnauthorized` so this poller's
+  /// 401s reach `SessionController.handleUnauthorized` too instead of just
+  /// silently keeping the last-known state forever (issue #316).
+  final VoidCallback? onUnauthorized;
 
   Timer? _timer;
   UpdateCheckResponse? _data;
@@ -153,7 +163,12 @@ class UpdateCheckController extends ChangeNotifier {
       final res = await api.getLatestUpdate(session, refresh: refresh);
       // enabled:false or a 404 (null) both clear the state — nothing shows.
       _data = (res != null && res.enabled) ? res : null;
-    } catch (_) {
+    } catch (e) {
+      if (e is CrumbApiException &&
+          (e.statusCode == 401 || e.statusCode == 403)) {
+        onUnauthorized?.call();
+        return;
+      }
       // Transient failure — keep the last known state, matching app.js's
       // empty catch in updCheck.
     } finally {

--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -83,6 +83,7 @@ class WallScreen extends StatefulWidget {
     this.onMaximizedCameraChanged,
     this.statsSink,
     this.onConfigChanged,
+    this.onUnauthorized,
   });
 
   final CrumbApi api;
@@ -137,6 +138,14 @@ class WallScreen extends StatefulWidget {
   /// The relevant option here is `showInfoBar` (per-tile header strip vs
   /// floating overlays). Null → defaults (header bar on).
   final ClientOptionsStore? clientOptions;
+
+  /// Called on a 401/403 from anything the wall itself polls or fetches
+  /// directly — `/status`+`/events` (via [LiveStatusController]) and each
+  /// tile/pane's own `cameraStreams` fetch. The Live tab never mints a media
+  /// token, so without this hook a session expiring while the user stays on
+  /// Live never reached the re-auth prompt (issue #316); wire this to
+  /// `SessionController.handleUnauthorized`.
+  final VoidCallback? onUnauthorized;
 
   @override
   State<WallScreen> createState() => _WallScreenState();
@@ -229,7 +238,13 @@ class _WallScreenState extends State<WallScreen> {
       const Duration(seconds: 2),
       (_) => _pollStats(),
     );
-    _liveStatus = LiveStatusController(api: widget.api, session: widget.session)
+    _liveStatus = LiveStatusController(
+      api: widget.api,
+      session: widget.session,
+      // Live-tab 401s (a bearer JWT that expires/is revoked while the user
+      // never leaves Live) otherwise never reached re-auth — issue #316.
+      onUnauthorized: widget.onUnauthorized,
+    )
       ..cameraIds = _shown.map((c) => c.id).toList()
       // A config_version bump means cameras/streams may have changed — ask the
       // host to re-fetch the camera list so the wall picks it up live (#146).
@@ -621,6 +636,7 @@ class _WallScreenState extends State<WallScreen> {
               onEditPtzPanel: () => unawaited(_beginPtzPanelEdit(_maximized!)),
               onLinkHaEntities: () => unawaited(_refreshHaLinksFor(_maximized!.id)),
               onHaLinksLoaded: _onHaLinksLoaded,
+              onUnauthorized: widget.onUnauthorized,
               onClose: _restore,
             ),
         ],
@@ -793,6 +809,7 @@ class _WallScreenState extends State<WallScreen> {
                     onEditHaOverlay: () =>
                         unawaited(_beginHaOverlayEdit(cam)),
                     onHaLinksLoaded: _onHaLinksLoaded,
+                    onUnauthorized: widget.onUnauthorized,
                     isAdmin: widget.isAdmin,
                   );
           }
@@ -862,6 +879,7 @@ class _WallScreenState extends State<WallScreen> {
                 onEditHaOverlay: () =>
                     unawaited(_beginHaOverlayEdit(cam)),
                 onHaLinksLoaded: _onHaLinksLoaded,
+                onUnauthorized: widget.onUnauthorized,
                 isAdmin: widget.isAdmin,
               ),
             ),
@@ -937,6 +955,7 @@ class _WallTile extends StatefulWidget {
     this.onEditPtzPanel,
     this.onEditHaOverlay,
     this.onHaLinksLoaded,
+    this.onUnauthorized,
     this.isAdmin = false,
     this.paneIdOverride,
   });
@@ -969,6 +988,11 @@ class _WallTile extends StatefulWidget {
   /// can track which visible cameras have a placed badge and drive
   /// `LiveStatusController.wantHaStates` (desktop P0 plan §4.4).
   final void Function(String cameraId, List<HaLink> links)? onHaLinksLoaded;
+
+  /// Called on a 401/403 from this tile's own `cameraStreams` fetch (in
+  /// `_load`/`_reconnectStalled`) — a bearer JWT expiring/being revoked while
+  /// the user stays on Live never reached re-auth otherwise (issue #316).
+  final VoidCallback? onUnauthorized;
 
   /// Gates the right-click menu's "Link HA entities…" item (issue #52
   /// desktop port) — `PUT /cameras/:id/ha/links` is admin-enforced
@@ -1236,7 +1260,14 @@ class _WallTileState extends State<_WallTile> {
         _disposePlayerDetached(superseded);
       }
       spawned = null; // ownership handed off — the catch must not dispose it
-    } catch (_) {
+    } catch (e) {
+      // cameraStreams's own 401/403 never reached SessionController — a
+      // bearer JWT expiring/being revoked while the user stays on Live never
+      // triggered re-auth otherwise (issue #316).
+      if (e is CrumbApiException &&
+          (e.statusCode == 401 || e.statusCode == 403)) {
+        widget.onUnauthorized?.call();
+      }
       // A Player created before open() failed is orphaned; dispose it so its
       // native mpv handle isn't leaked on a failed initial load (#132). On the
       // success path spawned is nulled above once the pane adopts the player
@@ -1325,7 +1356,15 @@ class _WallTileState extends State<_WallTile> {
       if (mounted) setState(() => _firstFrame = false);
       await player.open(Media(url));
       _watchdog?.resetBaseline();
-    } catch (_) {
+    } catch (e) {
+      // cameraStreams's own 401/403 never reached SessionController — surface
+      // it the same way _load's does (issue #316) rather than silently
+      // retrying a stall reconnect against a dead token forever.
+      if (e is CrumbApiException &&
+          (e.statusCode == 401 || e.statusCode == 403)) {
+        widget.onUnauthorized?.call();
+        return;
+      }
       // Left for the next backoff tick — the watchdog never gives up.
     }
   }
@@ -1805,6 +1844,7 @@ class _MaximizedPane extends StatefulWidget {
     this.onEditPtzPanel,
     this.onLinkHaEntities,
     this.onHaLinksLoaded,
+    this.onUnauthorized,
   });
 
   final CrumbApi api;
@@ -1874,6 +1914,11 @@ class _MaximizedPane extends StatefulWidget {
   /// Reported every time this pane (re)loads its own HA links — see
   /// `_WallTile.onHaLinksLoaded`'s doc; same contract.
   final void Function(String cameraId, List<HaLink> links)? onHaLinksLoaded;
+
+  /// Called on a 401/403 from this pane's own `cameraStreams` fetch (in
+  /// `_load`/`_reconnectStalled`) — see `_WallTile.onUnauthorized`'s doc;
+  /// same contract (issue #316).
+  final VoidCallback? onUnauthorized;
 
   @override
   State<_MaximizedPane> createState() => _MaximizedPaneState();
@@ -2222,7 +2267,14 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
         _controller = controller;
       });
       spawned = null; // ownership handed off — the catch must not dispose it
-    } catch (_) {
+    } catch (e) {
+      // cameraStreams's own 401/403 never reached SessionController — a
+      // bearer JWT expiring/being revoked while the user stays on Live never
+      // triggered re-auth otherwise (issue #316).
+      if (e is CrumbApiException &&
+          (e.statusCode == 401 || e.statusCode == 403)) {
+        widget.onUnauthorized?.call();
+      }
       // A Player created before open() failed is orphaned; dispose it so its
       // native mpv handle isn't leaked on a failed initial load (#132). On the
       // success path spawned is nulled above (after _player/_controller adopt
@@ -2248,7 +2300,15 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
       if (url == null) return;
       await player.open(Media(url));
       _watchdog?.resetBaseline();
-    } catch (_) {
+    } catch (e) {
+      // cameraStreams's own 401/403 never reached SessionController — surface
+      // it the same way _load's does (issue #316) rather than silently
+      // retrying a stall reconnect against a dead token forever.
+      if (e is CrumbApiException &&
+          (e.statusCode == 401 || e.statusCode == 403)) {
+        widget.onUnauthorized?.call();
+        return;
+      }
       // Left for the next backoff tick — the watchdog never gives up.
     }
   }


### PR DESCRIPTION
## Summary

Fixes #316 — a bearer JWT expiring or being revoked while the user stayed on the Live tab never reached the re-auth prompt, producing a permanent, misleading "Connection lost — indicators may be stale" banner with no recovery path.

`SessionController.handleUnauthorized` (which opens the in-place re-auth overlay while the app shell keeps running underneath) was wired from exactly one call site: `MediaTokenCache._mint`'s 401 branch, via `main.dart`'s `_startSession`. The Live tab never mints a media token (RTSP wall panes don't use `?token=`), so:

- `LiveStatusController._poll`'s `/status`+`/events` 401 was treated as an ordinary transient failure — after 3 consecutive ticks it flips `connectionLost = true`, rendered as the false banner.
- Wall tile/maximized-pane `cameraStreams` fetches (`_load`/`_reconnectStalled`) failed silently on 401.
- `RecordingAlertsController` and `UpdateCheckController` polled straight into the 401 with a bare `catch (_)`.

## Changes

- `LiveStatusController`, `RecordingAlertsController`, `UpdateCheckController` each gain an optional `onUnauthorized` callback (mirrors `MediaTokenCache`'s existing constructor param), invoked when a poll's failure is a `CrumbApiException` with `statusCode` 401 or 403. `LiveStatusController` additionally suppresses the connection-lost banner for that case (returns before touching `_failStreak`/`_connectionLost`) — an auth rejection is not a network problem, and today's banner copy is actively misleading when the footage itself is unaffected.
- `main.dart`'s `_startSession` wires all three controllers' `onUnauthorized` to `controller.handleUnauthorized`, the same pattern already used for `MediaTokenCache`.
- `WallScreen` gains an `onUnauthorized` callback, passed to its `LiveStatusController` and threaded down through `_WallTile`/`_MaximizedPane` so their own `cameraStreams` 401s (in `_load` and `_reconnectStalled`, 4 call sites total) reach the same hook. `MainShell` wires it to `sessionController.handleUnauthorized`.

## Verification

Not build-verified — the Flutter desktop client builds on a separate Windows host (winbuild) not available this session; no `flutter analyze`/`flutter test` was run. Traced every new `onUnauthorized` wire-up from its poller/fetch site back to `main.dart`'s `SessionController` to confirm the callback chain is complete and every constructor call site was updated. Please exercise a token-expiry-while-on-Live scenario on winbuild before merging (e.g. a short-lived token, or manually invalidating the session server-side while parked on the Live tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
