### PR TITLE
fix(android): v0.1.1 verification-pass polish (CancellationException + backoff clamp)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/data/CrumbRepository.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/CrumbRepository.kt
@@ -26,7 +26,7 @@ import javax.net.ssl.SSLHandshakeException
  * structured concurrency works and no error is shown. Every repository call
  * below wraps a cancellable suspend call, so this is a drop-in replacement.
  */
-private inline fun <T> runCatchingCancellable(block: () -> T): Result<T> =
+internal inline fun <T> runCatchingCancellable(block: () -> T): Result<T> =
     try {
         Result.success(block())
     } catch (e: CancellationException) {

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
@@ -151,7 +151,7 @@ fun LiveFullscreenScreen(
                 val res = repo.haStates().onSuccess { haStates = it }
                 failStreak = if (res.isSuccess) 0 else failStreak + 1
                 kotlinx.coroutines.delay(
-                    if (failStreak == 0) 2000L else (2000L shl (failStreak - 1)).coerceAtMost(30000L),
+                    if (failStreak == 0) 2000L else (2000L shl (failStreak - 1).coerceAtMost(4)).coerceAtMost(30000L),
                 )
             }
         }
@@ -263,7 +263,7 @@ fun LiveFullscreenScreen(
                     motionNow = st.cameras.firstOrNull { it.id == currentCameraId }?.recentMotion == true
                 }
                 failStreak = if (res.isSuccess) 0 else failStreak + 1
-                delay(if (failStreak == 0) 2000L else (2000L shl (failStreak - 1)).coerceAtMost(30000L))
+                delay(if (failStreak == 0) 2000L else (2000L shl (failStreak - 1).coerceAtMost(4)).coerceAtMost(30000L))
             }
         }
     }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackViewModel.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackViewModel.kt
@@ -10,6 +10,7 @@ import video.crumb.app.data.RecordedSpan
 import video.crumb.app.data.ResolvedSegment
 import video.crumb.app.data.CrumbRepository
 import video.crumb.app.data.isNotFound
+import video.crumb.app.data.runCatchingCancellable
 import video.crumb.app.data.toUserMessage
 import video.crumb.app.ui.Time
 import kotlinx.coroutines.Job
@@ -505,7 +506,7 @@ class PlaybackViewModel(
                 // failure (MediaTokenCache) — guard it like every other consumer
                 // (e.g. PlaybackWallScreen, ClipsScreen) so a token error can't
                 // crash the app; treat it as a genuine failure, same as below.
-                runCatching {
+                runCatchingCancellable {
                     repo.mediaUrls().scopedUrl(cameraId, qualityUrl(segment.url))
                 }.onSuccess { authedUrl ->
                     _state.update {
@@ -605,7 +606,7 @@ class PlaybackViewModel(
                 // guard it so a token hiccup during a background prefetch can't
                 // crash the app; dropped silently like every other prefetch
                 // failure below (the STATE_ENDED fallback still covers it).
-                val authedUrl = runCatching {
+                val authedUrl = runCatchingCancellable {
                     repo.mediaUrls().scopedUrl(cameraId, qualityUrl(next.url))
                 }.getOrNull() ?: return@onSuccess
                 _state.update { it.copy(nextSegment = next, nextSegmentUrl = authedUrl) }
@@ -978,7 +979,7 @@ class PlaybackViewModel(
             viewModelScope.launch {
                 // scopedUrl() throws on a media-token fetch failure — guard it like
                 // every other consumer and just drop the frame on failure.
-                val frameUrl = runCatching {
+                val frameUrl = runCatchingCancellable {
                     repo.mediaUrls().scopedUrl(cameraId, nearestFrame.url)
                 }.getOrNull()
                 if (frameUrl != null && _state.value.scrubbing) {
@@ -1043,7 +1044,7 @@ class PlaybackViewModel(
                     // like every other consumer; the scrubber still works without
                     // a filmstrip frame.
                     val frameUrl = nearestFrame?.let {
-                        runCatching { repo.mediaUrls().scopedUrl(cameraId, it.url) }.getOrNull()
+                        runCatchingCancellable { repo.mediaUrls().scopedUrl(cameraId, it.url) }.getOrNull()
                     }
                     _state.update { s ->
                         s.copy(filmstrip = frames, scrubFrameUrl = if (s.scrubbing) frameUrl else s.scrubFrameUrl)


### PR DESCRIPTION
Follow-ups from the v0.1.1 Fable verification of the merged Android fixes.

- **`CancellationException`** — the four `scopedUrl()` guards used plain `runCatching`, which swallows the `CancellationException` thrown when a seek / camera-switch cancels the token fetch mid-flight. So a cancelled seek still ran `.onFailure` (error flash / torn-down player) and the filmstrip path wrote a cancelled job's frames into the *new* camera's state. Switched to the repo's `runCatchingCancellable` (made `internal`), which re-throws `CancellationException` so cancelled work propagates cleanly while real failures still degrade gracefully.
- **backoff overflow** — the exponential poll backoff `2000L shl (failStreak-1)` overflowed to a negative/zero delay after ~54 consecutive failures (a request burst). Clamped the shift exponent at 4 (still reaches the 30 s ceiling). Applied to both the HA-states and motion polls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)