### PR TITLE
fix(setup): fail early when a bind-mounted config file is missing

### DIFF
--- a/docs-site/docs/troubleshooting/index.md
+++ b/docs-site/docs/troubleshooting/index.md
@@ -34,6 +34,31 @@ docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
 it. Remap the conflicting port in `docker-compose.yml`, or override
 `CRUMB_HTTPS_PORT` in `.env` for the Caddy HTTPS port.
 
+**A container dies with `not a directory: Are you trying to mount a
+directory onto a file`,** naming `caddy/Caddyfile` or
+`go2rtc/go2rtc.yaml`. That config file is missing from your copy of the
+repo. Compose bind-mounts it into the container, and when the source file
+doesn't exist Docker silently creates an empty **directory** in its place,
+then fails to mount it over a file. The error describes the symptom, not
+the cause.
+
+Remove the directory Docker left behind and restore the real file:
+
+```bash
+rmdir caddy/Caddyfile          # the empty directory Docker created
+git checkout -- caddy/Caddyfile
+docker compose up -d
+```
+
+Both the `rmdir` and the restore are needed: leaving the directory in
+place makes the next `up` fail exactly the same way. `scripts/setup-env.sh`
+now checks for this before you start the stack, so re-running it will also
+tell you which file is missing.
+
+This usually means the deployment directory holds a partial copy of the
+repo rather than a full checkout, which is easy to end up with when running
+from prebuilt images and only copying what looks necessary.
+
 ## After startup
 
 **`/health` stays `503`.** Give Postgres a moment to finish starting and

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -380,6 +380,38 @@ else
   log "NOTE: could not create ${BACKUP_DIR_HOST} — create it and chown 1001:1001 before 'docker compose up'."
 fi
 
+# ── Required bind-mounted FILES ──────────────────────────────────────────────
+# Same failure class as the backup directory above, but worse. The compose file
+# bind-mounts two config FILES from the repo. If either is missing, Docker does
+# not error usefully: it silently creates a DIRECTORY at that path, and the
+# container then dies with
+#
+#   error mounting ".../caddy/Caddyfile" to rootfs at "/etc/caddy/Caddyfile":
+#   not a directory: Are you trying to mount a directory onto a file
+#
+# which says nothing about the real problem (the file is missing) and leaves a
+# bogus directory behind that has to be removed by hand before a retry works.
+# Fail here instead, where we can name the file and the fix.
+#
+# This bites deployments that keep a partial copy of the repo rather than a full
+# checkout, which is a normal thing to do when running from prebuilt images.
+for required_file in "caddy/Caddyfile" "go2rtc/go2rtc.yaml"; do
+  path="${REPO_ROOT}/${required_file}"
+  if [[ -d "${path}" ]]; then
+    die "${path} is a DIRECTORY but must be a file.
+      Docker creates an empty directory here when the file is missing and a
+      container has already tried to start. Remove it and restore the file:
+        rmdir '${path}'
+        git checkout -- '${required_file}'"
+  elif [[ ! -f "${path}" ]]; then
+    die "missing required file: ${path}
+      docker-compose.yml bind-mounts this into a container. Without it the
+      container fails to start with a confusing 'not a directory' mount error.
+      Restore it with:
+        git checkout -- '${required_file}'"
+  fi
+done
+
 log "wrote ${ENV_FILE} (mode 600) with freshly generated secrets"
 log ""
 log "  Console sign-in (write these down, you will not be shown the password again):"


### PR DESCRIPTION
Hit in the wild while moving a long-running deployment back onto the stock compose.

## The failure
`docker-compose.yml` bind-mounts two config **files** from the repo: `caddy/Caddyfile` and `go2rtc/go2rtc.yaml`. If one is missing, Docker doesn't say so. It silently creates a **directory** at that path, and the container then dies with:

```
error mounting ".../caddy/Caddyfile" to rootfs at "/etc/caddy/Caddyfile":
not a directory: Are you trying to mount a directory onto a file
```

That names the symptom, not the cause. Worse, it leaves the bogus directory behind, so the obvious next step (restore the file, retry) still fails until you `rmdir` it by hand.

Easy state to reach when a deployment keeps a partial copy of the repo instead of a full checkout — normal when running from prebuilt images and copying only what looks necessary.

## Fix
A preflight in `setup-env.sh`. There's already precedent directly above it: the script prepares the backup directory specifically because *"if Docker auto-creates the bind-mount dir it ends up root-owned and the api can't write."* Same failure class, extended to the file mounts.

It handles **both** states:
- file missing → names the file and the `git checkout` to restore it
- path is a stray directory → tells you to `rmdir` it *and* restore, since that's what a user actually has by the time they investigate

Plus a troubleshooting entry for anyone who meets the raw Docker error before running setup.

## Verification
Exercised all three cases against a scratch tree:

| case | result |
|---|---|
| `Caddyfile` is a stray directory | ✅ errors, tells you to rmdir |
| `Caddyfile` missing entirely | ✅ errors, names the file |
| both files present | ✅ passes |

`bash -n` clean; confirmed it passes against a full checkout.

No Rust touched, so the Rust gate is unaffected.