### PR TITLE
feat(api): admin-only scrubbed diagnostics bundle (server side of #180)

### DIFF
--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -1034,6 +1034,34 @@ async function api(path, opts = {}) {
   return res.status === 204 ? null : res.json();
 }
 
+/* Download the admin-only scrubbed diagnostics bundle (GET /diagnostics/bundle).
+   A file download, so it can't use api() (which parses JSON); fetch the blob and
+   click a synthetic <a download>. The server has already redacted secrets. */
+async function downloadDiagnostics() {
+  setMsg('diag-msg', 'Preparing…');
+  try {
+    const res = await fetch('/diagnostics/bundle', { headers: { Authorization: 'Bearer ' + TOKEN } });
+    if (res.status === 401) { logout(); return; }
+    if (!res.ok) {
+      let m = res.statusText;
+      try { const j = await res.json(); m = j.message || j.error || m; } catch {}
+      throw new Error(m);
+    }
+    const blob = await res.blob();
+    const cd = res.headers.get('Content-Disposition') || '';
+    const match = cd.match(/filename="?([^"]+)"?/);
+    const name = (match && match[1]) || 'crumb-diagnostics.json';
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = name;
+    document.body.appendChild(a); a.click(); a.remove();
+    URL.revokeObjectURL(url);
+    setMsg('diag-msg', 'Downloaded ' + name);
+  } catch (e) {
+    setMsg('diag-msg', 'Failed: ' + e.message);
+  }
+}
+
 /* ── Scoped media tokens for camera snapshots (audit 2026-07-05 #2) ──
    A per-camera short-lived (~15 min) token from GET /media-token, cached here
    and used as ?token= on /cameras/{id}/frame.jpg, instead of putting the full
@@ -6570,6 +6598,16 @@ async function renderDetectionClips() {
         <span id="srv-frigate-test" style="margin-left:8px;font-size:12px;line-height:1.6"></span>
       </div>
       <div id="srv-frigate-msg" class="form-msg"></div>
+    </div>
+
+    <!-- Support diagnostics: admin-only scrubbed snapshot download (issue #180). -->
+    <div class="rp-section-head" style="margin-top:22px">
+      <div class="policy-section-title" style="margin-bottom:0">Diagnostics <span style="font-weight:400;color:var(--dim2);text-transform:none;letter-spacing:0">— support bundle</span></div>
+      <button class="primary sm" onclick="downloadDiagnostics()">Download bundle</button>
+    </div>
+    <div class="policy-section" style="margin-top:10px">
+      <div class="card-hint" style="margin:-2px 0 10px 2px">A scrubbed snapshot of this server's version, effective config, key environment, and schema state — for handing to the maintainer when something is wrong server-side. Secrets (tokens, passwords, URL credentials) are redacted before download; footage and live logs are never included.</div>
+      <div id="diag-msg" class="form-msg"></div>
     </div>
 
     <!-- ── MOTION DECODING (hwaccel), detection compute, not networking (S4) ── -->

--- a/services/api/src/diagnostics.rs
+++ b/services/api/src/diagnostics.rs
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Admin-only diagnostics bundle: a scrubbed, downloadable snapshot of the
+//! server's version, effective config, key environment, and schema state, so a
+//! maintainer can triage a tester's server-side issue without a shell on the box.
+//!
+//! Secure by default: the route is admin-only, and EVERYTHING it emits is run
+//! through [`redact`] before it leaves the box (a recursive pass that masks any
+//! value under a secret-shaped key AND any URL userinfo). A leak would require
+//! both an unexpected field name and a non-URL secret shape.
+//!
+//! Out of scope for now (issue #180): live logs and runtime health. Logs are
+//! stdout-only, so shipping them needs an in-process ring buffer (and the
+//! recorder's logs live in a separate process); that is a follow-up.
+
+use axum::{
+    extract::State,
+    http::header,
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use serde_json::{json, Value};
+
+use crate::auth_mw::AdminUser;
+use crate::error::ApiError;
+use crate::state::AppState;
+use crumb_common::db;
+
+// Version stamps, mirrored from `main.rs` via the same `include_str!`/`option_env!`
+// so this module stays self-contained (the test harness re-includes it into a
+// crate that has no `crate::VERSION`). Paths resolve relative to THIS file.
+const VERSION: &str = include_str!("../../../VERSION");
+const GIT_SHA: Option<&str> = option_env!("CRUMB_GIT_SHA");
+const BUILD_TIME: Option<&str> = option_env!("CRUMB_BUILD_TIME");
+
+/// Mount the diagnostics routes onto the root router.
+pub fn routes() -> Router<AppState> {
+    Router::new().route("/diagnostics/bundle", get(diagnostics_bundle))
+}
+
+/// `GET /diagnostics/bundle` — admin only. Returns a scrubbed JSON diagnostics
+/// snapshot as a file attachment.
+async fn diagnostics_bundle(
+    _admin: AdminUser,
+    State(state): State<AppState>,
+) -> Result<Response, ApiError> {
+    let pool = state.pool();
+
+    // Effective server settings (DB row; absent on a brand-new pre-wizard install).
+    let config = match db::get_server_settings(pool)
+        .await
+        .map_err(ApiError::Internal)?
+    {
+        Some(s) => serde_json::to_value(&s).unwrap_or(Value::Null),
+        None => Value::Null,
+    };
+
+    // Applied schema migrations — tells whether the DB is at the expected version.
+    // Non-fatal if the table is unreadable (report "unknown" rather than 500).
+    let database = match db::list_applied_migrations(pool).await {
+        Ok(rows) => {
+            let latest: Vec<String> = rows
+                .iter()
+                .rev()
+                .take(5)
+                .map(|(filename, _)| filename.clone())
+                .collect();
+            json!({
+                "applied_migration_count": rows.len(),
+                "latest_migrations": latest,
+            })
+        }
+        Err(_) => json!({ "applied_migration_count": null, "latest_migrations": [] }),
+    };
+
+    let mut bundle = json!({
+        "generated_at": chrono::Utc::now().to_rfc3339(),
+        "version": {
+            "service": "crumb-api",
+            "version": VERSION.trim(),
+            "git_sha": GIT_SHA.unwrap_or("unknown"),
+            "built_at": BUILD_TIME.unwrap_or("unknown"),
+        },
+        "config": config,
+        "env": safe_env(),
+        "database": database,
+        "notes": "Redacted: values under secret-shaped keys and any URL credentials. \
+                  Live logs and runtime health are not yet included (issue #180).",
+    });
+
+    // Belt-and-suspenders: scrub the ENTIRE bundle before it leaves the box.
+    redact(&mut bundle);
+
+    let body = serde_json::to_vec_pretty(&bundle).map_err(|e| ApiError::Internal(e.into()))?;
+    let ts = chrono::Utc::now().format("%Y%m%d-%H%M%S");
+    let filename = format!("crumb-diagnostics-{ts}.json");
+    Ok((
+        [
+            (header::CONTENT_TYPE, "application/json".to_owned()),
+            (
+                header::CONTENT_DISPOSITION,
+                format!("attachment; filename=\"{filename}\""),
+            ),
+        ],
+        body,
+    )
+        .into_response())
+}
+
+/// A curated, NON-secret subset of the environment. Deliberately a whitelist:
+/// never dump `std::env::vars()`, which would sweep up `DATABASE_URL`, the seed
+/// admin password hash, and any tokens. [`redact`] still runs over the result as
+/// a backstop.
+fn safe_env() -> Value {
+    const SAFE_KEYS: &[&str] = &[
+        "LOG_FORMAT",
+        "LOG_LEVEL",
+        "RUST_LOG",
+        "TZ",
+        "CRUMB_VERSION",
+        "CRUMB_IMAGE_PREFIX",
+        "MOTION_HWACCEL",
+        "SEGMENT_SECONDS",
+    ];
+    let mut map = serde_json::Map::new();
+    for key in SAFE_KEYS {
+        if let Ok(value) = std::env::var(key) {
+            map.insert((*key).to_owned(), Value::String(value));
+        }
+    }
+    Value::Object(map)
+}
+
+// ── redaction ────────────────────────────────────────────────────────────────
+
+/// Recursively scrub a JSON value in place: any value under a secret-shaped key
+/// (see [`is_secret_key`]) becomes `"***REDACTED***"`, and any string carrying
+/// URL userinfo (`scheme://user:pass@host`) has that userinfo masked. Two
+/// independent nets so a leak needs both a surprising field name and a non-URL
+/// secret shape.
+pub(crate) fn redact(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            for (key, val) in map.iter_mut() {
+                if is_secret_key(key) {
+                    *val = Value::String("***REDACTED***".to_owned());
+                } else {
+                    redact(val);
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items.iter_mut() {
+                redact(item);
+            }
+        }
+        Value::String(s) => {
+            if let Some(masked) = mask_url_userinfo(s) {
+                *s = masked;
+            }
+        }
+        _ => {}
+    }
+}
+
+/// A key whose value must never be emitted.
+fn is_secret_key(key: &str) -> bool {
+    let k = key.to_ascii_lowercase();
+    [
+        "token",
+        "password",
+        "passwd",
+        "secret",
+        "hash",
+        "apikey",
+        "api_key",
+        "credential",
+        "private",
+    ]
+    .iter()
+    .any(|needle| k.contains(needle))
+}
+
+/// If `s` contains a `scheme://userinfo@host...` URL, return it with the userinfo
+/// masked (`scheme://***@host...`); otherwise `None`. Dependency-free: no regex,
+/// so it never pulls a crate in for one pattern.
+fn mask_url_userinfo(s: &str) -> Option<String> {
+    let scheme_end = s.find("://")?;
+    // The bit before "://" must look like a URL scheme (letters/digits/+-.).
+    let scheme = &s[..scheme_end];
+    if scheme.is_empty()
+        || !scheme
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'))
+    {
+        return None;
+    }
+    let after_scheme = scheme_end + 3;
+    let rest = &s[after_scheme..];
+    // Authority ends at the first '/', '?', or '#'.
+    let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    let authority = &rest[..authority_end];
+    // No '@' in the authority => no userinfo to mask.
+    let at = authority.find('@')?;
+    // Rebuild: "<scheme>://" + "***@" + "<host + remainder>".
+    Some(format!("{}***@{}", &s[..after_scheme], &rest[at + 1..]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_secret_shaped_keys_anywhere_in_the_tree() {
+        let mut v = json!({
+            "version": "0.1.1",
+            "config": {
+                "frigate_api_base": "http://frigate:1984",
+                "ha_token": "super-secret-token",
+                "nested": { "password": "hunter2", "note": "keep" }
+            },
+            "list": [ { "api_key": "abc123" } ]
+        });
+        redact(&mut v);
+        assert_eq!(v["version"], "0.1.1");
+        assert_eq!(v["config"]["frigate_api_base"], "http://frigate:1984");
+        assert_eq!(v["config"]["ha_token"], "***REDACTED***");
+        assert_eq!(v["config"]["nested"]["password"], "***REDACTED***");
+        assert_eq!(v["config"]["nested"]["note"], "keep");
+        assert_eq!(v["list"][0]["api_key"], "***REDACTED***");
+    }
+
+    #[test]
+    fn masks_url_userinfo_but_keeps_the_host() {
+        // Documentation-range address, not a real camera (gitleaks:allow).
+        let masked = mask_url_userinfo("rtsp://admin:p%40ss@192.0.2.10:554/Streaming").unwrap();
+        assert_eq!(masked, "rtsp://***@192.0.2.10:554/Streaming");
+        // No userinfo => untouched.
+        assert!(mask_url_userinfo("http://frigate:1984/api").is_none());
+        // Not a URL => untouched.
+        assert!(mask_url_userinfo("just a plain string").is_none());
+        // '@' only in the path, not the authority => untouched.
+        assert!(mask_url_userinfo("https://host/path@thing").is_none());
+    }
+
+    #[test]
+    fn redact_masks_credential_urls_in_string_values() {
+        // A URL sitting under a NON-secret key must still have creds masked.
+        let mut v = json!({ "source_url": "rtsp://u:pw@192.0.2.10/s" }); // gitleaks:allow
+        redact(&mut v);
+        assert_eq!(v["source_url"], "rtsp://***@192.0.2.10/s");
+    }
+}

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -83,6 +83,7 @@ mod db_backup;
 mod detection;
 #[cfg(feature = "detection")]
 mod detection_ingester;
+mod diagnostics;
 mod discover;
 mod dto;
 mod error;
@@ -477,6 +478,7 @@ async fn main() -> anyhow::Result<()> {
         .merge(bookmarks::routes())
         .merge(timeline::routes())
         .merge(status::routes())
+        .merge(diagnostics::routes())
         .merge(stats::routes())
         .merge(ptz::routes())
         // Detection events list (authenticated, subject to rate-limit + gzip).

--- a/services/api/tests/auth_rbac.rs
+++ b/services/api/tests/auth_rbac.rs
@@ -1980,3 +1980,43 @@ async fn clips_total_reflects_window_not_page_size() {
         "total must reflect the full window (3), not the returned page size (#368)"
     );
 }
+
+// ─── diagnostics bundle (#180): admin-only, downloadable, scrubbed ────────────
+
+#[tokio::test]
+async fn diagnostics_bundle_is_admin_only_and_downloads() {
+    let app = TestApp::new().await;
+    let admin = seed_admin(app.pool()).await;
+    let admin_token = login(&app, &admin.username, &admin.password).await;
+
+    // Admin: 200, downloads as an attachment, parseable JSON with a version block.
+    let resp = app
+        .send(get_auth("/diagnostics/bundle", &admin_token))
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let cd = resp
+        .headers()
+        .get("content-disposition")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_owned();
+    assert!(
+        cd.contains("attachment") && cd.contains("crumb-diagnostics"),
+        "diagnostics bundle must download as an attachment (got {cd:?})"
+    );
+    let v = body_json(resp).await;
+    assert_eq!(v["version"]["service"], "crumb-api");
+    assert!(
+        v["database"].is_object(),
+        "bundle carries a database section"
+    );
+
+    // Viewer (authenticated non-admin): 403.
+    let cam = seed_camera(app.pool()).await;
+    let viewer = seed_viewer(app.pool(), &[cam]).await;
+    let viewer_token = login(&app, &viewer.username, &viewer.password).await;
+    let resp = app
+        .send(get_auth("/diagnostics/bundle", &viewer_token))
+        .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}

--- a/services/api/tests/support/mod.rs
+++ b/services/api/tests/support/mod.rs
@@ -57,6 +57,8 @@ pub mod config;
 pub mod config_routes;
 #[path = "../../src/db_backup.rs"]
 pub mod db_backup;
+#[path = "../../src/diagnostics.rs"]
+pub mod diagnostics;
 #[path = "../../src/discover.rs"]
 pub mod discover;
 #[path = "../../src/dto.rs"]
@@ -375,6 +377,7 @@ pub fn test_router() -> Router<AppState> {
         .merge(bookmarks::routes())
         .merge(timeline::routes())
         .merge(status::routes())
+        .merge(diagnostics::routes())
         .merge(stats::routes())
         .merge(stats::heavy_routes())
         .merge(ptz::routes())

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -9856,6 +9856,33 @@ pub async fn set_system_alert_quiet_hours(
     Ok(())
 }
 
+/// List the migrations recorded as applied in `schema_migrations`, oldest first.
+/// Read-only; used by the admin diagnostics bundle to report schema state.
+///
+/// # Errors
+///
+/// Returns an error if the query fails (e.g. the table does not exist on a
+/// pre-migration boot — callers should treat that as "unknown", not fatal).
+pub async fn list_applied_migrations(pool: &Pool) -> Result<Vec<(String, DateTime<Utc>)>> {
+    let client = get_conn(pool).await?;
+    let rows = client
+        .query(
+            "SELECT filename, applied_at FROM schema_migrations ORDER BY applied_at",
+            &[],
+        )
+        .await
+        .context("list_applied_migrations")?;
+    Ok(rows
+        .iter()
+        .map(|r| {
+            (
+                r.get::<_, String>("filename"),
+                r.get::<_, DateTime<Utc>>("applied_at"),
+            )
+        })
+        .collect())
+}
+
 // ─── schema migration runner (C4) ────────────────────────────────────────────
 
 /// Apply embedded `db/migrations/*.sql` files in filename order, idempotently,


### PR DESCRIPTION
The server-side piece of #180: an admin-only, downloadable, **scrubbed** diagnostics bundle so a maintainer can triage a tester's server-side issue without shell access. (The desktop client already shipped its half in #274.)

## What it adds
- **`GET /diagnostics/bundle`** (AdminUser-gated → `403` otherwise): a pretty-JSON snapshot delivered as a file attachment (`crumb-diagnostics-<ts>.json`), containing:
  - version (service / version / git sha / build time)
  - effective server settings (the DB `server_settings` row)
  - a curated, non-secret `env` whitelist (`LOG_FORMAT`, `TZ`, `MOTION_HWACCEL`, ...)
  - applied schema migrations (count + latest few) — tells whether the DB is at the expected version
- A **"Diagnostics — support bundle"** download button in the admin console's server-settings panel.

## Secure by default (load-bearing)
Everything is run through a recursive `redact()` pass before it leaves the box:
- any value under a **secret-shaped key** (`token` / `password` / `secret` / `hash` / `api_key` / `credential` / `private` / ...) → `"***REDACTED***"`
- any string carrying **URL userinfo** (`scheme://user:pass@host`) → `scheme://***@host` (dependency-free, no regex crate)

Two independent nets, so a leak would need both a surprising field name and a non-URL secret shape. `env` is a whitelist, never `std::env::vars()`. Footage and live logs are never included.

## Deliberately out of scope (follow-up on #180)
Live logs and runtime health. Logs are stdout-only, so shipping them needs an in-process ring buffer, and the recorder's logs live in a separate process — a bigger piece. The config + schema snapshot already covers a large class of "why isn't X working" server-side.

## Tests
- `redact()` unit tests: secret-shaped keys anywhere in the tree, credential-URL masking (with documentation-range IPs), and a URL under a non-secret key.
- Route test: admin → `200` + attachment; authenticated viewer → `403`.
- fmt + clippy `-D warnings` + full `cargo test --workspace` all green; admin.html script passes `node --check`.

Addresses #180 (server bundle piece).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
