### PR TITLE
perf(api,desktop): carry plate bbox in the ab-report

### DIFF
--- a/apps/desktop-flutter/lib/api/plates_api.dart
+++ b/apps/desktop-flutter/lib/api/plates_api.dart
@@ -240,6 +240,7 @@ class AbPassRead {
     required this.plate,
     required this.confidence,
     required this.eventId,
+    required this.bbox,
     required this.ts,
     required this.readCount,
   });
@@ -248,6 +249,11 @@ class AbPassRead {
   final String plate; // normalized uppercase alphanumeric
   final double? confidence;
   final String? eventId; // sibling detection event (snapshot source), or null
+  /// Plate box `[x, y, w, h]` (0..1 fractions of the snapshot frame), or null.
+  /// Served by the report itself so the benchmark can crop a pass image to the
+  /// plate without a per-row `GET /plates` round-trip. Null on a server older
+  /// than this field — callers fall back to the uncropped frame.
+  final List<double>? bbox;
   final DateTime ts;
   final int readCount; // raw reads collapsed into this entry
 
@@ -256,6 +262,7 @@ class AbPassRead {
     plate: (j['plate'] as String?) ?? '',
     confidence: (j['confidence'] as num?)?.toDouble(),
     eventId: j['event_id'] as String?,
+    bbox: _parseBbox(j['bbox']),
     ts: DateTime.parse(j['ts'] as String),
     readCount: (j['read_count'] as num?)?.toInt() ?? 1,
   );

--- a/apps/desktop-flutter/lib/ui/plates/ab_benchmark.dart
+++ b/apps/desktop-flutter/lib/ui/plates/ab_benchmark.dart
@@ -14,9 +14,11 @@
 // existing authed sources only — the sibling detection-event snapshot
 // (`GET /events/{id}/snapshot`) or the stored crumb-alpr crop
 // (`GET /plates/{id}/crop`) — never an unauthenticated provider URL. The
-// report itself carries no bbox, so the client-side plate crop (Frigate-only
-// passes) finds the read's bbox via one narrow `GET /plates` query and crops
-// with the shared plate_crop.dart helper, exactly like the Plates screen.
+// report carries each best read's bbox, so the client-side plate crop is
+// derived from the fetched frame with the shared plate_crop.dart helper
+// (exactly like the Plates screen) with NO extra round-trip: a row used to
+// spend a whole `GET /plates` range query just to re-find a box the server
+// already had in hand.
 
 import 'dart:typed_data';
 
@@ -786,12 +788,6 @@ const _abImagesCacheMax = 200;
 /// dialog racing for the same pass share one set of fetches.
 final Map<String, Future<_AbPassImages>> _abImagesInFlight = {};
 
-/// Bbox lookup memo (read id → bbox or null-for-none). The ab-report carries
-/// no bbox, so the crop path re-finds the read via `GET /plates`; memoized so
-/// scrolling back over rows doesn't re-query.
-final Map<String, List<double>?> _abBboxCache = {};
-const _abBboxCacheMax = 400;
-
 /// Resolve (and cache) both images for [p]. Shared by the row thumbnails and
 /// the confirm-true-plate dialog so both hit the same cache.
 Future<_AbPassImages> _resolvePassImages(CrumbApi api, Session s, AbPass p) {
@@ -847,7 +843,9 @@ Future<_AbPassImages> _resolvePassImagesUncached(
   // show the same image as `full`.
   Uint8List? crop;
   if (full != null && owner != null) {
-    final bbox = await _lookupAbBbox(api, s, p.cameraId, owner);
+    // The box comes with the report (see AbPassRead.bbox) — no per-row
+    // `GET /plates` round-trip to re-find a box the server already had.
+    final bbox = owner.bbox;
     if (bbox != null && bbox.length >= 4) {
       try {
         crop = await cachedPlateCrop(owner.readId, full, bbox);
@@ -874,41 +872,6 @@ Future<Uint8List?> _fetchAbBytes(Session s, String url) async {
     // fall through
   }
   return null;
-}
-
-/// Find [read]'s bbox: one narrow `GET /plates` query (same camera, ±2 s
-/// around the read's timestamp) and match the row by read id. A read with no
-/// bbox memoizes null (no point re-querying); a failed query is not memoized.
-Future<List<double>?> _lookupAbBbox(
-  CrumbApi api,
-  Session s,
-  String cameraId,
-  AbPassRead read,
-) async {
-  if (_abBboxCache.containsKey(read.readId)) return _abBboxCache[read.readId];
-  List<double>? bbox;
-  try {
-    final page = await api.listPlates(
-      s,
-      cameraIds: [cameraId],
-      start: read.ts.subtract(const Duration(seconds: 2)),
-      end: read.ts.add(const Duration(seconds: 2)),
-      limit: 50,
-    );
-    for (final r in page.plates) {
-      if (r.id == read.readId) {
-        bbox = r.bbox;
-        break;
-      }
-    }
-  } catch (_) {
-    return null; // transient — retry on the next mount
-  }
-  if (_abBboxCache.length >= _abBboxCacheMax) {
-    _abBboxCache.remove(_abBboxCache.keys.first);
-  }
-  _abBboxCache[read.readId] = bbox;
-  return bbox;
 }
 
 /// The pass images cell: full-frame context thumb + tight plate crop side by

--- a/services/api/src/plates.rs
+++ b/services/api/src/plates.rs
@@ -512,6 +512,11 @@ pub struct AbReadDto {
     /// Sibling detection event — the client fetches the pass image via the
     /// existing `GET /events/:id/snapshot` (or `GET /plates/:id/crop`).
     pub event_id: Option<Uuid>,
+    /// Plate box `[x, y, w, h]` (0..1 fractions of the snapshot frame), when
+    /// one was captured. Lets a client crop the pass image to the plate from
+    /// the report alone — without a per-row `GET /plates` round-trip to look
+    /// up a box the server already had.
+    pub bbox: Option<[f32; 4]>,
     pub ts: DateTime<Utc>,
     /// Raw reads collapsed into this engine's entry (dup-refinement count).
     pub read_count: usize,
@@ -523,6 +528,7 @@ fn ab_read_dto(b: &crumb_common::lpr_ab::EngineBest) -> AbReadDto {
         plate: b.plate.clone(),
         confidence: b.confidence,
         event_id: b.event_id,
+        bbox: b.bbox,
         ts: b.ts,
         read_count: b.read_count,
     }

--- a/services/common/src/lpr_ab.rs
+++ b/services/common/src/lpr_ab.rs
@@ -67,6 +67,11 @@ pub struct EngineBest {
     pub confidence: Option<f32>,
     /// Sibling detection event of the kept read, when one exists.
     pub event_id: Option<Uuid>,
+    /// Plate box `[x, y, w, h]` (0..1 fractions) of the kept read's snapshot
+    /// frame, when one was captured. Carried through so a client can crop the
+    /// pass image to the plate WITHOUT re-querying `/plates` per row just to
+    /// re-find a box the report already had in hand.
+    pub bbox: Option<[f32; 4]>,
     /// Timestamp of the kept read.
     pub ts: DateTime<Utc>,
     /// How many raw reads this engine contributed to the pass (collapsed
@@ -195,6 +200,7 @@ impl<'a> Cluster<'a> {
                 plate: self.best.plate.clone(),
                 confidence: self.best.confidence,
                 event_id: self.best.event_id,
+                bbox: self.best.bbox,
                 ts: self.best.ts,
                 read_count: self.count,
             },
@@ -460,6 +466,41 @@ mod tests {
         assert_eq!(f.read_count, 2, "both raw reads counted");
         assert!(passes[0].crumb_alpr.is_none());
         assert_eq!(passes[0].bucket_ts, t0(), "bucket = earliest read ts");
+    }
+
+    /// The kept read's bbox rides along into the pass, so a client can crop
+    /// the pass image to the plate straight from the report. Critically it is
+    /// the BEST read's box, never a collapsed duplicate's: a box is only valid
+    /// against the exact frame its own read was made on, so pairing the
+    /// survivor's frame with a discarded read's box would crop the wrong
+    /// region.
+    #[test]
+    fn kept_reads_bbox_rides_into_the_pass() {
+        let cam = Uuid::new_v4();
+        let mut low = mk_read(cam, ENGINE_FRIGATE, "9GXVL98", Some(0.70), t0());
+        low.bbox = Some([0.10, 0.10, 0.05, 0.05]);
+        let mut high = mk_read(cam, ENGINE_FRIGATE, "9GXV498", Some(0.87), t0() + secs(5));
+        high.bbox = Some([0.40, 0.60, 0.05, 0.05]);
+
+        let passes = pair_passes(&[low, high], 8, 0.25);
+        assert_eq!(passes.len(), 1, "one physical pass");
+        let f = passes[0].frigate.as_ref().expect("frigate best kept");
+        assert_eq!(
+            f.bbox,
+            Some([0.40, 0.60, 0.05, 0.05]),
+            "the surviving (higher-confidence) read's box, not the dropped duplicate's",
+        );
+    }
+
+    /// A read with no captured box stays `None` — the client falls back to the
+    /// uncropped frame rather than cropping to a bogus region.
+    #[test]
+    fn missing_bbox_stays_none() {
+        let cam = Uuid::new_v4();
+        let reads = vec![mk_read(cam, ENGINE_CRUMB, "8TKM204", Some(0.99), t0())];
+        let passes = pair_passes(&reads, 8, 0.25);
+        let c = passes[0].crumb_alpr.as_ref().expect("crumb best kept");
+        assert_eq!(c.bbox, None);
     }
 
     /// Both engines read the same car → one pass with both bests, agreement.


### PR DESCRIPTION
First of two changes for #391 (Engine Benchmark pass images load slowly).

## Problem
Every benchmark row spent a whole `GET /plates` range query (camera + a ±2 s window + `limit 50`, matched by read id) purely to re-find a bbox **the server already had in hand when it built the report**. `EngineBest` dropped `PlateRead.bbox`, so `AbReadDto` carried none.

In a live 24 h sample **178/178 reads already had a bbox stored**, so that round-trip was pure waste on every single row.

## Change
- `EngineBest` + `AbReadDto` carry `bbox`; `AbPassRead` (Dart) parses it with the existing `_parseBbox` helper, tolerating `null` from an older server.
- The benchmark uses it directly; `_lookupAbBbox` and its memo are deleted.

Halves the per-row network work — the remaining fetch is the pass image itself, which is what the follow-up change addresses (downscaled context thumb + native-res server-side crop).

## Correctness note
The box carried is the **kept** read's, never a collapsed duplicate's. A bbox is only valid against the exact frame its own read was made on, so pairing the surviving read's frame with a dropped duplicate's box would crop the wrong region. There's a unit test pinning this, plus one asserting a boxless read stays `None` so the client falls back to the uncropped frame.

## Verification
Full gate on a Rust box: `cargo fmt --check` ✅, `cargo clippy --all-targets -D warnings` ✅, `cargo test --workspace` ✅ (0 failures; the `lpr_ab` suite goes 57 → 59 with the new tests). `flutter analyze` on the changed Dart: **no issues**.

## Follow-up left in place
`_resolvePassImages`/`_AbThumb`/`_ConfirmPlateDialog` still thread a now-unused `CrumbApi` parameter. Deliberately not removed here — the follow-up change reworks these same signatures, and churning them twice would only make both diffs harder to read.

Refs #391