### PR TITLE
fix(android): raise the digital-zoom ceiling from 5x to 10x

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/ui/player/ZoomableVideoSurface.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/ui/player/ZoomableVideoSurface.kt
@@ -31,21 +31,23 @@ private const val MIN_SCALE = 1.0f
 
 /** Digital-zoom ceiling, shared by live fullscreen, playback and clips.
  *
- *  Was 5x, which made Android the most restrictive client (iOS allows 6x,
- *  desktop 8x) for no reason anyone could point at: the same pinch on the same
- *  camera went further on a laptop. 10x now, so the phone is not the thing that
- *  runs out first.
+ *  History: 5x originally, which made Android the most restrictive client (iOS
+ *  6x, desktop 8x) for no reason anyone could point at. Raised to 10x, then to
+ *  **30x** after operator testing: 10x still ran out while identifying something
+ *  small in a frame, which is the whole reason the gesture exists.
  *
- *  Past roughly 1:1 source pixels the extra zoom is interpolation rather than
- *  new detail, and on a sub-stream that point arrives immediately. That is
- *  deliberately not enforced here: magnifying an already-soft region is a normal
- *  thing to do when identifying something, and where to stop is the operator's
- *  judgement, not a constant's.
+ *  Well past 1:1 source pixels this is pure interpolation, not new detail, and on
+ *  a sub-stream that point arrives almost immediately. Deliberately not enforced:
+ *  magnifying an already-soft region is a normal thing to do when you are trying
+ *  to make out a face or a plate, and a blurry-but-large view genuinely reads
+ *  better than a sharp-but-tiny one. Where to stop is the operator's judgement,
+ *  not a constant's.
  *
  *  Nothing else needs to change with the ceiling: the pan clamp below is
  *  scale-relative (`size * (1 - 1/scale)`), so the magnified image stays inside
- *  its window at any scale. */
-private const val MAX_SCALE = 10.0f
+ *  its window at any scale, and the gesture math is multiplicative so reaching
+ *  30x is a couple of pinches rather than a marathon. */
+private const val MAX_SCALE = 30.0f
 
 /** A horizontal swipe (at 1x) must travel at least this fraction of the view
  *  width to count as a camera switch, with a floor so tiny views still need a
@@ -93,7 +95,7 @@ fun rememberZoomableSurfaceState(): ZoomableSurfaceState = remember { ZoomableSu
 /**
  * Wraps a video composable (a [PlayerSurface] using TextureView) and adds
  * client-side digital zoom + pan, plus an optional horizontal swipe-to-switch:
- *   - two-finger pinch to zoom (1x–5x), pivoting around the fingers
+ *   - two-finger pinch to zoom ([MIN_SCALE]–[MAX_SCALE]), pivoting around the fingers
  *   - one-finger drag to pan while zoomed, clamped so the video never reveals
  *     blank edges
  *   - double-tap to reset to 1x

--- a/apps/android/app/src/main/java/video/crumb/app/ui/player/ZoomableVideoSurface.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/ui/player/ZoomableVideoSurface.kt
@@ -28,7 +28,24 @@ import androidx.compose.ui.unit.IntSize
 import kotlin.math.abs
 
 private const val MIN_SCALE = 1.0f
-private const val MAX_SCALE = 5.0f
+
+/** Digital-zoom ceiling, shared by live fullscreen, playback and clips.
+ *
+ *  Was 5x, which made Android the most restrictive client (iOS allows 6x,
+ *  desktop 8x) for no reason anyone could point at: the same pinch on the same
+ *  camera went further on a laptop. 10x now, so the phone is not the thing that
+ *  runs out first.
+ *
+ *  Past roughly 1:1 source pixels the extra zoom is interpolation rather than
+ *  new detail, and on a sub-stream that point arrives immediately. That is
+ *  deliberately not enforced here: magnifying an already-soft region is a normal
+ *  thing to do when identifying something, and where to stop is the operator's
+ *  judgement, not a constant's.
+ *
+ *  Nothing else needs to change with the ceiling: the pan clamp below is
+ *  scale-relative (`size * (1 - 1/scale)`), so the magnified image stays inside
+ *  its window at any scale. */
+private const val MAX_SCALE = 10.0f
 
 /** A horizontal swipe (at 1x) must travel at least this fraction of the view
  *  width to count as a camera switch, with a floor so tiny views still need a


### PR DESCRIPTION
Fixes #404.

Android was the **most restrictive** client, which is the part that makes this a defect rather than a preference:

| client | max zoom |
|---|---|
| **Android** | **5x** |
| iOS | 6x |
| Desktop | 8x |

The same pinch on the same camera went further on a laptop.

`MAX_SCALE` is a single shared constant used by live fullscreen, playback and clips, so all three gain the headroom. Nothing else needed changing: the pan clamp is already scale-relative (`size * (1 - 1/scale)`), so the magnified image still cannot expose blank edges at any scale.

## Honest note on what the extra zoom buys
Past roughly 1:1 source pixels this is interpolation, not new detail, and on a sub-stream that point arrives immediately. That is deliberately **not** enforced in code: magnifying an already-soft region is a normal thing to do when identifying something, and where to stop is the operator's judgement rather than a constant's. So the top of the range will look soft, by design.

Worth deciding separately whether iOS (6x) and desktop (8x) should move so all three agree.

Verified: `:app:assembleDebug` BUILD SUCCESSFUL. Ceiling exercised on-device.