### PR TITLE
docs(recorder): VAAPI render-node robustness + escalated motion-decode-failure log

### DIFF
--- a/docker-compose.vaapi.example.yml
+++ b/docker-compose.vaapi.example.yml
@@ -20,6 +20,34 @@
 #   - The host 'render' group GID: `getent group render | cut -d: -f3`. Put it in
 #     RENDER_GID so the non-root container user (uid 1001) can open the node.
 #
+# ── STABILITY ON MULTI-GPU HOSTS (renderD numbers are NOT stable) ────────────
+# The renderD128 / renderD129 NUMBERS are assigned at boot and can REORDER when
+# you have more than one GPU (e.g. an iGPU + a discrete NVIDIA card). A GPU-driver
+# upgrade + reboot can move the iGPU from renderD128 to renderD129 and hand
+# renderD128 to the OTHER card. If MOTION_VAAPI_DEVICE still points at renderD128,
+# VAAPI decode now targets a card with no VAAPI: every motion-decode ffmpeg child
+# exits instantly ("Failed to initialise VAAPI connection"), motion detection goes
+# DOWN, and the recorder fails OPEN to continuous recording, silently.
+#
+# Robust fix: map the iGPU by its STABLE by-path symlink instead of the volatile
+# renderD number. The by-path name is tied to the PCI address, which does not move
+# across reboots. Find it with `ls -l /dev/dri/by-path` (look for the *-render
+# entry whose target is your iGPU's renderD* node), then in .env set e.g.:
+#   MOTION_VAAPI_DEVICE=/dev/dri/by-path/pci-0000:00:02.0-render
+# (0000:00:02.0 is the classic Intel iGPU address; use YOURS.) ffmpeg follows the
+# symlink to whichever renderD* the iGPU currently owns, so a driver upgrade can
+# no longer repoint decode at the wrong card.
+#
+# NOTE: server_settings.motion_hwaccel / motion_vaapi_device in the DB (set via
+# the admin console) OVERRIDE these env vars. If you set the decode mode in the
+# console, changing MOTION_HWACCEL here does nothing: change it in the console
+# (or clear the DB value) too.
+#
+# Immune-by-design alternative: MOTION_HWACCEL=cpu. Motion analysis runs at ~320px
+# / 5 fps, so software decode is cheap and cannot be affected by any GPU render-
+# node reordering, driver mismatch, or device-mapping problem. If iGPU power
+# savings don't justify the operational fragility on YOUR host, cpu is a safe pick.
+#
 # NVDEC (discrete NVIDIA) is a SEPARATE overlay (docker-compose.gpu.example.yml).
 # Pick whichever matches your hardware; don't apply both for the same decode mode.
 #
@@ -30,10 +58,14 @@ services:
     environment:
       # Force VAAPI decode (overrides the base 'auto').
       MOTION_HWACCEL: ${MOTION_HWACCEL:-vaapi}
-      # DRI render node for the iGPU. Override if yours isn't renderD128.
+      # DRI render node for the iGPU. Override if yours isn't renderD128. On a
+      # multi-GPU host, prefer the stable by-path symlink over the renderD number
+      # (see the STABILITY note in the header), e.g.:
+      #   MOTION_VAAPI_DEVICE=/dev/dri/by-path/pci-0000:00:02.0-render
       MOTION_VAAPI_DEVICE: ${MOTION_VAAPI_DEVICE:-/dev/dri/renderD128}
     devices:
-      # Map the iGPU render node into the container.
+      # Map the iGPU render node into the container. A by-path value resolves to
+      # the correct renderD* even if the numbers reorder across a reboot.
       - ${MOTION_VAAPI_DEVICE:-/dev/dri/renderD128}:${MOTION_VAAPI_DEVICE:-/dev/dri/renderD128}
     group_add:
       # Host 'render' group GID — required for the uid-1001 container user to open

--- a/docs-site/docs/configuration/environment-reference.md
+++ b/docs-site/docs/configuration/environment-reference.md
@@ -133,9 +133,9 @@ they're plumbed through for a future release, so they don't get rows here.
 
 | Key | Default | Notes |
 |---|---|---|
-| `MOTION_HWACCEL` | `auto` | `auto` probes for NVDEC and falls back to CPU; `cuda` forces NVDEC, `vaapi` forces an Intel/AMD iGPU, `cpu` forces software decode |
+| `MOTION_HWACCEL` | `auto` | `auto` probes for NVDEC and falls back to CPU; `cuda` forces NVDEC, `vaapi` forces an Intel/AMD iGPU, `cpu` forces software decode. The admin console setting (`server_settings.motion_hwaccel`) overrides this, DB wins over env. `cpu` is cheap at the ~320px/5fps analysis resolution and immune to GPU render-node/driver issues |
 | `MAX_GPU_DECODE_SESSIONS` | `4` | global cap on concurrent NVDEC decode sessions; a camera past the cap decodes on CPU instead of failing |
-| `MOTION_VAAPI_DEVICE` | `/dev/dri/renderD128` | DRI render node used when `MOTION_HWACCEL=vaapi`; wired in by the `docker-compose.vaapi.example.yml` overlay, ignored otherwise |
+| `MOTION_VAAPI_DEVICE` | `/dev/dri/renderD128` | DRI render node used when `MOTION_HWACCEL=vaapi`; wired in by the `docker-compose.vaapi.example.yml` overlay, ignored otherwise. On a multi-GPU host prefer the stable `/dev/dri/by-path/pci-<addr>-render` symlink, `renderD*` numbers can reorder across a driver upgrade + reboot. Also overridden by the DB (`server_settings.motion_vaapi_device`). See [Hardware decode](/configuration/hardware-decode) |
 | `RENDER_GID` | `993` | host `render` group GID, read by the VAAPI overlay's `group_add` (not by Crumb itself) so the uid-1001 container user can open the render node; find yours with `getent group render` |
 
 See [Hardware decode](/configuration/hardware-decode) for enabling this.

--- a/docs-site/docs/configuration/hardware-decode.md
+++ b/docs-site/docs/configuration/hardware-decode.md
@@ -45,6 +45,11 @@ Set `RENDER_GID` in `.env` to the host's render-group GID
 (`getent group render | cut -d: -f3`), and `MOTION_VAAPI_DEVICE` if the
 iGPU's render node isn't the default `/dev/dri/renderD128`.
 
+On a host with more than one GPU, point `MOTION_VAAPI_DEVICE` at the iGPU's
+**stable by-path symlink** rather than a bare `renderD128`, see
+[Keeping a VAAPI (iGPU) host stable](#keeping-a-vaapi-igpu-host-stable) below
+for why this matters.
+
 **NVIDIA (NVDEC):**
 
 ```bash
@@ -72,6 +77,62 @@ that no devices exist.
 
 A wrong pick is always safe: the recorder falls back to CPU automatically
 rather than failing to decode at all.
+
+:::note The DB setting wins over the env var
+If you set the decode mode in the admin console, that value is stored in the
+database (`server_settings.motion_hwaccel` / `motion_vaapi_device`) and
+**overrides** the `MOTION_HWACCEL` / `MOTION_VAAPI_DEVICE` environment
+variables. Changing the env var then has no effect until you also change it in
+the console (or clear the stored value). This trips people up during recovery:
+an env-only fix looks correct but does nothing while a DB value is set.
+:::
+
+## Keeping a VAAPI (iGPU) host stable
+
+This section only matters if you gave the recorder an Intel/AMD iGPU via VAAPI,
+**and the host has more than one GPU** (a common case: an iGPU for decode plus a
+discrete NVIDIA card). CPU and single-GPU installs can skip it.
+
+The `/dev/dri/renderD128`, `renderD129`, ... node **numbers** are assigned at
+boot and are not guaranteed stable across reboots when multiple GPUs are
+present. A GPU-driver upgrade followed by a reboot can renumber them, moving the
+iGPU from `renderD128` to `renderD129` and handing `renderD128` to the other
+card.
+
+If `MOTION_VAAPI_DEVICE` still names `renderD128`, VAAPI decode now points at a
+card with no VAAPI. Every motion-decode ffmpeg process exits immediately with
+`Failed to initialise VAAPI connection`, motion detection stops producing
+frames, and the recorder **fails open to continuous recording**, it keeps all
+footage, but does so silently, so nothing looks broken until you notice motion
+events have stopped or storage is filling faster than expected. (The recorder
+now logs a distinct, greppable `ERROR` line for exactly this case, search the
+recorder logs for `VAAPI decode init FAILING`.)
+
+**Robust fix: map the iGPU by its stable by-path symlink.** Every render node
+also has a name under `/dev/dri/by-path/` that is derived from the GPU's PCI
+address, which does not change across reboots. Point `MOTION_VAAPI_DEVICE` at
+that instead of the volatile number:
+
+```bash
+ls -l /dev/dri/by-path
+# find the *-render entry whose target is your iGPU's renderD* node, e.g.
+#   pci-0000:00:02.0-render -> ../renderD128
+```
+
+```ini
+# .env  (0000:00:02.0 is the classic Intel iGPU address; use YOURS)
+MOTION_VAAPI_DEVICE=/dev/dri/by-path/pci-0000:00:02.0-render
+```
+
+ffmpeg follows the symlink to whichever `renderD*` the iGPU currently owns, so a
+future driver upgrade can no longer repoint decode at the wrong card.
+
+**Immune-by-design alternative: use CPU decode.** Motion analysis runs at a
+downscaled ~320px, ~5 fps, so software decode is cheap, and it cannot be
+affected by render-node reordering, driver mismatches, or device-mapping
+problems at all. If the iGPU's power savings don't justify the extra operational
+fragility on your host, `MOTION_HWACCEL=cpu` (or the console's CPU option) is a
+safe, robust choice.
 
 ## Keeping an NVIDIA host stable
 

--- a/docs-site/docs/troubleshooting/index.md
+++ b/docs-site/docs/troubleshooting/index.md
@@ -105,6 +105,28 @@ alone is not enough, the NVIDIA container toolkit also activates on the
 `NVIDIA_VISIBLE_DEVICES` environment variable, so that must be set to
 `void` as well. Reboot at the next opportunity and put the overlay back.
 
+**Motion events stopped and storage is filling faster than usual, on a VAAPI
+(iGPU) install.** On a host with more than one GPU, the `/dev/dri/renderD*`
+node numbers can reorder across a driver upgrade + reboot, so a
+`MOTION_VAAPI_DEVICE` pinned to `renderD128` can end up pointing at a card
+with no VAAPI. Motion decode then fails to initialise and the recorder falls
+**open** to continuous recording, it keeps all footage, but silently. Confirm
+it in the recorder logs:
+
+```bash
+docker compose logs recorder | grep -i "VAAPI decode init FAILING"
+```
+
+A match (or a raw `Failed to initialise VAAPI connection` from ffmpeg)
+confirms the wrong render node. **Fix:** map the iGPU by its stable by-path
+symlink instead of the bare number (`MOTION_VAAPI_DEVICE=/dev/dri/by-path/pci-<addr>-render`),
+or switch motion decode to CPU, which is immune to this whole class of
+problem. Both are covered in
+[Hardware decode](/configuration/hardware-decode). If you set the decode mode
+in the admin console, remember the stored DB value **overrides** the
+`MOTION_HWACCEL` / `MOTION_VAAPI_DEVICE` env vars, change it in the console
+too, or an env-only fix will appear to do nothing.
+
 ## Cameras
 
 **A camera won't connect.** Usually a wrong RTSP URL or credentials.

--- a/docs/AI-INSTALL.md
+++ b/docs/AI-INSTALL.md
@@ -561,6 +561,17 @@ committed overlays at the repo root:
   the node, and `MOTION_VAAPI_DEVICE` if the iGPU's render node isn't
   `/dev/dri/renderD128` (check `ls -l /dev/dri/by-path`).
 
+  On a **multi-GPU host** (e.g. an iGPU plus a discrete NVIDIA card), set
+  `MOTION_VAAPI_DEVICE` to the iGPU's **stable by-path symlink** rather than a
+  bare `renderD128`, e.g. `/dev/dri/by-path/pci-0000:00:02.0-render` (use the
+  host's real PCI address). The `renderD*` numbers can reorder across a
+  GPU-driver upgrade + reboot; if that repoints VAAPI at the wrong card, motion
+  decode fails and the recorder falls open to continuous recording silently
+  (the recorder logs a distinct `VAAPI decode init FAILING` ERROR when this
+  happens). The by-path name is tied to the PCI address and does not move.
+  Immune-by-design alternative: `MOTION_HWACCEL=cpu`, software decode at the
+  ~320px/5fps analysis resolution is cheap and unaffected by GPU issues.
+
 - **NVIDIA (NVDEC)**, `docker-compose.gpu.example.yml` (host needs the NVIDIA
   driver + `nvidia-container-toolkit`):
 

--- a/services/recorder/src/motion.rs
+++ b/services/recorder/src/motion.rs
@@ -2387,8 +2387,9 @@ async fn run_pixel_diff_loop(
     // NVDEC session + VRAM leak indefinitely).  We drain stderr line-by-line in
     // a background task, logging at DEBUG level.
     let camera_id_log = camera.id;
+    let vaapi_selected = use_vaapi;
     let stderr_handle = tokio::spawn(async move {
-        drain_motion_stderr(stderr, camera_id_log).await;
+        drain_motion_stderr(stderr, camera_id_log, vaapi_selected).await;
     });
 
     // ── 7. Initialise per-loop state ──────────────────────────────────────────
@@ -3113,6 +3114,27 @@ async fn read_exact_frame(
 /// teardown `stderr_handle.await`.
 const STDERR_DRAIN_MAX_CONSECUTIVE_ERRORS: u32 = 100;
 
+/// True when an ffmpeg stderr line signals VAAPI hardware-decode
+/// INITIALISATION failure — the render node was opened but there is no usable
+/// VAAPI driver behind it, so ffmpeg exits immediately having decoded nothing.
+///
+/// This is the render-node-reordering trap (issue #411): on a multi-GPU host
+/// the `/dev/dri/renderD*` node NUMBERS are not stable across a GPU-driver
+/// upgrade + reboot. A fixed `renderD128` mapping can silently land on a card
+/// with no VAAPI (e.g. an NVIDIA GPU that took `renderD128` when the iGPU moved
+/// to `renderD129`). The device path still EXISTS, so the pre-launch presence
+/// check in `run_one_source` passes, but ffmpeg fails at runtime with one of
+/// these lines and exits with no frames — motion then fails OPEN to continuous
+/// recording, silently, until an operator notices. Matched case-insensitively
+/// against the known ffmpeg/libva messages.
+fn is_vaapi_init_failure(line: &str) -> bool {
+    let l = line.to_ascii_lowercase();
+    l.contains("failed to initialise vaapi")
+        || l.contains("failed to initialize vaapi")
+        || l.contains("no device available for decoder")
+        || (l.contains("device type vaapi") && l.contains("needed for"))
+}
+
 /// Drain the motion ffmpeg child's stderr to DEBUG logs until EOF, returning
 /// the number of lines drained (exercised by tests).
 ///
@@ -3126,14 +3148,25 @@ const STDERR_DRAIN_MAX_CONSECUTIVE_ERRORS: u32 = 100;
 /// a short pause, bounded by [`STDERR_DRAIN_MAX_CONSECUTIVE_ERRORS`]) rather
 /// than ending the drain, because only EOF (`Ok(0)` — the child exited) means
 /// there is nothing left to drain.
+///
+/// `vaapi_selected` = this child was launched with `-hwaccel vaapi`. When set,
+/// the FIRST stderr line matching [`is_vaapi_init_failure`] is re-logged at
+/// ERROR with an operator-actionable, greppable message (the render-node trap,
+/// issue #411). Escalated at most once per child so a back-off reconnect loop
+/// leaves a recurring-but-not-spammy trail. This only ADDS a log line; it does
+/// not change decode behavior or the fail-open path.
 async fn drain_motion_stderr(
     stderr: impl tokio::io::AsyncRead + Unpin,
     camera_id: uuid::Uuid,
+    vaapi_selected: bool,
 ) -> u64 {
     let mut reader = tokio::io::BufReader::new(stderr);
     let mut line: Vec<u8> = Vec::new();
     let mut drained: u64 = 0;
     let mut consecutive_errors: u32 = 0;
+    // Escalate the VAAPI-init-failure signature at most once per child, so a
+    // back-off reconnect loop doesn't flood the log with duplicate ERRORs.
+    let mut vaapi_failure_escalated = false;
     loop {
         line.clear();
         match reader.read_until(b'\n', &mut line).await {
@@ -3149,6 +3182,24 @@ async fn drain_motion_stderr(
                         ffmpeg_stderr = trimmed,
                         "motion ffmpeg"
                     );
+                    if vaapi_selected && !vaapi_failure_escalated && is_vaapi_init_failure(trimmed)
+                    {
+                        vaapi_failure_escalated = true;
+                        error!(
+                            camera_id     = %camera_id,
+                            ffmpeg_stderr = trimmed,
+                            "motion VAAPI decode init FAILING for this camera: the mapped \
+                             render node has no usable VAAPI driver, so the decoder exited \
+                             with no frames. Motion detection is DOWN for this camera and \
+                             recording has failed OPEN to continuous as a safety fallback. \
+                             Likely cause: the /dev/dri render-node NUMBER moved across a \
+                             GPU-driver upgrade + reboot (issue #411). Map the iGPU by its \
+                             STABLE by-path symlink (/dev/dri/by-path/pci-<addr>-render) \
+                             instead of a bare renderD128, or set motion decode to cpu \
+                             (note: server_settings.motion_hwaccel in the DB OVERRIDES the \
+                             MOTION_HWACCEL env var)."
+                        );
+                    }
                 }
             }
             Err(e) => {
@@ -4290,7 +4341,10 @@ mod tests {
         // stdout frame reader stalled (correctness item 5). The byte drain
         // must reach EOF having seen all three lines.
         let stderr: &[u8] = b"frame=1 fps=5\n\xff\xfe bad bytes\nframe=2 fps=5\n";
-        assert_eq!(drain_motion_stderr(stderr, uuid::Uuid::nil()).await, 3);
+        assert_eq!(
+            drain_motion_stderr(stderr, uuid::Uuid::nil(), false).await,
+            3
+        );
     }
 
     #[tokio::test]
@@ -4298,7 +4352,38 @@ mod tests {
         // A child that dies mid-line leaves a final chunk without '\n' — it is
         // still drained (read_until returns Ok(n>0) for it) before the Ok(0) EOF.
         let stderr: &[u8] = b"line one\ntruncated";
-        assert_eq!(drain_motion_stderr(stderr, uuid::Uuid::nil()).await, 2);
+        assert_eq!(
+            drain_motion_stderr(stderr, uuid::Uuid::nil(), true).await,
+            2
+        );
+    }
+
+    // ── VAAPI init-failure signature (render-node reorder trap, issue #411) ──────
+
+    #[test]
+    fn vaapi_init_failure_matches_known_ffmpeg_libva_messages() {
+        // The exact lines observed when a renderD* number moved onto a card with
+        // no VAAPI after a driver upgrade + reboot.
+        assert!(is_vaapi_init_failure(
+            "[AVHWDeviceContext @ 0x...] Failed to initialise VAAPI connection: unknown libva error."
+        ));
+        assert!(is_vaapi_init_failure(
+            "No device available for decoder: device type vaapi needed for codec h264."
+        ));
+        // Case-insensitive + the American spelling ffmpeg sometimes emits.
+        assert!(is_vaapi_init_failure("FAILED TO INITIALIZE VAAPI DEVICE"));
+    }
+
+    #[test]
+    fn vaapi_init_failure_ignores_ordinary_stderr() {
+        // Normal ffmpeg chatter must never trip the escalation.
+        assert!(!is_vaapi_init_failure("frame= 42 fps=5.0 q=-0.0 size=N/A"));
+        assert!(!is_vaapi_init_failure(
+            "[rtsp @ 0x...] method DESCRIBE failed: 401 Unauthorized"
+        ));
+        assert!(!is_vaapi_init_failure(
+            "Using VAAPI device /dev/dri/renderD128"
+        ));
     }
 
     // ── frame_absdiff ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Follows up #411 (item 3: make VAAPI motion decode robust to render-node reordering). Emission of the motion-detector-down alert (#413) and the default alert rule (migration 0038) already exist; this closes the documentation and diagnosability gap that let the incident run silently.

## Context
On a multi-GPU host, a GPU-driver upgrade + reboot can reorder the `/dev/dri/renderD*` node numbers. A motion-decode device pinned to a bare `renderD128` can then land on a card with no VAAPI: every motion-decode ffmpeg child exits instantly, motion detection goes down, and the recorder fails open to continuous recording, silently.

## What this changes

**Docs (primary):**
- Map the iGPU into the recorder container by its stable `by-path` symlink (`/dev/dri/by-path/pci-<addr>-render`) instead of a bare `renderD128`, so a driver upgrade cannot silently repoint decode at the wrong card.
- Document that the DB value `server_settings.motion_hwaccel` overrides the `MOTION_HWACCEL` env var, so an env-only fix is a no-op while a DB value is set.
- Document that CPU motion decode (~320px/5fps) is cheap and immune to this whole class of GPU issue.
- Covered in the VAAPI compose overlay header, `docs/AI-INSTALL.md`, `hardware-decode.md`, `environment-reference.md`, and a new troubleshooting entry.

**Diagnosability (recorder, additive only):**
- Add `is_vaapi_init_failure()` and, when VAAPI decode was selected, escalate the first matching ffmpeg stderr line to a distinct, greppable `ERROR` ("motion VAAPI decode init FAILING") that points the operator at the by-path fix or CPU decode.
- Logging only: no change to what is recorded or the fail-open path. Escalated at most once per child to avoid log flooding. Unit-tested.

## Deferred (separate PR, recorder-correctness-sensitive)
Auto-detect VAAPI-init failure and either probe render nodes to pick a working one, or auto-fall-back to CPU motion decode, so motion keeps functioning rather than only alerting. That changes decode behavior on the recorder and needs its own branch, tests, and sign-off.

## Testing
Added unit tests for the init-failure signature (matches the observed libva/ffmpeg messages and both spellings, rejects ordinary stderr). Full gate runs in CI.