### PR TITLE
fix(ios): stop the live stream controller when PiP closes after detaching

### DIFF
--- a/apps/ios/Crumb/Platform/PictureInPicture.swift
+++ b/apps/ios/Crumb/Platform/PictureInPicture.swift
@@ -111,6 +111,16 @@ final class LivePictureInPicture: NSObject, ObservableObject {
     private var controller: AVPictureInPictureController?
     private let renderingQueue = DispatchQueue(label: "video.crumb.pip.rendering")
 
+    /// Set by `Fmp4VideoView.onDisappear` when its view left the SwiftUI
+    /// hierarchy while PiP was still active (deliberately skipping
+    /// `controller.stop()` so PiP could keep showing the feed). Invoked once,
+    /// when PiP actually stops, so the now-orphaned `Fmp4StreamController` —
+    /// which nothing else can reach to tear down, since it retains itself
+    /// strongly via its own `URLSession(delegate: self)` — finally gets a
+    /// `stop()` call instead of leaking its HTTP stream + demux pipeline for
+    /// the rest of the process's life.
+    var onStoppedWhileDetached: (() -> Void)?
+
     /// Attach to the display layer that's already rendering the live stream
     /// (the same one `Fmp4StreamController.displayLayer` feeds — no separate
     /// decode/pipeline is created for PiP).
@@ -149,7 +159,11 @@ extension LivePictureInPicture: AVPictureInPictureControllerDelegate {
         Task { @MainActor in self.isActive = true }
     }
     nonisolated func pictureInPictureControllerDidStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
-        Task { @MainActor in self.isActive = false }
+        Task { @MainActor in
+            self.isActive = false
+            self.onStoppedWhileDetached?()
+            self.onStoppedWhileDetached = nil
+        }
     }
 }
 

--- a/apps/ios/Crumb/Video/Fmp4/Fmp4Player.swift
+++ b/apps/ios/Crumb/Video/Fmp4/Fmp4Player.swift
@@ -64,6 +64,10 @@ struct Fmp4VideoView: View {
             controller.start(provider: streamProvider)
             #if os(iOS)
             pip?.attach(to: controller.displayLayer)
+            // Clear any teardown registered by a PREVIOUS disappear of this
+            // same `pip` — we're attached and visible again now, so the normal
+            // `onDisappear` logic below governs this session fresh.
+            pip?.onStoppedWhileDetached = nil
             #endif
         }
         .onChange(of: controller.videoSize) { if let s = $0 { onVideoSize?(s) } }
@@ -75,8 +79,20 @@ struct Fmp4VideoView: View {
             // whether PiP should keep the feed alive. `detach()` here just
             // releases OUR reference; if PiP is genuinely still active the
             // system keeps its own strong reference until the user closes it.
-            if pip?.isActive != true { pip?.detach() }
-            if pip?.isActive != true { controller.stop() }
+            if pip?.isActive != true {
+                pip?.detach()
+                controller.stop()
+            } else {
+                // PiP is keeping the stream alive without this view. Once PiP
+                // itself eventually stops (system-closed, or the user swipes it
+                // away) nothing else will ever call `stop()` on `controller` —
+                // `Fmp4StreamController`'s own `URLSession(delegate: self)`
+                // retains it strongly, so it would otherwise leak its HTTP
+                // stream + demux pipeline for the rest of the process's life.
+                // Register a teardown PiP invokes once it actually stops (see
+                // `LivePictureInPicture.onStoppedWhileDetached`).
+                pip?.onStoppedWhileDetached = { [weak controller] in controller?.stop() }
+            }
         }
         #else
         .onDisappear { controller.stop() }


### PR DESCRIPTION
## Summary
- Fullscreen live → PiP → Back → close PiP left nobody holding a reference to call `Fmp4StreamController.stop()`. The view's `onDisappear` correctly skips `stop()` while PiP is active (so PiP keeps showing the feed), but nothing revisits that once the SwiftUI view is gone and PiP later actually stops.
- The controller's own `URLSession(delegate: self)` retains it strongly, so it leaked its HTTP stream + demux pipeline for the rest of the process's life — repeat the flow N times, leak N pipelines.
- `LivePictureInPicture` now exposes `onStoppedWhileDetached`, set by `Fmp4VideoView.onDisappear` only when leaving the hierarchy while PiP is still active, invoked once (and cleared) from the PiP-stopped delegate callback. Cleared again on `onAppear` so a later normal attach/disappear cycle isn't affected by a stale registration.

Fixes #337

## Citation verification
- `Platform/PictureInPicture.swift` is actually at `apps/ios/Crumb/Platform/PictureInPicture.swift` (no `Video/` prefix as originally cited) — content at lines 107-154 matched exactly otherwise.
- `LiveWallView.swift`'s `onBack` is at lines 284-287 (iOS)/371-374 (macOS), not "293-296" as originally cited — content (only clears `selectedCameraId`) matches.
- `Fmp4Player.swift:72-80` matched exactly.

## Test plan
- [ ] Build on a Mac/Xcode
- [ ] Open a camera fullscreen, start PiP, tap Back, close the PiP window, then check (Xcode memory graph / Instruments) that the stream's `URLSession`/demux queue actually tear down instead of continuing to run
- [ ] Repeat several times and confirm no accumulation of live pipelines

⚠️ Not compiled or tested — iOS has no build host/CI in this environment; needs a Mac/Xcode build + manual exercise before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)