### PR TITLE
fix(clients): stop discovery preferring a TLS URL the app cannot use

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/auth/ServerDiscovery.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/auth/ServerDiscovery.kt
@@ -26,7 +26,23 @@ data class DiscoveredServer(
     val ip: String,
     val port: Int,
     val version: String?,
-)
+    /**
+     * Whether this host's TLS certificate validated normally. Always true for
+     * plain http.
+     *
+     * The discovery probe deliberately trusts any certificate so it can still
+     * FIND a TLS-fronted server, but real API traffic does not. Returning an
+     * https URL whose certificate the app will later reject yields a server
+     * that "was found" and then refuses to connect. The bundled Caddy issues
+     * from its own internal CA, so a stock stack lands exactly here.
+     */
+    val certTrusted: Boolean = true,
+) {
+    val isHttps: Boolean get() = url.startsWith("https://")
+
+    /** Usable without the operator first trusting a certificate. */
+    val usableAsIs: Boolean get() = !isHttps || certTrusted
+}
 
 /**
  * Max probes in flight at once — bounds socket pressure so a /24 finishes in a
@@ -90,14 +106,41 @@ suspend fun discoverCrumbServers(
         }.awaitAll()
     }.filterNotNull()
 
-    collapseDualExposed(found)
+    // Re-probe each https hit with the VALIDATING client to learn whether its
+    // certificate would survive real API traffic. Cheap: a scan usually turns up
+    // at most one TLS host, and the answer decides whether preferring the TLS
+    // URL would hand back something that cannot actually connect.
+    val checked = found.map { s ->
+        if (!s.isHttps) s else s.copy(certTrusted = certValidates(plainClient, "${s.url}/health"))
+    }
+
+    collapseDualExposed(checked)
         .sortedWith(
             compareBy(
+                { !it.usableAsIs },
                 { it.ip.substringAfterLast('.').toIntOrNull() ?: 0 },
                 { it.port },
             ),
         )
 }
+
+/**
+ * Whether [url] completes over TLS using a client that performs NORMAL
+ * certificate validation. False for a self-signed or otherwise untrusted cert
+ * (what the bundled Caddy serves), which is exactly the case where handing the
+ * operator this URL would produce a connect failure after a successful "found".
+ *
+ * Any failure counts as untrusted: the point is "would real traffic work",
+ * and a probe that cannot complete is not a URL worth preferring.
+ */
+private suspend fun certValidates(validatingClient: OkHttpClient, url: String): Boolean =
+    withContext(Dispatchers.IO) {
+        runCatching {
+            validatingClient.newCall(
+                Request.Builder().url(url).get().build(),
+            ).execute().use { it.isSuccessful }
+        }.getOrDefault(false)
+    }
 
 /**
  * The (isHttps, port) probe candidates per host: plain :8080 + TLS :8443, plus an
@@ -119,13 +162,22 @@ internal fun candidatePorts(port: Int?): List<Pair<Boolean, Int>> {
  * separate entries.
  */
 internal fun collapseDualExposed(found: List<DiscoveredServer>): List<DiscoveredServer> {
-    val dual = found
-        .filter { it.port == 8443 && it.url.startsWith("https://") }
+    // Prefer the TLS URL ONLY when its certificate validates, because that is
+    // the only case where real API traffic can use it. With the bundled Caddy
+    // (its own internal CA) it does not, and dropping the working http URL in
+    // favour of it produced a "found" server that then refused to connect.
+    val trustedTls = found
+        .filter { it.isHttps && it.certTrusted }
         .map { it.ip }
         .toSet()
-    return found.filterNot {
-        it.port == 8080 && it.url.startsWith("http://") && it.ip in dual
-    }
+    val plainHosts = found.filterNot { it.isHttps }.map { it.ip }.toSet()
+    return found
+        .filterNot { !it.isHttps && it.ip in trustedTls }
+        // An untrusted TLS host with a working plain sibling is dropped rather
+        // than offered as a choice that fails. With no sibling it is kept: it
+        // may be all the operator exposes.
+        .filterNot { it.isHttps && !it.certTrusted && it.ip in plainHosts }
+        .sortedBy { !it.usableAsIs }
 }
 
 /**

--- a/apps/desktop-flutter/lib/api/discovery_api.dart
+++ b/apps/desktop-flutter/lib/api/discovery_api.dart
@@ -23,7 +23,13 @@ import 'crumb_api.dart';
 
 /// One server found by [DiscoveryApi.discoverServers].
 class DiscoveredServer {
-  DiscoveredServer({required this.url, required this.ip, required this.port, this.version});
+  DiscoveredServer({
+    required this.url,
+    required this.ip,
+    required this.port,
+    this.version,
+    this.certTrusted = true,
+  });
 
   /// Full base URL, e.g. `http://<lan-ip>:8080` or `https://<lan-ip>:8443`.
   final String url;
@@ -31,7 +37,22 @@ class DiscoveredServer {
   final int port;
   final String? version;
 
+  /// Whether this host's TLS certificate validated against the system trust
+  /// store. Always true for plain http.
+  ///
+  /// This matters because the discovery probe deliberately accepts ANY
+  /// certificate so it can still *find* a TLS-fronted server, but the app's
+  /// normal API client does not. Handing back an https URL whose certificate
+  /// the app will later reject produces a server that "was found" and then
+  /// refuses to connect, which is exactly the wrong answer. The bundled Caddy
+  /// issues from its own internal CA, so an out-of-the-box stack lands here.
+  final bool certTrusted;
+
   bool get isHttps => url.startsWith('https://');
+
+  /// True when this entry is usable without the operator first trusting a
+  /// certificate. Ranked above [certTrusted] == false entries.
+  bool get usableAsIs => !isHttps || certTrusted;
 }
 
 /// LAN server discovery, added as an extension (not a method on [CrumbApi]
@@ -73,11 +94,22 @@ extension DiscoveryApi on CrumbApi {
 
     final httpClient = HttpClient()
       ..connectionTimeout = const Duration(milliseconds: 500);
+
+    // Hosts whose TLS certificate did NOT validate. badCertificateCallback
+    // fires only on a validation failure, so membership here is exactly "the
+    // app's normal client would refuse this URL". We still return true to keep
+    // probing (we want to FIND the server either way), but we remember, so the
+    // result can be ranked and labelled honestly instead of silently handing
+    // back a URL that will not connect.
+    final untrusted = <String>{};
     final httpsClient = HttpClient()
       ..connectionTimeout = const Duration(milliseconds: 500)
       // Discovery only reads the unauthenticated /health signature; a LAN
       // server's TLS cert is typically self-signed, so don't reject it here.
-      ..badCertificateCallback = (cert, host, port) => true;
+      ..badCertificateCallback = (cert, host, port) {
+        untrusted.add('$host:$port');
+        return true;
+      };
 
     try {
       final probes = <(String ip, bool isHttps, int port)>[
@@ -102,17 +134,40 @@ extension DiscoveryApi on CrumbApi {
       // 64-way concurrent, matching the Rust `buffer_unordered(64)`.
       await Future.wait(List.generate(64, (_) => worker()));
 
-      // Collapse the plain+TLS front doors of a *single* host into one
-      // entry: if the same IP answers on both http:8080 and https:8443, keep
-      // only the secure URL. Distinct hosts and genuinely different ports
-      // stay separate.
-      final dual = found
-          .where((s) => s.isHttps && s.port == 8443)
+      // Stamp each https hit with whether its certificate actually validated.
+      for (var i = 0; i < found.length; i++) {
+        final s = found[i];
+        if (!s.isHttps) continue;
+        found[i] = DiscoveredServer(
+          url: s.url,
+          ip: s.ip,
+          port: s.port,
+          version: s.version,
+          certTrusted: !untrusted.contains('${s.ip}:${s.port}'),
+        );
+      }
+
+      // Collapse the plain+TLS front doors of a *single* host into one entry.
+      // Prefer the TLS URL ONLY when its certificate validates, because that is
+      // the only case where the app's normal client can actually use it. With
+      // the bundled Caddy (its own internal CA) the cert does not validate, and
+      // dropping the working http URL in favour of it produced a "found" server
+      // that then refused to connect. In that case keep the plain URL, which
+      // always works, and leave the TLS one out rather than offering a choice
+      // that fails.
+      final trustedTls = found
+          .where((s) => s.isHttps && s.certTrusted)
           .map((s) => s.ip)
           .toSet();
-      found.removeWhere((s) => s.port == 8080 && !s.isHttps && dual.contains(s.ip));
+      final plainHosts = found.where((s) => !s.isHttps).map((s) => s.ip).toSet();
+      found.removeWhere((s) => !s.isHttps && trustedTls.contains(s.ip));
+      found.removeWhere((s) => s.isHttps && !s.certTrusted && plainHosts.contains(s.ip));
 
       found.sort((a, b) {
+        // Usable-as-is first: a self-signed TLS host with no plain-http sibling
+        // is still worth showing (it may be all the operator exposes), but it
+        // must never outrank one that just works.
+        if (a.usableAsIs != b.usableAsIs) return a.usableAsIs ? -1 : 1;
         int lastOctet(String ip) => int.tryParse(ip.split('.').last) ?? 0;
         final byIp = lastOctet(a.ip).compareTo(lastOctet(b.ip));
         if (byIp != 0) return byIp;

--- a/apps/desktop-flutter/lib/ui/discovery/server_discovery_panel.dart
+++ b/apps/desktop-flutter/lib/ui/discovery/server_discovery_panel.dart
@@ -73,7 +73,15 @@ class _ServerDiscoveryPanelState extends State<ServerDiscoveryPanel> {
       } else if (found.length == 1) {
         widget.onServerSelected(found[0].url);
         setState(() {
-          _message = 'Found ${found[0].url}';
+          // Say so when the only hit is a TLS server whose certificate does not
+          // validate (e.g. the bundled Caddy's internal CA). It is filled in
+          // because it may be all that is exposed, but connecting will fail
+          // until that certificate is trusted, and "Found <url>" alone would
+          // make that look like a Crumb bug rather than a trust decision.
+          _message = found[0].usableAsIs
+              ? 'Found ${found[0].url}'
+              : 'Found ${found[0].url} (self-signed certificate, '
+                  'trust it on this machine or use the plain http port)';
           _found = const [];
         });
       } else {


### PR DESCRIPTION
Fixes #400.

## The bug
"Find my server" returned `https://<host>:8443` and **deleted** the working `http://<host>:8080` entry for the same host, on the reasoning that the secure URL is the better one to hand back.

The problem is that the discovery probe deliberately trusts **any** certificate so it can find a TLS-fronted server, while real API traffic validates normally:

| | probe | real API client |
|---|---|---|
| desktop | `badCertificateCallback => true` | no override, validates |
| android | trust-all `X509TrustManager` | no override, validates |

The bundled Caddy issues from its own internal CA. So a stock stack discovers a URL that was "found", then refuses to connect, with nothing on screen connecting the two facts. Reported after a deployment moved onto the stock compose and Caddy started running for the first time.

## Fix
Record whether each https host's certificate **actually validates**, and prefer the TLS URL only when it does.

- **Desktop**: `badCertificateCallback` fires *only* on a validation failure, so recording the host inside it is precisely "the normal client would refuse this URL". No extra requests.
- **Android**: re-probe each https hit with the validating client. Cheap, since a scan turns up at most one TLS host, and it is the same question asked directly.

Ranking afterwards:
- TLS with a **trusted** cert wins over plain http (unchanged intent, now actually correct)
- TLS with an **untrusted** cert and a working plain sibling is **dropped**, not offered as a choice that fails
- TLS with an untrusted cert and **no** sibling is kept, since it may be all the operator exposes, but ranked last and labelled

The desktop panel now says the certificate is self-signed and what to do about it, rather than just "Found <url>".

An operator who has fronted Crumb with a genuinely trusted certificate still gets https preferred, which was the original intent.

## Cross-client
Both affected, both fixed here. iOS/macOS have no discovery yet.

## Verification
`flutter analyze` on both changed Dart files: no issues. Android `:app:assembleDebug`: BUILD SUCCESSFUL.

Not yet exercised against a live dual-exposed host end-to-end. The reporting instance now runs Caddy on 8443 alongside the API on 8080, so it is the natural place to confirm the behaviour before merge.