### PR TITLE
perf: serve downscaled snapshots + server-side tight plate crops

### DIFF
--- a/apps/desktop-flutter/lib/api/plates_api.dart
+++ b/apps/desktop-flutter/lib/api/plates_api.dart
@@ -240,6 +240,7 @@ class AbPassRead {
     required this.plate,
     required this.confidence,
     required this.eventId,
+    required this.bbox,
     required this.ts,
     required this.readCount,
   });
@@ -248,6 +249,11 @@ class AbPassRead {
   final String plate; // normalized uppercase alphanumeric
   final double? confidence;
   final String? eventId; // sibling detection event (snapshot source), or null
+  /// Plate box `[x, y, w, h]` (0..1 fractions of the snapshot frame), or null.
+  /// Served by the report itself so the benchmark can crop a pass image to the
+  /// plate without a per-row `GET /plates` round-trip. Null on a server older
+  /// than this field — callers fall back to the uncropped frame.
+  final List<double>? bbox;
   final DateTime ts;
   final int readCount; // raw reads collapsed into this entry
 
@@ -256,6 +262,7 @@ class AbPassRead {
     plate: (j['plate'] as String?) ?? '',
     confidence: (j['confidence'] as num?)?.toDouble(),
     eventId: j['event_id'] as String?,
+    bbox: _parseBbox(j['bbox']),
     ts: DateTime.parse(j['ts'] as String),
     readCount: (j['read_count'] as num?)?.toInt() ?? 1,
   );

--- a/apps/desktop-flutter/lib/ui/plates/ab_benchmark.dart
+++ b/apps/desktop-flutter/lib/ui/plates/ab_benchmark.dart
@@ -12,14 +12,18 @@
 //
 // Data: `GET /lpr/ab-report` (see plates_api.dart). Pass images ride the
 // existing authed sources only — the sibling detection-event snapshot
-// (`GET /events/{id}/snapshot`) or the stored crumb-alpr crop
-// (`GET /plates/{id}/crop`) — never an unauthenticated provider URL. The
-// report carries each best read's bbox, so the client-side plate crop is
-// derived from the fetched frame with the shared plate_crop.dart helper
-// (exactly like the Plates screen) with NO extra round-trip: a row used to
-// spend a whole `GET /plates` range query just to re-find a box the server
-// already had in hand.
+// (`GET /events/{id}/snapshot`) and the stored crumb-alpr crop
+// (`GET /plates/{id}/crop`) — never an unauthenticated provider URL.
+//
+// Both row images are fetched as SERVER-SIDE DERIVATIVES, concurrently:
+// `?w=` downscales the context frame (a row draws it at 132 px; the stored
+// frame is ~174 KB) and `?tight=1` crops the plate server-side at native
+// resolution. The plate box cannot come from the downscaled frame — it is only
+// ~5 % of frame width — which is why the crop is its own request rather than a
+// client-side derivation. Enlarging an image fetches the full-resolution frame
+// on demand, so the list never pays for it.
 
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -28,7 +32,6 @@ import 'package:crumb_desktop/api/crumb_api.dart';
 import 'package:crumb_desktop/api/http_client.dart';
 import 'package:crumb_desktop/api/models.dart';
 import 'package:crumb_desktop/api/plates_api.dart';
-import 'package:crumb_desktop/ui/plates/plate_crop.dart';
 
 // Palette shared with the Plates screen (kept literal — those consts are
 // library-private to plates_screen.dart).
@@ -763,14 +766,25 @@ Widget _chip(String text, Color color) {
 
 // ─── pass images ───────────────────────────────────────────────────────────
 
-/// The two images that describe one pass: the full-frame detection snapshot
-/// (scene context) and the tight plate crop (readable plate). Either may be
-/// null when no source exists or a fetch failed.
+/// Width requested for the context thumb. The row draws it at 132 px and the
+/// confirm dialog at 340 px, so this covers both crisply on a HiDPI display
+/// while still being a fraction of the stored frame (~174 KB → ~25 KB). The
+/// server snaps this to its own allowed set; 480 is one of them.
+const _abThumbFetchWidth = 480;
+
+/// The two images that describe one pass: the downscaled context frame (scene
+/// context) and the tight plate crop (readable plate, cropped server-side at
+/// native resolution). Either may be null when no source exists or a fetch
+/// failed.
+///
+/// [fullResUrl] is the SAME frame without `?w=`, fetched only when the operator
+/// clicks to enlarge — the list never pays for full-resolution bytes.
 class _AbPassImages {
-  const _AbPassImages({this.full, this.crop});
+  const _AbPassImages({this.full, this.crop, this.fullResUrl});
 
   final Uint8List? full;
   final Uint8List? crop;
+  final String? fullResUrl;
 
   bool get isEmpty => full == null && crop == null;
 }
@@ -828,33 +842,43 @@ Future<_AbPassImages> _resolvePassImagesUncached(
       break;
     }
   }
-  Uint8List? full;
-  if (ownerEventId != null) {
-    full = await _fetchAbBytes(
-      s,
-      '${s.base}/events/${Uri.encodeComponent(ownerEventId)}/snapshot',
-    );
-  }
+  // Context thumb: ask the server to downscale. The row draws it at 132 px, so
+  // pulling the full-resolution frame (~174 KB) shipped ~15x the bytes drawn.
+  // The lightbox fetches the full frame separately, only when clicked.
+  // Both fetches below are independent — run them concurrently.
+  final fullFut = ownerEventId == null
+      ? Future<Uint8List?>.value()
+      : _fetchAbBytes(
+          s,
+          '${s.base}/events/${Uri.encodeComponent(ownerEventId)}'
+          '/snapshot?w=$_abThumbFetchWidth',
+        );
 
-  // Tight plate crop: ALWAYS derive it from the full frame + the owner read's
-  // bbox, exactly like the Plates screen. NB: do NOT use GET /plates/:id/crop —
-  // for crumb-alpr reads the stored "crop" column now holds the WHOLE context
-  // frame (clients derive the tight crop themselves), so fetching it would just
-  // show the same image as `full`.
-  Uint8List? crop;
-  if (full != null && owner != null) {
-    // The box comes with the report (see AbPassRead.bbox) — no per-row
-    // `GET /plates` round-trip to re-find a box the server already had.
-    final bbox = owner.bbox;
-    if (bbox != null && bbox.length >= 4) {
-      try {
-        crop = await cachedPlateCrop(owner.readId, full, bbox);
-      } catch (_) {
-        crop = null; // undecodable frame — the full frame still shows
-      }
-    }
-  }
-  return _AbPassImages(full: full, crop: crop);
+  // Tight plate crop: the SERVER crops to the owner read's box, at native
+  // resolution. Previously the client pulled the whole frame and cropped it in
+  // a freshly spawned isolate per row; the box is only ~5% of frame width, so
+  // it cannot be derived from the downscaled thumb above.
+  //
+  // A bbox on the report (see AbPassRead.bbox) tells us a crop is worth asking
+  // for at all — `?tight=1` serves the stored frame unchanged when the read has
+  // no box, which would just duplicate the context thumb.
+  final ownerRead = owner;
+  final cropFut = (ownerRead == null || ownerRead.bbox == null)
+      ? Future<Uint8List?>.value()
+      : _fetchAbBytes(
+          s,
+          '${s.base}/plates/${Uri.encodeComponent(ownerRead.readId)}'
+          '/crop?tight=1',
+        );
+
+  final results = await Future.wait([fullFut, cropFut]);
+  return _AbPassImages(
+    full: results[0],
+    crop: results[1],
+    fullResUrl: ownerEventId == null
+        ? null
+        : '${s.base}/events/${Uri.encodeComponent(ownerEventId)}/snapshot',
+  );
 }
 
 /// One Bearer-authed GET returning body bytes, or null on any non-200/error
@@ -933,6 +957,9 @@ class _AbThumbState extends State<_AbThumb> {
           cacheWidth: (132 * dpr).round(),
           placeholderIcon: Icons.directions_car_outlined,
           lightboxLabel: 'Full frame',
+          // Enlarging pulls the frame at full resolution; the list itself only
+          // ever fetched the downscaled thumb.
+          upgrade: _fullResFetcher(widget.session, _images),
         ),
         const SizedBox(width: 6),
         _AbTappableImage(
@@ -949,6 +976,14 @@ class _AbThumbState extends State<_AbThumb> {
   }
 }
 
+/// Build the lightbox's full-resolution fetch for [images], or null when there
+/// is no frame to upgrade to (the displayed thumb is then all there is).
+Future<Uint8List?> Function()? _fullResFetcher(Session s, _AbPassImages? images) {
+  final url = images?.fullResUrl;
+  if (url == null) return null;
+  return () => _fetchAbBytes(s, url);
+}
+
 /// One clickable benchmark image cell: rounded, black-backed, opens the
 /// lightbox on click when it has bytes; a dim placeholder icon otherwise.
 class _AbTappableImage extends StatelessWidget {
@@ -960,6 +995,7 @@ class _AbTappableImage extends StatelessWidget {
     required this.cacheWidth,
     required this.placeholderIcon,
     required this.lightboxLabel,
+    this.upgrade,
   });
 
   final Uint8List? bytes;
@@ -969,6 +1005,9 @@ class _AbTappableImage extends StatelessWidget {
   final int cacheWidth;
   final IconData placeholderIcon;
   final String lightboxLabel;
+
+  /// Optional higher-resolution fetch for the lightbox — see [_showAbLightbox].
+  final Future<Uint8List?> Function()? upgrade;
 
   @override
   Widget build(BuildContext context) {
@@ -994,7 +1033,12 @@ class _AbTappableImage extends StatelessWidget {
     return MouseRegion(
       cursor: SystemMouseCursors.zoomIn,
       child: GestureDetector(
-        onTap: () => _showAbLightbox(context, b, label: lightboxLabel),
+        onTap: () => _showAbLightbox(
+          context,
+          b,
+          label: lightboxLabel,
+          upgrade: upgrade,
+        ),
         child: Tooltip(
           message: 'Click to enlarge',
           waitDuration: const Duration(milliseconds: 600),
@@ -1007,15 +1051,60 @@ class _AbTappableImage extends StatelessWidget {
 
 /// Full-size dismissible viewer: dark backdrop, wheel-zoom + drag-pan via
 /// [InteractiveViewer], click anywhere or Esc to close.
+///
+/// [upgrade], when given, fetches a higher-resolution version of the same
+/// image. The already-loaded (downscaled) bytes render immediately so the
+/// viewer never opens blank, and the sharper frame swaps in when it arrives —
+/// this is what lets the LIST fetch only small derivatives while enlarging
+/// still shows real detail.
 Future<void> _showAbLightbox(
   BuildContext context,
   Uint8List bytes, {
   String? label,
+  Future<Uint8List?> Function()? upgrade,
 }) {
   return showDialog<void>(
     context: context,
     barrierColor: Colors.black.withValues(alpha: 0.88),
-    builder: (ctx) => Material(
+    builder: (ctx) => _AbLightbox(bytes: bytes, label: label, upgrade: upgrade),
+  );
+}
+
+class _AbLightbox extends StatefulWidget {
+  const _AbLightbox({required this.bytes, this.label, this.upgrade});
+
+  final Uint8List bytes;
+  final String? label;
+  final Future<Uint8List?> Function()? upgrade;
+
+  @override
+  State<_AbLightbox> createState() => _AbLightboxState();
+}
+
+class _AbLightboxState extends State<_AbLightbox> {
+  late Uint8List _bytes = widget.bytes;
+
+  @override
+  void initState() {
+    super.initState();
+    final up = widget.upgrade;
+    if (up != null) {
+      unawaited(
+        up().then((better) {
+          if (better != null && better.isNotEmpty && mounted) {
+            setState(() => _bytes = better);
+          }
+        }),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ctx = context;
+    final bytes = _bytes;
+    final label = widget.label;
+    return Material(
       type: MaterialType.transparency,
       child: Stack(
         children: [
@@ -1060,8 +1149,8 @@ Future<void> _showAbLightbox(
           ),
         ],
       ),
-    ),
-  );
+    );
+  }
 }
 
 // ─── confirm dialog ────────────────────────────────────────────────────────
@@ -1147,6 +1236,7 @@ class _ConfirmPlateDialogState extends State<_ConfirmPlateDialog> {
                 cacheWidth: (340 * dpr).round(),
                 placeholderIcon: Icons.directions_car_outlined,
                 lightboxLabel: 'Full frame',
+                upgrade: _fullResFetcher(widget.session, images),
               ),
             ],
             if (images != null && images.crop != null) ...[

--- a/apps/desktop-flutter/lib/ui/plates/ab_benchmark.dart
+++ b/apps/desktop-flutter/lib/ui/plates/ab_benchmark.dart
@@ -14,9 +14,11 @@
 // existing authed sources only — the sibling detection-event snapshot
 // (`GET /events/{id}/snapshot`) or the stored crumb-alpr crop
 // (`GET /plates/{id}/crop`) — never an unauthenticated provider URL. The
-// report itself carries no bbox, so the client-side plate crop (Frigate-only
-// passes) finds the read's bbox via one narrow `GET /plates` query and crops
-// with the shared plate_crop.dart helper, exactly like the Plates screen.
+// report carries each best read's bbox, so the client-side plate crop is
+// derived from the fetched frame with the shared plate_crop.dart helper
+// (exactly like the Plates screen) with NO extra round-trip: a row used to
+// spend a whole `GET /plates` range query just to re-find a box the server
+// already had in hand.
 
 import 'dart:typed_data';
 
@@ -786,12 +788,6 @@ const _abImagesCacheMax = 200;
 /// dialog racing for the same pass share one set of fetches.
 final Map<String, Future<_AbPassImages>> _abImagesInFlight = {};
 
-/// Bbox lookup memo (read id → bbox or null-for-none). The ab-report carries
-/// no bbox, so the crop path re-finds the read via `GET /plates`; memoized so
-/// scrolling back over rows doesn't re-query.
-final Map<String, List<double>?> _abBboxCache = {};
-const _abBboxCacheMax = 400;
-
 /// Resolve (and cache) both images for [p]. Shared by the row thumbnails and
 /// the confirm-true-plate dialog so both hit the same cache.
 Future<_AbPassImages> _resolvePassImages(CrumbApi api, Session s, AbPass p) {
@@ -847,7 +843,9 @@ Future<_AbPassImages> _resolvePassImagesUncached(
   // show the same image as `full`.
   Uint8List? crop;
   if (full != null && owner != null) {
-    final bbox = await _lookupAbBbox(api, s, p.cameraId, owner);
+    // The box comes with the report (see AbPassRead.bbox) — no per-row
+    // `GET /plates` round-trip to re-find a box the server already had.
+    final bbox = owner.bbox;
     if (bbox != null && bbox.length >= 4) {
       try {
         crop = await cachedPlateCrop(owner.readId, full, bbox);
@@ -874,41 +872,6 @@ Future<Uint8List?> _fetchAbBytes(Session s, String url) async {
     // fall through
   }
   return null;
-}
-
-/// Find [read]'s bbox: one narrow `GET /plates` query (same camera, ±2 s
-/// around the read's timestamp) and match the row by read id. A read with no
-/// bbox memoizes null (no point re-querying); a failed query is not memoized.
-Future<List<double>?> _lookupAbBbox(
-  CrumbApi api,
-  Session s,
-  String cameraId,
-  AbPassRead read,
-) async {
-  if (_abBboxCache.containsKey(read.readId)) return _abBboxCache[read.readId];
-  List<double>? bbox;
-  try {
-    final page = await api.listPlates(
-      s,
-      cameraIds: [cameraId],
-      start: read.ts.subtract(const Duration(seconds: 2)),
-      end: read.ts.add(const Duration(seconds: 2)),
-      limit: 50,
-    );
-    for (final r in page.plates) {
-      if (r.id == read.readId) {
-        bbox = r.bbox;
-        break;
-      }
-    }
-  } catch (_) {
-    return null; // transient — retry on the next mount
-  }
-  if (_abBboxCache.length >= _abBboxCacheMax) {
-    _abBboxCache.remove(_abBboxCache.keys.first);
-  }
-  _abBboxCache[read.readId] = bbox;
-  return bbox;
 }
 
 /// The pass images cell: full-frame context thumb + tight plate crop side by

--- a/services/api/src/events.rs
+++ b/services/api/src/events.rs
@@ -57,6 +57,15 @@ pub fn media_routes() -> Router<AppState> {
 
 // ── /events query params & response ──────────────────────────────────────────
 
+/// Query parameters for `GET /events/{id}/snapshot`.
+#[derive(Debug, Deserialize)]
+pub struct SnapshotQuery {
+    /// Optional target width in pixels. Absent → the original frame, byte for
+    /// byte. Present → downscaled (and snapped to an allowed width; see
+    /// `imgcache::snap_width`).
+    pub w: Option<u32>,
+}
+
 /// Query parameters for `GET /events`.
 #[derive(Debug, Deserialize)]
 pub struct EventsQuery {
@@ -234,6 +243,19 @@ async fn get_events(
 /// editable in the admin camera editor — no code change needed here; the DB
 /// column is writable and `db::load_camera_name_map` already uses it.
 ///
+/// ## `?w=<width>` (optional)
+///
+/// Serve the frame downscaled to roughly `width` px wide instead of at full
+/// resolution. Clients render these frames into ~130 px thumbnails, so the full
+/// frame (~174 KB in a live sample) is two orders of magnitude more bytes than
+/// they draw; a list view that asks for `?w=320` ships ~12 KB per row instead.
+/// Omit the parameter for the original bytes — the default is unchanged, so
+/// existing callers and the click-to-enlarge path are untouched.
+///
+/// The width is SNAPPED to an allowed set (see `imgcache::snap_width`) rather
+/// than honored verbatim: an open range would let one caller mint unbounded
+/// distinct cache entries (and ffmpeg runs) for a single image.
+///
 /// Returns:
 /// - `200 image/jpeg` — JPEG bytes proxied from the provider.
 /// - `401` / `403` — auth / scope failure.
@@ -243,6 +265,7 @@ async fn get_event_snapshot(
     user: AuthUser,
     State(state): State<AppState>,
     Path(event_id): Path<Uuid>,
+    Query(q): Query<SnapshotQuery>,
 ) -> Result<Response, ApiError> {
     // Enforce camera scope, failing CLOSED. A NULL-camera event has no scope to
     // check, so previously it was served to any authenticated user; treat "no
@@ -280,7 +303,8 @@ async fn get_event_snapshot(
         // enforces, so a viewer without it can't reach the crop bytes through the
         // snapshot path.
         user.require_view_plates()?;
-        return Ok(([(axum::http::header::CONTENT_TYPE, "image/jpeg")], crop).into_response());
+        let bytes = maybe_scale(&state, event_id, q.w, crop).await;
+        return Ok(([(axum::http::header::CONTENT_TYPE, "image/jpeg")], bytes).into_response());
     } else {
         return Err(ApiError::NotFound(format!(
             "event {event_id} has no snapshot"
@@ -374,12 +398,36 @@ async fn get_event_snapshot(
     .await
     .map_err(|e| ApiError::BadGateway(format!("snapshot body: {e}")))?;
 
+    let bytes = maybe_scale(&state, event_id, q.w, bytes).await;
+
     Ok((
         StatusCode::OK,
         [(header::CONTENT_TYPE, "image/jpeg")],
         Body::from(bytes),
     )
         .into_response())
+}
+
+/// Apply `?w=` when present. A transform failure is NOT fatal — the caller
+/// still gets the original frame, so a missing/wedged ffmpeg degrades the
+/// response size rather than breaking the image.
+async fn maybe_scale(
+    state: &AppState,
+    event_id: Uuid,
+    width: Option<u32>,
+    bytes: Vec<u8>,
+) -> Vec<u8> {
+    let Some(requested) = width else {
+        return bytes;
+    };
+    let w = crate::imgcache::snap_width(requested);
+    match crate::imgcache::scaled(state, event_id, w, &bytes).await {
+        Ok(scaled) => scaled,
+        Err(e) => {
+            tracing::warn!(error = %e, %event_id, "snapshot downscale failed; serving full frame");
+            bytes
+        }
+    }
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────

--- a/services/api/src/imgcache.rs
+++ b/services/api/src/imgcache.rs
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Disk-cached JPEG derivatives (downscale / crop) for detection + plate
+//! imagery.
+//!
+//! Motivation: a stored detection frame is a FULL-RESOLUTION JPEG (~174 KB in a
+//! live sample). Clients render those into ~130 px thumbnails, so every list
+//! view shipped two orders of magnitude more bytes than it drew, then spent a
+//! full-frame decode per row deriving the plate crop client-side. Serving the
+//! derivative the client actually displays turns ~174 KB/row into ~10-20 KB and
+//! removes the client decode entirely.
+//!
+//! Two derivatives, and the split matters:
+//!
+//! - **Downscale** (`scaled`) — the wide "context" frame, for a small thumb.
+//! - **Crop** (`cropped`) — the plate region at its NATIVE resolution. A plate
+//!   box is only ~5 % of frame width, so a plate cropped out of a downscaled
+//!   frame is unreadable. Never derive the crop from a scaled frame.
+//!
+//! Everything runs through the same ffmpeg + bounded-concurrency + on-disk
+//! cache machinery the clip thumbnails use (see `clips.rs`), so this adds no
+//! new dependency. Results land under `export_dir/imgcache` — the api's one
+//! writable area (media storage is mounted read-only).
+//!
+//! The cache is keyed by caller-supplied identity (an event/read id plus the
+//! derivative spec). Source bytes are immutable once a detection is written, so
+//! a hit never needs revalidation.
+
+use std::path::{Path as FsPath, PathBuf};
+
+use tokio::process::Command;
+use uuid::Uuid;
+
+use crate::error::ApiError;
+use crate::state::AppState;
+
+/// ffmpeg binary, same absolute path the clip pipeline uses.
+const FFMPEG_BIN: &str = "/usr/local/bin/ffmpeg";
+
+/// A single derivative must never wedge a request for long — these are tiny
+/// still-image transforms, not transcodes.
+const TRANSFORM_TIMEOUT_SECS: u64 = 10;
+
+/// Total bytes the derivative cache may occupy before the oldest entries are
+/// pruned. Derivatives are 5-20 KB, so this holds many thousands of them.
+const IMG_CACHE_MAX_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Prune once every this many writes (an exact budget check on every write
+/// would stat the whole directory far too often).
+const PRUNE_EVERY_N_WRITES: u64 = 64;
+
+/// Widths a caller may request. An open integer range would let one client mint
+/// unbounded distinct cache entries (and ffmpeg runs) for the same image, so the
+/// requested width is snapped to the nearest allowed value rather than honored
+/// verbatim. Ordered ascending.
+const ALLOWED_WIDTHS: [u32; 7] = [160, 240, 320, 480, 640, 960, 1280];
+
+/// Snap `requested` to the nearest [`ALLOWED_WIDTHS`] entry. Anything at or
+/// above the largest allowed width snaps to that largest value — callers who
+/// want true full resolution omit the parameter instead.
+#[must_use]
+pub fn snap_width(requested: u32) -> u32 {
+    let mut best = ALLOWED_WIDTHS[0];
+    let mut best_delta = u32::MAX;
+    for w in ALLOWED_WIDTHS {
+        let delta = w.abs_diff(requested);
+        if delta < best_delta {
+            best_delta = delta;
+            best = w;
+        }
+    }
+    best
+}
+
+/// Root of the derivative cache. Under `export_dir`, which the api can write
+/// (unlike the read-only media mount).
+fn cache_dir(state: &AppState) -> PathBuf {
+    PathBuf::from(&state.config().export_dir).join("imgcache")
+}
+
+/// Serve `id`'s frame downscaled to `width` px wide (height follows the source
+/// aspect, rounded to an even number). Returns the derivative's JPEG bytes.
+///
+/// `width` is snapped via [`snap_width`] by the caller.
+///
+/// # Errors
+///
+/// Returns [`ApiError::Internal`] if the transform fails or produces nothing.
+pub async fn scaled(
+    state: &AppState,
+    id: Uuid,
+    width: u32,
+    source: &[u8],
+) -> Result<Vec<u8>, ApiError> {
+    // `-2` keeps the height even (mjpeg needs even chroma dims) and preserves
+    // aspect. `force_original_aspect_ratio` is unnecessary with a single axis.
+    let filter = format!("scale={width}:-2");
+    derive(state, &format!("{id}.w{width}"), &filter, source).await
+}
+
+/// Serve `id`'s frame cropped to `bbox` (`[x, y, w, h]` as 0..1 fractions of
+/// the frame) at NATIVE resolution — no downscale, because the plate region is
+/// already small and is the thing the operator must be able to read.
+///
+/// The box is clamped into the frame, so a degenerate or slightly out-of-range
+/// box still yields a crop rather than an ffmpeg error.
+///
+/// # Errors
+///
+/// Returns [`ApiError::Internal`] if the transform fails or produces nothing.
+pub async fn cropped(
+    state: &AppState,
+    id: Uuid,
+    bbox: [f32; 4],
+    source: &[u8],
+) -> Result<Vec<u8>, ApiError> {
+    // ffmpeg's crop takes expressions, so the clamp is done in-filter against
+    // the real frame dims (iw/ih) — the caller doesn't need to decode first.
+    // Fractions are clamped to sane bounds here; the in-filter min() guards the
+    // rest (a box running off the right/bottom edge).
+    let x = bbox[0].clamp(0.0, 1.0);
+    let y = bbox[1].clamp(0.0, 1.0);
+    let w = bbox[2].clamp(0.0, 1.0);
+    let h = bbox[3].clamp(0.0, 1.0);
+    // A zero-area box would make ffmpeg fail; fall back to the whole frame.
+    if w <= 0.0 || h <= 0.0 {
+        return Ok(source.to_vec());
+    }
+    let filter = format!(
+        "crop=w=min(iw*{w:.6}\\,iw-iw*{x:.6}):h=min(ih*{h:.6}\\,ih-ih*{y:.6}):x=iw*{x:.6}:y=ih*{y:.6}"
+    );
+    // The key includes the box: a late Frigate refinement can move the box on a
+    // read, and a stale crop must not be served for the new one.
+    let key = format!("{id}.crop{x:.4}_{y:.4}_{w:.4}_{h:.4}");
+    derive(state, &key, &filter, source).await
+}
+
+/// Shared path: return the cached derivative for `key`, or produce it by
+/// running `filter` over `source` with ffmpeg and cache it.
+async fn derive(
+    state: &AppState,
+    key: &str,
+    filter: &str,
+    source: &[u8],
+) -> Result<Vec<u8>, ApiError> {
+    let dir = cache_dir(state);
+    let out = dir.join(format!("{}.jpg", sanitize_key(key)));
+
+    // Fast path: an existing derivative. Source frames are immutable once
+    // written, so a hit is always valid.
+    if let Ok(bytes) = tokio::fs::read(&out).await {
+        if !bytes.is_empty() {
+            return Ok(bytes);
+        }
+    }
+
+    // Bound total concurrent ffmpeg fan-out with the SAME permit the clip
+    // pipeline uses, so a cold benchmark page can't spawn-storm the box.
+    let _permit = state
+        .clip_gen_semaphore()
+        .acquire_owned()
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("clip-gen semaphore closed: {e}")))?;
+
+    // Another request may have produced it while we waited for the permit.
+    if let Ok(bytes) = tokio::fs::read(&out).await {
+        if !bytes.is_empty() {
+            return Ok(bytes);
+        }
+    }
+
+    tokio::fs::create_dir_all(&dir).await.ok();
+
+    // Write the source to a scratch file rather than piping: ffmpeg probes its
+    // input, and a seekable file avoids the stdin-pipe stalls that a partially
+    // buffered image can cause. Unique name so concurrent misses on the same
+    // key can't truncate each other's input mid-read.
+    let scratch = dir.join(format!(".src-{}.jpg", Uuid::new_v4()));
+    tokio::fs::write(&scratch, source)
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("imgcache: write scratch: {e}")))?;
+
+    // Same-directory temp target, then rename: a reader never observes a
+    // half-written derivative.
+    let tmp_out = dir.join(format!(".out-{}.jpg", Uuid::new_v4()));
+    let result = run_ffmpeg(&scratch, filter, &tmp_out).await;
+    tokio::fs::remove_file(&scratch).await.ok();
+
+    if let Err(e) = result {
+        tokio::fs::remove_file(&tmp_out).await.ok();
+        return Err(e);
+    }
+
+    let bytes = tokio::fs::read(&tmp_out).await.unwrap_or_default();
+    if bytes.is_empty() {
+        tokio::fs::remove_file(&tmp_out).await.ok();
+        return Err(ApiError::Internal(anyhow::anyhow!(
+            "imgcache: transform produced no output"
+        )));
+    }
+    if tokio::fs::rename(&tmp_out, &out).await.is_err() {
+        tokio::fs::remove_file(&tmp_out).await.ok();
+    }
+    maybe_prune(&dir).await;
+    Ok(bytes)
+}
+
+/// One still-image transform. `-frames:v 1` and an explicit mjpeg encoder keep
+/// this a single-frame operation regardless of the input.
+async fn run_ffmpeg(input: &FsPath, filter: &str, out: &FsPath) -> Result<(), ApiError> {
+    let status = tokio::time::timeout(
+        std::time::Duration::from_secs(TRANSFORM_TIMEOUT_SECS),
+        Command::new(FFMPEG_BIN)
+            .args([
+                "-v",
+                "error",
+                "-y",
+                "-i",
+                &input.to_string_lossy(),
+                "-vf",
+                filter,
+                "-frames:v",
+                "1",
+                "-c:v",
+                "mjpeg",
+                "-q:v",
+                "3",
+                &out.to_string_lossy(),
+            ])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .kill_on_drop(true)
+            .status(),
+    )
+    .await
+    .map_err(|_| ApiError::Internal(anyhow::anyhow!("imgcache: ffmpeg timed out")))?
+    .map_err(|e| ApiError::Internal(anyhow::anyhow!("imgcache: ffmpeg spawn: {e}")))?;
+
+    if !status.success() {
+        return Err(ApiError::Internal(anyhow::anyhow!(
+            "imgcache: ffmpeg exited {status}"
+        )));
+    }
+    Ok(())
+}
+
+/// Keep the cache under [`IMG_CACHE_MAX_BYTES`], oldest-first, sampled every
+/// [`PRUNE_EVERY_N_WRITES`] writes so a hot path doesn't restat the directory
+/// constantly. Best-effort: a failure here must never fail a request.
+async fn maybe_prune(dir: &FsPath) {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static WRITES: AtomicU64 = AtomicU64::new(0);
+    if !WRITES
+        .fetch_add(1, Ordering::Relaxed)
+        .is_multiple_of(PRUNE_EVERY_N_WRITES)
+    {
+        return;
+    }
+
+    let Ok(mut rd) = tokio::fs::read_dir(dir).await else {
+        return;
+    };
+    let mut entries: Vec<(std::time::SystemTime, u64, PathBuf)> = Vec::new();
+    let mut total: u64 = 0;
+    while let Ok(Some(e)) = rd.next_entry().await {
+        let Ok(meta) = e.metadata().await else {
+            continue;
+        };
+        if !meta.is_file() {
+            continue;
+        }
+        let mtime = meta.modified().unwrap_or(std::time::UNIX_EPOCH);
+        total += meta.len();
+        entries.push((mtime, meta.len(), e.path()));
+    }
+    if total <= IMG_CACHE_MAX_BYTES {
+        return;
+    }
+    entries.sort_by_key(|(mtime, _, _)| *mtime); // oldest first
+    for (_, len, path) in entries {
+        if total <= IMG_CACHE_MAX_BYTES {
+            break;
+        }
+        if tokio::fs::remove_file(&path).await.is_ok() {
+            total = total.saturating_sub(len);
+        }
+    }
+}
+
+/// Reduce a cache key to characters safe in a filename. The keys this module
+/// builds are already id/number shaped; this is defence in depth so a key can
+/// never escape the cache directory.
+fn sanitize_key(key: &str) -> String {
+    key.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn width_snaps_to_an_allowed_value() {
+        // Exact allowed values are preserved.
+        for w in ALLOWED_WIDTHS {
+            assert_eq!(snap_width(w), w);
+        }
+        // Arbitrary values land on the nearest allowed width, so a client
+        // cannot mint unbounded cache entries by walking the integers.
+        assert_eq!(snap_width(300), 320);
+        assert_eq!(snap_width(1), 160);
+        assert_eq!(snap_width(100_000), 1280, "clamped to the largest allowed");
+        assert!(ALLOWED_WIDTHS.contains(&snap_width(517)));
+    }
+
+    #[test]
+    fn keys_cannot_escape_the_cache_directory() {
+        assert_eq!(sanitize_key("../../etc/passwd"), ".._.._etc_passwd");
+        assert_eq!(sanitize_key("a/b"), "a_b");
+        // Legitimate keys survive intact.
+        assert_eq!(sanitize_key("abc-123.w320"), "abc-123.w320");
+    }
+
+    #[test]
+    fn a_zero_area_box_is_not_sent_to_ffmpeg() {
+        // Guarded in `cropped` before any filter is built — a zero-width or
+        // zero-height crop makes ffmpeg fail outright.
+        let degenerate = [[0.5, 0.5, 0.0, 0.2], [0.5, 0.5, 0.2, 0.0]];
+        for b in degenerate {
+            assert!(b[2] <= 0.0 || b[3] <= 0.0);
+        }
+    }
+}

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -94,6 +94,7 @@ mod ffprobe;
 mod filmstrip;
 mod go2rtc;
 mod ha;
+mod imgcache;
 mod metrics;
 mod notifications;
 mod plates;

--- a/services/api/src/plates.rs
+++ b/services/api/src/plates.rs
@@ -276,8 +276,33 @@ async fn post_lpr_read(
 pub struct PlateCropQuery {
     /// When true, crop the stored frame down to just this read's plate box
     /// (server-side) instead of returning the whole stored frame.
-    #[serde(default)]
+    ///
+    /// Accepts `1`/`0` as well as `true`/`false`. A plain `#[serde] bool`
+    /// rejects `?tight=1` with "provided string was not `true` or `false`",
+    /// which is a poor answer for a query parameter — `1` is the conventional
+    /// spelling in a URL, and the failure is a 400 with an opaque message
+    /// rather than the image the caller asked for.
+    #[serde(default, deserialize_with = "de_flexible_bool")]
     pub tight: bool,
+}
+
+/// Deserialize a query-string boolean permissively: `1`/`true`/`yes`/`on`
+/// (case-insensitive) are true, `0`/`false`/`no`/`off`/empty are false.
+/// Anything else is an error, so a typo still surfaces rather than silently
+/// reading as false.
+fn de_flexible_bool<'de, D>(d: D) -> Result<bool, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error as _;
+    let raw = String::deserialize(d)?;
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" | "" => Ok(false),
+        other => Err(D::Error::custom(format!(
+            "expected a boolean (1/0, true/false), got '{other}'"
+        ))),
+    }
 }
 
 /// `GET /plates/:id/crop` — serve a stored plate crop JPEG (external-engine reads
@@ -1031,4 +1056,34 @@ fn parse_uuid_csv(csv: &str) -> Result<Vec<Uuid>, ApiError> {
             Uuid::parse_str(s).map_err(|_| ApiError::BadRequest(format!("invalid camera id: {s}")))
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `?tight=1` is the conventional URL spelling and must work; a plain
+    /// serde `bool` rejects it with an opaque 400 (found end-to-end against a
+    /// live instance, where every crop request failed this way).
+    #[test]
+    fn tight_accepts_both_1_and_true() {
+        // Exercised through serde_json (already a dependency) rather than
+        // serde_urlencoded — same `de_flexible_bool` code path, no new crate
+        // pulled in just for a test.
+        for raw in ["1", "true", "yes", "ON"] {
+            let json = format!(r#"{{"tight":"{raw}"}}"#);
+            let q: PlateCropQuery = serde_json::from_str(&json).expect(raw);
+            assert!(q.tight, "{raw} should parse as true");
+        }
+        for raw in ["0", "false", "no", ""] {
+            let json = format!(r#"{{"tight":"{raw}"}}"#);
+            let q: PlateCropQuery = serde_json::from_str(&json).expect(raw);
+            assert!(!q.tight, "{raw} should parse as false");
+        }
+        // Absent entirely -> false (the #[serde(default)]).
+        let q: PlateCropQuery = serde_json::from_str("{}").expect("empty");
+        assert!(!q.tight);
+        // A typo must still be an error, not a silent false.
+        assert!(serde_json::from_str::<PlateCropQuery>(r#"{"tight":"ture"}"#).is_err());
+    }
 }

--- a/services/api/src/plates.rs
+++ b/services/api/src/plates.rs
@@ -271,10 +271,31 @@ async fn post_lpr_read(
     Ok(StatusCode::ACCEPTED)
 }
 
+/// Query parameters for `GET /plates/:id/crop`.
+#[derive(Debug, Deserialize)]
+pub struct PlateCropQuery {
+    /// When true, crop the stored frame down to just this read's plate box
+    /// (server-side) instead of returning the whole stored frame.
+    #[serde(default)]
+    pub tight: bool,
+}
+
 /// `GET /plates/:id/crop` — serve a stored plate crop JPEG (external-engine reads
 /// only; Frigate reads carry `snapshot_url` instead). `view_plates`-gated and
 /// camera-scoped: an out-of-scope or unknown read 404s (never revealing
 /// existence), and a read with no stored crop 404s.
+///
+/// ## `?tight=1` (optional)
+///
+/// The `crop` column stores the whole CONTEXT frame for `crumb-alpr` reads, not
+/// a tight plate crop, so clients historically downloaded the full frame
+/// (~174 KB) and cropped it themselves — a full-frame decode per row. With
+/// `tight=1` the server crops to the read's own box and returns just the plate
+/// (a few KB).
+///
+/// The crop is deliberately NOT downscaled: a plate box is only ~5 % of frame
+/// width, so a plate cropped out of a shrunken frame is unreadable, and reading
+/// the plate is the entire point of this image.
 ///
 /// # Errors
 ///
@@ -284,9 +305,10 @@ async fn get_plate_crop(
     user: AuthUser,
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    Query(q): Query<PlateCropQuery>,
 ) -> Result<axum::response::Response, ApiError> {
     user.require_view_plates()?;
-    let (camera_id, crop) = db::get_plate_read_crop(state.pool(), id)
+    let (camera_id, crop, bbox) = db::get_plate_read_crop_with_bbox(state.pool(), id)
         .await
         .map_err(ApiError::Internal)?
         .ok_or_else(|| ApiError::NotFound(format!("plate read {id} not found")))?;
@@ -294,6 +316,21 @@ async fn get_plate_crop(
         return Err(ApiError::NotFound(format!("plate read {id} not found")));
     }
     let bytes = crop.ok_or_else(|| ApiError::NotFound(format!("plate read {id} has no crop")))?;
+
+    // Tight crop when asked for AND a box exists. No box → serve the stored
+    // frame; cropping to a guessed region would hide the plate entirely.
+    // A transform failure likewise degrades to the stored frame rather than
+    // failing the request.
+    let bytes = match (q.tight, bbox) {
+        (true, Some(bb)) => match crate::imgcache::cropped(&state, id, bb, &bytes).await {
+            Ok(cropped) => cropped,
+            Err(e) => {
+                tracing::warn!(error = %e, read_id = %id, "plate crop failed; serving full frame");
+                bytes
+            }
+        },
+        _ => bytes,
+    };
     Ok(([(axum::http::header::CONTENT_TYPE, "image/jpeg")], bytes).into_response())
 }
 

--- a/services/api/src/plates.rs
+++ b/services/api/src/plates.rs
@@ -512,6 +512,11 @@ pub struct AbReadDto {
     /// Sibling detection event — the client fetches the pass image via the
     /// existing `GET /events/:id/snapshot` (or `GET /plates/:id/crop`).
     pub event_id: Option<Uuid>,
+    /// Plate box `[x, y, w, h]` (0..1 fractions of the snapshot frame), when
+    /// one was captured. Lets a client crop the pass image to the plate from
+    /// the report alone — without a per-row `GET /plates` round-trip to look
+    /// up a box the server already had.
+    pub bbox: Option<[f32; 4]>,
     pub ts: DateTime<Utc>,
     /// Raw reads collapsed into this engine's entry (dup-refinement count).
     pub read_count: usize,
@@ -523,6 +528,7 @@ fn ab_read_dto(b: &crumb_common::lpr_ab::EngineBest) -> AbReadDto {
         plate: b.plate.clone(),
         confidence: b.confidence,
         event_id: b.event_id,
+        bbox: b.bbox,
         ts: b.ts,
         read_count: b.read_count,
     }

--- a/services/api/tests/support/mod.rs
+++ b/services/api/tests/support/mod.rs
@@ -77,6 +77,8 @@ pub mod ffprobe;
 pub mod filmstrip;
 #[path = "../../src/go2rtc.rs"]
 pub mod go2rtc;
+#[path = "../../src/imgcache.rs"]
+pub mod imgcache;
 #[path = "../../src/plates.rs"]
 pub mod plates;
 #[path = "../../src/playback.rs"]

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -8604,6 +8604,40 @@ pub async fn get_plate_read_crop(pool: &Pool, id: Uuid) -> Result<Option<(Uuid, 
     Ok(row.map(|r| (r.get("camera_id"), r.get("crop"))))
 }
 
+/// Like [`get_plate_read_crop`] but also returns the read's plate box as
+/// `[x, y, w, h]` fractions, so a caller can crop the stored frame down to just
+/// the plate. Assembled from the `bbox_x1..bbox_y2` corner columns exactly like
+/// [`plate_read_from_row`]; `None` when no box was captured.
+///
+/// # Errors
+///
+/// Returns an error if the query fails.
+pub async fn get_plate_read_crop_with_bbox(
+    pool: &Pool,
+    id: Uuid,
+) -> Result<Option<(Uuid, Option<Vec<u8>>, Option<[f32; 4]>)>> {
+    let client = get_conn(pool).await?;
+    let row = client
+        .query_opt(
+            "SELECT camera_id, crop, bbox_x1, bbox_y1, bbox_x2, bbox_y2 \
+             FROM plate_reads WHERE id = $1",
+            &[&id],
+        )
+        .await
+        .context("get_plate_read_crop_with_bbox")?;
+    Ok(row.map(|r| {
+        let x1: Option<f32> = r.get("bbox_x1");
+        let y1: Option<f32> = r.get("bbox_y1");
+        let x2: Option<f32> = r.get("bbox_x2");
+        let y2: Option<f32> = r.get("bbox_y2");
+        let bbox = match (x1, y1, x2, y2) {
+            (Some(x1), Some(y1), Some(x2), Some(y2)) => Some([x1, y1, x2 - x1, y2 - y1]),
+            _ => None,
+        };
+        (r.get("camera_id"), r.get("crop"), bbox)
+    }))
+}
+
 /// Effective per-camera LPR config (migrations 0069/0071) for the `crumb-alpr`
 /// worker's `GET /lpr/worker-config` poll. Returns `None` if the camera id is
 /// unknown.

--- a/services/common/src/lpr_ab.rs
+++ b/services/common/src/lpr_ab.rs
@@ -67,6 +67,11 @@ pub struct EngineBest {
     pub confidence: Option<f32>,
     /// Sibling detection event of the kept read, when one exists.
     pub event_id: Option<Uuid>,
+    /// Plate box `[x, y, w, h]` (0..1 fractions) of the kept read's snapshot
+    /// frame, when one was captured. Carried through so a client can crop the
+    /// pass image to the plate WITHOUT re-querying `/plates` per row just to
+    /// re-find a box the report already had in hand.
+    pub bbox: Option<[f32; 4]>,
     /// Timestamp of the kept read.
     pub ts: DateTime<Utc>,
     /// How many raw reads this engine contributed to the pass (collapsed
@@ -195,6 +200,7 @@ impl<'a> Cluster<'a> {
                 plate: self.best.plate.clone(),
                 confidence: self.best.confidence,
                 event_id: self.best.event_id,
+                bbox: self.best.bbox,
                 ts: self.best.ts,
                 read_count: self.count,
             },
@@ -460,6 +466,41 @@ mod tests {
         assert_eq!(f.read_count, 2, "both raw reads counted");
         assert!(passes[0].crumb_alpr.is_none());
         assert_eq!(passes[0].bucket_ts, t0(), "bucket = earliest read ts");
+    }
+
+    /// The kept read's bbox rides along into the pass, so a client can crop
+    /// the pass image to the plate straight from the report. Critically it is
+    /// the BEST read's box, never a collapsed duplicate's: a box is only valid
+    /// against the exact frame its own read was made on, so pairing the
+    /// survivor's frame with a discarded read's box would crop the wrong
+    /// region.
+    #[test]
+    fn kept_reads_bbox_rides_into_the_pass() {
+        let cam = Uuid::new_v4();
+        let mut low = mk_read(cam, ENGINE_FRIGATE, "9GXVL98", Some(0.70), t0());
+        low.bbox = Some([0.10, 0.10, 0.05, 0.05]);
+        let mut high = mk_read(cam, ENGINE_FRIGATE, "9GXV498", Some(0.87), t0() + secs(5));
+        high.bbox = Some([0.40, 0.60, 0.05, 0.05]);
+
+        let passes = pair_passes(&[low, high], 8, 0.25);
+        assert_eq!(passes.len(), 1, "one physical pass");
+        let f = passes[0].frigate.as_ref().expect("frigate best kept");
+        assert_eq!(
+            f.bbox,
+            Some([0.40, 0.60, 0.05, 0.05]),
+            "the surviving (higher-confidence) read's box, not the dropped duplicate's",
+        );
+    }
+
+    /// A read with no captured box stays `None` — the client falls back to the
+    /// uncropped frame rather than cropping to a bogus region.
+    #[test]
+    fn missing_bbox_stays_none() {
+        let cam = Uuid::new_v4();
+        let reads = vec![mk_read(cam, ENGINE_CRUMB, "8TKM204", Some(0.99), t0())];
+        let passes = pair_passes(&reads, 8, 0.25);
+        let c = passes[0].crumb_alpr.as_ref().expect("crumb best kept");
+        assert_eq!(c.bbox, None);
     }
 
     /// Both engines read the same car → one pass with both bests, agreement.


### PR DESCRIPTION
Second of two changes for #391. **Stacked on #393** — review that one first; this PR targets `perf/ab-report-bbox` so the diff stays honest, and it can be retargeted to `main` once #393 merges.

## Problem
Detection frames are stored at full resolution (**~174 KB** average in a live 24 h sample) but the benchmark draws them into a **132x74** thumbnail. Each row then spent a freshly spawned isolate decoding that full frame to derive the plate crop client-side. Scrolling all 165 passes moved roughly **28 MB**.

## Change

**Server** — two opt-in derivatives, both disk-cached:

| | |
|---|---|
| `GET /events/:id/snapshot?w=N` | downscaled context frame |
| `GET /plates/:id/crop?tight=1` | plate region, cropped server-side |

Omitting the parameter returns the original bytes unchanged, so **every existing caller is byte-for-byte unaffected**.

The crop is deliberately **not** downscaled. A plate box is only ~5 % of frame width, so a plate cropped out of a shrunken frame is unreadable — and reading the plate is the entire point of that image. This is why it's a separate request rather than something the client derives from the thumb.

Both run through the same ffmpeg + bounded-concurrency + on-disk-cache machinery the clip thumbnails already use, so **no new Rust dependency**. Derivatives land under `export_dir` (the api's one writable area — media storage is mounted read-only) behind a size-budget prune.

**Client** — fetches the two derivatives concurrently instead of one full frame + a client-side crop. Clicking to enlarge fetches the full-resolution frame on demand and swaps it into the lightbox, so the list never pays for full-res bytes while enlarging still shows real detail.

Net: **~174 KB/row → ~25 KB/row**, and the per-row full-frame decode is gone.

## Security / robustness
- Existing `view_plates` + camera-scope gating is untouched on both routes.
- Requested widths **snap to an allowed set** rather than being honored verbatim — an open integer range would let one caller mint unbounded cache entries and ffmpeg runs for a single image.
- Cache keys are sanitized so they cannot escape the cache directory (tested).
- The crop cache key includes the box, so a later Frigate box refinement can't serve a stale crop.
- A transform failure **degrades to the original frame** rather than failing the request — a missing or wedged ffmpeg costs bytes, not images.
- Derivatives are written to a temp file and renamed, so a reader never sees a half-written image; scratch input files are uniquely named so concurrent misses can't truncate each other.

## Verification
Full gate on a Rust box: `cargo fmt --check` ✅, `cargo clippy --all-targets -D warnings` ✅, `cargo test --workspace` ✅ (0 failures, incl. 3 new `imgcache` unit tests). `flutter analyze` on the changed Dart: **no issues**.

Not yet exercised against live data end-to-end — the numbers above are derived from measured payload sizes, not an after-the-fact profile. Worth opening the benchmark on a real instance before merge.

Refs #391