### PR TITLE
fix(android): use Download glyph for playback wall Export action

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackWallScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackWallScreen.kt
@@ -24,8 +24,8 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmarks
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Schedule
-import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -356,7 +356,7 @@ fun PlaybackWallScreen(
                     if (caps.export || store.isAdmin) {
                         HintTooltip("Export footage") {
                             IconButton(onClick = onOpenExport) {
-                                Icon(Icons.Default.Share, contentDescription = "Export footage")
+                                Icon(Icons.Default.Download, contentDescription = "Export footage")
                             }
                         }
                     }


### PR DESCRIPTION
## What
The multi-camera **playback wall**'s top-bar "Export footage" action used `Icons.Default.Share`, which reads as a system share/send button rather than an export/download action.

## Why
The Export screen itself already uses `Icons.Default.Download`. Matching it makes the wall's entry point communicate *download/export footage* instead of *share to another app*.

## Change
- `PlaybackWallScreen.kt`: swap the Export action glyph `Share` → `Download` (import + usage). Tooltip and `contentDescription` ("Export footage") unchanged; navigation and RBAC gating untouched. Cosmetic only.

Built clean on the Android toolchain (`:app:assembleDebug` BUILD SUCCESSFUL).

Fixes #388