### PR TITLE
docs: warn about the NVIDIA driver-upgrade trap on GPU hosts

### DIFF
--- a/docs-site/docs/configuration/hardware-decode.md
+++ b/docs-site/docs/configuration/hardware-decode.md
@@ -72,3 +72,59 @@ that no devices exist.
 
 A wrong pick is always safe: the recorder falls back to CPU automatically
 rather than failing to decode at all.
+
+## Keeping an NVIDIA host stable
+
+This section only matters if you gave the recorder an NVIDIA GPU. VAAPI
+and CPU installs can skip it.
+
+Upgrading the host's NVIDIA driver replaces the userspace libraries, but
+the kernel module already loaded in memory stays at the old version until
+the machine reboots. Until then the two disagree, `nvidia-smi` reports
+`Driver/library version mismatch`, and Docker can no longer start a
+container that asks for the GPU.
+
+The dangerous part is the delay. Containers that are already running keep
+working, because their GPU mounts were established before the upgrade. The
+stack looks healthy, possibly for days. The breakage only surfaces the next
+time a container is **recreated**, so a machine can silently lose the
+ability to restart its own recorder and only reveal it during an update, or
+after a power cut. For a recorder that is supposed to be running
+unattended, that is a bad way to find out.
+
+Two things make this much less likely to catch you:
+
+**Reboot after a driver upgrade.** Not eventually, as part of the upgrade.
+Then confirm with `nvidia-smi` before assuming you are back.
+
+**Don't let driver upgrades happen unattended.** Ubuntu and Debian enable
+`unattended-upgrades` out of the box, so this can happen without anyone
+running `apt` at all, and it will not reboot for you. On those systems you
+can hold the driver and kernel back while still receiving ordinary security
+patches, by dropping a file into `/etc/apt/apt.conf.d/`:
+
+```
+Unattended-Upgrade::Package-Blacklist {
+        "^nvidia-";
+        "^libnvidia-";
+        "^xserver-xorg-video-nvidia";
+        "^linux-image";
+        "^linux-headers";
+        "^linux-generic";
+        "^linux-modules";
+};
+```
+
+Driver and kernel updates then happen when *you* choose, paired with the
+reboot they need. Check it took effect with:
+
+```bash
+sudo unattended-upgrade --dry-run --debug | grep -i blacklist
+```
+
+Kernel upgrades are worth holding for the same reason: a new kernel without
+a reboot leaves the running module and the installed modules out of step.
+
+If you hit this, [Troubleshooting](/troubleshooting/) covers recovery,
+including how to get the recorder running again without the GPU when a
+reboot has to wait.

--- a/docs-site/docs/troubleshooting/index.md
+++ b/docs-site/docs/troubleshooting/index.md
@@ -44,6 +44,42 @@ clear within a minute or two.
 (`MOTION_HWACCEL=auto`); recording itself never needed the GPU in the
 first place. See [Hardware decode](/configuration/hardware-decode).
 
+**The recorder won't start, and the error mentions
+`/run/nvidia-persistenced/socket: no such file or directory`.** The host's
+NVIDIA driver was upgraded, but the machine hasn't been rebooted since, so
+the kernel module still loaded in memory no longer matches the newly
+installed userspace libraries. Confirm it with `nvidia-smi` on the host, a
+mismatch reports:
+
+```
+Failed to initialize NVML: Driver/library version mismatch
+```
+
+**Fix: reboot the host.** Rolling Crumb back to an earlier image does not
+help, the fault is on the host, not in Crumb.
+
+This one is worth understanding because of *when* it bites. A container
+that is already running keeps working fine after the driver upgrade,
+because its GPU mounts were established before the upgrade happened. So
+the stack looks completely healthy, sometimes for hours or days. The
+failure only appears the next time a container is **recreated**, which
+might be a Crumb update, a `docker compose up -d`, or an unrelated
+restart. In other words the machine can quietly lose the ability to
+restart its own recorder, and you find out at the worst moment. If your
+host installs updates automatically (Ubuntu and Debian do by default),
+see [Hardware decode](/configuration/hardware-decode) for how to stop
+driver upgrades landing unattended.
+
+Only installs that hand the recorder an NVIDIA device are affected. The
+base stack boots GPU-free, and VAAPI installs are unaffected.
+
+If a reboot has to wait and you would rather be recording than have GPU
+stats, start the recorder without the GPU by dropping the GPU overlay from
+your `docker compose` command. Note that removing the device reservation
+alone is not enough, the NVIDIA container toolkit also activates on the
+`NVIDIA_VISIBLE_DEVICES` environment variable, so that must be set to
+`void` as well. Reboot at the next opportunity and put the overlay back.
+
 ## Cameras
 
 **A camera won't connect.** Usually a wrong RTSP URL or credentials.

--- a/docs/AI-INSTALL.md
+++ b/docs/AI-INSTALL.md
@@ -203,6 +203,20 @@ is present, **stay on CPU.** Never block the install on a GPU.
 **Verify (if enabled):** `nvidia-smi` works (NVIDIA) or a `/dev/dri/renderD*`
 node exists (VAAPI); otherwise skip.
 
+**If NVIDIA was enabled, tell the user about the driver-upgrade trap** (and
+offer to mitigate it, do not change their update policy without asking):
+upgrading the host NVIDIA driver without rebooting leaves the loaded kernel
+module mismatched against the new libraries. Already-running containers keep
+working, so nothing looks wrong, but the next container **recreate** fails with
+`open /run/nvidia-persistenced/socket: no such file or directory` and the
+recorder will not start. On a recorder meant to run unattended this surfaces at
+the worst time, during an update or after a power cut. Fix is a host reboot;
+rolling Crumb's image back does not help. Debian/Ubuntu enable
+`unattended-upgrades` by default, so this can happen with no one running `apt`.
+Mitigation (hold driver + kernel back while still taking security patches) is in
+`docs-site/docs/configuration/hardware-decode.md`, "Keeping an NVIDIA host
+stable"; recovery is in `docs-site/docs/troubleshooting/index.md`.
+
 ---
 
 ## 5. Bring up the stack


### PR DESCRIPTION
Documents a failure mode hit in the wild: a host NVIDIA driver upgrade stops the recorder from ever starting again, with a long silent delay before it shows up.

## The failure
Upgrading the host's NVIDIA driver replaces the userspace libraries, but the kernel module already loaded stays at the old version until reboot. `nvidia-smi` then reports `Driver/library version mismatch`, `nvidia-persistenced` dies, and Docker can't start a container that asks for the GPU:

```
open /run/nvidia-persistenced/socket: no such file or directory
```

## Why it deserves its own docs
**The delay is the dangerous part.** Containers already running keep working — their GPU mounts predate the upgrade — so the stack looks completely healthy, potentially for days. The failure only appears on the next container **recreate**.

For an NVR that's supposed to run unattended, that means the machine can quietly lose the ability to restart its own recorder, and you discover it during an update or after a power cut. Rolling Crumb's image back doesn't help, because the fault is host-side — which is exactly the wrong-turn a user is most likely to take.

Debian/Ubuntu enable `unattended-upgrades` by default, so this can happen with **nobody having run `apt` at all**.

## What's added
- **Troubleshooting** — symptom, why it's delayed, reboot as the fix, and how to keep recording without the GPU when a reboot has to wait. Notes that clearing the device reservation alone is insufficient: the NVIDIA container toolkit also activates on `NVIDIA_VISIBLE_DEVICES`, so it must be set to `void`.
- **Hardware decode** — a "Keeping an NVIDIA host stable" section: reboot promptly after driver upgrades, plus an apt blacklist holding driver + kernel back while ordinary security patches keep flowing, with a verification command.
- **AI-INSTALL** — when NVIDIA is enabled, tell the user about the trap. Explicitly instructs the agent **not** to change a user's update policy without asking.

## Scoping
Deliberately not alarmist: **only installs that hand the recorder an NVIDIA device are affected.** The base stack boots GPU-free (`docker-compose.yml` keeps NVIDIA opt-in via `docker-compose.gpu.example.yml`), and VAAPI installs are unaffected. Each page says so.

Docs-only; no code or compose changes.

Per COMPONENT-MAP: install-runbook and docs-site rows both updated in this change.