### PR TITLE
feat(api): surface motion-detector-down state in decode-status + admin console

### DIFF
--- a/db/migrations/0072_camera_motion_health.sql
+++ b/db/migrations/0072_camera_motion_health.sql
@@ -1,0 +1,47 @@
+-- 0072_camera_motion_health.sql
+--
+-- Per-camera CURRENT motion-detector health, so an operator looking at the
+-- admin console can SEE that a Motion-mode camera's detector is down and the
+-- recorder is failing OPEN (recording continuously as a fallback) right now.
+--
+-- Why a dedicated current-state row instead of scanning system_events:
+-- the recorder already emits a `motion_detector_unhealthy` system_events row
+-- (services/recorder/src/motion.rs), and migration 0038 routes it to the
+-- notification engine. But that is an EVENT (edge), not a STATE (level): there
+-- is no matching "healthy again" row, so events alone cannot answer "is this
+-- camera unhealthy RIGHT NOW?" (the whole reason the #411 fault ran ~5 days
+-- unseen: the fail-open safety worked, so continuous segments looked identical
+-- to a busy scene). This table is the LEVEL signal: exactly one row per camera,
+-- upserted by the recorder's health aggregator (motion.rs `aggregate_health`)
+-- on every camera-level health TRANSITION in either direction, so it always
+-- reflects the current state, not "ever fired".
+--
+-- `healthy = false` means the camera's motion detection is currently down and
+-- the recording task is failing open (persisting every segment as if Continuous
+-- mode) until health returns — footage is NOT being lost, only the disk-saving
+-- benefit of Motion mode is suspended. `changed_at` is when the CURRENT state
+-- began (advanced only when `healthy` flips, so it reads as "unhealthy since
+-- <time>"); `updated_at` is the last write (staleness of the report).
+--
+-- Rows cascade with the camera; the recorder also deletes a camera's row when
+-- it stops that camera's worker (disabled/removed), mirroring
+-- camera_decode_status. No seed rows: absence means "recorder has never
+-- reported" (older recorder image, not booted, or the camera is not in Motion
+-- mode) — the API surfaces that as null, which the UI renders as "no report",
+-- NOT as unhealthy.
+--
+-- IF NOT EXISTS keeps this idempotent for the migration runner.
+CREATE TABLE IF NOT EXISTS camera_motion_health (
+    camera_id  uuid        PRIMARY KEY
+                           REFERENCES cameras(id) ON DELETE CASCADE,
+    -- Current camera-level motion-detector health. false = failing open
+    -- (recording continuously as a fallback) right now.
+    healthy    boolean     NOT NULL,
+    -- Short human-readable cause when unhealthy (which source(s) are down);
+    -- NULL when healthy.
+    reason     text,
+    -- When the CURRENT healthy value began (advanced only on a flip).
+    changed_at timestamptz NOT NULL DEFAULT now(),
+    -- Last write of this row (report freshness / staleness).
+    updated_at timestamptz NOT NULL DEFAULT now()
+);

--- a/docs/COMPONENT-MAP.md
+++ b/docs/COMPONENT-MAP.md
@@ -180,6 +180,7 @@ a "new camera capability" is usually also a "new/changed API endpoint" and a
 | Tuner UIs | `admin.html` motion tuner, desktop inline tuner in `app.js`, android `feature/tuner`, iOS `Features/Tuner` | Four tuner surfaces exist; a new knob must reach all four or be explicitly deferred |
 | Docs | `docs/MOTION-DETECTION-DESIGN.md`, `docs/MOTION-ADAPTIVE-THRESHOLD.md` | |
 | Schema | per-camera detector/threshold settings ride `cameras`/policies: rows B and C | |
+| Detector-health visibility | recorder `aggregate_health` upserts current per-camera health to `camera_motion_health` (migration `0072`) on every transition (LEVEL signal, not the EDGE `motion_detector_unhealthy` system_event); `GET /config/decode-status` LEFT JOINs it (`CameraDecodeStatus`/`CameraDecodeStatusDto` `motion_healthy`/`_since`/`_reason`); `admin.html` `motionHealthBadgeHtml` renders a `var(--danger)` "Motion detection DOWN, recording continuously as fallback" badge in the decode-status panel | Fail-open recording looks identical to a busy scene; without a LEVEL signal a broken detector is invisible in-app (issue #411). Push alert already ships via `0038` + `notifications.rs`. **Deferred:** desktop/android/iOS surfacing of the same field |
 
 ### G. Auth, RBAC, sessions, or security posture change
 

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -6259,13 +6259,30 @@ function decodeCamBadgeHtml(c) {
   return badge + why;
 }
 
+/* Per-camera motion-detector health (migration 0072). A prominent danger badge
+   when the detector is DOWN and the recorder is failing OPEN (recording
+   continuously as a fallback) right now; nothing when healthy (motion_healthy
+   === true) or unreported (motion_healthy == null, e.g. Continuous-mode camera
+   or an older recorder). This is what makes an invisible fail-open fault (a
+   broken detector produces the same continuous segments as a busy scene)
+   visible in-app without needing a configured push channel. */
+function motionHealthBadgeHtml(c) {
+  if (c.motion_healthy !== false) return '';
+  const forStr = c.motion_health_since ? decodeAgo(c.motion_health_since).replace(' ago', '') : '';
+  const forSuffix = forStr ? ` (for ${esc(forStr)})` : '';
+  const sinceTitle = c.motion_health_since ? ` Recording continuously since ${esc(new Date(c.motion_health_since).toLocaleString())}.` : '';
+  const why = c.motion_health_reason ? ` Cause: ${esc(c.motion_health_reason)}.` : '';
+  return `<span title="Motion detection is DOWN for this camera, so the recorder is recording continuously as a fail-open fallback. Footage is NOT being lost, only the disk-saving benefit of Motion mode is suspended.${sinceTitle}${why}" style="display:inline-block;padding:1px 8px;border-radius:10px;font-size:11px;font-weight:700;background:rgba(229,72,77,.15);color:var(--danger);white-space:nowrap">⚠ Motion detection DOWN, recording continuously as fallback${forSuffix}</span>`;
+}
+
 function decodeCamsHtml(st) {
   const cams = (st && st.cameras) || [];
   if (!cams.length) return '<div class="card-hint" style="margin-top:8px">No motion-decode workers reported yet, rows appear when the recorder (re)starts a camera\'s motion worker.</div>';
   return cams.map(c => `
-    <div style="display:flex;align-items:center;gap:10px;padding:4px 0;border-bottom:1px solid var(--border);min-width:0">
+    <div style="display:flex;align-items:center;gap:10px;padding:4px 0;border-bottom:1px solid var(--border);min-width:0;flex-wrap:wrap">
       <span style="flex:0 0 170px;font-size:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${esc(c.camera_name)}">${esc(c.camera_name)}</span>
       ${decodeCamBadgeHtml(c)}
+      ${motionHealthBadgeHtml(c)}
       <span style="flex:1"></span>
       <span style="font-size:11px;color:var(--dim2);white-space:nowrap">${decodeAgo(c.updated_at)}</span>
     </div>`).join('');

--- a/services/api/src/config_routes.rs
+++ b/services/api/src/config_routes.rs
@@ -4021,6 +4021,9 @@ async fn get_decode_status(
             updated_at: s.updated_at,
             audio_sample_rate: s.audio_sample_rate,
             audio_transcoding: s.audio_transcoding,
+            motion_healthy: s.motion_healthy,
+            motion_health_since: s.motion_health_since,
+            motion_health_reason: s.motion_health_reason,
         })
         .collect();
 

--- a/services/api/src/dto.rs
+++ b/services/api/src/dto.rs
@@ -1047,6 +1047,20 @@ pub struct CameraDecodeStatusDto {
     /// `true` when the recorder is re-encoding this camera's audio to 48 kHz AAC
     /// (source rate > 48 kHz), `false` when bit-exact copied, `null` when unknown.
     pub audio_transcoding: Option<bool>,
+    /// Current motion-detector health (migration 0072). `false` means the
+    /// camera's motion detection is DOWN and the recorder is failing OPEN
+    /// (recording continuously as a fallback) right now — footage is not being
+    /// lost, only the disk-saving benefit of Motion mode is suspended. `true`
+    /// when healthy. `null` when the recorder has never reported health for this
+    /// camera (older recorder image, not a Motion-mode camera, or not booted).
+    pub motion_healthy: Option<bool>,
+    /// When the current `motion_healthy` state began (advanced only on a flip),
+    /// so an unhealthy row reads as "recording continuously since <time>".
+    /// `null` when there is no health row.
+    pub motion_health_since: Option<DateTime<Utc>>,
+    /// Short human-readable cause when `motion_healthy == false` (which
+    /// source(s) stopped delivering frames); `null` when healthy or no row.
+    pub motion_health_reason: Option<String>,
 }
 
 /// `GET /config/decode-status` response — what the recorder is ACTUALLY using

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -6151,10 +6151,14 @@ pub async fn list_camera_decode_status(pool: &Pool) -> Result<Vec<CameraDecodeSt
             SELECT s.camera_id, c.name AS camera_name,
                    s.requested, s.active, s.fallback_reason, s.updated_at,
                    a.sample_rate AS audio_sample_rate,
-                   a.transcoding AS audio_transcoding
+                   a.transcoding AS audio_transcoding,
+                   h.healthy    AS motion_healthy,
+                   h.changed_at AS motion_health_since,
+                   h.reason     AS motion_health_reason
             FROM camera_decode_status s
             JOIN cameras c ON c.id = s.camera_id
             LEFT JOIN camera_audio_status a ON a.camera_id = s.camera_id
+            LEFT JOIN camera_motion_health h ON h.camera_id = s.camera_id
             ORDER BY c.name, s.camera_id
             ",
             &[],
@@ -6172,8 +6176,75 @@ pub async fn list_camera_decode_status(pool: &Pool) -> Result<Vec<CameraDecodeSt
             updated_at: row.get("updated_at"),
             audio_sample_rate: row.get("audio_sample_rate"),
             audio_transcoding: row.get("audio_transcoding"),
+            motion_healthy: row.get("motion_healthy"),
+            motion_health_since: row.get("motion_health_since"),
+            motion_health_reason: row.get("motion_health_reason"),
         })
         .collect())
+}
+
+/// Upsert one camera's CURRENT motion-detector health (`camera_motion_health`,
+/// migration 0072). Written by the recorder's health aggregator
+/// (`services/recorder/src/motion.rs` `aggregate_health`) on every camera-level
+/// health TRANSITION, so the row is a LEVEL signal (current state), not the
+/// EDGE `motion_detector_unhealthy` system_events emit. `changed_at` advances
+/// only when `healthy` actually flips, so it reads as "unhealthy since <time>";
+/// `updated_at` always advances so staleness of the report is visible.
+///
+/// Best-effort at the call site (telemetry) — a failed write never affects the
+/// in-memory fail-open signal, which flips independently and instantly.
+///
+/// # Errors
+/// Returns an error if the database query fails.
+pub async fn upsert_camera_motion_health(
+    pool: &Pool,
+    camera_id: Uuid,
+    healthy: bool,
+    reason: Option<&str>,
+) -> Result<()> {
+    let client = get_conn(pool).await?;
+    client
+        .execute(
+            r"
+            INSERT INTO camera_motion_health (camera_id, healthy, reason, changed_at, updated_at)
+            VALUES ($1, $2, $3, now(), now())
+            ON CONFLICT (camera_id) DO UPDATE
+                SET healthy    = EXCLUDED.healthy,
+                    reason     = EXCLUDED.reason,
+                    -- Advance changed_at only on a real flip so it stays the
+                    -- 'since when' of the CURRENT state, not the last write.
+                    changed_at = CASE
+                        WHEN camera_motion_health.healthy <> EXCLUDED.healthy THEN now()
+                        ELSE camera_motion_health.changed_at
+                    END,
+                    updated_at = now()
+            ",
+            &[&camera_id, &healthy, &reason],
+        )
+        .await
+        .context("upsert_camera_motion_health")?;
+    Ok(())
+}
+
+/// Delete one camera's motion-health row.
+///
+/// Called by the supervisor when it stops the worker of a disabled/removed
+/// camera (mirrors `delete_camera_decode_status`), so the admin panel never
+/// shows a stale health badge for a camera that has no worker left to report.
+/// Camera deletion also cascades via the FK — this covers the disable case.
+///
+/// # Errors
+/// Returns an error if the database query fails.
+pub async fn delete_camera_motion_health(pool: &Pool, camera_id: Uuid) -> Result<()> {
+    let client = get_conn(pool).await?;
+    client
+        .execute(
+            "DELETE FROM camera_motion_health WHERE camera_id = $1",
+            &[&camera_id],
+        )
+        .await
+        .context("delete_camera_motion_health")?;
+    Ok(())
 }
 
 // ─── motion RAM-cache telemetry (migration 0039) ──────────────────────────────
@@ -10427,6 +10498,10 @@ static MIGRATIONS: &[(&str, &str)] = &[
     (
         "0071_lpr_engine_none.sql",
         include_str!("../../../db/migrations/0071_lpr_engine_none.sql"),
+    ),
+    (
+        "0072_camera_motion_health.sql",
+        include_str!("../../../db/migrations/0072_camera_motion_health.sql"),
     ),
 ];
 

--- a/services/common/src/types.rs
+++ b/services/common/src/types.rs
@@ -996,6 +996,20 @@ pub struct CameraDecodeStatus {
     /// 48 kHz AAC (source rate > 48 kHz), `Some(false)` when bit-exact copied,
     /// `None` when unknown / no audio-status row.
     pub audio_transcoding: Option<bool>,
+    /// Current motion-detector health (migration 0072, LEFT JOINed from
+    /// `camera_motion_health`): `Some(true)` when the detector is healthy,
+    /// `Some(false)` when it is currently down and the recorder is failing OPEN
+    /// (recording continuously as a fallback) right now, `None` when the
+    /// recorder has never reported health for this camera (older image, not a
+    /// Motion-mode camera, or not booted yet).
+    pub motion_healthy: Option<bool>,
+    /// When the current `motion_healthy` state began (advanced only on a flip),
+    /// so an unhealthy row reads as "recording continuously since <time>".
+    /// `None` when there is no health row.
+    pub motion_health_since: Option<DateTime<Utc>>,
+    /// Short human-readable cause when `motion_healthy == Some(false)` (which
+    /// source(s) stopped delivering frames); `None` when healthy or no row.
+    pub motion_health_reason: Option<String>,
 }
 
 // ─── motion RAM-cache telemetry (migration 0039) ──────────────────────────────

--- a/services/recorder/src/main.rs
+++ b/services/recorder/src/main.rs
@@ -958,6 +958,13 @@ impl RecorderSupervisor {
                 if let Err(e) = db::delete_camera_motion_cache_status(&self.pool, id).await {
                     warn!(camera_id = %id, error = %e, "failed to delete motion-cache status row");
                 }
+                // Same for the motion-health current-state row (migration 0072):
+                // a stopped/disabled camera has no worker left to report health,
+                // so drop the stale row (absence renders as "no report", never
+                // as unhealthy). Camera DELETEs also cascade it via the FK.
+                if let Err(e) = db::delete_camera_motion_health(&self.pool, id).await {
+                    warn!(camera_id = %id, error = %e, "failed to delete motion-health row");
+                }
             }
         }
 

--- a/services/recorder/src/motion.rs
+++ b/services/recorder/src/motion.rs
@@ -1488,6 +1488,10 @@ pub async fn run(
             alert_after_secs,
         )
         .await;
+        // Persist the current-state row too (migration 0072) so the admin
+        // console shows this camera as failing open right now — this path never
+        // reaches the aggregator that would otherwise write it.
+        persist_motion_health(&pool, camera_id, false, Some("no motion source enabled")).await;
         cancel.cancelled().await;
         info!(camera_id = %camera_id, "motion task exiting");
         return;
@@ -1562,9 +1566,10 @@ pub async fn run(
     let aggregator = {
         let health_tx = health_tx.clone();
         let cancel = cancel.clone();
+        let pool = pool.clone();
         tokio::spawn(async move {
             aggregate_health(
-                enabled, pixel_rx, frigate_rx, ha_rx, health_tx, camera_id, cancel,
+                enabled, pixel_rx, frigate_rx, ha_rx, health_tx, camera_id, pool, cancel,
             )
             .await;
         })
@@ -1934,6 +1939,7 @@ async fn idle_before_recheck(cancel: &CancellationToken) {
 /// the recording task reads, applying the [`FailOpenGate`] rule. Re-evaluates on
 /// any per-source change AND every second (so the down-past-grace clause fires on
 /// time even with no new event). Publishes a final unhealthy on teardown.
+#[allow(clippy::too_many_arguments)]
 async fn aggregate_health(
     enabled: Vec<SourceKind>,
     mut pixel_rx: Option<tokio::sync::watch::Receiver<bool>>,
@@ -1941,6 +1947,7 @@ async fn aggregate_health(
     mut ha_rx: Option<tokio::sync::watch::Receiver<bool>>,
     health_tx: MotionHealthTx,
     camera_id: uuid::Uuid,
+    pool: Pool,
     cancel: CancellationToken,
 ) {
     let start = Utc::now();
@@ -1991,16 +1998,26 @@ async fn aggregate_health(
         }
         let camera_healthy = gate.healthy(now);
         if last_sent != Some(camera_healthy) {
-            if camera_healthy {
-                info!(camera_id = %camera_id, "motion health: RECOVERED (a source is healthy)");
-            } else {
-                warn!(
-                    camera_id = %camera_id,
-                    "motion health: FAIL-OPEN (no source healthy, or one down past grace)"
-                );
-            }
+            // Flip the in-memory fail-open signal FIRST and unconditionally —
+            // recording correctness must never wait on the telemetry DB write
+            // below (same rule as report_health).
             let _ = health_tx.send(camera_healthy);
             last_sent = Some(camera_healthy);
+            if camera_healthy {
+                info!(camera_id = %camera_id, "motion health: RECOVERED (a source is healthy)");
+                // Level signal for the admin console (migration 0072): current
+                // state is healthy again — clears the "recording continuously"
+                // badge. Best-effort; never blocks the fail-open flip above.
+                persist_motion_health(&pool, camera_id, true, None).await;
+            } else {
+                let reason = fail_open_reason(&last_healthy);
+                warn!(
+                    camera_id = %camera_id,
+                    reason = %reason,
+                    "motion health: FAIL-OPEN (no source healthy, or one down past grace)"
+                );
+                persist_motion_health(&pool, camera_id, false, Some(&reason)).await;
+            }
         }
 
         tokio::select! {
@@ -2013,8 +2030,59 @@ async fn aggregate_health(
     }
 
     // Teardown: the recording task must not trust a stale healthy reading.
+    // NOTE: we deliberately do NOT persist this teardown unhealthy to
+    // `camera_motion_health` — teardown is worker shutdown, not a detector
+    // fault. The last in-loop state stays until the worker restarts and the
+    // aggregator re-evaluates (conservative: an operator sees the last real
+    // state, and staleness is visible via `updated_at`), and the supervisor
+    // deletes the row outright for a disabled/removed camera.
     let _ = health_tx.send(false);
     info!(camera_id = %camera_id, "motion health aggregator exiting");
+}
+
+/// Best-effort upsert of a camera's CURRENT motion-detector health
+/// (`camera_motion_health`, migration 0072), surfaced by
+/// `GET /config/decode-status` so the admin console can show a camera that is
+/// failing open (recording continuously as a fallback) right now. Telemetry
+/// only — a failed write is logged at DEBUG and never affects the fail-open
+/// signal, which flips independently and instantly.
+async fn persist_motion_health(
+    pool: &Pool,
+    camera_id: uuid::Uuid,
+    healthy: bool,
+    reason: Option<&str>,
+) {
+    if let Err(e) =
+        crumb_common::db::upsert_camera_motion_health(pool, camera_id, healthy, reason).await
+    {
+        debug!(
+            camera_id = %camera_id,
+            error = %e,
+            "motion-health upsert failed (telemetry only)"
+        );
+    }
+}
+
+/// Build the short, operator-facing reason persisted when a camera goes
+/// fail-open: which enabled source(s) are currently not delivering frames.
+/// Pure (no I/O) and deterministic (down sources sorted) so it is unit-testable
+/// and the DTO/badge text is stable. `last_healthy` maps each enabled source to
+/// its last-observed health; a source reads as down when `false`.
+#[must_use]
+fn fail_open_reason(last_healthy: &std::collections::HashMap<SourceKind, bool>) -> String {
+    let mut down: Vec<&'static str> = last_healthy
+        .iter()
+        .filter(|&(_, &healthy)| !healthy)
+        .map(|(kind, _)| kind.as_str())
+        .collect();
+    down.sort_unstable();
+    match down.as_slice() {
+        // Empty only if every source reads healthy — the gate can still fail
+        // open transiently on the down-past-grace clause; give a generic cause.
+        [] => "motion detection unhealthy".to_string(),
+        [one] => format!("{one} motion detection not delivering frames"),
+        many => format!("{} motion sources not delivering frames", many.join(", ")),
+    }
 }
 
 /// Await the next change on an optional per-source health watch. A `None` slot
@@ -4302,6 +4370,56 @@ mod tests {
         assert!(should_emit_unhealthy_alert(0, 0, false));
     }
 
+    // ── fail-open reason string (persisted to camera_motion_health, mig 0072) ────
+
+    fn health_map(pairs: &[(SourceKind, bool)]) -> std::collections::HashMap<SourceKind, bool> {
+        pairs.iter().copied().collect()
+    }
+
+    #[test]
+    fn fail_open_reason_names_the_single_down_source() {
+        // The #411 scenario: a single pixel detector producing zero frames.
+        let m = health_map(&[(SourceKind::Pixel, false)]);
+        assert_eq!(
+            fail_open_reason(&m),
+            "pixel motion detection not delivering frames"
+        );
+    }
+
+    #[test]
+    fn fail_open_reason_lists_multiple_down_sources_sorted() {
+        // Deterministic (sorted) despite HashMap iteration order, so the DTO /
+        // badge text is stable across reads.
+        let m = health_map(&[
+            (SourceKind::Ha, false),
+            (SourceKind::Pixel, false),
+            (SourceKind::Frigate, false),
+        ]);
+        assert_eq!(
+            fail_open_reason(&m),
+            "frigate, ha, pixel motion sources not delivering frames"
+        );
+    }
+
+    #[test]
+    fn fail_open_reason_reports_only_the_down_ones() {
+        // A healthy source is not named; only the source(s) that stopped.
+        let m = health_map(&[(SourceKind::Pixel, true), (SourceKind::Frigate, false)]);
+        assert_eq!(
+            fail_open_reason(&m),
+            "frigate motion detection not delivering frames"
+        );
+    }
+
+    #[test]
+    fn fail_open_reason_all_healthy_gives_generic_cause() {
+        // The down-past-grace clause can drive a transient fail-open even when
+        // every source's last reading is healthy — give a generic, non-empty
+        // cause rather than an empty string.
+        let m = health_map(&[(SourceKind::Pixel, true)]);
+        assert_eq!(fail_open_reason(&m), "motion detection unhealthy");
+    }
+
     #[test]
     fn alert_gate_generation_bumps_on_each_transition() {
         // Simulates the transition bookkeeping `report_health` performs,
@@ -5882,6 +6000,26 @@ mod tests {
 
     // ── health aggregator: dropped source sender ⇒ fail-open ────────────────────
 
+    /// A deadpool pool pointing at a port where nothing listens, so the
+    /// aggregator's best-effort `camera_motion_health` upsert fails fast and is
+    /// swallowed (telemetry-only). This test exercises health AGGREGATION and
+    /// the fail-open signal, not persistence — no database is required.
+    fn unreachable_pool() -> Pool {
+        let mut cfg = deadpool_postgres::Config::new();
+        cfg.host = Some("127.0.0.1".to_string());
+        cfg.port = Some(1); // nothing listens ⇒ connect refused immediately
+        cfg.dbname = Some("crumb_test_unreachable".to_string());
+        cfg.user = Some("nobody".to_string());
+        // Mirror the crate's real pool construction (services/common/src/db.rs):
+        // builder(NoTls) → Tokio1 runtime → build. Lazy — no connection is made
+        // until first checkout, which then fails fast and is swallowed.
+        cfg.builder(tokio_postgres::NoTls)
+            .expect("unreachable test pool builder")
+            .runtime(deadpool_postgres::Runtime::Tokio1)
+            .build()
+            .expect("build unreachable test pool")
+    }
+
     /// Await the camera health watch reaching `want`, with a hard timeout so a
     /// broken aggregator fails the test instead of hanging it.
     async fn wait_for_camera_health(rx: &mut tokio::sync::watch::Receiver<bool>, want: bool) {
@@ -5911,6 +6049,7 @@ mod tests {
             None,
             cam_tx,
             uuid::Uuid::nil(),
+            unreachable_pool(),
             cancel.clone(),
         ));
 


### PR DESCRIPTION
Follows up #411 (item 2: distinguish "fail-open because the detector is broken" from "recording because there is motion", and make it visible in-app). Emission of the alert (#413) and the default-enabled notification rule (migration 0038) already exist; this adds the missing IN-APP signal, no push channel required.

## The gap
When a motion detector goes down, the recorder correctly fails open (records continuously so no footage is lost). But fail-open continuous segments look identical to a busy scene, and an operator viewing the admin console had no way to SEE that a camera's motion detection was down and recording continuously as a fallback. That is exactly why the #411 incident ran days undetected.

## Why a new LEVEL signal
The existing `motion_detector_unhealthy` system_event is an EDGE with no "healthy again" marker, so events alone cannot answer "is this camera unhealthy right now". New table `camera_motion_health` (migration `0072`, registered) holds exactly one row per camera, upserted by the recorder's health aggregator (`aggregate_health`) on every camera-level transition in either direction, so it always reflects current state. `changed_at` advances only on a flip (reads as "recording continuously since <time>"); the row is deleted when a camera's worker stops (mirrors `camera_decode_status`) and cascades on camera delete.

## Recorder-correctness note
The in-memory fail-open signal (`health_tx.send`) still flips FIRST and unconditionally; the `camera_motion_health` write is best-effort telemetry after it, errors swallowed at DEBUG, and never gates recording. Teardown-unhealthy is deliberately NOT persisted (worker shutdown is not a detector fault; the supervisor deletes the row instead). No change to what gets recorded or to the fail-open path.

## Surfacing
`GET /config/decode-status` LEFT JOINs the row and returns `motion_healthy` / `motion_health_since` / `motion_health_reason`. `admin.html` renders a `var(--danger)` "Motion detection DOWN, recording continuously as fallback (for <elapsed>)" badge in the decode-status panel; nothing when healthy or unreported.

## Notification path
Verified clean end-to-end: `motion_detector_unhealthy` is recognized at the rule lookup, the `0038` rule is enabled, cooldown 900s is honored, and it has a human label. No default channel shipped (that would be phone-home).

## Deferred follow-ups
Desktop (Flutter), Android, and iOS do not yet surface the new per-camera field. Noted in `COMPONENT-MAP.md`. Pure-Frigate/HA-only motion cameras with no local decode row do not appear in the decode-status panel, so their badge would not show there; the common pixel path and the #411 case are covered.

## Testing
Unit tests for `fail_open_reason` (single / multiple / mixed / all-healthy). The existing aggregate_health test gains a lazy unreachable pool so the best-effort upsert fails fast and is swallowed. Full gate runs in CI. `node --check` on the extracted admin.html script passed.