### PR TITLE
fix(ios): don't discard a successful login on a transient /auth/me failure

### DIFF
--- a/apps/ios/Crumb/Features/Auth/AuthViewModel.swift
+++ b/apps/ios/Crumb/Features/Auth/AuthViewModel.swift
@@ -80,11 +80,27 @@ final class AuthViewModel: ObservableObject {
                 remember: rememberMe
             ))
             container.store.setToken(resp.token)
+        } catch {
+            // Only a failure of `login` itself means there's no valid session —
+            // clear the (nonexistent) token so the form stays on the login screen.
+            container.store.setToken(nil)
+            self.error = error.userMessage
+            isLoading = false
+            return
+        }
+
+        do {
+            // A separate `do` block: `login` above already succeeded and the
+            // token is stored, so a failure here must NOT discard that session
+            // (mirrors `AppContainer.validateSession`'s "401 clears, anything
+            // else keeps the user signed in" split). A network blip on this
+            // second call used to log the user right back out immediately
+            // after a successful login. A real 401 here still clears the
+            // session on its own via `CrumbAPI.execute`'s `clearSession()`.
             let me = try await container.api.me()
             container.applyUser(me)
             container.store.username = me.username
         } catch {
-            container.store.setToken(nil)
             self.error = error.userMessage
         }
 


### PR DESCRIPTION
## Summary
- `AuthViewModel.login()` wrapped both the `login` call and the immediate follow-up `me()` call in a single `do`/`catch`, so a purely transient network blip on the *second* call cleared the just-stored token and logged the user right back out of a session that had just succeeded.
- Split into two `do`/`catch` blocks: a `login` failure still clears the token (no session exists yet), but a `me()` failure after a successful `login` only surfaces an error — mirrors `AppContainer.validateSession`'s "401 clears, anything else keeps the user signed in" split. A real 401 from `me()` already clears the session on its own via `CrumbAPI.execute`'s `clearSession()`, so this doesn't weaken that path.

Fixes #341

## Citation verification
Citation (`AuthViewModel.swift:74-89`) matched exactly against `origin/main` @ `4946497`.

## Test plan
- [ ] Build on a Mac/Xcode
- [ ] Log in successfully, then simulate a network blip specifically on the follow-up `/auth/me` call, and confirm the user stays logged in (with an error surfaced) rather than being bounced back to the login screen

⚠️ Not compiled or tested — iOS has no build host/CI in this environment; needs a Mac/Xcode build + manual exercise before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)