### PR TITLE
fix(api): v0.1.1 cross-boundary audit batch (clips total, live cap, plate-clip cap, long-GOP intensity)

### DIFF
--- a/services/api/src/auth_mw.rs
+++ b/services/api/src/auth_mw.rs
@@ -182,6 +182,17 @@ impl AuthUser {
     pub fn require_clips(&self) -> Result<(), ApiError> {
         Self::require(self.can_clips(), "viewing clips")
     }
+    /// Authorize a detection/plate (`d:`) clip. Those clips are played from the
+    /// Plates tab, which is revealed by `view_plates`, so either capability is
+    /// sufficient — otherwise a `{view_plates, clips:false}` role sees a working
+    /// Plates tab whose every Play 403s. Motion (`m:`) clips still require
+    /// `clips`. (#370)
+    pub fn require_clips_or_view_plates(&self) -> Result<(), ApiError> {
+        Self::require(
+            self.can_clips() || self.can_view_plates(),
+            "viewing clips",
+        )
+    }
     pub fn require_ptz(&self) -> Result<(), ApiError> {
         Self::require(self.can_ptz(), "PTZ control")
     }

--- a/services/api/src/auth_mw.rs
+++ b/services/api/src/auth_mw.rs
@@ -188,10 +188,7 @@ impl AuthUser {
     /// Plates tab whose every Play 403s. Motion (`m:`) clips still require
     /// `clips`. (#370)
     pub fn require_clips_or_view_plates(&self) -> Result<(), ApiError> {
-        Self::require(
-            self.can_clips() || self.can_view_plates(),
-            "viewing clips",
-        )
+        Self::require(self.can_clips() || self.can_view_plates(), "viewing clips")
     }
     pub fn require_ptz(&self) -> Result<(), ApiError> {
         Self::require(self.can_ptz(), "PTZ control")

--- a/services/api/src/clips.rs
+++ b/services/api/src/clips.rs
@@ -192,6 +192,10 @@ async fn get_clips(
         .collect();
 
     let mut clips: Vec<ClipDescriptor> = Vec::new();
+    // Full-window count of detection events (the DB COUNT, independent of the
+    // page `limit`), so the response `total` is the honest window total rather
+    // than the returned page size. (#368)
+    let mut det_total: usize = 0;
 
     // ── Detections (events table; source = per-camera resolved) ──
     if want_det {
@@ -203,9 +207,10 @@ async fn get_clips(
             limit,
             offset: 0,
         };
-        let (rows, _total) = db::list_detection_events(state.pool(), &dq)
+        let (rows, total_det) = db::list_detection_events(state.pool(), &dq)
             .await
             .map_err(ApiError::Internal)?;
+        det_total = total_det.max(0) as usize;
         for r in rows {
             // Motion-labelled detection events duplicate the segment-derived motion
             // clips below — skip them so the feed isn't double-counted.
@@ -244,6 +249,11 @@ async fn get_clips(
             });
         }
     }
+
+    // Detection clips actually pushed (page-limited, minus the motion-labelled
+    // duplicates skipped above); the gap between this and `det_total` is what the
+    // clients page toward by growing their limit.
+    let det_pushed = clips.len();
 
     // ── Motion (contiguous has_motion segment runs; always Crumb own-footage) ──
     if want_mot {
@@ -287,7 +297,19 @@ async fn get_clips(
         }
     }
 
-    // Newest first, capped.
+    // Motion runs are gathered unbounded, so their count is exact.
+    let motion_count = clips.len() - det_pushed;
+
+    // Honest full-window total, so a client gating a "Load more (N of M)"
+    // affordance on `returned < total` (growing its `limit`, offset 0) knows more
+    // exist. Previously `total` was computed AFTER the truncate below and so
+    // always equalled the returned page size, making "Load more" dead. `det_total`
+    // is the DB COUNT of detection events; it includes the motion-labelled events
+    // skipped above as motion-clip duplicates, so `total` can read a hair high
+    // when a source emits them — never low, so it never hides clips. (#368)
+    let total = det_total + motion_count;
+
+    // Newest first, then cap to the requested page.
     clips.sort_by_key(|c| std::cmp::Reverse(c.start_ts));
     clips.truncate(limit as usize);
 
@@ -307,7 +329,6 @@ async fn get_clips(
         .await
         .map_err(ApiError::Internal)?;
 
-    let total = clips.len();
     Ok(Json(ClipsResponse {
         clips,
         total,
@@ -608,7 +629,14 @@ async fn get_clip_media(
     Query(mq): Query<MediaQuery>,
     req: Request,
 ) -> Result<Response, ApiError> {
-    user.require_clips()?;
+    // `d:` = detection/plate clips (played from the Plates tab, gated on
+    // view_plates); authorize by clips OR view_plates. `m:` motion clips still
+    // require clips. (#370)
+    if id.starts_with("d:") {
+        user.require_clips_or_view_plates()?;
+    } else {
+        user.require_clips()?;
+    }
     let rc = resolve_clip(&state, &id).await?;
     // Camera-access denial is 403 (Forbidden), matching playback.rs / events.rs —
     // NOT 404. `resolve_clip` above already 404s a genuinely missing clip; once it
@@ -796,7 +824,13 @@ async fn get_clip_thumbnail(
     Path(id): Path<String>,
     headers: HeaderMap,
 ) -> Result<Response, ApiError> {
-    user.require_clips()?;
+    // See get_clip_media: `d:` plate/detection clips accept clips OR
+    // view_plates; `m:` motion clips require clips. (#370)
+    if id.starts_with("d:") {
+        user.require_clips_or_view_plates()?;
+    } else {
+        user.require_clips()?;
+    }
     let rc = resolve_clip(&state, &id).await?;
     let (cam, start, end) = (rc.camera_id, rc.start, rc.end);
     // Camera-access denial is 403 (Forbidden), matching playback.rs / events.rs —

--- a/services/api/src/playback.rs
+++ b/services/api/src/playback.rs
@@ -141,7 +141,12 @@ async fn live_stream_mp4(
     AxumPath(camera_id): AxumPath<Uuid>,
     Query(q): Query<LiveStreamQuery>,
 ) -> Result<Response, ApiError> {
-    user.require_playback()?;
+    // Live viewing is an any-viewer surface, camera-scope only — it is NOT the
+    // recorded-`playback` capability (which gates `play`/`serve_segment`/etc).
+    // The sibling live route `live_webrtc` is likewise camera-scope only; this
+    // MSE path must match it, or a role with `playback:false` (a supported
+    // "recorded-footage-only" config) 403s on iOS/macOS live while the WebRTC
+    // and RTSP clients keep working. (#369)
     user.assert_camera_access(camera_id)?;
 
     let cam = db::get_camera(state.pool(), camera_id)

--- a/services/api/tests/auth_rbac.rs
+++ b/services/api/tests/auth_rbac.rs
@@ -1714,3 +1714,136 @@ async fn bookmark_viewall_sees_all_but_manages_only_own() {
     let resp = app.send(delete(&viewers_bookmark, &viewer_token)).await;
     assert_eq!(resp.status(), StatusCode::NO_CONTENT);
 }
+
+// ─── capability unmasking after #326/#365 (media tokens carry real caps) ──────
+//
+// Once media tokens carry the minter's REAL capabilities (not a hardcoded full
+// set), two routes revealed latent over-gating:
+//   #369: live is an any-viewer surface — a role with playback:false must still
+//         reach live fMP4, matching its WebRTC/RTSP siblings, even though the
+//         recorded-playback routes are correctly gated.
+//   #370: plate/detection (`d:`) clips are played from the Plates tab, which is
+//         revealed by view_plates, so view_plates alone must authorize them.
+
+fn mk_caps(playback: bool, clips: bool, view_plates: bool) -> crumb_common::types::Capabilities {
+    crumb_common::types::Capabilities {
+        export: false,
+        playback,
+        clips,
+        ptz: false,
+        bookmarks: crumb_common::types::BookmarkScope::Own,
+        manage_views: false,
+        view_plates,
+    }
+}
+
+async fn seed_viewer_caps(
+    app: &TestApp,
+    cams: &[Uuid],
+    capabilities: crumb_common::types::Capabilities,
+) -> SeededUser {
+    let role = crumb_common::db::create_role(app.pool(), &unique("caps-role"), &capabilities, cams)
+        .await
+        .expect("create_role (caps)");
+    seed_viewer_user(app.pool(), role.id).await
+}
+
+#[tokio::test]
+async fn live_fmp4_allows_role_without_playback_capability() {
+    let app = TestApp::new().await;
+    let cam = seed_camera(app.pool()).await;
+    // A "recorded-footage-only" role: playback:false. Live must still work.
+    let user = seed_viewer_caps(&app, &[cam], mk_caps(false, false, false)).await;
+    let token = login(&app, &user.username, &user.password).await;
+
+    // Live fMP4: the cap gate must NOT 403. (go2rtc is unreachable in tests, so
+    // any non-403/401 status proves the capability gate let the request through.)
+    let resp = app
+        .send(get_auth(&format!("/live/{cam}/stream.mp4"), &token))
+        .await;
+    assert_ne!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "live fMP4 must not require the recorded-playback capability (#369)"
+    );
+    assert_ne!(resp.status(), StatusCode::UNAUTHORIZED);
+
+    // Contrast: a RECORDED route still requires playback → 403.
+    let resp = app
+        .send(get_auth(&format!("/cameras/{cam}/motion-grid"), &token))
+        .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "recorded playback routes must still enforce the playback capability"
+    );
+}
+
+#[tokio::test]
+async fn plate_clip_authorized_by_view_plates_without_clips_capability() {
+    let app = TestApp::new().await;
+    let cam = seed_camera(app.pool()).await;
+    let event = seed_event(app.pool(), cam).await;
+    let clip_id = format!("d:{event}");
+
+    // {view_plates:true, clips:false} — the Plates-tab role. Must pass the clip
+    // cap gate (media serving then fails on absent footage, but never with 403).
+    let vp = seed_viewer_caps(&app, &[cam], mk_caps(false, false, true)).await;
+    let vp_token = login(&app, &vp.username, &vp.password).await;
+    let resp = app
+        .send(get_auth(&format!("/clip/{clip_id}/clip.mp4"), &vp_token))
+        .await;
+    assert_ne!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "view_plates must authorize a `d:` clip even without the clips capability (#370)"
+    );
+
+    // {clips:false, view_plates:false} — neither → the cap gate 403s.
+    let none = seed_viewer_caps(&app, &[cam], mk_caps(false, false, false)).await;
+    let none_token = login(&app, &none.username, &none.password).await;
+    let resp = app
+        .send(get_auth(&format!("/clip/{clip_id}/clip.mp4"), &none_token))
+        .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a role with neither clips nor view_plates must be refused the clip"
+    );
+}
+
+#[tokio::test]
+async fn clips_total_reflects_window_not_page_size() {
+    // #368: `total` must be the full-window count so a client's "Load more"
+    // (grow-the-limit) affordance knows more exist. Before the fix it was
+    // computed after truncation and always equalled the returned page size.
+    let app = TestApp::new().await;
+    let cam = seed_camera(app.pool()).await;
+    for _ in 0..3 {
+        seed_event(app.pool(), cam).await; // label 'person' → 3 detection clips
+    }
+    let admin = seed_admin(app.pool()).await;
+    let token = login(&app, &admin.username, &admin.password).await;
+
+    let now = Utc::now();
+    let start = (now - chrono::Duration::hours(1)).format("%Y-%m-%dT%H:%M:%SZ");
+    let end = (now + chrono::Duration::hours(1)).format("%Y-%m-%dT%H:%M:%SZ");
+    let resp = app
+        .send(get_auth(
+            &format!("/clips?camera_ids={cam}&start={start}&end={end}&type=detection&limit=1"),
+            &token,
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert_eq!(
+        v["clips"].as_array().unwrap().len(),
+        1,
+        "the page must honor limit=1"
+    );
+    assert_eq!(
+        v["total"].as_i64().unwrap(),
+        3,
+        "total must reflect the full window (3), not the returned page size (#368)"
+    );
+}

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -515,12 +515,22 @@ fn camera_from_row(row: &tokio_postgres::Row) -> Result<Camera> {
 /// Upper bound on a single segment's wall-clock duration, used as the sargable
 /// lower-bound offset in time-window queries (`start_ts >= start - MAX_SEGMENT_LEN`).
 ///
-/// The recorder caps `SEGMENT_SECONDS` at 6s; we use 2× that (12s) so even a
-/// boundary-straddling segment (or a slightly long final segment recovered at
-/// shutdown) is always captured. Over-estimating only widens the index range
-/// scan slightly; under-estimating would drop a real overlapping segment, so we
-/// err generous.
-pub const MAX_SEGMENT_LEN: chrono::Duration = chrono::Duration::seconds(12);
+/// `SEGMENT_SECONDS` (2..=6s) is only the *timer target*. Because the recorder
+/// muxes with `-c copy -f segment`, a segment can only be cut on a keyframe, so
+/// its real wall-clock length tracks the camera's GOP, not the timer. On a
+/// smart-codec / long-GOP camera (Hikvision/Dahua "H.264+/H.265+") a segment can
+/// legitimately run far longer than a few seconds; the recorder tolerates up to
+/// `MAX_SEGMENT_RECEIPT_TIMEOUT_SECS` (3600s, in `recorder::recording`) before it
+/// treats the stream as stalled. This bound MUST match that ceiling: at 12s (the
+/// old 2×`SEGMENT_SECONDS` value) a long segment that starts more than 12s before
+/// a query window but overlaps into it was silently dropped, so the motion-
+/// intensity ribbon and the playback timeline showed a false gap at the window's
+/// left edge on exactly the long-GOP cameras the recorder engineers for. Over-
+/// estimating only widens the index range-scan (still sargable, still an index
+/// range on `start_ts`, just up to an hour of lookback); under-estimating drops a
+/// real overlapping segment, so we pin it to the recorder's own tolerance. Keep
+/// in sync with `MAX_SEGMENT_RECEIPT_TIMEOUT_SECS`. (#372)
+pub const MAX_SEGMENT_LEN: chrono::Duration = chrono::Duration::seconds(3600);
 
 /// Default page size for the keyset-paginated reconcile boot load
 /// ([`list_segments_after`]). Each page is one round-trip; 10k rows is a few MB
@@ -13334,12 +13344,13 @@ mod tests {
         let (start, end) = (sec(0), sec(100));
 
         // A: starts 5s BEFORE the window and overlaps into it ([-5s, +5s), 0.8).
-        //    5s < MAX_SEGMENT_LEN (12s), so the lower bound must keep it.
+        //    5s < MAX_SEGMENT_LEN, so the lower bound must keep it.
         insert_scored_segment(&pool, camera_id, storage_id, sec(-5), sec(5), 0.8).await;
         // B: fully inside, mid-window ([50s, 56s), 0.5).
         insert_scored_segment(&pool, camera_id, storage_id, sec(50), sec(56), 0.5).await;
-        // C: an hour before the window, no overlap — must never leak in.
-        insert_scored_segment(&pool, camera_id, storage_id, sec(-3600), sec(-3595), 0.9).await;
+        // C: two hours before the window (outside even the 3600s bound), no
+        //    overlap — must never leak in.
+        insert_scored_segment(&pool, camera_id, storage_id, sec(-7200), sec(-7195), 0.9).await;
 
         let buckets = motion_intensity_buckets(&pool, camera_id, start, end, 100)
             .await
@@ -13361,6 +13372,56 @@ mod tests {
             "mid-window segment must land in bucket 50 (got {})",
             buckets[50]
         );
+    }
+
+    /// Regression (#372): a long-GOP camera legitimately persists segments far
+    /// longer than the old 12s bound (the recorder tolerates up to 3600s with
+    /// `-c copy`). A segment that starts well before the window but overlaps into
+    /// it MUST still be bucketed; the old `start - 12s` lower bound dropped it,
+    /// showing a false gap at the window's left edge. This pins the widened bound.
+    #[tokio::test]
+    async fn motion_intensity_keeps_long_gop_overhang_segment() {
+        let Some(url) = test_db_url() else {
+            eprintln!("skipping: TEST_DATABASE_URL not set");
+            return;
+        };
+        let pool = migrated_public_pool(&url).await;
+        let policy_id = insert_nondefault_policy(&pool).await;
+        let camera_id = seed_camera_for_test(&pool, policy_id).await;
+        let storage_name = format!("test-storage-{}", Uuid::new_v4().simple());
+        let storage_id = create_storage(&pool, &storage_name, "/does/not/matter", None, None)
+            .await
+            .expect("create_storage")
+            .id;
+
+        let base = Utc
+            .timestamp_millis_opt(1_700_000_000_000)
+            .single()
+            .unwrap();
+        let sec = |n: i64| base + chrono::Duration::seconds(n);
+        // Window [base, base+100s); n=100 → one bucket per second.
+        let (start, end) = (sec(0), sec(100));
+
+        // A long-GOP segment: starts 300s before the window (>> the old 12s
+        // bound) and runs to +10s, overlapping the window start. The old bound
+        // would drop it; the widened bound must keep it so bucket 0 carries 0.7.
+        insert_scored_segment(&pool, camera_id, storage_id, sec(-300), sec(10), 0.7).await;
+
+        let buckets = motion_intensity_buckets(&pool, camera_id, start, end, 100)
+            .await
+            .expect("motion_intensity_buckets");
+        assert_eq!(buckets.len(), 100);
+        assert!(
+            (buckets[0] - 0.7).abs() < 1e-6,
+            "long-GOP overhang segment must land in bucket 0 (got {})",
+            buckets[0]
+        );
+        assert!(
+            (buckets[9] - 0.7).abs() < 1e-6,
+            "long-GOP overhang segment spans through bucket 9 (got {})",
+            buckets[9]
+        );
+        assert_eq!(buckets[20], 0.0, "no score after the overhang segment ends");
     }
 
     /// The batched `motion_intensity_buckets_multi` must return, for every


### PR DESCRIPTION
Server-side batch from the v0.1.1 multi-agent cross-boundary audit. Four confirmed defects, grouped because they share one Rust gate (one build/test host). Each has a regression test; full workspace gate is green (fmt, clippy `-D warnings`, `cargo test --workspace`).

## Fixes

- **#368** clips `total` computed after truncation → dead "Load more". Now counts the full window (detection `COUNT(*)` + unbounded motion runs) before the page cap. Test: `clips_total_reflects_window_not_page_size`.
- **#369** live fMP4 required the recorded `playback` capability while WebRTC/RTSP siblings are camera-scope only → a `playback:false` role lost iOS/macOS live. Gate dropped to match siblings. Test: `live_fmp4_allows_role_without_playback_capability` (also asserts recorded routes still enforce `playback`).
- **#370** plate/detection `d:` clips required `clips`, but the Plates tab is revealed by `view_plates` → a `{view_plates, clips:false}` role's Plays all 403'd. Now `clips OR view_plates` for `d:` clips; `m:` motion clips still require `clips`. Test: `plate_clip_authorized_by_view_plates_without_clips_capability`.
- **#372** the 12s motion-intensity/timeline sargable bound dropped long-GOP segments (with `-c copy`, segment length tracks GOP; recorder tolerates 3600s), showing a false gap at each window's left edge. Widened `MAX_SEGMENT_LEN` to the recorder's own tolerance. Test: `motion_intensity_keeps_long_gop_overhang_segment`.

## Notes

- **#370 depends on #365**: the server now accepts `view_plates` for `d:` clips, but the *media-token* path only carries `view_plates` once #365 lands. Bearer already carries it (tested here). Merge #365 first (or alongside).
- **#369 / #370** are latent bugs unmasked by the caps-in-token design (#326/#365), not caused by it. They only bite custom limited roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
