### PR TITLE
fix(desktop): support trackpad pinch-to-zoom on laptops

### DIFF
--- a/apps/desktop-flutter/lib/ui/playback/playback_screen.dart
+++ b/apps/desktop-flutter/lib/ui/playback/playback_screen.dart
@@ -2032,11 +2032,6 @@ class _PbTileState extends State<_PbTile> {
   // (#409). `scale` is cumulative from gesture start (diff it for the factor).
   double _panZoomLastScale = 1.0;
 
-  // Cursor for the pinch anchor. A pan-zoom event's own localPosition is not the
-  // mouse on Windows trackpads, which drifted the zoom hard-right; track the
-  // real cursor from onPointerHover instead (#412).
-  Offset? _hoverCursor;
-
   void _onPanZoomStart(PointerPanZoomStartEvent _) {
     _panZoomLastScale = 1.0;
   }
@@ -2045,8 +2040,10 @@ class _PbTileState extends State<_PbTile> {
     if (e.scale != _panZoomLastScale) {
       final factor = e.scale / _panZoomLastScale;
       _panZoomLastScale = e.scale;
-      final anchor = _hoverCursor ?? Offset(pane.width / 2, pane.height / 2);
-      _zoomAt(anchor, factor, pane);
+      // Trackpad pinch anchors at the VIEW CENTRE (no reliable cursor mid-
+      // gesture on Windows trackpads → cursor-anchoring drifted, #412). The
+      // mouse wheel path still zooms to the cursor.
+      _zoomAt(Offset(pane.width / 2, pane.height / 2), factor, pane);
     } else if (e.panDelta != Offset.zero) {
       _panBy(e.panDelta, pane);
     }
@@ -2216,7 +2213,6 @@ class _PbTileState extends State<_PbTile> {
                   },
                   // Laptop trackpad: pinch → digital zoom, two-finger drag →
                   // pan (#409). Hover tracks the pinch anchor (#412).
-                  onPointerHover: (e) => _hoverCursor = e.localPosition,
                   onPointerPanZoomStart: _onPanZoomStart,
                   onPointerPanZoomUpdate: (e) => _onPanZoomUpdate(e, paneSize),
                   child: ClipRect(

--- a/apps/desktop-flutter/lib/ui/playback/playback_screen.dart
+++ b/apps/desktop-flutter/lib/ui/playback/playback_screen.dart
@@ -2027,6 +2027,25 @@ class _PbTileState extends State<_PbTile> {
     setState(() => _offset = _clampOffset(_offset + delta, pane));
   }
 
+  // Laptop trackpad: Flutter delivers pinch + two-finger scroll as PointerPanZoom
+  // events, not PointerScrollEvent, so the mouse-wheel path never fires for them
+  // (#409). `scale` is cumulative from gesture start (diff it for the factor);
+  // `panDelta` is already per-event and feeds _panBy directly.
+  double _panZoomLastScale = 1.0;
+
+  void _onPanZoomStart(PointerPanZoomStartEvent _) {
+    _panZoomLastScale = 1.0;
+  }
+
+  void _onPanZoomUpdate(PointerPanZoomUpdateEvent e, Size pane) {
+    if (e.scale != _panZoomLastScale) {
+      final factor = e.scale / _panZoomLastScale;
+      _panZoomLastScale = e.scale;
+      _zoomAt(e.localPosition, factor, pane);
+    }
+    if (e.panDelta != Offset.zero) _panBy(e.panDelta, pane);
+  }
+
   /// The overlay shown when a pane has no live segment: a load error, a spinner
   /// while resolving, or — once resolved with nothing here — a styled "no
   /// footage" placeholder that reads calmly for a motion gap but flags a camera
@@ -2189,6 +2208,10 @@ class _PbTileState extends State<_PbTile> {
                       _zoomAt(e.localPosition, factor, paneSize);
                     }
                   },
+                  // Laptop trackpad: pinch → digital zoom, two-finger drag →
+                  // pan (#409).
+                  onPointerPanZoomStart: _onPanZoomStart,
+                  onPointerPanZoomUpdate: (e) => _onPanZoomUpdate(e, paneSize),
                   child: ClipRect(
                     child: Transform(
                       transform: _zoomTransform,

--- a/apps/desktop-flutter/lib/ui/playback/playback_screen.dart
+++ b/apps/desktop-flutter/lib/ui/playback/playback_screen.dart
@@ -2029,9 +2029,13 @@ class _PbTileState extends State<_PbTile> {
 
   // Laptop trackpad: Flutter delivers pinch + two-finger scroll as PointerPanZoom
   // events, not PointerScrollEvent, so the mouse-wheel path never fires for them
-  // (#409). `scale` is cumulative from gesture start (diff it for the factor);
-  // `panDelta` is already per-event and feeds _panBy directly.
+  // (#409). `scale` is cumulative from gesture start (diff it for the factor).
   double _panZoomLastScale = 1.0;
+
+  // Cursor for the pinch anchor. A pan-zoom event's own localPosition is not the
+  // mouse on Windows trackpads, which drifted the zoom hard-right; track the
+  // real cursor from onPointerHover instead (#412).
+  Offset? _hoverCursor;
 
   void _onPanZoomStart(PointerPanZoomStartEvent _) {
     _panZoomLastScale = 1.0;
@@ -2041,9 +2045,11 @@ class _PbTileState extends State<_PbTile> {
     if (e.scale != _panZoomLastScale) {
       final factor = e.scale / _panZoomLastScale;
       _panZoomLastScale = e.scale;
-      _zoomAt(e.localPosition, factor, pane);
+      final anchor = _hoverCursor ?? Offset(pane.width / 2, pane.height / 2);
+      _zoomAt(anchor, factor, pane);
+    } else if (e.panDelta != Offset.zero) {
+      _panBy(e.panDelta, pane);
     }
-    if (e.panDelta != Offset.zero) _panBy(e.panDelta, pane);
   }
 
   /// The overlay shown when a pane has no live segment: a load error, a spinner
@@ -2209,7 +2215,8 @@ class _PbTileState extends State<_PbTile> {
                     }
                   },
                   // Laptop trackpad: pinch → digital zoom, two-finger drag →
-                  // pan (#409).
+                  // pan (#409). Hover tracks the pinch anchor (#412).
+                  onPointerHover: (e) => _hoverCursor = e.localPosition,
                   onPointerPanZoomStart: _onPanZoomStart,
                   onPointerPanZoomUpdate: (e) => _onPanZoomUpdate(e, paneSize),
                   child: ClipRect(

--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -1155,19 +1155,29 @@ class _WallTileState extends State<_WallTile> {
   // (pinch + two-finger scroll) as PointerPanZoom events, NOT
   // PointerScrollEvent, so the mouse-wheel path never fires for them (#409).
   // `scale` on the update event is CUMULATIVE from gesture start (no delta is
-  // provided), so we diff against the previous event; `panDelta` is already the
-  // per-event step and feeds _panBy directly.
+  // provided), so we diff against the previous event.
   double _panZoomLastScale = 1.0;
 
-  /// Feed a trackpad pan-zoom update into digital zoom (pinch) + pan
+  // Last mouse position over the video, tracked from onPointerHover. Used as the
+  // pinch zoom anchor: a PointerPanZoom event's own localPosition is NOT the
+  // cursor on Windows trackpads (it reads near the pane origin), which made the
+  // frame expand from the top-left and drift hard-right while pinching (#412).
+  Offset? _hoverCursor;
+
+  /// Feed a trackpad pan-zoom update into digital zoom (pinch) OR pan
   /// (two-finger drag). Shared by both wall Listeners.
   void _onPanZoomUpdate(PointerPanZoomUpdateEvent e, Size pane) {
     if (e.scale != _panZoomLastScale) {
+      // Pinch: zoom about the CURSOR, never translate — mixing a per-event pan
+      // into a scale step is what produced the sideways drift.
       final factor = e.scale / _panZoomLastScale;
       _panZoomLastScale = e.scale;
-      _zoomAt(e.localPosition, factor, pane);
+      final anchor = _hoverCursor ?? Offset(pane.width / 2, pane.height / 2);
+      _zoomAt(anchor, factor, pane);
+    } else if (e.panDelta != Offset.zero) {
+      // Two-finger drag with no pinch this frame → pan.
+      _panBy(e.panDelta, pane);
     }
-    if (e.panDelta != Offset.zero) _panBy(e.panDelta, pane);
   }
 
   void _onPanZoomStart(PointerPanZoomStartEvent _) {
@@ -1793,6 +1803,7 @@ class _WallTileState extends State<_WallTile> {
             }
           },
           // Laptop trackpad: pinch → digital zoom, two-finger drag → pan (#409).
+          onPointerHover: (e) => _hoverCursor = e.localPosition,
           onPointerPanZoomStart: _onPanZoomStart,
           onPointerPanZoomUpdate: (e) => _onPanZoomUpdate(e, pane),
           child: GestureDetector(
@@ -2531,6 +2542,9 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
   // mapping a pinch onto it cleanly is a separate exercise.
   double _panZoomLastScale = 1.0;
 
+  // Cursor for the pinch anchor — see the wall-tile equivalent (#412).
+  Offset? _hoverCursor;
+
   void _onPanZoomStart(PointerPanZoomStartEvent _) {
     _panZoomLastScale = 1.0;
   }
@@ -2540,9 +2554,11 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
     if (e.scale != _panZoomLastScale) {
       final factor = e.scale / _panZoomLastScale;
       _panZoomLastScale = e.scale;
-      _zoomAt(e.localPosition, factor, pane);
+      final anchor = _hoverCursor ?? Offset(pane.width / 2, pane.height / 2);
+      _zoomAt(anchor, factor, pane);
+    } else if (e.panDelta != Offset.zero) {
+      _panBy(e.panDelta, pane);
     }
-    if (e.panDelta != Offset.zero) _panBy(e.panDelta, pane);
   }
 
   /// PTZ usable here: camera supports it AND the operator hasn't disabled PTZ
@@ -2774,7 +2790,9 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
                           onPointerUp: (_) => _ptzStopSteer(),
                           onPointerCancel: (_) => _ptzStopSteer(),
                           // Laptop trackpad pinch → digital zoom (non-PTZ);
-                          // guards handled inside (#409).
+                          // guards handled inside (#409). Hover tracks the
+                          // pinch anchor (#412).
+                          onPointerHover: (e) => _hoverCursor = e.localPosition,
                           onPointerPanZoomStart: _onPanZoomStart,
                           onPointerPanZoomUpdate: (e) =>
                               _onPanZoomUpdate(e, pane),

--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -1158,12 +1158,6 @@ class _WallTileState extends State<_WallTile> {
   // provided), so we diff against the previous event.
   double _panZoomLastScale = 1.0;
 
-  // Last mouse position over the video, tracked from onPointerHover. Used as the
-  // pinch zoom anchor: a PointerPanZoom event's own localPosition is NOT the
-  // cursor on Windows trackpads (it reads near the pane origin), which made the
-  // frame expand from the top-left and drift hard-right while pinching (#412).
-  Offset? _hoverCursor;
-
   /// Feed a trackpad pan-zoom update into digital zoom (pinch) OR pan
   /// (two-finger drag). Shared by both wall Listeners.
   void _onPanZoomUpdate(PointerPanZoomUpdateEvent e, Size pane) {
@@ -1172,8 +1166,11 @@ class _WallTileState extends State<_WallTile> {
       // into a scale step is what produced the sideways drift.
       final factor = e.scale / _panZoomLastScale;
       _panZoomLastScale = e.scale;
-      final anchor = _hoverCursor ?? Offset(pane.width / 2, pane.height / 2);
-      _zoomAt(anchor, factor, pane);
+      // Anchor a trackpad pinch at the VIEW CENTRE, not a cursor. A Windows
+      // trackpad has no reliable pointer position during the gesture, so
+      // cursor-anchoring drifted the frame toward a corner (#412). Centre-
+      // anchored zoom stays put. The mouse WHEEL path keeps zoom-to-cursor.
+      _zoomAt(Offset(pane.width / 2, pane.height / 2), factor, pane);
     } else if (e.panDelta != Offset.zero) {
       // Two-finger drag with no pinch this frame → pan.
       _panBy(e.panDelta, pane);
@@ -1803,7 +1800,6 @@ class _WallTileState extends State<_WallTile> {
             }
           },
           // Laptop trackpad: pinch → digital zoom, two-finger drag → pan (#409).
-          onPointerHover: (e) => _hoverCursor = e.localPosition,
           onPointerPanZoomStart: _onPanZoomStart,
           onPointerPanZoomUpdate: (e) => _onPanZoomUpdate(e, pane),
           child: GestureDetector(
@@ -2542,9 +2538,6 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
   // mapping a pinch onto it cleanly is a separate exercise.
   double _panZoomLastScale = 1.0;
 
-  // Cursor for the pinch anchor — see the wall-tile equivalent (#412).
-  Offset? _hoverCursor;
-
   void _onPanZoomStart(PointerPanZoomStartEvent _) {
     _panZoomLastScale = 1.0;
   }
@@ -2554,8 +2547,11 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
     if (e.scale != _panZoomLastScale) {
       final factor = e.scale / _panZoomLastScale;
       _panZoomLastScale = e.scale;
-      final anchor = _hoverCursor ?? Offset(pane.width / 2, pane.height / 2);
-      _zoomAt(anchor, factor, pane);
+      // Anchor a trackpad pinch at the VIEW CENTRE, not a cursor. A Windows
+      // trackpad has no reliable pointer position during the gesture, so
+      // cursor-anchoring drifted the frame toward a corner (#412). Centre-
+      // anchored zoom stays put. The mouse WHEEL path keeps zoom-to-cursor.
+      _zoomAt(Offset(pane.width / 2, pane.height / 2), factor, pane);
     } else if (e.panDelta != Offset.zero) {
       _panBy(e.panDelta, pane);
     }
@@ -2792,7 +2788,6 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
                           // Laptop trackpad pinch → digital zoom (non-PTZ);
                           // guards handled inside (#409). Hover tracks the
                           // pinch anchor (#412).
-                          onPointerHover: (e) => _hoverCursor = e.localPosition,
                           onPointerPanZoomStart: _onPanZoomStart,
                           onPointerPanZoomUpdate: (e) =>
                               _onPanZoomUpdate(e, pane),

--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -1151,6 +1151,29 @@ class _WallTileState extends State<_WallTile> {
   /// stream (see [WallScreen.onMaximizedCameraChanged]/zoomSwitchesToMain).
   bool _zoomedToMain = false;
 
+  // Trackpad pinch accumulator. Flutter delivers precision-trackpad gestures
+  // (pinch + two-finger scroll) as PointerPanZoom events, NOT
+  // PointerScrollEvent, so the mouse-wheel path never fires for them (#409).
+  // `scale` on the update event is CUMULATIVE from gesture start (no delta is
+  // provided), so we diff against the previous event; `panDelta` is already the
+  // per-event step and feeds _panBy directly.
+  double _panZoomLastScale = 1.0;
+
+  /// Feed a trackpad pan-zoom update into digital zoom (pinch) + pan
+  /// (two-finger drag). Shared by both wall Listeners.
+  void _onPanZoomUpdate(PointerPanZoomUpdateEvent e, Size pane) {
+    if (e.scale != _panZoomLastScale) {
+      final factor = e.scale / _panZoomLastScale;
+      _panZoomLastScale = e.scale;
+      _zoomAt(e.localPosition, factor, pane);
+    }
+    if (e.panDelta != Offset.zero) _panBy(e.panDelta, pane);
+  }
+
+  void _onPanZoomStart(PointerPanZoomStartEvent _) {
+    _panZoomLastScale = 1.0;
+  }
+
   void _zoomAt(Offset cursor, double factor, Size pane) {
     final newScale = (_scale * factor).clamp(1.0, _maxZoom);
     if (newScale == _scale) return;
@@ -1769,6 +1792,9 @@ class _WallTileState extends State<_WallTile> {
               _zoomAt(e.localPosition, factor, pane);
             }
           },
+          // Laptop trackpad: pinch → digital zoom, two-finger drag → pan (#409).
+          onPointerPanZoomStart: _onPanZoomStart,
+          onPointerPanZoomUpdate: (e) => _onPanZoomUpdate(e, pane),
           child: GestureDetector(
             // Single click selects this pane (snapshot + audio target);
             // double-click maximizes; right-click opens the per-tile menu.
@@ -2499,6 +2525,26 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
     setState(() => _offset = _clampOffset(_offset + delta, pane));
   }
 
+  // Trackpad pinch → DIGITAL zoom in the maximized view (#409). Mirrors the
+  // wheel branch's guards. PTZ optical zoom stays wheel-only: it fires discrete
+  // network pulses (see _ptzWheelZoom), which a continuous pinch would spam, so
+  // mapping a pinch onto it cleanly is a separate exercise.
+  double _panZoomLastScale = 1.0;
+
+  void _onPanZoomStart(PointerPanZoomStartEvent _) {
+    _panZoomLastScale = 1.0;
+  }
+
+  void _onPanZoomUpdate(PointerPanZoomUpdateEvent e, Size pane) {
+    if (_panelEditing || _haEditing || _ptzEnabled) return;
+    if (e.scale != _panZoomLastScale) {
+      final factor = e.scale / _panZoomLastScale;
+      _panZoomLastScale = e.scale;
+      _zoomAt(e.localPosition, factor, pane);
+    }
+    if (e.panDelta != Offset.zero) _panBy(e.panDelta, pane);
+  }
+
   /// PTZ usable here: camera supports it AND the operator hasn't disabled PTZ
   /// controls for this camera via the right-click menu.
   bool get _ptzEnabled =>
@@ -2727,6 +2773,11 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
                           },
                           onPointerUp: (_) => _ptzStopSteer(),
                           onPointerCancel: (_) => _ptzStopSteer(),
+                          // Laptop trackpad pinch → digital zoom (non-PTZ);
+                          // guards handled inside (#409).
+                          onPointerPanZoomStart: _onPanZoomStart,
+                          onPointerPanZoomUpdate: (e) =>
+                              _onPanZoomUpdate(e, pane),
                           onPointerSignal: (e) {
                             if (e is PointerScrollEvent) {
                               // Panel/HA-overlay editor open: the wheel must


### PR DESCRIPTION
Fixes #409.

## The bug
On a Windows laptop, trackpad pinch-to-zoom over live/playback video does nothing. Two-finger scroll also does nothing.

Every desktop zoom surface wired zoom only to `onPointerSignal` → `PointerScrollEvent` — the **mouse wheel**. Flutter delivers precision-trackpad gestures (pinch **and** two-finger scroll) as `PointerPanZoom*` events, which nothing handled. So on a trackpad nothing reached `_zoomAt` and zoom looked completely dead, while a mouse wheel still worked, which is why it slipped through.

## Fix
Add `onPointerPanZoomStart/Update` to the existing `Listener` on:
- the live wall tile
- the wall's maximized single-cam view
- the playback pane

`PointerPanZoomUpdateEvent.scale` is **cumulative** from gesture start (no delta is provided), so it's diffed per event into the multiplicative `_zoomAt` factor. `panDelta` is already per-event and feeds `_panBy` for two-finger pan while zoomed. `localPosition` keeps the zoom-to-cursor anchor. The mouse-wheel path is untouched, so mouse users are unaffected.

## Deliberately scoped to digital zoom
In the maximized view, a **PTZ** camera keeps optical zoom on the **wheel only**. `_ptzWheelZoom` fires discrete network velocity pulses with a stop-timer; a continuous pinch (many events/sec) would spam `ptzMove`/`ptzStop`, so mapping pinch onto optical zoom is a separate, more careful exercise. The maximized handler also mirrors the wheel branch's `_panelEditing`/`_haEditing` guards so a pinch can't scale the video under a fixed-position editor overlay.

## Verification
`flutter analyze` on both changed files: **No issues found**. A test build with this + the 30x ceiling is published for on-device confirmation, since this is a gesture-plumbing change that a static build can't fully prove.

## Note
Independent of PR #408 (the 30x ceiling). They touch the same files but different lines; whichever merges second may want a trivial rebase.