### PR TITLE
fix(ios): batch the timeline-intensity fan-out (429 storm at 100+ cameras)

### DIFF
--- a/apps/ios/Crumb/Features/Playback/PlaybackViewModel.swift
+++ b/apps/ios/Crumb/Features/Playback/PlaybackViewModel.swift
@@ -205,23 +205,58 @@ final class PlaybackViewModel: ObservableObject {
         }
     }
 
+    /// Must match the server's `MAX_INTENSITY_BATCH` (services/api/src/timeline.rs):
+    /// the batch route 400s above this many camera ids, so we chunk. (#373)
+    private static let maxIntensityBatch = 64
+
     private func loadIntensity(_ startMs: Int64, _ endMs: Int64) async {
         let ids = timelineCameraIds.isEmpty ? [cameraId] : timelineCameraIds
         let startISO = iso(startMs), endISO = iso(endMs)
-        // Fan out one per-camera intensity request (the endpoint is single-camera),
-        // in parallel: each Task inherits the main actor, and its await frees the
-        // actor so the requests overlap — no off-actor / Sendable captures.
-        let handles: [(String, Task<[Float]?, Never>)] = ids.map { id in
-            (id, Task {
-                (try? await self.container.api.timelineIntensity(
-                    cameraId: id, start: startISO, end: endISO, buckets: self.motionBucketsCount))?.buckets
-            })
+
+        // Use the batch endpoint: one request per <=64-camera chunk instead of one
+        // request per camera. The old per-camera fan-out issued N requests into the
+        // shared rate limiter on every scrub re-center, so a large wall 429'd and
+        // dropped motion bars. Falls back to the per-camera route on 404 (a server
+        // predating the batch endpoint) or 400. (#373)
+        var byId: [String: [Float]] = [:]
+        var batchUnsupported = false
+        var i = 0
+        while i < ids.count {
+            let chunk = Array(ids[i ..< min(i + Self.maxIntensityBatch, ids.count)])
+            i += Self.maxIntensityBatch
+            do {
+                let resp = try await container.api.timelineIntensityBatch(
+                    cameraIds: chunk, start: startISO, end: endISO, buckets: motionBucketsCount)
+                for (id, buckets) in resp.cameras { byId[id] = buckets }
+            } catch APIError.http(let statusCode, _) where statusCode == 404 || statusCode == 400 {
+                batchUnsupported = true
+                break
+            } catch {
+                // Transient failure for this chunk: leave its cameras zeroed (matches
+                // the old per-camera `try?` behavior); the next scrub retries.
+            }
         }
-        var result: [(id: String, buckets: [Float])] = []
-        for (id, handle) in handles {
-            if let buckets = await handle.value { result.append((id: id, buckets: buckets)) }
+
+        if batchUnsupported {
+            // Pre-batch server: fall back to the per-camera fan-out. Each Task
+            // inherits the main actor and frees it on await, so requests overlap.
+            let handles: [(String, Task<[Float]?, Never>)] = ids.map { id in
+                (id, Task {
+                    (try? await self.container.api.timelineIntensity(
+                        cameraId: id, start: startISO, end: endISO, buckets: self.motionBucketsCount))?.buckets
+                })
+            }
+            byId = [:]
+            for (id, handle) in handles {
+                if let buckets = await handle.value { byId[id] = buckets }
+            }
         }
+
         guard !Task.isCancelled else { return }
+        // Preserve the requested order (the server's map is unordered).
+        let result: [(id: String, buckets: [Float])] = ids.compactMap { id in
+            byId[id].map { (id: id, buckets: $0) }
+        }
         motionByCamera = result
         motionBuckets = result.first(where: { $0.id == cameraId })?.buckets ?? result.first?.buckets ?? []
         motionStartMs = startMs

--- a/apps/ios/Crumb/Models/Models.swift
+++ b/apps/ios/Crumb/Models/Models.swift
@@ -282,6 +282,20 @@ struct IntensityResponse: Decodable {
     enum CodingKeys: String, CodingKey { case buckets }
 }
 
+/// Batched motion intensity: `GET /timeline/intensity/batch` returns one bucket
+/// array per requested camera, keyed by camera id. Every requested camera is
+/// present (all-zeros for one with no footage or outside the caller's scope).
+struct IntensityBatchResponse: Decodable {
+    let cameras: [String: [Float]]
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        cameras = try c.decodeIfPresent([String: [Float]].self, forKey: .cameras) ?? [:]
+    }
+
+    enum CodingKeys: String, CodingKey { case cameras }
+}
+
 // MARK: - Playback
 
 struct ResolvedSegment: Decodable {

--- a/apps/ios/Crumb/Networking/CrumbAPI.swift
+++ b/apps/ios/Crumb/Networking/CrumbAPI.swift
@@ -71,6 +71,19 @@ final class CrumbAPI {
         ])
     }
 
+    /// Batched form of `timelineIntensity`: one request for up to
+    /// `MAX_INTENSITY_BATCH` (64) cameras instead of one per camera. The server
+    /// 400s above that cap, so callers must chunk. Returns a map keyed by camera
+    /// id (all-zeros for cameras with no footage or outside scope).
+    func timelineIntensityBatch(cameraIds: [String], start: String, end: String, buckets: Int = 240) async throws -> IntensityBatchResponse {
+        try await get("timeline/intensity/batch", query: [
+            "camera_ids": cameraIds.joined(separator: ","),
+            "start": start,
+            "end": end,
+            "buckets": "\(buckets)",
+        ])
+    }
+
     // MARK: - Playback
 
     func play(cameraId: String, ts: String, stream: String = "main") async throws -> ResolvedSegment {


### PR DESCRIPTION
Fixes the iOS timeline fan-out 429 storm (#373) from the v0.1.1 cross-boundary audit.

The playback timeline fanned out one `GET /timeline/intensity` per camera in the wall on every scrub re-center. At ~100+ cameras that floods the shared rate limiter (240 burst / 4 per second over JSON routes), so intensity requests `429` and silently vanish (missing motion bars) and a spans/events request caught in the drained bucket surfaces a visible playback error. Desktop already uses the batch endpoint; iOS was the only client still fanning out. (Concurrency-capping alone would not help: 100 requests at 4/sec sustained is still ~25s.)

## Change

- `Models.swift`: `IntensityBatchResponse` (`{ cameras: [id: [Float]] }`).
- `CrumbAPI.swift`: `timelineIntensityBatch(cameraIds:start:end:buckets:)`.
- `PlaybackViewModel.swift`: `loadIntensity` now requests in <=64-camera chunks (matching the server `MAX_INTENSITY_BATCH`) and merges, falling back to the per-camera route on `404` (a server predating the batch endpoint) or `400`. A 100-camera wall now issues 2 requests instead of 100.

Pairs with #367 (desktop chunking) and the server cap.

## Verification

macmini (Xcode 26.6): `Crumb` (iOS) and `Crumb-mac` (macOS) both `** BUILD SUCCEEDED **`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
