### PR TITLE
fix(api): carry view_plates in media tokens so plate crops load (regression)

### DIFF
--- a/services/api/src/auth.rs
+++ b/services/api/src/auth.rs
@@ -522,6 +522,7 @@ async fn media_token(
         export: user.capabilities.export,
         playback: user.capabilities.playback,
         clips: user.capabilities.clips,
+        view_plates: user.capabilities.view_plates,
         exp: u64::try_from(exp.timestamp()).unwrap_or(0),
         iat: u64::try_from(now.timestamp()).unwrap_or(0),
     };

--- a/services/api/src/auth_mw.rs
+++ b/services/api/src/auth_mw.rs
@@ -527,20 +527,22 @@ fn try_media_token(token: &str, state: &AppState) -> Option<AuthUser> {
 }
 
 /// Reconstruct a media principal's [`Capabilities`] from a decoded
-/// [`MediaClaims`]. `export`/`playback`/`clips` come straight from the token
-/// (the minting user's real capabilities — never widened); every other
-/// capability is denied, because a media token never grants ptz, bookmark,
-/// view-management, or plate access. Pure, so the "no amplification" property
-/// is directly unit-testable.
+/// [`MediaClaims`]. `export`/`playback`/`clips`/`view_plates` come straight from
+/// the token (the minting user's real capabilities — never widened); the rest
+/// (ptz, bookmark, view-management) are always denied, since a media token is
+/// only ever used to fetch media. `view_plates` is carried because plate crops
+/// (`GET /events/{id}/snapshot` crumb-alpr fallback and `GET /plates/{id}/crop`)
+/// require it and clients fetch them with a media token. Pure, so the
+/// "no amplification" property is directly unit-testable.
 fn media_capabilities_from_claims(claims: &MediaClaims) -> Capabilities {
     Capabilities {
         export: claims.export,
         playback: claims.playback,
         clips: claims.clips,
+        view_plates: claims.view_plates,
         ptz: false,
         bookmarks: BookmarkScope::None,
         manage_views: false,
-        view_plates: false,
     }
 }
 
@@ -566,7 +568,8 @@ mod media_cap_tests {
     use super::media_capabilities_from_claims;
     use crate::dto::MediaClaims;
 
-    fn claims(export: bool, playback: bool, clips: bool) -> MediaClaims {
+    #[allow(clippy::fn_params_excessive_bools)] // test helper mirroring the cap flags
+    fn claims(export: bool, playback: bool, clips: bool, view_plates: bool) -> MediaClaims {
         MediaClaims {
             sub: "00000000-0000-0000-0000-000000000000".to_owned(),
             typ: super::MEDIA_TOKEN_TYP.to_owned(),
@@ -574,6 +577,7 @@ mod media_cap_tests {
             export,
             playback,
             clips,
+            view_plates,
             exp: 0,
             iat: 0,
         }
@@ -582,24 +586,25 @@ mod media_cap_tests {
     #[test]
     fn media_token_never_amplifies_capabilities() {
         // Regression guard for the media-token capability-escalation advisory: a
-        // token minted by a viewer WITHOUT export/playback/clips must reconstruct
-        // a principal without them — the token must not restore a capability the
-        // caller's role withheld.
-        let caps = media_capabilities_from_claims(&claims(false, false, false));
+        // token minted by a viewer WITHOUT export/playback/clips/view_plates must
+        // reconstruct a principal without them — the token must not restore a
+        // capability the caller's role withheld.
+        let caps = media_capabilities_from_claims(&claims(false, false, false, false));
         assert!(!caps.export, "no-export token must not grant export");
         assert!(!caps.playback, "no-playback token must not grant playback");
         assert!(!caps.clips, "no-clips token must not grant clips");
+        assert!(!caps.view_plates, "no-view_plates token must not grant it");
         // A media token never carries these regardless of the claim.
         assert!(!caps.ptz);
         assert!(!caps.manage_views);
-        assert!(!caps.view_plates);
     }
 
     #[test]
     fn media_token_preserves_held_capabilities() {
         // A caller who legitimately holds these still gets a working token,
-        // hard-scoped to its one camera by the caller.
-        let caps = media_capabilities_from_claims(&claims(true, true, true));
-        assert!(caps.export && caps.playback && caps.clips);
+        // hard-scoped to its one camera by the caller. view_plates in particular
+        // must survive, or plate crops fetched with the token render blank.
+        let caps = media_capabilities_from_claims(&claims(true, true, true, true));
+        assert!(caps.export && caps.playback && caps.clips && caps.view_plates);
     }
 }

--- a/services/api/src/dto.rs
+++ b/services/api/src/dto.rs
@@ -110,6 +110,12 @@ pub struct MediaClaims {
     pub playback: bool,
     /// The minting user's `clips` capability.
     pub clips: bool,
+    /// The minting user's `view_plates` capability. Carried because the plate
+    /// crop served by `GET /events/{id}/snapshot` (the crumb-alpr stored-crop
+    /// fallback) and `GET /plates/{id}/crop` both require it, and clients fetch
+    /// those with a scoped media token; without carrying it, an authorized
+    /// user's token gets 403 and plate crops render blank.
+    pub view_plates: bool,
     /// Expiry — Unix timestamp (seconds). Short (~15 min; see auth.rs).
     pub exp: u64,
     /// Issued-at — Unix timestamp.

--- a/services/api/tests/auth_rbac.rs
+++ b/services/api/tests/auth_rbac.rs
@@ -962,6 +962,139 @@ async fn camera_frame_route_rejects_full_jwt_but_accepts_scoped_token() {
     assert_ne!(scoped.status(), StatusCode::FORBIDDEN);
 }
 
+// ─── crumb-alpr plate crop via scoped media token (regression: #364) ──────────
+//
+// The Android / desktop / iOS clients render a license-plate crop with an
+// `<img>`-style request to GET /events/{id}/snapshot carrying a *scoped media
+// token* (`?token=`), never the bearer JWT — an image request can't set an
+// Authorization header. That snapshot route falls back to the linked
+// plate_read's stored `crop` bytes (the crumb-alpr external-engine path) and
+// gates that fallback behind the `view_plates` capability.
+//
+// Regression #364 (media tokens hard-coded `view_plates=false`): every
+// crumb-alpr crop came back 403 through the media-token path and rendered as a
+// black tile on the clients — even for a viewer who DID hold `view_plates`.
+// iPhone was unaffected only because it happened to still hold a pre-regression
+// token. These two tests pin the contract end to end: mint a REAL media token
+// and prove the crop is served (200) when the minter holds `view_plates`, and
+// refused (403) when it does not — so the capability can never again be dropped
+// silently on the mint→reconstruct round-trip.
+
+/// Insert a crumb-alpr event with a NULL `snapshot_url` (so `get_event_snapshot`
+/// takes the crop-fallback branch, not the Frigate proxy path) linked to a
+/// `plate_reads` row carrying `crop` bytes. Returns the event id.
+async fn seed_alpr_crop_event(app: &TestApp, camera_id: Uuid, crop: &[u8]) -> Uuid {
+    let now = Utc::now();
+    let event_id: Uuid = {
+        let client = app.pool().get().await.expect("pool.get (alpr event)");
+        client
+            .query_one(
+                "INSERT INTO events (camera_id, ts, label, score, thumb_path, snapshot_url)
+                 VALUES ($1, $2, 'car', 0.9, NULL, NULL) RETURNING id",
+                &[&camera_id, &now],
+            )
+            .await
+            .expect("insert crumb-alpr event")
+            .get("id")
+    };
+
+    crumb_common::db::upsert_plate_read(
+        app.pool(),
+        &crumb_common::db::UpsertPlateReadParams {
+            camera_id,
+            ts: now,
+            plate: crumb_common::db::normalize_plate("ALPR123"),
+            plate_raw: Some("ALPR123".to_owned()),
+            confidence: Some(0.95),
+            source_id: "crumb-alpr".to_owned(),
+            provider_event_id: Some(format!("alpr-{event_id}")),
+            event_id: Some(event_id),
+            snapshot_url: None,
+            bbox: None,
+            crop: Some(crop.to_vec()),
+            raw: serde_json::json!({}),
+        },
+    )
+    .await
+    .expect("seed crumb-alpr plate_read");
+
+    event_id
+}
+
+/// Seed a viewer whose role lacks `view_plates` (but is otherwise a normal
+/// playback viewer) granted the given cameras.
+async fn seed_viewer_no_plates(pool: &deadpool_postgres::Pool, cameras: &[Uuid]) -> SeededUser {
+    use crumb_common::types::{BookmarkScope, Capabilities};
+    let caps = Capabilities {
+        export: false,
+        playback: true,
+        clips: true,
+        ptz: false,
+        bookmarks: BookmarkScope::Own,
+        manage_views: true,
+        view_plates: false,
+    };
+    let role = crumb_common::db::create_role(pool, &unique("noplates-role"), &caps, cameras)
+        .await
+        .expect("create_role (no view_plates)");
+    seed_viewer_user(pool, role.id).await
+}
+
+#[tokio::test]
+async fn crumb_alpr_crop_served_via_media_token_when_view_plates_held() {
+    let app = TestApp::new().await;
+    let cam = seed_camera(app.pool()).await;
+
+    // JPEG SOI + APP0 marker bytes; the handler serves these verbatim.
+    let crop = vec![0xFFu8, 0xD8, 0xFF, 0xE0, 0x00, 0x10];
+    let event_id = seed_alpr_crop_event(&app, cam, &crop).await;
+
+    // seed_viewer grants view_plates, so the minted media token must carry it.
+    let viewer = seed_viewer(app.pool(), &[cam]).await;
+    let token = login(&app, &viewer.username, &viewer.password).await;
+    let media = mint_media_token(&app, &token, cam).await;
+
+    let resp = app
+        .send(get(&format!("/events/{event_id}/snapshot?token={media}")))
+        .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "a media token minted by a view_plates holder must serve the crumb-alpr crop \
+         (regression #364: it used to 403 because the token dropped view_plates)"
+    );
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(
+        bytes.as_ref(),
+        crop.as_slice(),
+        "the served body must be the stored crop bytes, unmodified"
+    );
+}
+
+#[tokio::test]
+async fn crumb_alpr_crop_refused_via_media_token_without_view_plates() {
+    let app = TestApp::new().await;
+    let cam = seed_camera(app.pool()).await;
+
+    let crop = vec![0xFFu8, 0xD8, 0xFF, 0xE0];
+    let event_id = seed_alpr_crop_event(&app, cam, &crop).await;
+
+    // Viewer WITHOUT view_plates → the media token must not carry it, so the
+    // crop fallback stays gated (the token can't amplify past its minter).
+    let viewer = seed_viewer_no_plates(app.pool(), &[cam]).await;
+    let token = login(&app, &viewer.username, &viewer.password).await;
+    let media = mint_media_token(&app, &token, cam).await;
+
+    let resp = app
+        .send(get(&format!("/events/{event_id}/snapshot?token={media}")))
+        .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a media token minted without view_plates must NOT unlock the crumb-alpr crop"
+    );
+}
+
 // ─── revocable sessions (P0-SESSIONS) ──────────────────────────────────────────
 
 /// Read the caller's session list and return the jti flagged `is_current`.


### PR DESCRIPTION
Fixes #364. Regression from the v0.1.1 deploy (interaction of #326 + #333), caught live on prod.

`#333` made the crumb-alpr plate-crop path (`GET /events/{id}/snapshot` fallback and `GET /plates/{id}/crop`) require `view_plates`. `#326` reconstructs media tokens with `view_plates: false` hardcoded. Clients fetch crops with a **scoped media token** (Android `MediaUrls.authedScoped(cameraId, "/events/{eventId}/snapshot")`), so those requests now 403 and the crop renders black.

Confirmed on prod: crumb-alpr reads (stored crop) show black, frigate reads (snapshot proxy, no gate) render, iOS is fine (bearer token has `view_plates`).

**Fix:** carry the minter's real `view_plates` into the media token, exactly like `export`/`playback`/`clips`. No amplification (it is the minter's own capability), and the crop path stays gated. Unit test updated to assert `view_plates` is carried and still never amplified.

Gate: `cargo fmt`/`clippy`/`test --workspace` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)