### PR TITLE
fix(ios): clamp trun sample_count to prevent OOM on malformed fMP4

### DIFF
--- a/apps/ios/Crumb/Video/Fmp4/Fmp4Demuxer.swift
+++ b/apps/ios/Crumb/Video/Fmp4/Fmp4Demuxer.swift
@@ -396,11 +396,28 @@ final class Fmp4Demuxer {
             let hasFlags = flags & 0x400 != 0
             let hasCTS = flags & 0x800 != 0
 
+            // `sampleCount` is a raw 32-bit field from the box (up to ~4.29B) with
+            // nothing to validate it against the box's actual size — the per-sample
+            // read guards below (`t.count >= p + 4`) only skip OUT-OF-RANGE READS,
+            // they don't stop the loop, so a malformed/hostile 16-byte `trun`
+            // claiming billions of samples would still `reserveCapacity`/`append`
+            // that many entries (~4.29B × 8 bytes ≈ 48 GB) and OOM. Clamp to what
+            // the box could plausibly hold given its declared per-sample fields,
+            // plus an absolute sanity cap — real fragments carry at most a few
+            // hundred samples.
+            let bytesPerSample = (hasDuration ? 4 : 0) + (hasSize ? 4 : 0) + (hasFlags ? 4 : 0) + (hasCTS ? 4 : 0)
+            let maxSamplesPerFragment = 10_000
+            var boundedSampleCount = min(sampleCount, maxSamplesPerFragment)
+            if bytesPerSample > 0 {
+                let availableBytes = max(0, t.count - p)
+                boundedSampleCount = min(boundedSampleCount, availableBytes / bytesPerSample)
+            }
+
             var sizes: [Int] = []
             var durations: [UInt32] = []
-            sizes.reserveCapacity(sampleCount)
-            durations.reserveCapacity(sampleCount)
-            for _ in 0..<sampleCount {
+            sizes.reserveCapacity(boundedSampleCount)
+            durations.reserveCapacity(boundedSampleCount)
+            for _ in 0..<boundedSampleCount {
                 var duration = defaultSampleDuration
                 if hasDuration { if t.count >= p + 4 { duration = beU32(t, p) }; p += 4 }
                 var size = defaultSampleSize


### PR DESCRIPTION
## Summary
- `Fmp4Demuxer.parseTraf` read `trun`'s `sample_count` as a raw 32-bit value (up to ~4.29B) with no validation against the box's actual byte length, then `reserveCapacity`'d and unconditionally appended that many entries to `sizes`/`durations` regardless of whether the per-sample reads were actually in range.
- A malformed/hostile `trun` (corrupt stream, resync-into-garbage, or a hostile/MITM server — go2rtc's live stream is plain HTTP) could claim billions of samples in a 16-byte box and OOM the process.
- Clamped `sampleCount` to `min(sampleCount, (remaining bytes) / bytesPerSample)` when any per-sample field is present, plus an absolute cap of 10,000 samples/fragment (real fragments carry a few hundred at most).

Fixes #335

## Citation verification
Audit citation (`Fmp4Demuxer.swift:385,399-412`, function `parseTraf`) matched exactly against `origin/main` @ `4946497`.

## Test plan
- [ ] Build on a Mac/Xcode, confirm normal playback (live + recorded) is unaffected
- [ ] Feed a synthetic malformed `moof`/`trun` (huge `sample_count`, tiny box) and confirm the demuxer skips/reconnects instead of OOMing

⚠️ Not compiled or tested — iOS has no build host/CI in this environment; needs a Mac/Xcode build + manual exercise before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)