### PR TITLE
docs: v0.1.1 presentation hygiene + release-process bump step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,8 @@ runbook is the single source of truth.
   (`apps/desktop` is the retired Tauri client, kept for reference.)
 - **Android** (`apps/android`): Kotlin / Jetpack Compose / Media3, built with
   Gradle (JDK 17, SDK 34).
-- **iOS** (`apps/ios`): Swift; still partial and gated on further work.
+- **iOS** (`apps/ios`): Swift / SwiftUI; built to near-parity, not yet
+  distributable (pre-TestFlight — needs a paid Apple account, see README § License).
 
 Each client's manifests (`Cargo.toml`, `build.gradle.kts`, Swift package files)
 are the authoritative source for toolchain versions and dependencies.

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@
 
 It is a side project. One maintainer, built on my own time, running at home in production
 today: eleven cameras, multiple storage volumes, recording day in and day out for months.
-**It is about 90% of where I want v1 to be, and the next milestone is v0.1.0, the first minor
-release.** The recorder, the Windows desktop client, and the Android app are the polished daily
+**It is about 90% of where I want v1 to be. The first minor release (v0.1.0) shipped in July
+2026, and the work continues toward v1.** The recorder, the Windows desktop client, and the Android app are the polished daily
 drivers. The macOS app works but sits behind Android and Windows until demand says otherwise,
 and the iOS app is built and actively developed but not yet distributable (Apple wants a paid
 developer account, see [License](#license)). Both macOS and iOS get kept up to date, they just
@@ -204,7 +204,7 @@ so if you have thoughts on how it should work,
 
 > [!IMPORTANT]
 > ## Looking for testers
-> **This is the first public release and I genuinely need help testing it.** CrumbVMS runs
+> **Crumb is early public software and I genuinely need help testing it.** CrumbVMS runs
 > clean on my hardware, but that is the whole problem: one person, one set of cameras, one GPU,
 > one disk layout. The only way to learn how it holds up in the real world is to get it onto
 > hardware that is not mine. If you run cameras at home (bonus points for an existing Frigate
@@ -400,7 +400,7 @@ For contributors working in this repo:
 services/   # Rust backend: common (types, DB, migrations), api (axum + web admin at /admin), recorder
 apps/       # desktop-flutter (Flutter + libmpv), android (Kotlin/Compose), ios; desktop = retired Tauri client
 db/         # PostgreSQL migrations; the segment index is the single source of truth
-site/       # crumbvms.com source (static, zero-dep build)
+# (crumbvms.com lives in its own separate repo, not included here — see .gitignore)
 ```
 
 ## The itch this scratches

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,10 +14,6 @@ Instead, **use GitHub private vulnerability reporting**: on the repository, go
 to **Security → Report a vulnerability** and file a private advisory. This keeps
 the report visible only to the maintainer until it's resolved.
 
-> **Maintainer setup:** enable **private vulnerability reporting** in the
-> repository's **Settings → Security** before the first invite goes out, the
-> GitHub advisory path above depends on it.
-
 When you report, please include as much of the following as you can:
 
 - the affected component (server API, recorder, or a specific client);

--- a/docs/CLIENTS.md
+++ b/docs/CLIENTS.md
@@ -1,7 +1,7 @@
 # CrumbVMS clients, install & connect
 
 CrumbVMS's server is the recorder. You watch live, scrub the timeline, and manage
-cameras through a **client**. There are five:
+cameras through a **client**. There are six:
 
 | Client | Platform | Tech | How you get it |
 |---|---|---|---|

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -76,12 +76,22 @@ between releases.
    The repo squash-merges, so this is every merged PR (each subject ends in
    `(#N)`); drop it into the GitHub Release notes / `CHANGELOG.md` alongside the
    curated Added/Changed/Fixed prose.
-3. Tag and push:
+3. **Bump `VERSION` and finalize the `CHANGELOG`** (a small release PR landed on
+   `main` before the tag):
+   - Set the `VERSION` file to the new version. The api `include_str!`s it,
+     reports it as the server version, **and compares it against the latest
+     GitHub release for the update-available check** — skip this and the shipped
+     server self-reports the *previous* version and flags its own release as an
+     available update.
+   - Add a dated `## [X.Y.Z] - <date>` section to `CHANGELOG.md` from the bullets
+     in step 2 (curated), and add/point the `[Unreleased]` compare-link in the
+     footer (`compare/vX.Y.Z...HEAD`).
+4. Tag and push (only after step 3 is on `main`):
    ```bash
    git tag -a v1.2.0 -m "Crumb v1.2.0"
    git push origin v1.2.0
    ```
-4. CI builds `recorder` and `api` and tags them `v1.2.0` (+ short SHA). If a
+5. CI builds `recorder` and `api` and tags them `v1.2.0` (+ short SHA). If a
    registry is configured (below), they're pushed; otherwise they're built and
    validated but not pushed.
 


### PR DESCRIPTION
Fixes #358 — the v0.1.1 README/repo presentation audit's doc findings.

- **README** — milestone reworded (v0.1.0 shipped July 2026, not "the next milestone"); "first public release" softened; the repo map's `site/` entry annotated as a separate repo (it's gitignored, not in this tree).
- **CONTRIBUTING** — iOS reworded from "still partial" to near-parity / pre-TestFlight, matching README + CHANGELOG.
- **SECURITY.md** — dropped a stale "maintainer setup" to-do (private vulnerability reporting is already enabled on the repo).
- **docs/CLIENTS.md** — "There are five" → six (the table lists six).
- **docs/RELEASE.md** — "Cutting a release" now has an explicit **step 3** to bump the `VERSION` file and date the CHANGELOG before tagging. The api `include_str!`s `VERSION`, reports it, and compares it to the latest GitHub release for the update check — so skipping the bump made the shipped server flag *its own release* as an available update.

Also created the `camera-report` issue-template label out-of-band (the template referenced a non-existent label, so one-click camera reports arrived unlabeled).

**Deferred to the release cut:** the CHANGELOG `## [0.1.1]` section + the `VERSION` bump — done at tag time once all v0.1.1 PRs are merged (per the new RELEASE.md step). The v0.1.1 notes will credit the multi-audit Fable program this release came out of.

Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)