### PR TITLE
fix(ios): within-segment seeks and failed media-token mints during playback

### DIFF
--- a/apps/ios/Crumb/Features/Playback/PlaybackView.swift
+++ b/apps/ios/Crumb/Features/Playback/PlaybackView.swift
@@ -106,7 +106,15 @@ struct PlaybackView: View {
         // `cameraId`/`mediaUrls` let the HEVC-retag range-proxy re-mint a fresh
         // scoped media token if this segment plays longer than the token's
         // ~15 min TTL (P0-SESSIONS) — see `SegmentPlayer.feed`.
-        .onChange(of: vm.currentSegmentURL) { url in
+        //
+        // Keyed on `seekGeneration`, not `currentSegmentURL` directly: a scrub
+        // that lands back in the SAME ~4s segment resolves to a byte-identical
+        // (cached-token) URL, and SwiftUI's `onChange` never fires for a value
+        // that didn't change — that made within-segment seeks a silent no-op.
+        // `seekGeneration` bumps on every resolution regardless, so this always
+        // fires; `SegmentPlayer.feed`'s same-URL branch still does the reseek.
+        .onChange(of: vm.seekGeneration) { _ in
+            let url = vm.currentSegmentURL
             player.feed(url: url, offsetMs: vm.segmentOffsetMs, playing: vm.playing && !vm.scrubbing,
                         segmentStartMs: vm.currentSegment.map { Int64((parseISO8601($0.start)?.timeIntervalSince1970 ?? 0) * 1000) } ?? 0,
                         segmentPath: vm.currentSegment?.url, cameraId: vm.cameraId, mediaUrls: vm.mediaUrls())

--- a/apps/ios/Crumb/Features/Playback/PlaybackViewModel.swift
+++ b/apps/ios/Crumb/Features/Playback/PlaybackViewModel.swift
@@ -19,6 +19,13 @@ final class PlaybackViewModel: ObservableObject {
     @Published var playheadMs: Int64 = 0
     @Published var currentSegment: ResolvedSegment?
     @Published var currentSegmentURL: URL?
+    /// Bumped on every `seekTo` resolution (success or failure), even when
+    /// `currentSegmentURL` lands on the SAME URL as before (a scrub that stays
+    /// within the current ~4s segment reuses its cached token/URL). The view's
+    /// `.onChange` keys off this instead of `currentSegmentURL` so a within-
+    /// segment reseek isn't silently dropped — `Equatable`'s `onChange` never
+    /// fires for a value that didn't change.
+    @Published var seekGeneration = 0
     @Published var segmentOffsetMs: Int64 = 0
     @Published var playing = false
     @Published var speed: Float = 1
@@ -246,12 +253,29 @@ final class PlaybackViewModel: ObservableObject {
                 let segment = try await container.api.play(cameraId: cameraId, ts: iso(tsMs))
                 guard !Task.isCancelled else { return }
                 let startMs = parseMs(segment.start)
-                currentSegment = segment
-                currentSegmentURL = await container.mediaUrls().scopedURL(cameraId: cameraId, qualityPath(segment.url))
+                let url = await container.mediaUrls().scopedURL(cameraId: cameraId, qualityPath(segment.url))
                 guard !Task.isCancelled else { return }
+                guard let url else {
+                    // Media-token mint failed (transient — offline blip, session
+                    // hiccup). Treat it like any other seek failure instead of
+                    // leaving `currentSegment` set with a nil URL: that combination
+                    // left playback silently black with no error and no retry,
+                    // because the error/Retry UI below only shows when
+                    // `currentSegment == nil`.
+                    currentSegment = nil
+                    currentSegmentURL = nil
+                    segmentOffsetMs = 0
+                    self.error = "Couldn't load this clip. Check your connection and retry."
+                    noFootageAtPlayhead = false
+                    seekGeneration += 1
+                    return
+                }
+                currentSegment = segment
+                currentSegmentURL = url
                 segmentOffsetMs = max(tsMs - startMs, 0)
                 error = nil
                 noFootageAtPlayhead = false
+                seekGeneration += 1
             } catch {
                 guard !Task.isCancelled else { return }
                 currentSegment = nil
@@ -264,6 +288,7 @@ final class PlaybackViewModel: ObservableObject {
                     self.error = error.userMessage
                     noFootageAtPlayhead = false
                 }
+                seekGeneration += 1
             }
         }
     }

--- a/apps/ios/Crumb/Features/Playback/PlaybackViewModel.swift
+++ b/apps/ios/Crumb/Features/Playback/PlaybackViewModel.swift
@@ -429,9 +429,13 @@ final class PlaybackViewModel: ObservableObject {
         playheadMs = startMs
         error = nil
         noFootageAtPlayhead = false
-        // Setting this re-fires the view's feed(url); the player recognises the
-        // just-advanced URL and no-ops (SegmentPlayer.justAdvanced).
         currentSegmentURL = signal.url
+        // The view now keys the feed on `seekGeneration`, not the URL, so bump it
+        // here so `feed(url)` re-fires: the player recognises the just-advanced URL
+        // and no-ops it, which is what CLEARS `SegmentPlayer.justAdvanced`. Without
+        // this bump the latch stays set, and the first within-segment seek after a
+        // gapless advance is silently swallowed during playback.
+        seekGeneration += 1
         resetPrefetch() // let the NEW current segment queue its own next
     }
 


### PR DESCRIPTION
## Summary
Two related bugs in `PlaybackViewModel.seekTo`, fixed together (same function, tightly related):

- **Within-segment seek is a silent no-op (#338).** A seek landing in the same ~4s segment re-mints a byte-identical (cached-token) `currentSegmentURL`; `PlaybackView`'s `.onChange(of: vm.currentSegmentURL)` never fires on an unchanged value, so `SegmentPlayer.feed`'s same-URL reseek branch was unreachable dead code. Added a `seekGeneration` counter that bumps on every seek resolution (success or failure) regardless of whether the URL changed, and keyed the view's `.onChange` on that instead, reading `vm.currentSegmentURL`'s current value inside the handler.
- **Media-token mint failure leaves playback black with no retry (#342).** If `scopedURL` returned `nil` (transient token-mint blip), `currentSegment` stayed non-nil while `currentSegmentURL` went `nil` and `error` stayed `nil` — the existing error/Retry UI only shows when `currentSegment == nil`, so nothing surfaced and nothing retried. Now a `nil` URL is treated like any other seek failure (clears `currentSegment`, sets a retryable `error`), reusing the existing UI instead of adding a new one.

Fixes #338
Fixes #342

## Citation verification
Both citations matched exactly against `origin/main` @ `4946497` (`PlaybackViewModel.swift:239-269`; `PlaybackView.swift:109-113,896-907`; `MediaUrls.swift:49-56`).

## Test plan
- [ ] Build on a Mac/Xcode
- [ ] Scrub the timeline to a point within the currently-playing ~4s segment and confirm the video actually seeks instead of no-op'ing
- [ ] Simulate a transient media-token failure (e.g. brief network drop during a seek) and confirm an error + Retry button appear instead of a silent black screen

⚠️ Not compiled or tested — iOS has no build host/CI in this environment; needs a Mac/Xcode build + manual exercise before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)