### PR TITLE
fix(ios): stream export downloads to disk instead of buffering in memory

### DIFF
--- a/apps/ios/Crumb/Features/Export/ExportViewModel.swift
+++ b/apps/ios/Crumb/Features/Export/ExportViewModel.swift
@@ -466,8 +466,13 @@ final class ExportViewModel: ObservableObject {
         }
         var req = URLRequest(url: remote)
         req.timeoutInterval = 300   // exports can be large; give the download room
-        let (data, response) = try await URLSession.crumbMedia.data(for: req)
+        // `.download(for:)` streams the response straight to a temp file instead
+        // of buffering it in memory like `.data(for:)` did — a batch export is
+        // routinely hundreds of MB to multi-GB, and holding the whole file as an
+        // in-memory `Data` mid-download was a jetsam risk.
+        let (downloadedURL, response) = try await URLSession.crumbMedia.download(for: req)
         guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            try? FileManager.default.removeItem(at: downloadedURL)
             throw URLError(.badServerResponse)
         }
 
@@ -475,7 +480,7 @@ final class ExportViewModel: ObservableObject {
             .appendingPathComponent("crumb-export-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let localURL = dir.appendingPathComponent(suggestedFilename(for: file))
-        try data.write(to: localURL, options: .atomic)
+        try FileManager.default.moveItem(at: downloadedURL, to: localURL)
         return localURL
     }
 


### PR DESCRIPTION
## Summary
- `ExportViewModel.downloadToTemp` used `URLSession.data(for:)`, which buffers the entire response body in memory before returning it. Export output files (share sheet on iOS, save-panel on macOS) routinely run hundreds of MB to multiple GB for a batch export — a straightforward jetsam risk mid-download.
- Switched to `URLSession.download(for:)`, which streams the response to a temp file; that temp file is then moved into this function's own managed temp directory (replacing the old `data.write(...)`). Same ephemeral `.crumbMedia` session.

Fixes #340

## Citation verification
Citation (`ExportViewModel.swift:463-480`) matched exactly against `origin/main` @ `4946497`.

## Test plan
- [ ] Build on a Mac/Xcode
- [ ] Download a large export output file via the iOS share sheet and the macOS save panel, confirm memory stays flat during download (Instruments) and the resulting local file is byte-identical to before

⚠️ Not compiled or tested — iOS has no build host/CI in this environment; needs a Mac/Xcode build + manual exercise before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)