### PR TITLE
fix(ios): hop session-token clear to the main actor on a 401

### DIFF
--- a/apps/ios/Crumb/Networking/CrumbAPI.swift
+++ b/apps/ios/Crumb/Networking/CrumbAPI.swift
@@ -334,7 +334,12 @@ final class CrumbAPI {
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse else { throw APIError.invalidResponse }
         guard (200...299).contains(http.statusCode) else {
-            if http.statusCode == 401 { store.clearSession() }
+            // `imageData` is nonisolated and resumes off the main actor after the
+            // `await` above — `store.clearSession()` synchronously writes
+            // `KeychainStore`'s `@Published var token` (see KeychainStore.swift),
+            // which SwiftUI expects to only ever change on the main thread. Hop
+            // over rather than call it directly from here.
+            if http.statusCode == 401 { Task { @MainActor in self.store.clearSession() } }
             throw APIError.http(statusCode: http.statusCode, data: data)
         }
         return data
@@ -407,8 +412,14 @@ final class CrumbAPI {
             // A runtime 401 means the token expired/was revoked. Drop the session
             // so the app returns to login instead of silently failing every call.
             // (403 is a capability denial, not a session problem — left untouched.)
+            //
+            // `execute` is nonisolated and resumes off the main actor after the
+            // `await` above — `store.clearSession()` synchronously writes
+            // `KeychainStore`'s `@Published var token`, which SwiftUI expects to
+            // only ever change on the main thread (an unsynchronized read/write
+            // race otherwise). Hop over rather than call it directly from here.
             if http.statusCode == 401 {
-                store.clearSession()
+                Task { @MainActor in store.clearSession() }
             }
             throw APIError.http(statusCode: http.statusCode, data: data)
         }


### PR DESCRIPTION
## Summary
- `CrumbAPI.execute`/`imageData` are nonisolated and resume off the main actor after their `await`; on a 401 both called `store.clearSession()` synchronously from that context.
- `clearSession()` → `setToken(nil)` synchronously writes `KeychainStore`'s `@Published var token`, which SwiftUI expects only on the main thread — an unsynchronized read/write race.
- Hopped both call sites through `Task { @MainActor in store.clearSession() }`, the minimal of the two options the audit suggested (the other being annotating `KeychainStore` `@MainActor` and auditing every caller).

Fixes #336

## Citation verification
Both citations (`CrumbAPI.swift:337,410-412`; `KeychainStore.swift:72`) matched exactly against `origin/main` @ `4946497`.

## Test plan
- [ ] Build on a Mac/Xcode
- [ ] Force a 401 (e.g. revoke/expire a token server-side) while mid-request and confirm the app returns to login with no "Publishing changes from background threads" diagnostic

⚠️ Not compiled or tested — iOS has no build host/CI in this environment; needs a Mac/Xcode build + manual exercise before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)