### PR TITLE
fix(desktop): v0.1.1 verification-pass polish (6 fixes)

### DIFF
--- a/apps/desktop-flutter/lib/api/motion_timeline_api.dart
+++ b/apps/desktop-flutter/lib/api/motion_timeline_api.dart
@@ -206,9 +206,26 @@ extension MotionTimelineApi on CrumbApi {
     int buckets,
   ) async {
     final results = await Future.wait(
-      cameraIds.map(
-        (id) => fetchIntensity(s, id, start, end, buckets: buckets),
-      ),
+      cameraIds.map((id) async {
+        try {
+          return await fetchIntensity(s, id, start, end, buckets: buckets);
+        } catch (_) {
+          // Per-camera failure tolerance (restored — the #271 fallback used a
+          // bare Future.wait, so one transient per-camera error sank the WHOLE
+          // refresh into the error state). Degrade that one camera to a zero
+          // bucket and keep the rest; self-heals on the next idle tick. Only the
+          // old-server (no batch endpoint) path reaches here.
+          final startMs = start.millisecondsSinceEpoch;
+          final endMs = end.millisecondsSinceEpoch;
+          return IntensityBuckets(
+            cameraId: id,
+            startMs: startMs,
+            endMs: endMs,
+            bucketMs: buckets > 0 ? ((endMs - startMs) / buckets).round() : 0,
+            buckets: List<double>.filled(buckets > 0 ? buckets : 0, 0.0),
+          );
+        }
+      }),
     );
     return {for (final r in results) r.cameraId: r};
   }

--- a/apps/desktop-flutter/lib/services/diagnostics_service.dart
+++ b/apps/desktop-flutter/lib/services/diagnostics_service.dart
@@ -182,8 +182,13 @@ class DiagnosticsService extends ChangeNotifier {
     // routinely echo back the full URL being opened. Strip the userinfo
     // regardless of scheme so a restream credential never survives into an
     // exported diagnostics file.
+    // Case-insensitive so `RTSP://`/`HTTP://` are covered, and the userinfo is
+    // matched GREEDILY up to the LAST `@` before the path — so a password that
+    // itself contains `@` (e.g. `user:p@ss@host`) is fully redacted rather than
+    // leaving the trailing `ss@` exposed. `[^/\s]+` stops at the first `/`, so a
+    // later `@` in the path/query (`?email=a@b`) is never mis-swallowed.
     out = out.replaceAllMapped(
-      RegExp(r'([a-z][a-z0-9+.-]*://)[^/@\s]+@'),
+      RegExp(r'([a-z][a-z0-9+.-]*://)[^/\s]+@', caseSensitive: false),
       (m) => '${m[1]}[REDACTED]@',
     );
     return out;

--- a/apps/desktop-flutter/lib/ui/clips/clips_screen.dart
+++ b/apps/desktop-flutter/lib/ui/clips/clips_screen.dart
@@ -920,6 +920,15 @@ class _ClipPlayerState extends State<_ClipPlayer> {
           }
         }
       }
+      // The property loop above awaits; the overlay can be closed (this State
+      // disposed) during that gap. Bail BEFORE wiring listeners / calling
+      // setState on a dead State — and dispose the just-created, never-adopted
+      // player so its native mpv handle doesn't leak (#323). The later
+      // `if (!mounted) return` couldn't help — it sat after the setState.
+      if (!mounted) {
+        player.dispose();
+        return;
+      }
       _playingSub = player.stream.playing.listen((playing) {
         if (playing) _watchdog?.cancel();
       });

--- a/apps/desktop-flutter/lib/ui/plates/plates_screen.dart
+++ b/apps/desktop-flutter/lib/ui/plates/plates_screen.dart
@@ -2289,6 +2289,15 @@ class _PlateClipPlayerState extends State<_PlateClipPlayer> {
           }
         }
       }
+      // The property loop above awaits; the overlay can be closed (this State
+      // disposed) during that gap. Bail BEFORE wiring listeners / calling
+      // setState on a dead State — and dispose the just-created, never-adopted
+      // player so its native mpv handle doesn't leak (#323). The later
+      // `if (!mounted) return` couldn't help — it sat after the setState.
+      if (!mounted) {
+        player.dispose();
+        return;
+      }
       _playingSub = player.stream.playing.listen((playing) {
         if (playing) {
           _everPlayed = true;

--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -1363,7 +1363,13 @@ class _WallTileState extends State<_WallTile> {
     // The first pane to come up becomes the default capture target.
     SnapshotRegistry.instance.register(
       _paneId,
-      SnapshotTarget(player: player, cameraName: widget.camera.name),
+      // Label the snapshot from `_shown` (the just-promoted camera), NOT
+      // `widget.camera` — under a rapid carousel double-flip A->B->C, promoting
+      // B's player while `widget.camera` already reads C would otherwise file a
+      // snapshot of B's footage under C's name (the #321/#330 mislabel class,
+      // via the snapshot path). `_shown` is set to the promoted camera
+      // immediately before this call, and equals `widget.camera` on first load.
+      SnapshotTarget(player: player, cameraName: _shown.name),
     );
     // Register as an audio pane (muted until it becomes the audible pane).
     widget.audio?.registerPane(
@@ -2032,6 +2038,14 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
   VideoController? _controller;
   String? _error;
 
+  /// Generation guard for [_load]. Since #322 the right-click stream-override
+  /// menu can call [_load] again while a prior load is still awaiting
+  /// `cameraStreams`/`open()`; without this, both loads adopt their own
+  /// player+watchdog and the later one overwrites `_player`/`_watchdog`, leaking
+  /// the earlier player's live decoder until app exit. Same pattern as
+  /// `_WallTileState._loadGen`.
+  int _loadGen = 0;
+
   /// True once this pane's own (main-stream) player has decoded a frame —
   /// until then the warm-start controller (if any) covers the wait.
   bool _firstFrame = false;
@@ -2293,6 +2307,11 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
     // listener below and briefly shows the warm-start stand-in (if any) /
     // loading spinner while the new tier buffers — expected for an explicit
     // quality change. No-op on the very first call (_player is still null).
+    //
+    // Supersede any in-flight load (the #322 reload race): a later _load() bumps
+    // this generation, and the earlier call bails after its awaits instead of
+    // adopting a second player + watchdog (which would leak the first).
+    final gen = ++_loadGen;
     final previous = _player;
     if (previous != null) {
       _watchdog?.dispose();
@@ -2313,6 +2332,7 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
         widget.camera.id,
       );
       _streams = streams; // gate the right-click Data-saver item
+      if (gen != _loadGen || !mounted) return; // superseded by a newer _load()
       // Honor an explicit per-camera stream override from the right-click
       // menu (Main/Sub/Data saver) — issue #322, this pane used to ignore
       // `streamPrefs` entirely. `isMaximized: false` here means "don't force
@@ -2373,7 +2393,9 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
         if (h != null && h > 0) _videoH = h;
       });
       await player.open(Media(url));
-      if (!mounted) {
+      if (gen != _loadGen || !mounted) {
+        // A newer _load() superseded us (or the pane unmounted) while opening —
+        // don't adopt, and dispose the player we spawned so it doesn't leak.
         _disposePlayerDetached(player);
         return;
       }
@@ -2430,7 +2452,13 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
         widget.session,
         widget.camera.id,
       );
-      final url = streams.rtspMain ?? streams.preferredForWall;
+      // Honor the same per-camera override _load() uses (issue #322) — otherwise
+      // a stall recovery (camera reboot / go2rtc restart) silently reverts an
+      // explicit Sub/Data-saver choice back to Main until the pane is re-maximized.
+      final prefs = widget.streamPrefs;
+      final url = (prefs != null && prefs.hasOverride(widget.camera.id))
+          ? prefs.liveStreamUrl(widget.camera.id, streams, isMaximized: false)
+          : (streams.rtspMain ?? streams.preferredForWall);
       if (url == null) return;
       await player.open(Media(url));
       _watchdog?.resetBaseline();

--- a/apps/desktop-flutter/test/diagnostics_scrub_test.dart
+++ b/apps/desktop-flutter/test/diagnostics_scrub_test.dart
@@ -44,6 +44,30 @@ void main() {
     expect(out, contains('"username":"admin"'), reason: 'non-secrets survive');
   });
 
+  test('RTSP/URL userinfo credentials are redacted (any case, @ in password)', () {
+    // The load-bearing case: mpv/ffmpeg echo the full go2rtc restream URL, which
+    // embeds user:pass@ — it must never reach the exported log.
+    // ignore: this is a fabricated test credential, not a real one
+    final lower = scrub('Playing: rtsp://cam:s3cret@192.0.2.6:554/stream1'); // gitleaks:allow
+    expect(lower, isNot(contains('s3cret')));
+    expect(lower, contains('rtsp://[REDACTED]@192.0.2.6:554/stream1'));
+
+    // Uppercase scheme is still caught (regex is case-insensitive).
+    final upper = scrub('RTSP://user:pass@host:8554/cam failed'); // gitleaks:allow
+    expect(upper, isNot(contains('pass')));
+    expect(upper, contains('[REDACTED]@host:8554'));
+
+    // A password containing '@' is fully redacted (greedy to the LAST @).
+    final atPw = scrub('open rtsp://user:p@ss@host/stream refused'); // gitleaks:allow
+    expect(atPw, isNot(contains('p@ss')));
+    expect(atPw, isNot(contains('ss@host')));
+    expect(atPw, contains('rtsp://[REDACTED]@host/stream'));
+
+    // No userinfo → nothing redacted; a later '@' in the path/query is not swallowed.
+    const clean = 'GET http://host:8080/media/x.mp4?to=a@b done';
+    expect(scrub(clean), clean);
+  });
+
   test('ordinary log lines pass through untouched', () {
     const line = 'GET /cameras → 200 (41ms)';
     expect(scrub(line), line);


### PR DESCRIPTION
Follow-ups from the v0.1.1 Fable verification of the merged desktop fixes — each was a *partial* fix or a low-severity edge the verification caught. `flutter analyze lib test` clean (0 errors/warnings); the diagnostics scrub test passes including a new userinfo case.

- **maximized `_load` race** — added a `_loadGen` generation guard; the #322 reload path could adopt two players/watchdogs and leak the first's live decoder.
- **snapshot label** — tile `_adopt` now labels from `_shown` (the promoted camera), not `widget.camera`, closing the #321/#330 mislabel via the snapshot path.
- **reconnect override** — maximized `_reconnectStalled` now honors the per-camera stream override (a stall recovery reverted Sub/Data-saver to Main).
- **dispose guard** — clips/plates mounted-check now runs *before* the adopt `setState` (it sat after, so an overlay closed mid-load could throw), disposing the un-adopted player on bail (#323).
- **intensity tolerance** — the per-camera intensity fallback restores per-camera failure tolerance (the #271 bare `Future.wait` sank the whole refresh on one transient error).
- **scrub edges** — the diagnostics userinfo redaction is now case-insensitive and greedy to the last `@` (`RTSP://` and `p@ss`-style passwords were escaping); **adds a test**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)