### PR TITLE
fix(install): secrets-overlay project name, password escaping, env/TZ/DR hygiene

### DIFF
--- a/docker-compose.secrets.example.yml
+++ b/docker-compose.secrets.example.yml
@@ -17,7 +17,13 @@
 # NOTE: empty string env values below are intentional — both the postgres
 # entrypoint and the app's secret reader treat an empty var as "unset" and fall
 # through to the *_FILE source, so there is no "both var and _FILE set" conflict.
-name: crumb
+#
+# IMPORTANT: this overlay must NOT set a top-level `name:` — Compose lets the
+# last file's project name win, so overriding it here would silently re-home the
+# whole stack to a different project on adoption: a brand-new empty Postgres
+# volume, port collisions with the running stack, and an apparent total loss of
+# the segment index. The base file's `name: crumbvms` is inherited; keep it that
+# way so the DB volume (`crumbvms_crumb_pgdata`) stays put.
 
 secrets:
   db_password:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
   postgres:
     image: postgres:16-alpine
     restart: unless-stopped
+    logging: *default-logging
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -181,20 +182,25 @@ services:
       MAINTENANCE_UNTIL: ${MAINTENANCE_UNTIL:-}         # unix seconds; suppress low-disk/offline alerts during planned maintenance
       CAMERA_OFFLINE_BOOT_GRACE_SECS: ${CAMERA_OFFLINE_BOOT_GRACE_SECS:-}   # grace before offline alerts after boot (empty = default 180)
       # Thumbnail cache + pregen tuning (all optional; empty = built-in default). (#229)
+      # NB: THUMB_EXTRACT_TIMEOUT_SECS / _INTERVAL_SECS / _MAX_ATTEMPTS / _MAX_WIDTH
+      # / _MIN_WIDTH / _NEAR_BLACK_LUMA are compile-time consts, NOT env-read — they
+      # are deliberately not forwarded here (forwarding them implied a tunability
+      # that does not exist).
       THUMB_CACHE_DIR: ${THUMB_CACHE_DIR:-}
       THUMB_CACHE_MAX_BYTES: ${THUMB_CACHE_MAX_BYTES:-}
       THUMB_CACHE_TTL_SECONDS: ${THUMB_CACHE_TTL_SECONDS:-}
       THUMB_EXTRACT_MAX_CONCURRENCY: ${THUMB_EXTRACT_MAX_CONCURRENCY:-}
-      THUMB_EXTRACT_TIMEOUT_SECS: ${THUMB_EXTRACT_TIMEOUT_SECS:-}
-      THUMB_INTERVAL_SECS: ${THUMB_INTERVAL_SECS:-}
-      THUMB_MAX_ATTEMPTS: ${THUMB_MAX_ATTEMPTS:-}
-      THUMB_MAX_WIDTH: ${THUMB_MAX_WIDTH:-}
-      THUMB_MIN_WIDTH: ${THUMB_MIN_WIDTH:-}
-      THUMB_NEAR_BLACK_LUMA: ${THUMB_NEAR_BLACK_LUMA:-}
       THUMB_PREGEN_ENABLED: ${THUMB_PREGEN_ENABLED:-}
       THUMB_PREGEN_LOOKBACK_HOURS: ${THUMB_PREGEN_LOOKBACK_HOURS:-}
       THUMB_PREGEN_SCAN_SECS: ${THUMB_PREGEN_SCAN_SECS:-}
       THUMB_PREGEN_WIDTH: ${THUMB_PREGEN_WIDTH:-}
+      # On-demand media caches + mobile/data-saver tuning (all optional; empty =
+      # default). Documented in docs/MOBILE-PERFORMANCE.md — forwarded here so a
+      # value set in .env actually reaches the api (compose only passes listed keys).
+      MOBILE_STREAM_ENABLED: ${MOBILE_STREAM_ENABLED:-}
+      MOBILE_STREAM_WIDTH: ${MOBILE_STREAM_WIDTH:-}
+      SEGMENT_LOW_CACHE_MAX_BYTES: ${SEGMENT_LOW_CACHE_MAX_BYTES:-}
+      EXPORT_CACHE_MAX_BYTES: ${EXPORT_CACHE_MAX_BYTES:-}
       # Behind the bundled Caddy (or any reverse proxy), set TRUST_PROXY=1 so the
       # rate limiter keys on the client IP from X-Forwarded-For instead of the
       # proxy's own address (one bucket for ALL HTTPS users otherwise). Leave
@@ -220,6 +226,7 @@ services:
   caddy:
     image: caddy:2-alpine
     restart: unless-stopped
+    logging: *default-logging
     depends_on:
       - api
     volumes:
@@ -241,6 +248,7 @@ services:
     profiles: ["frigate"]
     image: eclipse-mosquitto:2
     restart: unless-stopped
+    logging: *default-logging
     volumes:
       - ./mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
     ports:

--- a/docs/OPS-BACKUP-RECOVERY.md
+++ b/docs/OPS-BACKUP-RECOVERY.md
@@ -122,13 +122,21 @@ cd /opt/crumb/app
 docker compose stop recorder api
 docker compose stop postgres
 
-# Move the corrupt data volume aside (don't delete until recovery is confirmed).
-docker volume ls | grep crumb_pgdata
-docker volume rename crumb_crumb_pgdata crumb_pgdata_corrupt_$(date +%Y%m%d) 2>/dev/null \
-  || { docker run --rm -v crumb_crumb_pgdata:/from -v crumb_pgdata_corrupt:/to alpine \
-         sh -c 'cp -a /from/. /to/' ; }   # if your docker can't rename volumes, copy then prune
+# Resolve the ACTUAL Postgres data volume name. On a stock install the Compose
+# project is `crumbvms`, so the volume is `crumbvms_crumb_pgdata` — but resolve
+# it rather than hardcode, in case your project name differs.
+PGVOL=$(docker volume ls -q | grep crumb_pgdata | head -1)
+echo "Postgres data volume: $PGVOL"
 
-docker compose up -d postgres             # fresh empty volume → applies db/migrations on init
+# Move the corrupt data volume aside (don't delete until recovery is confirmed).
+docker volume rename "$PGVOL" "${PGVOL}_corrupt_$(date +%Y%m%d)" \
+  || { docker run --rm -v "$PGVOL":/from -v "${PGVOL}_corrupt":/to alpine \
+         sh -c 'cp -a /from/. /to/' && docker volume rm "$PGVOL" ; }
+         # ^ if your Docker can't rename volumes: copy the data aside, then remove
+         #   the original so the next `up -d` recreates it empty.
+
+docker compose up -d postgres             # recreates an empty data volume; api/recorder
+                                          # apply db/migrations on their next boot (NOT postgres initdb)
 scripts/restore-db.sh --yes backups/<most-recent>.sql.gz
 docker compose up -d recorder api         # reconcile re-indexes on-disk segments
 ```

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -84,6 +84,16 @@ if [[ "${PROMPT}" -eq 1 ]]; then
   printf 'Admin password (leave blank to auto-generate): '
   read -rs ADMIN_INPUT; echo
   if [[ -n "${ADMIN_INPUT}" ]]; then
+    # This value is written verbatim into .env, and Docker Compose's dotenv
+    # loader interpolates `$` (it wants `$$`) and treats `#` as an inline comment
+    # — so a password containing these would be silently corrupted before it
+    # reaches the api, and first login would fail with no diagnostic anywhere.
+    # Reject the .env-breaking characters up front; the operator can change the
+    # password to anything in the app after first sign-in.
+    case "${ADMIN_INPUT}" in
+      *'$'*|*'`'*|*'#'*|*'"'*|*"'"*|*'\'*)
+        die "admin password can't contain \$ \` # \" ' or backslash (they corrupt .env parsing). Use other symbols, or set it in the app after first login." ;;
+    esac
     printf 'Confirm admin password: '
     read -rs ADMIN_CONFIRM; echo
     [[ "${ADMIN_INPUT}" == "${ADMIN_CONFIRM}" ]] || die "passwords did not match"

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -374,6 +374,18 @@ impl ApiConfig {
              (openssl rand -hex 32) or let setup-env.sh / the auto-secret bootstrap create it"
         );
 
+        // Same backstop for the go2rtc password. Unlike Postgres (unpublished),
+        // go2rtc's RTSP is LAN-published (0.0.0.0:18554), so the documented
+        // `change-me` placeholder would let any host on the LAN open live camera
+        // streams with a guessable credential. setup-env.sh generates a strong
+        // one; this only fires if someone hand-wrote the placeholder into .env.
+        let go2rtc_pass = require_secret("GO2RTC_PASS")?;
+        anyhow::ensure!(
+            go2rtc_pass != "change-me",
+            "GO2RTC_PASS is the known placeholder value ('change-me'); generate a \
+             real one or let setup-env.sh create it — go2rtc RTSP is LAN-exposed"
+        );
+
         let bind_str = optional_env("API_BIND", "0.0.0.0:8080");
         let bind_addr: SocketAddr = bind_str
             .parse()
@@ -395,7 +407,7 @@ impl ApiConfig {
             crumb_go2rtc_api_base: optional_env("CRUMB_GO2RTC_API_BASE", "http://recorder:1984"),
             crumb_go2rtc_rtsp_base: optional_env("CRUMB_GO2RTC_RTSP_BASE", ""),
             go2rtc_user: require_secret("GO2RTC_USER")?,
-            go2rtc_pass: require_secret("GO2RTC_PASS")?,
+            go2rtc_pass,
             export_dir: optional_env("EXPORT_DIR", "/data/exports"),
             export_ttl_seconds: parse_env("EXPORT_TTL_SECONDS", 86_400_u64)?,
             export_max_concurrent: parse_env("EXPORT_MAX_CONCURRENT", 2usize)?.max(1),

--- a/services/api/src/db_backup.rs
+++ b/services/api/src/db_backup.rs
@@ -33,7 +33,7 @@
 //! ## Schedule
 //!
 //! Daily at `DB_BACKUP_SCHEDULE` (a local wall-clock `HH:MM`, default
-//! `03:15`) in the `TZ` timezone (IANA name, default `America/Los_Angeles`).
+//! `03:15`) in the `TZ` timezone (IANA name, default `UTC` when unset).
 //! Legacy sidecar values are tolerated: `@daily` maps to the default, and a
 //! simple 5-field daily cron (`M H * * *`) is read as `H:M`. On boot, if the
 //! newest dump is missing or older than ~25 h, a catch-up dump runs
@@ -95,20 +95,25 @@ fn env_keep(key: &str, default: usize) -> usize {
     })
 }
 
-/// Timezone the schedule is evaluated in: `TZ` env (IANA name), default
-/// `America/Los_Angeles`. `chrono-tz` embeds the IANA db, so no system tzdata
-/// is needed in the image.
+/// Timezone the schedule is evaluated in: `TZ` env (IANA name), default `UTC`
+/// when unset or unparseable. `chrono-tz` embeds the IANA db, so no system
+/// tzdata is needed in the image.
 ///
 /// `pub(crate)` so `/config/server` can report the same resolved zone to the
 /// console (#237), keeping the displayed schedule TZ in lockstep with the zone
 /// the backup scheduler actually uses.
 pub(crate) fn schedule_tz() -> Tz {
+    // UTC when TZ is unset or unparseable — matches the documented contract in
+    // .env.example ("if unset the default is UTC, NOT any local zone"). In Docker,
+    // compose always injects TZ (default UTC); this fallback only matters on a
+    // bare-metal/systemd deployment with no TZ at all, where a hidden local-zone
+    // default would silently run the nightly backup on the wrong wall clock.
     let Ok(v) = std::env::var("TZ") else {
-        return Tz::America__Los_Angeles;
+        return Tz::UTC;
     };
     v.trim().parse::<Tz>().unwrap_or_else(|_| {
-        tracing::warn!("TZ='{v}' is not a recognized IANA timezone — using America/Los_Angeles");
-        Tz::America__Los_Angeles
+        tracing::warn!("TZ='{v}' is not a recognized IANA timezone — using UTC");
+        Tz::UTC
     })
 }
 

--- a/services/common/src/config.rs
+++ b/services/common/src/config.rs
@@ -107,7 +107,8 @@ pub struct Config {
 
     /// `RECORDER_TZ` — IANA timezone the per-camera archive-schedule cron is
     /// evaluated in, so a "Daily at 02:00" schedule fires at **local** 02:00
-    /// (DST-correct), not 02:00 UTC. Default: `America/Los_Angeles` (never UTC).
+    /// (DST-correct), not 02:00 UTC. Falls back to `TZ`, else `UTC` when neither
+    /// is set (matching the documented .env.example contract).
     pub archive_cron_tz: chrono_tz::Tz,
 
     // ── motion ─────────────────────────────────────────────────────────────
@@ -413,13 +414,11 @@ impl Config {
             archive_storage_name: optional_env("ARCHIVE_STORAGE_NAME", "Bulk-Archive"),
             // RECORDER_TZ wins; otherwise inherit the container's TZ (compose
             // forwards it, and setup-env.sh sets it to the host zone) so a
-            // non-US operator's archive/retention cron matches their wall clock
-            // instead of always running in LA. America/Los_Angeles only if
-            // neither is set (bare-metal with no TZ at all). (#228)
-            archive_cron_tz: parse_tz_env(
-                "RECORDER_TZ",
-                &optional_env("TZ", "America/Los_Angeles"),
-            ),
+            // non-US operator's archive/retention cron matches their wall clock.
+            // UTC only if neither is set (bare-metal with no TZ at all) — matches
+            // the documented .env.example contract ("if unset the default is UTC,
+            // NOT any local zone"). (#228)
+            archive_cron_tz: parse_tz_env("RECORDER_TZ", &optional_env("TZ", "UTC")),
             motion_hwaccel,
             motion_vaapi_device: optional_env("MOTION_VAAPI_DEVICE", "/dev/dri/renderD128"),
             max_gpu_decode_sessions: parse_env("MAX_GPU_DECODE_SESSIONS", 4)?,
@@ -461,7 +460,7 @@ fn require_secret(key: &str) -> Result<String> {
 }
 
 /// Parse an IANA timezone from `key`, falling back to `default` (and to
-/// `America/Los_Angeles` if even that fails to parse).
+/// `UTC` if even that fails to parse).
 ///
 /// The fallback is deliberately non-fatal — a typo'd `RECORDER_TZ` must not
 /// stop the recorder from booting — but it must be LOUD: silently swallowing
@@ -482,7 +481,7 @@ fn parse_tz_env(key: &str, default: &str) -> chrono_tz::Tz {
         Err(_) => {
             let fallback = default
                 .parse::<chrono_tz::Tz>()
-                .unwrap_or(chrono_tz::Tz::America__Los_Angeles);
+                .unwrap_or(chrono_tz::Tz::UTC);
             tracing::error!(
                 "env var '{key}' = '{raw}' is not a valid IANA timezone \
                  (e.g. 'America/Los_Angeles'); falling back to '{fallback}' — \


### PR DESCRIPTION
Fixes the v0.1.1 install/upgrade audit findings. Closes #354, #355, #356.

## #354 (HIGH) — secrets overlay orphaned the DB volume
`docker-compose.secrets.example.yml` set `name: crumb` while the base is `name: crumbvms`. Compose lets the last file's project name win, so adopting the secrets overlay silently re-homed the stack to project `crumb` — a brand-new empty Postgres volume, port collisions, and **apparent total loss of the segment index**. Removed the `name:` (inherits `crumbvms`) + added a guard note. **Verified:** `docker compose -f docker-compose.yml -f docker-compose.secrets.example.yml config` now reports `name: crumbvms`.

## #355 — `setup-env.sh --prompt` password corruption
The `--prompt` admin password was written verbatim into `.env`, where compose's dotenv loader interpolates `$` (wants `$$`) and treats `#` as a comment → a mangled seed password and a silent first-login failure. Now rejects the `.env`-breaking characters (`$ ` `` ` `` ` # " ' \`) with a clear message.

## #356 — hygiene batch
- **DR runbook** (`docs/OPS-BACKUP-RECOVERY.md`) resolves the real pgdata volume name instead of a wrong hardcode, drops the error-suppressing `2>/dev/null`, and fixes a wrong "migrations on postgres init" claim.
- **Compose env drift**: forwards the documented-but-inert `MOBILE_STREAM_*` / `SEGMENT_LOW_CACHE_MAX_BYTES` / `EXPORT_CACHE_MAX_BYTES`; drops six dead `THUMB_*` forwards (compile-time consts).
- **TZ fallback** → UTC (not `America/Los_Angeles`), matching the documented `.env` contract.
- **Secure default**: boot refusal extended to `GO2RTC_PASS == "change-me"` (go2rtc RTSP is LAN-published).
- **Log anchor** added to postgres/caddy/mosquitto.

Deferred: empty `WEBRTC_CANDIDATE` ICE entry (low/plausible, needs go2rtc-version verification).

## Gate
`docker compose config` resolves clean; base+secrets both report `name: crumbvms`; `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace` all green; `setup-env.sh` passes `bash -n` and generates a valid `.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)