### PR TITLE
fix(ios,desktop): raise digital-zoom ceilings to 30x to match Android

### DIFF
--- a/apps/desktop-flutter/lib/main.dart
+++ b/apps/desktop-flutter/lib/main.dart
@@ -1477,7 +1477,10 @@ class _LivePaneState extends State<LivePane> {
   double _scale = 1.0;
   Offset _offset = Offset.zero;
 
-  static const double _maxZoom = 8.0;
+  // Digital-zoom ceiling. Keep in sync with the other _maxZoom constants, the
+  // clips ceiling, Android MAX_SCALE and the iOS zoomable() default: they drifted
+  // to 5/6/8 independently before, so the phone ran out first for no reason.
+  static const double _maxZoom = 30.0;
 
   /// Zoom about `cursor` (pane px) by `factor`, keeping the point under the
   /// cursor fixed — the surveillance zoom-to-cursor behaviour.

--- a/apps/desktop-flutter/lib/ui/clips/clips_screen.dart
+++ b/apps/desktop-flutter/lib/ui/clips/clips_screen.dart
@@ -43,7 +43,9 @@ enum ClipsDensity { compact, normal, large }
 
 const _clipsPageSize = 200;
 const _thumbConcurrency = 6;
-const _clipZoomMax = 5.0;
+// Digital-zoom ceiling for clips. Keep in sync with the _maxZoom constants,
+// Android MAX_SCALE and the iOS zoomable() default (see #404).
+const _clipZoomMax = 30.0;
 const _clipLoadTimeout = Duration(milliseconds: 4500);
 const _clipMaxRetries = 2;
 

--- a/apps/desktop-flutter/lib/ui/playback/playback_screen.dart
+++ b/apps/desktop-flutter/lib/ui/playback/playback_screen.dart
@@ -2001,7 +2001,10 @@ class _PbTileState extends State<_PbTile> {
   // stream, so there is no sub→main swap like the live wall's zoomToMain.
   double _scale = 1.0;
   Offset _offset = Offset.zero;
-  static const double _maxZoom = 8.0;
+  // Digital-zoom ceiling. Keep in sync with the other _maxZoom constants, the
+  // clips ceiling, Android MAX_SCALE and the iOS zoomable() default: they drifted
+  // to 5/6/8 independently before, so the phone ran out first for no reason.
+  static const double _maxZoom = 30.0;
 
   void _zoomAt(Offset cursor, double factor, Size pane) {
     final newScale = (_scale * factor).clamp(1.0, _maxZoom);

--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -1145,7 +1145,10 @@ class _WallTileState extends State<_WallTile> {
   // (the wall stays up); drag pans when zoomed. Double-click still maximizes.
   double _scale = 1.0;
   Offset _offset = Offset.zero;
-  static const double _maxZoom = 8.0;
+  // Digital-zoom ceiling. Keep in sync with the other _maxZoom constants, the
+  // clips ceiling, Android MAX_SCALE and the iOS zoomable() default: they drifted
+  // to 5/6/8 independently before, so the phone ran out first for no reason.
+  static const double _maxZoom = 30.0;
 
   /// True while a zoom-in has temporarily switched this tile to the main
   /// stream (see [WallScreen.onMaximizedCameraChanged]/zoomSwitchesToMain).
@@ -2070,7 +2073,10 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
 
   double _scale = 1.0;
   Offset _offset = Offset.zero;
-  static const double _maxZoom = 8.0;
+  // Digital-zoom ceiling. Keep in sync with the other _maxZoom constants, the
+  // clips ceiling, Android MAX_SCALE and the iOS zoomable() default: they drifted
+  // to 5/6/8 independently before, so the phone ran out first for no reason.
+  static const double _maxZoom = 30.0;
 
   /// Mirror of the custom-panel controller state for THIS camera: whether a
   /// custom panel is active (saved layout or edit session) and whether it's

--- a/apps/ios/Crumb/Platform/Zoomable.swift
+++ b/apps/ios/Crumb/Platform/Zoomable.swift
@@ -6,7 +6,7 @@ extension View {
     /// Makes a view zoomable/pannable. iOS: pinch to zoom, drag to pan, double-tap
     /// to reset. macOS: scroll-wheel to zoom, drag to pan, double-click to reset
     /// (a mouse can't pinch). Pan is clamped to the content edges.
-    func zoomable(minZoom: CGFloat = 1, maxZoom: CGFloat = 6,
+    func zoomable(minZoom: CGFloat = 1, maxZoom: CGFloat = 30,
                   onZoomChange: ((CGFloat) -> Void)? = nil) -> some View {
         modifier(Zoomable(minZoom: minZoom, maxZoom: maxZoom, onZoomChange: onZoomChange))
     }
@@ -15,7 +15,7 @@ extension View {
     /// PTZ drag controls on PTZ cameras). `onZoomChange` reports the live scale
     /// (1 = not zoomed) so callers can, e.g., hide overlays that can't track a
     /// digital zoom.
-    @ViewBuilder func zoomable(enabled: Bool, minZoom: CGFloat = 1, maxZoom: CGFloat = 6,
+    @ViewBuilder func zoomable(enabled: Bool, minZoom: CGFloat = 1, maxZoom: CGFloat = 30,
                                onZoomChange: ((CGFloat) -> Void)? = nil) -> some View {
         if enabled { zoomable(minZoom: minZoom, maxZoom: maxZoom, onZoomChange: onZoomChange) } else { self }
     }


### PR DESCRIPTION
Follow-up to #404 / #405. Android went to 30x after operator testing, which left the other clients behind and simply inverted the inconsistency instead of fixing it.

## Six ceilings had drifted apart
| client / surface | was | now |
|---|---|---|
| Android (live, playback, clips) | 5x → 30x | 30x |
| iOS `zoomable()` default | **6x** | 30x |
| Desktop live (`main.dart`) | **8x** | 30x |
| Desktop playback | **8x** | 30x |
| Desktop wall (x2) | **8x** | 30x |
| Desktop clips | **5x** | 30x |

Nothing justified any of the differences. Desktop clips being 5x is notable: it was as restrictive as Android's original ceiling, on the client with the most screen to work with.

## Anti-drift
Desktop keeps this value in **four** separate constants plus the clips one, which is exactly how they drifted apart. Each now carries a comment saying it must stay in sync with the others and with the Android/iOS values.

A single shared constant would be the real fix. Left out of this PR to keep it a pure value change, but worth doing.

## iOS
Only the `zoomable()` default changes. Both call sites (`LiveFullscreenView`, `PlaybackView`) use the default and neither passes an explicit `maxZoom`, so this is sufficient.

## Verification
- **Desktop**: `flutter analyze` on all four changed files — **no new issues**. The one reported `unnecessary_import` is pre-existing at `clips_screen.dart:18`; this change touches line 46.
- **iOS**: parsed clean with `swiftc -parse` against the iOS SDK on a Mac. **Not a full Xcode build** — it is a one-token default-value change, but flagging the limit rather than implying more.
- Android 30x already confirmed on-device.

Past 1:1 source pixels this is interpolation rather than new detail, which is deliberate and unchanged from #405: a blurry-but-large view of a face or plate reads better than a sharp-but-tiny one, and where to stop is the operator's judgement.