### PR TITLE
fix(ios): hop HEVC-retag totalSize write to the main actor

### DIFF
--- a/apps/ios/Crumb/Features/Playback/HEVCRetag.swift
+++ b/apps/ios/Crumb/Features/Playback/HEVCRetag.swift
@@ -468,7 +468,13 @@ final class HEVCRetagLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate {
                 }
                 if self.totalSize == nil, let cr = http.value(forHTTPHeaderField: "Content-Range"),
                    let slash = cr.firstIndex(of: "/"), let total = Int(cr[cr.index(after: slash)...]) {
-                    self.totalSize = total
+                    // `totalSize` isn't isolated (this class isn't `@MainActor`),
+                    // and `serveRangeStreamed`'s read of it runs on whatever
+                    // executor the resource-loader delegate callback landed on.
+                    // Hop through `MainActor.run` for the write, same as every
+                    // other mutation of this delegate's state in this file
+                    // (`fetchHeader` above, `proxyTasks[key] = nil` below).
+                    await MainActor.run { self.totalSize = total }
                 }
 
                 var chunk = Data()


### PR DESCRIPTION
## Summary
- `HEVCRetagLoaderDelegate.proxyRange` wrote `self.totalSize` directly from a background `Task` after an `await` — an unsynchronized cross-executor write. Every other mutation of this delegate's state in the same file (`fetchHeader`'s writes, and this same function's own `proxyTasks[key] = nil`) is hopped through `await MainActor.run`; `totalSize` was the one inconsistent case. `serveRangeStreamed` reads it from whatever executor the resource-loader delegate callback lands on, so in the worst case this could produce a wrong `contentLength`.
- Hopped the write through `await MainActor.run`, matching the neighboring pattern.
- The audit also flagged per-byte iteration over `byteStream` (multi-MB `mdat` ranges iterated one `UInt8` at a time) as a CPU cost. That's inherent to `URLSession.AsyncBytes` (`Element == UInt8`) — Foundation has no bulk-read alternative without adding a dependency (e.g. swift-async-algorithms), which is out of scope for a minimal fix per this project's dependency policy (AGENTS.md golden rule 6). Left as-is; noted in issue #343 as a possible follow-up (e.g. a custom `URLSessionDataDelegate`-based reader).

Fixes #343

## Citation verification
Citation (`HEVCRetag.swift:469-472` write vs `399-403` read) matched exactly against `origin/main` @ `4946497`.

## Test plan
- [ ] Build on a Mac/Xcode
- [ ] Play a long recorded segment that outlives the ~15 min media token (forces the retag range-proxy re-mint path) and confirm no incorrect `contentLength`/AVFoundation resource-loader misbehavior

⚠️ Not compiled or tested — iOS has no build host/CI in this environment; needs a Mac/Xcode build + manual exercise before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)