### PR TITLE
fix(api): default media-token capability claims instead of rejecting old tokens

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,47 @@ revisit.
 
 ---
 
+## 2026-07-29, Media-token capability claims default to false rather than failing to decode
+
+**Decision.** The capability claims on `MediaClaims` (`export`, `playback`,
+`clips`, `view_plates`) are `#[serde(default)]`. A media token minted by a server
+version that predates one of them still decodes, with that capability `false`.
+
+**Context.** They were deliberately NOT defaulted, on the reasoning that a
+pre-upgrade token lacking a claim should fail to decode and force a clean
+re-mint. The re-mint half does not exist: no client re-mints on a media-route
+401, they only react to a 401 on the mint call itself. So adding a required claim
+stopped every previously-minted token from decoding, and every warm client lost
+ALL media (live tiles, thumbnails, filmstrips, segments, clips, admin previews)
+until its cached token reached `exp`, up to the full 15-minute TTL. Bearer JSON
+calls kept working, so nothing prompted a re-auth that would have cleared the
+caches. Self-healing, but it read as a fleet-wide outage after a routine upgrade.
+
+**Why defaulting is the safe direction.** An old token still authenticates for
+basic media but carries no capabilities, so the capability-gated routes deny it
+exactly as they would for a user who never held those rights. The token is still
+signed, still `typ: "media"`, and still scoped to one camera by `cam`. This
+grants strictly LESS privilege than intended, never more. A short-lived loss of
+gated features beats a total media blackout.
+
+**Rejected: client-side re-mint on a media 401 as the immediate fix.** It is the
+better long-term answer and stays open, but media URLs are consumed by
+third-party loaders (Coil and ExoPlayer, media_kit, AVFoundation, plain `<img>`
+in the admin console), so catching a 401 means per-client interceptor plumbing
+across four surfaces. Worth doing, but not as the thing standing between an
+upgrade and a working deployment.
+
+**Accepted trade-offs.** For the TTL after an upgrade that adds a claim, a warm
+client silently lacks a capability it should have: exports, clips or plate crops
+may 403 until the token rotates. That is visible and recoverable, unlike the
+blackout. Covered by two tests: an old-shape token still authenticates on a
+capability-free media route, and is refused a plate crop even though the minting
+user holds `view_plates`.
+
+**Revisit if:** clients gain media-401 re-mint, at which point the strict
+behaviour could return without an outage, though there is little reason to want
+it back.
+
 ## 2026-07-20, Admin-only outbound probes (stream-test / ONVIF discovery) are not SSRF-guarded; risk accepted under the LAN-only, single-operator trust model
 
 **Context.** An API reliability/security audit flagged that `POST

--- a/services/api/src/auth_mw.rs
+++ b/services/api/src/auth_mw.rs
@@ -506,6 +506,16 @@ impl FromRequestParts<AppState> for AdminUser {
 /// principal to a single camera additionally means even a carried capability
 /// can only ever touch that one camera's media. `user_id` is carried through
 /// for audit/log correlation.
+///
+/// # Tokens minted before a capability claim existed (issue #366)
+///
+/// The cap claims are `#[serde(default)]` (see [`MediaClaims`]), so a token from
+/// a server version that predates one of them still decodes here, with that
+/// capability `false`. That is intentional: the alternative (a decode failure)
+/// took ALL media away from every warm client for the token's remaining TTL
+/// after any upgrade that added a claim. Such a token authenticates for basic
+/// media but is denied by the capability-gated routes, which is strictly less
+/// privilege than the minting user held, never more.
 fn try_media_token(token: &str, state: &AppState) -> Option<AuthUser> {
     let mut validation = Validation::new(Algorithm::HS256);
     validation.validate_exp = true;

--- a/services/api/src/dto.rs
+++ b/services/api/src/dto.rs
@@ -101,20 +101,46 @@ pub struct MediaClaims {
     /// requested resource belongs to this camera.
     pub cam: String,
     /// The minting user's `export` capability, carried so the media principal
-    /// grants no more than the caller actually held. These cap fields are NOT
-    /// `#[serde(default)]`: a pre-upgrade token that lacks them must fail to
-    /// decode (→ a clean 401 and automatic re-mint) rather than silently
-    /// deserialize as something with the wrong caps.
+    /// grants no more than the caller actually held.
+    ///
+    /// # Why these cap fields ARE `#[serde(default)]` (issue #366)
+    ///
+    /// They deliberately were not, on the reasoning that a pre-upgrade token
+    /// lacking them should fail to decode and force a clean re-mint. In practice
+    /// that produced a far worse failure. Adding a required claim means every
+    /// token minted by the previous version stops decoding, so **every warm
+    /// client loses ALL media** (live tiles, thumbnails, filmstrips, segments,
+    /// clips, admin previews) until its cached token reaches `exp` — up to the
+    /// full 15-minute TTL. Bearer JSON calls keep working, so nothing prompts a
+    /// re-auth that would clear the caches, and no client re-mints on a
+    /// media-route 401. It self-heals, but it reads as a fleet-wide outage after
+    /// every routine upgrade that touches this struct.
+    ///
+    /// Defaulting to `false` fails closed in the direction that actually matters:
+    /// an old token still authenticates for basic media, but carries **no**
+    /// capabilities, so the capability-gated routes (export, clips, plates) deny
+    /// it exactly as they would for a user who never had those rights. The token
+    /// is still signed, still `typ: "media"`, and still scoped to one camera by
+    /// `cam`, so this grants strictly LESS privilege than intended, never more.
+    /// A short-lived degradation of gated features beats a total media blackout.
+    ///
+    /// Clients re-minting on a media-route 401 is still the durable fix and is
+    /// tracked separately; this removes the outage without waiting on four
+    /// clients.
+    #[serde(default)]
     pub export: bool,
     /// The minting user's `playback` (recorded-footage) capability.
+    #[serde(default)]
     pub playback: bool,
     /// The minting user's `clips` capability.
+    #[serde(default)]
     pub clips: bool,
     /// The minting user's `view_plates` capability. Carried because the plate
     /// crop served by `GET /events/{id}/snapshot` (the crumb-alpr stored-crop
     /// fallback) and `GET /plates/{id}/crop` both require it, and clients fetch
     /// those with a scoped media token; without carrying it, an authorized
     /// user's token gets 403 and plate crops render blank.
+    #[serde(default)]
     pub view_plates: bool,
     /// Expiry — Unix timestamp (seconds). Short (~15 min; see auth.rs).
     pub exp: u64,

--- a/services/api/tests/auth_rbac.rs
+++ b/services/api/tests/auth_rbac.rs
@@ -2020,3 +2020,88 @@ async fn diagnostics_bundle_is_admin_only_and_downloads() {
         .await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
+
+// ─── pre-upgrade media tokens (issue #366) ─────────────────────────────────────
+
+/// Forge a media token in the shape a PREVIOUS server version minted: valid
+/// signature, `typ: "media"`, scoped to `camera`, but **without** the capability
+/// claims that were added later.
+///
+/// Signed with the same `JWT_SECRET` the test harness sets, so this is exactly
+/// what a warm client's cached token looks like across an upgrade that adds a
+/// claim — not an invalid token.
+fn forge_old_shape_media_token(user_id: Uuid, camera: Uuid) -> String {
+    use jsonwebtoken::{encode, EncodingKey, Header};
+    let now = Utc::now().timestamp() as u64;
+    // Deliberately omits export/playback/clips/view_plates.
+    let claims = serde_json::json!({
+        "sub": user_id.to_string(),
+        "typ": "media",
+        "cam": camera.to_string(),
+        "exp": now + 900,
+        "iat": now,
+    });
+    let secret = std::env::var("JWT_SECRET").expect("harness sets JWT_SECRET");
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .expect("forge media token")
+}
+
+/// A token minted before the capability claims existed must still DECODE, so an
+/// upgrade does not black out media on every warm client for the token's
+/// remaining TTL (#366).
+///
+/// Uses live fMP4 because it is gated on camera access alone, so a non-401 here
+/// isolates "the token authenticated" from any capability question. go2rtc is
+/// unreachable in tests, so the status will not be 200 — 401 is the failure this
+/// asserts against.
+#[tokio::test]
+async fn old_shape_media_token_still_authenticates() {
+    let app = TestApp::new().await;
+    let cam = seed_camera(app.pool()).await;
+    let viewer = seed_viewer(app.pool(), &[cam]).await;
+
+    let old = forge_old_shape_media_token(viewer.user_id, cam);
+    let resp = app
+        .send(get(&format!("/live/{cam}/stream.mp4?token={old}")))
+        .await;
+
+    assert_ne!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "a pre-upgrade media token must still decode: rejecting it took ALL media \
+         away from every warm client until its 15-minute TTL expired (#366)"
+    );
+}
+
+/// ...but it must carry NO capabilities, so capability-gated media is denied.
+/// This is the half that makes defaulting safe: the degradation is a loss of
+/// privilege, never a gain.
+#[tokio::test]
+async fn old_shape_media_token_carries_no_capabilities() {
+    let app = TestApp::new().await;
+    let cam = seed_camera(app.pool()).await;
+    let crop = vec![0xFFu8, 0xD8, 0xFF, 0xE0, 0x00, 0x10];
+    let event_id = seed_alpr_crop_event(&app, cam, &crop).await;
+
+    // seed_viewer HOLDS view_plates, so a current-shape token would be served
+    // (see crumb_alpr_crop_served_via_media_token_when_view_plates_held). The
+    // refusal below must therefore come from the token's defaulted claim, not
+    // from the user lacking the right.
+    let viewer = seed_viewer(app.pool(), &[cam]).await;
+    let old = forge_old_shape_media_token(viewer.user_id, cam);
+
+    let resp = app
+        .send(get(&format!("/events/{event_id}/snapshot?token={old}")))
+        .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "an old-shape token must default view_plates to false and be refused the \
+         plate crop, even though the minting user holds the capability: the token \
+         must never grant more than it proves"
+    );
+}


### PR DESCRIPTION
Fixes #366.

## The outage
Adding a required claim to `MediaClaims` took **all media** away from every warm client for up to the full 15-minute token TTL. A token minted by the previous version stopped decoding, so live tiles, thumbnails, filmstrips, segments, clips and admin previews died at once after a routine upgrade. Bearer JSON calls kept working, so nothing prompted a re-auth that would have cleared the media-token caches, and no client re-mints on a media-route 401.

## Why the strictness bought nothing
The claims were deliberately **not** `serde(default)`, on the reasoning that a stale token should fail closed into "a clean 401 and automatic re-mint". **The re-mint half never existed.** Clients only react to a 401 on the mint call itself, not on a media fetch. So the strict behaviour delivered the failure without the recovery.

## The change
Default them to `false`. An old token still authenticates for basic media but carries **no** capabilities, so export/clips/plates deny it exactly as they would a user who never held those rights.

The token remains signed, `typ`-checked, and scoped to one camera by `cam`. This grants **strictly less** privilege than intended, never more. A short-lived loss of gated features beats a total media blackout.

## Tests pin both halves
Neither is much use alone, since the whole question is whether it degrades in the safe direction:

1. **`old_shape_media_token_still_authenticates`** — a forged old-shape token (valid signature, `typ: "media"`, correct `cam`, **no** cap claims) must not 401. Uses live fMP4 because it is gated on camera access alone, isolating "authenticated" from any capability question.
2. **`old_shape_media_token_carries_no_capabilities`** — the same token is refused the plate crop with a 403 **even though the minting user holds `view_plates`**. That is what proves the refusal comes from the defaulted claim rather than from the user lacking the right.

## Verification
Full gate on a Rust box: `cargo fmt --check` ✅, `cargo clippy --all-targets -D warnings` ✅, `cargo test --workspace` ✅ — 0 failures, both new tests passing.

## Not in this PR
Client-side re-mint on a media-route 401 remains the better long-term fix and stays open. It needs interceptor plumbing across four clients, because media URLs are consumed by third-party loaders (Coil/ExoPlayer, media_kit, AVFoundation, plain `<img>`). This removes the outage without waiting on that.

Reasoning and revisit triggers recorded in `docs/DECISIONS.md`, since this reverses a documented decision.