### PR TITLE
fix(android): keep playback digital zoom across motion-segment gaps

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
@@ -109,6 +109,7 @@ import video.crumb.app.ui.player.MediaFactory
 import video.crumb.app.ui.player.PlayerSurface
 import video.crumb.app.ui.player.ViewTransform
 import video.crumb.app.ui.player.ZoomableVideoSurface
+import video.crumb.app.ui.player.rememberZoomableSurfaceState
 import video.crumb.app.feature.live.rememberIsMetered
 import video.crumb.app.ui.theme.NavyDeep
 import video.crumb.app.ui.theme.NavySurface
@@ -217,6 +218,14 @@ fun PlaybackScreen(
 
     // The camera currently shown (owned by the VM; updated on switch/swipe).
     val cameraId = state.cameraId
+
+    // Digital-zoom state hoisted ABOVE the video `when` below, so a zoomed view
+    // survives the surface briefly leaving the composition when scrubbing or
+    // jumping across a quiet gap on a motion camera (there `currentSegment` nulls
+    // and the video branch flips off-screen, unmounting the surface). Reset only
+    // on an actual camera change, so scrubbing the same camera keeps the zoom. (#386)
+    val zoomState = rememberZoomableSurfaceState()
+    LaunchedEffect(cameraId) { zoomState.reset() }
 
     // Ordered enabled-camera ids (live-wall order) for the picker + swipe nav.
     var cameraIds by remember { mutableStateOf<List<String>>(emptyList()) }
@@ -855,6 +864,8 @@ fun PlaybackScreen(
                             // Track zoom/pan so a "Current view" snapshot can crop to
                             // exactly what's on screen.
                             onTransformChange = { viewTransform = it },
+                            // Hoisted so the zoom survives segment gaps (#386).
+                            state = zoomState,
                         ) {
                             PlayerSurface(
                                 player = player,

--- a/apps/android/app/src/main/java/video/crumb/app/ui/player/ZoomableVideoSurface.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/ui/player/ZoomableVideoSurface.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -46,6 +47,31 @@ data class ViewTransform(
     val offsetX: Float,
     val offsetY: Float,
 )
+
+/**
+ * Hoistable zoom/pan state for [ZoomableVideoSurface]. By default the surface
+ * owns an internal one (so it resets whenever the surface leaves the
+ * composition, e.g. Live camera switches). A caller that wants the zoom to
+ * SURVIVE the surface unmounting/remounting, e.g. playback scrubbing across a
+ * quiet gap on a motion camera, where `currentSegment` briefly nulls and flips
+ * the video off-screen, hoists this above that boundary and passes it in, then
+ * [reset]s it on an actual camera change. (#386)
+ */
+@Stable
+class ZoomableSurfaceState {
+    var zoom by mutableFloatStateOf(1f)
+    var offset by mutableStateOf(Offset.Zero)
+
+    /** Return to fully zoomed out (1x, no pan). */
+    fun reset() {
+        zoom = 1f
+        offset = Offset.Zero
+    }
+}
+
+/** Remember a [ZoomableSurfaceState] across recomposition. */
+@Composable
+fun rememberZoomableSurfaceState(): ZoomableSurfaceState = remember { ZoomableSurfaceState() }
 
 /**
  * Wraps a video composable (a [PlayerSurface] using TextureView) and adds
@@ -84,15 +110,24 @@ fun ZoomableVideoSurface(
     suppressPan: Boolean = false,
     onSwipeCamera: ((Int) -> Unit)? = null,
     onTransformChange: ((ViewTransform) -> Unit)? = null,
+    state: ZoomableSurfaceState = rememberZoomableSurfaceState(),
     content: @Composable () -> Unit,
 ) {
-    var zoom by remember { mutableFloatStateOf(1f) }
-    var offset by remember { mutableStateOf(Offset.Zero) }   // content-space pan
+    // Local working copies seeded from the hoisted [state]. On (re)mount the seed
+    // re-reads `state`, so a preserved zoom survives the surface briefly leaving
+    // the composition (e.g. playback scrubbing across a motion-camera gap).
+    // report() writes changes back so `state` stays authoritative. (#386)
+    var zoom by remember { mutableFloatStateOf(state.zoom) }
+    var offset by remember { mutableStateOf(state.offset) }   // content-space pan
     var size by remember { mutableStateOf(IntSize.Zero) }
 
     // Report transform changes (zoom/pan/reset) to the parent for snapshot cropping.
     val transformCb = rememberUpdatedState(onTransformChange)
     fun report() {
+        // Keep the hoisted state authoritative so a preserved zoom survives the
+        // surface remounting on a segment transition. (#386)
+        state.zoom = zoom
+        state.offset = offset
         transformCb.value?.invoke(
             ViewTransform(scale = zoom, offsetX = offset.x, offsetY = offset.y),
         )


### PR DESCRIPTION
Fixes #386.

## Bug
On a **motion camera** in playback, digital-zooming into an area and then scrubbing across a quiet gap (or tapping "jump to next motion") reset the view to 1x / fully zoomed out.

## Root cause
`ZoomableVideoSurface` held its zoom/pan in an **un-keyed `remember`**, so the zoom survived recomposition but not the surface leaving the composition. In `PlaybackScreen` the video is the `else` branch of a `when` whose earlier branches fire when `currentSegment == null` (spinner, "No footage at this time"). On a motion camera, scrubbing across a gap or jumping to the next motion transiently nulls `currentSegment`, flips the `when` off the video branch, and **unmounts** the surface; the remounted surface re-inits `remember { 1f }`. Continuous cameras rarely hit it (contiguous segments). Desktop already preserves zoom across segments.

## Fix
- New optional `ZoomableSurfaceState` holder. By default the surface owns an internal one, so **Live and Clips are unchanged** (they still reset on unmount).
- `PlaybackScreen` hoists that state **above the video `when`**, so the zoom persists across the surface unmounting/remounting on a segment transition. The surface seeds its working copy from the hoisted state on (re)mount and writes changes back, keeping the state authoritative.
- The zoom resets only on an **actual camera change** (`LaunchedEffect(cameraId)`), so scrubbing the same camera keeps the zoom while switching cameras starts fresh.

2 files, +48/-2. Callers: only `PlaybackScreen` opts into the hoisted behavior; `LiveFullscreenScreen` and `ClipsScreen` use the default.

## Verification
`assembleDebug` on the Android build host: **BUILD SUCCESSFUL** (only pre-existing deprecation warnings). This is a gesture/scrub UX behavior, so best confirmed on-device — the debug APK is ready to sideload for a real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
