### PR TITLE
fix(ios): shield content on .inactive so the app-switcher snapshot can't leak it

### DIFF
--- a/apps/ios/Crumb/App/CrumbApp.swift
+++ b/apps/ios/Crumb/App/CrumbApp.swift
@@ -40,6 +40,15 @@ struct RootView: View {
     /// `BiometricLockView` reports success.
     @State private var isLocked = false
     #if os(iOS)
+    /// Shown (opaque, no re-auth challenge) while the scene is `.inactive` and
+    /// the lock is enabled — purely so the app-switcher snapshot (captured
+    /// around the `.inactive`/`.background` transition, before `.background`
+    /// itself actually fires) can't show live camera content. Distinct from
+    /// `isLocked`: `.inactive` also fires on plenty of harmless momentary
+    /// interruptions (Control Center, an incoming-call banner, a system
+    /// alert) where forcing a full Face ID/passcode challenge every time
+    /// would be obnoxious — this is a passive cover, not a re-auth gate.
+    @State private var privacyShieldVisible = false
     @Environment(\.scenePhase) private var scenePhase
     #endif
 
@@ -58,8 +67,20 @@ struct RootView: View {
             }
             .animation(.easeInOut(duration: 0.3), value: container.isLoggedIn)
 
+            #if os(iOS)
+            if container.isLoggedIn && settings.biometricLockEnabled && privacyShieldVisible && !isLocked {
+                CrumbColors.background.ignoresSafeArea()
+                    .transition(.opacity)
+            }
+            #endif
+
             if container.isLoggedIn && settings.biometricLockEnabled && isLocked {
-                BiometricLockView(onUnlocked: { isLocked = false })
+                BiometricLockView(onUnlocked: {
+                    isLocked = false
+                    #if os(iOS)
+                    privacyShieldVisible = false
+                    #endif
+                })
                     .transition(.opacity)
             }
         }
@@ -80,7 +101,21 @@ struct RootView: View {
         }
         #if os(iOS)
         .onChange(of: scenePhase) { phase in
-            if phase == .background, settings.biometricLockEnabled { isLocked = true }
+            guard settings.biometricLockEnabled else { return }
+            switch phase {
+            case .background:
+                isLocked = true
+                privacyShieldVisible = true
+            case .inactive:
+                // The app-switcher snapshot is captured around this transition
+                // (before `.background` itself fires) — cover the content now,
+                // without forcing the full unlock challenge `.background` does.
+                privacyShieldVisible = true
+            case .active:
+                if !isLocked { privacyShieldVisible = false }
+            @unknown default:
+                break
+            }
         }
         #endif
     }


### PR DESCRIPTION
## Summary
- `RootView` only raised the biometric lock overlay on the `.background` scene-phase transition, but iOS captures the app-switcher snapshot around the `.inactive`/`.background` transition — before `.background` itself fires — so a live camera frame could end up visible in the app switcher despite the lock being enabled.
- Added a separate `privacyShieldVisible` cover shown on `.inactive` (an opaque `CrumbColors.background` fill, no re-auth challenge triggered) so momentary interruptions (Control Center, an incoming-call banner, a system alert) don't force a full Face ID/passcode prompt on every one of them. The existing `.background` handling still promotes to the actual `isLocked`/`BiometricLockView` challenge, unchanged. iOS-only (`#if os(iOS)`), matching the existing scope of this feature.

Fixes #344

## Citation verification
Citation (`CrumbApp.swift:81-85`) matched exactly against `origin/main` @ `4946497`.

## Test plan
- [ ] Build on a Mac/Xcode
- [ ] With the biometric lock enabled, swipe up to the app switcher while a camera is showing live video and confirm the snapshot shows the shield, not the camera frame
- [ ] Confirm a brief Control Center swipe / incoming-call banner does NOT trigger the Face ID/passcode prompt, only an actual background transition does

⚠️ Not compiled or tested — iOS has no build host/CI in this environment; needs a Mac/Xcode build + manual exercise before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)