### PR TITLE
docs(ops): remove the postgres container before the volume swap in DR recovery

### DIFF
--- a/docs/OPS-BACKUP-RECOVERY.md
+++ b/docs/OPS-BACKUP-RECOVERY.md
@@ -120,7 +120,10 @@ errors; `docker compose logs postgres` shows corruption / WAL errors.
 ```bash
 cd /opt/crumb/app
 docker compose stop recorder api
-docker compose stop postgres
+# Stop AND REMOVE the postgres container. A merely-stopped container still holds a
+# reference to its data volume, which makes the `docker volume rm` in the fallback
+# below fail with "volume is in use". `up -d postgres` recreates the container.
+docker compose rm -sf postgres
 
 # Resolve the ACTUAL Postgres data volume name. On a stock install the Compose
 # project is `crumbvms`, so the volume is `crumbvms_crumb_pgdata` — but resolve


### PR DESCRIPTION
From the v0.1.1 Fable verification pass (install/docs): the disaster-recovery "Postgres corrupt" procedure still couldn't complete on stock Docker.

`docker compose stop postgres` leaves the stopped container **attached to the data volume**, so the fallback's `docker volume rm "$PGVOL"` fails with `volume is in use`. Replaced the stop with **`docker compose rm -sf postgres`** — the volume is then free to move aside / remove, and `up -d postgres` recreates the container.

Completes the DR-runbook fix from #356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)