### PR TITLE
fix(android): grey HA badges after 2 missed polls (client-side staleness)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaBadgeOverlay.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaBadgeOverlay.kt
@@ -266,6 +266,10 @@ fun HaBadgeOverlayLayer(
     videoWidth: Int,
     videoHeight: Int,
     modifier: Modifier = Modifier,
+    // Client-observed staleness (>= 2 missed `/ha/states` polls). ORed with the
+    // server's own `stale` flag so a badge greys when EITHER Crumb->HA or
+    // phone->Crumb has gone quiet. (#371)
+    clientStale: Boolean = false,
     onBadgeTap: (HaLinkDto) -> Unit,
 ) {
     if (videoWidth <= 0 || videoHeight <= 0) return
@@ -290,7 +294,7 @@ fun HaBadgeOverlayLayer(
             val (bw, bh) = badgeSize(link, ps)
             val x = (fx + (link.overlayX ?: 0.0).toFloat() * fw).coerceIn(fx, (fx + fw - bw).coerceAtLeast(fx))
             val y = (fy + (link.overlayY ?: 0.0).toFloat() * fh).coerceIn(fy, (fy + fh - bh).coerceAtLeast(fy))
-            HaBadge(link, states, x, y, bw, bh, onBadgeTap)
+            HaBadge(link, states, clientStale, x, y, bw, bh, onBadgeTap)
         }
     }
 }
@@ -299,6 +303,7 @@ fun HaBadgeOverlayLayer(
 private fun HaBadge(
     link: HaLinkDto,
     states: HaStatesResponse?,
+    clientStale: Boolean,
     xDp: Float,
     yDp: Float,
     wDp: Float,
@@ -306,7 +311,8 @@ private fun HaBadge(
     onTap: (HaLinkDto) -> Unit,
 ) {
     val st = states?.stateFor(link.entityId)
-    val stale = states?.stale == true
+    // Stale when the server says so OR this client has missed >= 2 polls (#371).
+    val stale = states?.stale == true || clientStale
     val visual = badgeVisual(link, st?.state, stale)
     val bg = parseHexColor(link.overlayBgColor) ?: BadgeDefaultBg
     val opacity = (link.overlayOpacity?.toFloat() ?: 1f).coerceIn(0.05f, 1f)

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
@@ -143,19 +143,29 @@ fun LiveFullscreenScreen(
     // Gate on lifecycle so it doesn't poll while backgrounded, and back off under
     // failure (matches the motion poll below).
     val haHasPlaced = haLinks.any { it.hasPlacement }
+    // Client-side staleness. The server `stale` flag only reflects Crumb->HA
+    // reachability; it says nothing about whether THIS phone is still reaching
+    // Crumb. If the phone loses the Crumb API (Wi-Fi drop, server restart) while
+    // go2rtc video keeps playing, the last-known HA states would otherwise keep
+    // rendering as live security state (e.g. a door "Closed") indefinitely. Count
+    // consecutive `/ha/states` misses and, at >= 2, treat the badges as stale --
+    // matching desktop (`live_status_controller.haStale`) and iOS
+    // (`HomeAssistant` missStreak >= 2). (#371)
+    var haMissStreak by remember { mutableStateOf(0) }
     LaunchedEffect(currentCameraId, haHasPlaced, haSheetOpen) {
         if (!haHasPlaced && !haSheetOpen) return@LaunchedEffect
         lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-            var failStreak = 0
             while (true) {
                 val res = repo.haStates().onSuccess { haStates = it }
-                failStreak = if (res.isSuccess) 0 else failStreak + 1
+                haMissStreak = if (res.isSuccess) 0 else haMissStreak + 1
                 kotlinx.coroutines.delay(
-                    if (failStreak == 0) 2000L else (2000L shl (failStreak - 1).coerceAtMost(4)).coerceAtMost(30000L),
+                    if (haMissStreak == 0) 2000L else (2000L shl (haMissStreak - 1).coerceAtMost(4)).coerceAtMost(30000L),
                 )
             }
         }
     }
+    // Server-reported OR client-observed staleness (>= 2 missed polls).
+    val haStale = haStates?.stale == true || haMissStreak >= 2
     // Decoded video pixel size (for contain-fit badge placement) and the current
     // digital-zoom scale (badges hide while zoomed — they'd misalign, matching
     // the desktop `hideBadges: scale > 1.01` rule). Both feed HaBadgeOverlayLayer.
@@ -608,6 +618,7 @@ fun LiveFullscreenScreen(
             HaBadgeOverlayLayer(
                 links = haLinks,
                 states = haStates,
+                clientStale = haStale,
                 videoWidth = videoSize.width,
                 videoHeight = videoSize.height,
                 onBadgeTap = { haBadgeSelected = it },


### PR DESCRIPTION
Fixes the Android HA-badge staleness divergence (#371) from the v0.1.1 cross-boundary audit.

The server `stale` flag on `/ha/states` only reflects Crumb->HA reachability; it says nothing about whether the phone still reaches Crumb. When the phone lost the Crumb API (Wi-Fi drop, server restart) while go2rtc video kept playing, the Android live view kept rendering last-known HA states ("Closed", "Clear") as live security state indefinitely, while desktop and iOS grey their badges after 2 missed polls. For a security product, showing stale physical-security state as current is the concern.

## Change

- `LiveFullscreenScreen.kt`: track consecutive `/ha/states` misses in the poller and derive `haStale = states.stale || missStreak >= 2`, passed into the overlay.
- `HaBadgeOverlay.kt`: `HaBadgeOverlayLayer`/`HaBadge` take a `clientStale` flag and OR it with the server `stale` flag, so a badge greys when EITHER Crumb->HA or phone->Crumb has gone quiet.

Mirrors desktop `live_status_controller.haStale` and iOS `HomeAssistant` `missStreak >= 2`.

## Verification

Android `assembleDebug` on the SDK host: BUILD SUCCESSFUL (only pre-existing deprecation warnings). No Compose/HA test precedent in the Android suite; the staleness logic mirrors the already-tested desktop/iOS equivalents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
