### PR TITLE
feat(go2rtc): first-class RTSP restream auth opt-out (GO2RTC_AUTH=off)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,14 @@ CRUMB_GO2RTC_RTSP_BASE=
 # generates a strong GO2RTC_PASS. GO2RTC_USER is just the Basic-auth username slot.
 GO2RTC_USER=go2rtc
 GO2RTC_PASS=change-me
+# OPTIONAL restream auth opt-out (issue #398). Default (unset/anything but 'off')
+# keeps the LAN RTSP restream AUTHENTICATED, the secure default. Set to 'off' ONLY
+# if you deliberately want an open, credential-free restream on a trusted LAN:
+#   GO2RTC_AUTH=off
+# means anything on your LAN can pull every camera from rtsp://<host>:18554/<name>
+# with no password. The internal go2rtc REST API (:1984) stays authenticated
+# regardless, so GO2RTC_USER/PASS are still required. docs/COMPOSE.md § go2rtc.
+# GO2RTC_AUTH=off
 # External BYO-Frigate go2rtc (only cameras served_by='frigate'); separate creds.
 GO2RTC_RTSP_BASE=
 GO2RTC_API_BASE=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       GO2RTC_USER: ${GO2RTC_USER:?GO2RTC_USER is required (run scripts/setup-env.sh)}
       GO2RTC_PASS: ${GO2RTC_PASS:?GO2RTC_PASS is required (run scripts/setup-env.sh)}
       GO2RTC_EMBEDDED: ${GO2RTC_EMBEDDED:-true}          # false only if you run an external restreamer
+      GO2RTC_AUTH: ${GO2RTC_AUTH:-}                       # 'off' opens the LAN RTSP restream (no auth); empty/anything else = authenticated (docs/COMPOSE.md)
       WEBRTC_CANDIDATE: ${WEBRTC_CANDIDATE:-}            # set <server-LAN-ip>:8556 so WebRTC reaches LAN clients
       TZ: ${TZ:-UTC}                                     # local wall-clock for quiet hours, backups, log timestamps (setup-env.sh detects the host TZ)
       GO2RTC_RTSP_BASE: ${GO2RTC_RTSP_BASE:-}            # external BYO-Frigate go2rtc (served_by='frigate' only)
@@ -144,6 +145,7 @@ services:
       GO2RTC_API_BASE: ${GO2RTC_API_BASE:-}
       GO2RTC_USER: ${GO2RTC_USER:?GO2RTC_USER is required (run scripts/setup-env.sh)}
       GO2RTC_PASS: ${GO2RTC_PASS:?GO2RTC_PASS is required (run scripts/setup-env.sh)}
+      GO2RTC_AUTH: ${GO2RTC_AUTH:-}                       # keep in sync with the recorder; 'off' = credential-free client stream URLs
       MEDIA_ROOT: ${MEDIA_ROOT:-/data}
       LIVE_STORAGE_PATH: ${LIVE_STORAGE_PATH:-/data/live}
       ARCHIVE_STORAGE_PATH: ${ARCHIVE_STORAGE_PATH:-/data/archive}

--- a/docs-site/docs/configuration/environment-reference.md
+++ b/docs-site/docs/configuration/environment-reference.md
@@ -55,6 +55,7 @@ console's Server & streaming settings, that value wins.
 | `GO2RTC_USER` | `go2rtc` | a fixed, non-secret Basic-auth username label (not generated); required, compose fails fast if unset |
 | `GO2RTC_PASS` | generated | required; required to be strong, rotate with care (needs a recorder + api restart) |
 | `GO2RTC_EMBEDDED` | `true` | set `false` only if running an external restreamer |
+| `GO2RTC_AUTH` | empty (auth ON) | optional restream auth opt-out. Leave unset for the secure default (authenticated LAN RTSP restream). Set to `off` to run an OPEN, credential-free restream on a trusted LAN: any LAN client can then pull every camera at `rtsp://<host>:18554/<name>` with no password. Any value other than `off` (including empty) keeps auth ON. The internal go2rtc REST API (`:1984`) stays authenticated regardless, so `GO2RTC_USER`/`GO2RTC_PASS` are still required. |
 | `GO2RTC_RTSP_BASE` / `GO2RTC_API_BASE` | empty | a separate, external Frigate go2rtc instance, only used for cameras served by it |
 
 ## Recording

--- a/docs/AI-INSTALL.md
+++ b/docs/AI-INSTALL.md
@@ -260,6 +260,15 @@ authenticated with `GO2RTC_USER`/`GO2RTC_PASS`. Don't add a host port for it.
 (Upgrading an install that predates the embedding? `docker compose up -d
 --remove-orphans` removes the old standalone go2rtc container.)
 
+The LAN RTSP restream (`18554`) is **authenticated by default**, and that is the
+recommended posture, do not disable it on your own initiative. An operator on a
+trusted, segmented LAN may explicitly opt out by setting `GO2RTC_AUTH=off` in
+`.env`, which opens ONLY that RTSP listener (any LAN client can then pull every
+camera with no password); the internal `:1984` REST API stays authenticated
+regardless. It is loud when set: startup `WARN` logs in both the recorder and
+api, plus a red badge on the admin console's Server page. Any value but `off`
+(including unset) keeps auth on. Full detail: `docs/COMPOSE.md` § go2rtc.
+
 The `recorder` service sets `stop_grace_period: 90s`: its clean shutdown
 finalizes in-flight segments and storage-migration batches, and Docker's
 default 10 s grace would SIGKILL it mid-teardown. Don't remove or shorten it.

--- a/docs/COMPOSE.md
+++ b/docs/COMPOSE.md
@@ -105,6 +105,32 @@ grants.
 > LAN scanning, **not** a replacement for the api's per-user JWT/RBAC on the
 > MSE/WebRTC-signaling/JPEG planes.
 
+#### Opting the LAN RTSP restream out of auth (`GO2RTC_AUTH=off`)
+
+The RTSP restream is authenticated by default, and that is the recommended
+posture. Turning auth on is not a local change: every consumer (a Frigate or
+other NVR pulling `rtsp://host:18554/<stream>`, plus every client) needs the
+credential at the same instant. On a segmented, trusted LAN an operator may
+reasonably decide that coordination cost is not worth it, so the opt-out is a
+first-class, supported setting rather than a config-file fork.
+
+Set `GO2RTC_AUTH=off` in `.env` to open ONLY the LAN-facing RTSP listener
+(`:18554`). With it set:
+
+- the recorder renders an effective go2rtc config at startup that omits the
+  `rtsp:` listener's credentials (the tracked `go2rtc/go2rtc.yaml` is mounted
+  read-only and is never edited), so a deployment stays byte-identical to
+  upstream and only sets one env var;
+- the api hands out credential-free `rtsp://host:18554/<name>` URLs;
+- the recorder logs a startup `WARN`, the api logs one too, and the admin
+  console's **Server** page shows a red "OPEN, no auth" badge, so an open
+  restream is never a silent surprise.
+
+Any value other than exactly `off` (including empty or unset) keeps auth ON.
+The internal go2rtc REST API (`:1984`) stays authenticated in both postures, so
+`GO2RTC_USER`/`GO2RTC_PASS` remain required. To re-secure the restream, remove
+`GO2RTC_AUTH` (or set it to anything but `off`) and restart the stack.
+
 ### recorder volumes and the motion RAM cache
 
 - `${MEDIA_HOST_PATH}:/data` — one broad media root, **read-write** (the

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -49,6 +49,67 @@ mounting the Docker socket, a meaningful privilege for a default-path service.
 - A first-party, socket-free recovery mechanism becomes available (e.g. the
   recorder self-restarting a wedged internal subsystem, or a healthcheck-driven
   restart that does not need the Docker socket).
+## 2026-07-31, go2rtc restream auth opt-out is a first-class env choice (`GO2RTC_AUTH=off`), LAN-RTSP only, secure default preserved
+
+**Decision.** The LAN-facing go2rtc RTSP restream (`:8554`, published `:18554`)
+can be run without authentication via a single explicit env var, `GO2RTC_AUTH=off`
+(issue #398). It is secure by default: unset, empty, and any unrecognized value
+all keep auth ON, byte-for-byte unchanged from prior behavior. When set to `off`:
+the recorder renders an effective go2rtc config at startup that omits ONLY the
+`rtsp:` listener's `username`/`password` (the tracked `go2rtc/go2rtc.yaml` stays
+read-only and un-edited), the api hands out credential-free
+`rtsp://host:18554/<name>` URLs, and the posture is logged loudly by both
+containers and shown as a red badge on the admin console's Server page. The
+internal go2rtc REST API (`:1984`, never host-published) stays authenticated in
+BOTH postures.
+
+**Context.** Before this, the only way to run an open restream was to edit the
+tracked `go2rtc/go2rtc.yaml`, an invisible fork of a repo-managed file that no
+fresh checkout reproduces and that makes a deployment stop matching what users
+run. Turning auth on is a coordination cost paid at one instant by every consumer
+(a BYO Frigate/NVR pulling the restream, plus every client); on a segmented,
+trusted LAN an operator may reasonably decline it. The project should let them
+express that as configuration, not as a patch.
+
+**Why LAN-RTSP-only, internal REST always authed.** go2rtc auth is per-listener.
+The `:1984` REST API is the stream-management surface (enumerate/PUT/DELETE any
+camera) and is reachable only over the compose bridge as `recorder:1984`; the api
+and reconcile loop depend on its auth as free defense-in-depth. Only the LAN RTSP
+listener is what an operator wants open, so only its credentials are ever removed.
+
+**Why render, not empty-username magic.** go2rtc treats a listener with no
+`username`/`password` as open. We render that state explicitly (strip the two
+`rtsp:` keys) rather than passing an empty `${GO2RTC_USER}` and relying on
+substitution semantics, because an empty credential is ambiguous (it could break
+env substitution or silently disable auth in a way that drifts across go2rtc
+versions). Confidence that an omitted listener credential is go2rtc 1.9.x's "no
+auth" state: high, it is the documented model and matches the in-repo note that
+RTSP auth is purely listener-credential-driven with no separate toggle. The
+render path also fails safe: if reading the template or writing the effective
+config fails, the recorder falls back to the authenticated template, so a failure
+can never silently open the restream.
+
+**Rejected.** (1) Flipping the default to off, explicitly out of scope: a
+permissive default is paid silently by every operator who never read the docs,
+whereas the coordination cost is paid once, deliberately, by the operator who
+opts out. (2) Relying on an empty `GO2RTC_USER` to disable auth, ambiguous and
+version-fragile as above. (3) Editing the tracked `go2rtc.yaml` (the status quo),
+invisible drift, and the mount is read-only anyway. (4) Also opening the internal
+`:1984` REST listener, no benefit, loses free defense-in-depth on the
+stream-management surface.
+
+**Accepted trade-offs.** Opt-out is all-or-nothing across cameras (go2rtc auth is
+per-listener, not per-stream) and per-deployment, not per-user. The rendered
+effective config lives at a writable temp path (overridable via
+`GO2RTC_RENDERED_CONFIG`), regenerated each boot from the template so it cannot
+drift. `GO2RTC_AUTH` must be set on both the recorder (renders the config) and the
+api (URL construction); compose forwards it to both.
+
+**Revisit if:** go2rtc gains a per-stream or per-user auth model; go2rtc changes
+how an omitted listener credential is interpreted (retest the render path); or a
+demand emerges for a scoped RTSP credential (per-camera / short-lived) rather than
+the single shared one, which would change the calculus for both the default and
+the opt-out.
 
 ## 2026-07-29, Media-token capability claims default to false rather than failing to decode
 

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -211,6 +211,12 @@ CRUMB_GO2RTC_RTSP_BASE=
 # restarting recorder + api.
 GO2RTC_USER=${GO2RTC_USER}
 GO2RTC_PASS=${GO2RTC_PASS}
+# OPTIONAL restream auth opt-out (issue #398). Left UNSET here on purpose: the
+# secure default is an AUTHENTICATED LAN RTSP restream. Set GO2RTC_AUTH=off ONLY
+# to deliberately run an open, credential-free restream on a trusted LAN (any LAN
+# client can then pull every camera at rtsp://<host>:18554/<name>). The internal
+# go2rtc REST API (:1984) stays authenticated regardless. docs/COMPOSE.md § go2rtc.
+# GO2RTC_AUTH=off
 # External (BRING-YOUR-OWN) Frigate's go2rtc — only for cameras served_by='frigate'.
 # This is a SEPARATE go2rtc instance with its own credentials (if any);
 # GO2RTC_USER/PASS above are never sent to it.

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -426,6 +426,9 @@ tbody tr.selected td:first-child{box-shadow:inset 3px 0 0 var(--accent);}
 .warn-note{border-left:2px solid var(--warn);padding:6px 10px;font-size:12px;color:var(--dim);line-height:1.5;margin-top:10px;}
 .info-note b,.info-note strong{color:var(--text);}
 .warn-note b,.warn-note strong{color:var(--warn);}
+/* Danger variant: an OPEN/unauthenticated posture the operator must not miss. */
+.warn-note.danger{border-left-color:var(--danger);}
+.warn-note.danger b,.warn-note.danger strong{color:var(--danger);}
 /* ── Code ── */
 code{background:var(--surface2);padding:1px 5px;border-radius:4px;font-size:12px;font-family:ui-monospace,monospace;}
 /* ── Inheritance banner, flattened: left accent rule, no filled box ── */
@@ -888,6 +891,17 @@ function infoHint(text) {
   // stopPropagation/preventDefault so clicking the icon inside a <label>
   // doesn't toggle the control it annotates.
   return `<span class="info-hint" tabindex="0" role="button" title="${t}" aria-label="${t}" data-info="${t}" onclick="event.preventDefault();event.stopPropagation();toast(this.getAttribute('data-info'),'info',7000)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toast(this.getAttribute('data-info'),'info',7000)}">${icon('info',13)}</span>`;
+}
+/* Restream auth posture badge (issue #398). `authed` is the DTO's
+   restream_rtsp_authenticated: true = secure default (green), false = the
+   operator set GO2RTC_AUTH=off and the LAN RTSP restream is OPEN (red). An
+   undefined value (older server) shows a neutral "unknown" chip. */
+function restreamAuthBadge(authed) {
+  if (authed === true)
+    return `<span class="pill" style="color:var(--ok);border:1px solid var(--ok)">Authenticated</span>`;
+  if (authed === false)
+    return `<span class="pill" style="color:var(--danger);border:1px solid var(--danger)">OPEN, no auth</span>`;
+  return `<span class="pill" style="color:var(--dim)">unknown</span>`;
 }
 /* Tooltip copy for the motion detection controls (shared by the camera Motion
    tab and the dedicated Motion-tuning view). */
@@ -6901,8 +6915,16 @@ async function renderServerSettings() {
         <div class="fg-ctl"><input id="srv-crumb-rtsp" class="mono" value="${esc(s.crumb_rtsp_base||'')}" placeholder="rtsp://&lt;this-host&gt;:18554" style="max-width:420px" title="Public RTSP address native clients pull from. Empty = the in-network container default." /></div>
         <label class="fg-label" for="srv-crumb-api">Crumb API base ${infoHint('go2rtc REST/WebRTC base for the web player. Empty = the container default.')}</label>
         <div class="fg-ctl"><input id="srv-crumb-api" class="mono" value="${esc(s.crumb_api_base||'')}" placeholder="http://go2rtc:1984" style="max-width:420px" title="go2rtc REST/WebRTC base for the web player. Empty = the container default." /></div>
+        <label class="fg-label">Restream auth ${infoHint('Whether the LAN RTSP restream (rtsp://<host>:18554) requires a username/password. Set by GO2RTC_AUTH; not editable here.')}</label>
+        <div class="fg-ctl">${restreamAuthBadge(s.restream_rtsp_authenticated)}</div>
         <div class="fg-full card-hint">Frigate stream addresses &amp; the motion-decode backend moved to <b>Detection &amp; clips</b>.</div>
       </div>
+      ${s.restream_rtsp_authenticated === false ? `<div class="warn-note danger" style="margin-top:10px">
+        <b>The RTSP restream is OPEN.</b> <code>GO2RTC_AUTH=off</code> is set, so any client on the LAN can pull
+        every camera from <code>rtsp://&lt;this-host&gt;:18554/&lt;name&gt;</code> with no credentials. This is an
+        explicit opt-out. To re-secure it, remove <code>GO2RTC_AUTH</code> (or set it to anything other than
+        <code>off</code>) and restart the stack. The internal go2rtc REST API (:1984) stays authenticated either way.
+      </div>` : ''}
     </div>
     <div class="policy-section">
       <div class="policy-section-title">Features</div>

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -133,6 +133,23 @@ pub struct ApiConfig {
     pub go2rtc_user: String,
     pub go2rtc_pass: String,
 
+    /// `GO2RTC_AUTH` — whether Crumb's own go2rtc RTSP restream listener
+    /// (`:18554`, LAN-published) requires authentication (issue #398).
+    ///
+    /// **Secure by default: `true`.** Only the explicit opt-out token
+    /// `GO2RTC_AUTH=off` sets this to `false`; unset / empty / unrecognized all
+    /// keep it `true` (see [`crumb_common::config::go2rtc_rtsp_auth_enabled`]).
+    ///
+    /// When `true` (default), `GET /cameras/{id}/streams` embeds
+    /// `GO2RTC_USER:GO2RTC_PASS@` into the `rtsp://` URLs it hands clients, as
+    /// before. When `false`, the LAN restream is open and the API hands out
+    /// credential-free `rtsp://host:18554/<name>` URLs.
+    ///
+    /// This does NOT affect the internal go2rtc REST API (`:1984`), which stays
+    /// authenticated in both postures — the API always keeps `go2rtc_user` /
+    /// `go2rtc_pass` for its own internal REST calls regardless of this flag.
+    pub go2rtc_rtsp_auth: bool,
+
     // -- export -------------------------------------------------------------
     /// `EXPORT_DIR` -- directory where completed export MP4 files are written.
     ///
@@ -408,6 +425,8 @@ impl ApiConfig {
             crumb_go2rtc_rtsp_base: optional_env("CRUMB_GO2RTC_RTSP_BASE", ""),
             go2rtc_user: require_secret("GO2RTC_USER")?,
             go2rtc_pass,
+            // Issue #398: secure by default — auth ON unless GO2RTC_AUTH=off.
+            go2rtc_rtsp_auth: crumb_common::config::go2rtc_rtsp_auth_enabled_env(),
             export_dir: optional_env("EXPORT_DIR", "/data/exports"),
             export_ttl_seconds: parse_env("EXPORT_TTL_SECONDS", 86_400_u64)?,
             export_max_concurrent: parse_env("EXPORT_MAX_CONCURRENT", 2usize)?.max(1),

--- a/services/api/src/config_routes.rs
+++ b/services/api/src/config_routes.rs
@@ -3822,7 +3822,10 @@ async fn redetect_camera(
 
 // ─── server / streaming settings ─────────────────────────────────────────────
 
-fn server_settings_to_dto(s: ServerSettings) -> ServerSettingsDto {
+fn server_settings_to_dto(
+    s: ServerSettings,
+    restream_rtsp_authenticated: bool,
+) -> ServerSettingsDto {
     ServerSettingsDto {
         server_address: s.server_address,
         crumb_rtsp_base: s.crumb_rtsp_base,
@@ -3839,6 +3842,8 @@ fn server_settings_to_dto(s: ServerSettings) -> ServerSettingsDto {
         // schedule times in the server's real zone instead of a hardcoded
         // one (#237). A PUT to /config/server never changes it.
         tz: crate::db_backup::schedule_tz().name().to_string(),
+        // Issue #398: runtime posture from the GO2RTC_AUTH env, not the DB row.
+        restream_rtsp_authenticated,
     }
 }
 
@@ -3853,7 +3858,10 @@ async fn get_server_settings(
         .ok_or_else(|| {
             ApiError::Internal(anyhow::anyhow!("server_settings row missing; run ensure"))
         })?;
-    Ok(Json(server_settings_to_dto(s)))
+    Ok(Json(server_settings_to_dto(
+        s,
+        state.config().go2rtc_rtsp_auth,
+    )))
 }
 
 /// `PUT /config/server` — update server & streaming base-URL settings.
@@ -3907,7 +3915,10 @@ async fn update_server_settings(
     .await
     .context("update_server_settings")?;
     tracing::info!(version = s.version, "server settings updated");
-    Ok(Json(server_settings_to_dto(s)))
+    Ok(Json(server_settings_to_dto(
+        s,
+        state.config().go2rtc_rtsp_auth,
+    )))
 }
 
 // ─── health-alert maintenance window (issue #46) ────────────────────────────────

--- a/services/api/src/dto.rs
+++ b/services/api/src/dto.rs
@@ -958,6 +958,13 @@ pub struct ServerSettingsDto {
     /// Monotonically increasing version counter; bumped on every PUT. Clients
     /// poll this (via `/status`) to detect changes and reload stream URLs.
     pub version: i64,
+    /// Whether Crumb's own go2rtc RTSP restream (LAN-published `:18554`)
+    /// requires authentication (issue #398). Read-only, derived from the
+    /// `GO2RTC_AUTH` env posture (not the `server_settings` row), so a PUT never
+    /// changes it. `true` = secure default (clients get credentialed URLs);
+    /// `false` = the operator set `GO2RTC_AUTH=off` and the restream is OPEN to
+    /// any LAN client. The console renders a loud warning when this is `false`.
+    pub restream_rtsp_authenticated: bool,
     /// Resolved IANA timezone the server evaluates its schedules in (from the
     /// `TZ` env; `America/Los_Angeles` if unset/invalid). Read-only, derived from
     /// the environment (not the `server_settings` row, so a PUT never changes

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -153,6 +153,18 @@ async fn main() -> anyhow::Result<()> {
     let cfg = ApiConfig::from_env()?;
     let bind_addr = cfg.bind_addr;
     info!(bind_addr = %bind_addr, "configuration loaded");
+    // Issue #398: surface the go2rtc RTSP restream auth posture at startup. The
+    // recorder owns + logs the actual listener config; the api logs it too so an
+    // "open restream" is visible in both containers' logs and never a surprise.
+    if cfg.go2rtc_rtsp_auth {
+        info!("go2rtc RTSP restream auth: ENABLED (default); client stream URLs carry credentials");
+    } else {
+        tracing::warn!(
+            "go2rtc RTSP restream auth is DISABLED (GO2RTC_AUTH=off): the LAN restream \
+             (rtsp://<host>:18554) is OPEN to any client and /cameras/*/streams URLs carry no \
+             credentials. Operator opt-out; the internal go2rtc REST API stays authenticated"
+        );
+    }
 
     // ── 3. database pool ──────────────────────────────────────────────────────
     let pool = build_pool(&cfg.database_url, cfg.db_pool_size)?;

--- a/services/api/src/playback.rs
+++ b/services/api/src/playback.rs
@@ -614,11 +614,21 @@ async fn live_streams(
     let b = resolve_bases(&state).await;
     // P0-GO2RTC (lighter lockdown): embed Crumb's go2rtc RTSP credentials into
     // the CRUMB base only — never into frigate_rtsp (a separate BYO instance).
-    let crumb_rtsp_authed = crumb_common::db::inject_rtsp_credentials(
-        &b.crumb_rtsp,
-        &state.config().go2rtc_user,
-        &state.config().go2rtc_pass,
-    );
+    //
+    // Issue #398: when the operator has explicitly opted the LAN restream out of
+    // auth (`GO2RTC_AUTH=off`), go2rtc's RTSP listener is open, so hand clients
+    // credential-free `rtsp://host:18554/<name>` URLs (embedding a user:pass@
+    // that the listener no longer expects would be misleading, and there is no
+    // secret to embed). Default (auth ON) is unchanged: creds are embedded.
+    let crumb_rtsp_authed = if state.config().go2rtc_rtsp_auth {
+        crumb_common::db::inject_rtsp_credentials(
+            &b.crumb_rtsp,
+            &state.config().go2rtc_user,
+            &state.config().go2rtc_pass,
+        )
+    } else {
+        b.crumb_rtsp.clone()
+    };
 
     // ── 4. build stream URLs ──────────────────────────────────────────────────
     // RTSP URLs are resolved via the canonical helper so legacy rows (absolute
@@ -912,6 +922,37 @@ mod tests {
         assert_eq!(resolved.segment_id, seg.id);
         assert_eq!(resolved.duration_ms, seg.duration_ms);
         assert_eq!(resolved.has_motion, seg.has_motion);
+    }
+
+    // ── go2rtc RTSP restream auth posture (issue #398) ────────────────────────
+
+    /// The `live_streams` handler chooses the Crumb RTSP base by the auth
+    /// posture: auth ON embeds `user:pass@` into the base (the default), auth OFF
+    /// hands out the bare base with NO credentials. This mirrors that exact
+    /// branch so the contract is pinned: a credential-free URL when, and only
+    /// when, the operator opted out, and a fully qualified `rtsp://` in both.
+    fn crumb_rtsp_base_for(auth_on: bool, base: &str, user: &str, pass: &str) -> String {
+        if auth_on {
+            crumb_common::db::inject_rtsp_credentials(base, user, pass)
+        } else {
+            base.to_owned()
+        }
+    }
+
+    #[test]
+    fn rtsp_url_embeds_credentials_when_auth_on() {
+        let out = crumb_rtsp_base_for(true, "rtsp://host:18554", "u", "p");
+        assert_eq!(out, "rtsp://u:p@host:18554");
+        // A per-camera stream name resolves onto the credentialed base.
+        assert_eq!(format!("{out}/driveway"), "rtsp://u:p@host:18554/driveway");
+    }
+
+    #[test]
+    fn rtsp_url_omits_credentials_when_auth_off() {
+        let out = crumb_rtsp_base_for(false, "rtsp://host:18554", "u", "p");
+        assert_eq!(out, "rtsp://host:18554", "no user:pass@ when auth is off");
+        assert!(!out.contains('@'), "auth-off URL must carry no userinfo");
+        assert_eq!(format!("{out}/driveway"), "rtsp://host:18554/driveway");
     }
 
     // ── guard_path_traversal ──────────────────────────────────────────────────

--- a/services/common/src/config.rs
+++ b/services/common/src/config.rs
@@ -434,6 +434,49 @@ impl Config {
     }
 }
 
+// ── go2rtc RTSP restream auth posture (issue #398) ─────────────────────────────
+
+/// Explicit opt-out token for `GO2RTC_AUTH`. Only this exact value (case-
+/// insensitive, surrounding whitespace ignored) disables auth on the LAN-facing
+/// go2rtc RTSP restream listener. Every other value keeps auth ON.
+pub const GO2RTC_AUTH_OFF_TOKEN: &str = "off";
+
+/// Whether Crumb's own go2rtc RTSP restream listener (`:8554`, LAN-published as
+/// `:18554`) should require authentication.
+///
+/// **Secure by default.** Returns `true` for every input EXCEPT the explicit
+/// opt-out token [`GO2RTC_AUTH_OFF_TOKEN`] (`"off"`). Unset (`None`), empty, and
+/// any unrecognized value all keep auth ON, so a typo, a blank `${VAR:-}`
+/// expansion, or a stray value can never silently open the restream. Disabling
+/// auth is only ever the operator's explicit, documented choice.
+///
+/// This governs ONLY the LAN-facing RTSP listener. go2rtc's internal REST API
+/// (`:1984`, never host-published) stays authenticated in both postures as
+/// defense-in-depth; it is not affected by this function.
+///
+/// # Examples
+///
+/// ```
+/// use crumb_common::config::go2rtc_rtsp_auth_enabled;
+/// assert!(go2rtc_rtsp_auth_enabled(None));            // unset  → ON
+/// assert!(go2rtc_rtsp_auth_enabled(Some("")));        // empty  → ON
+/// assert!(go2rtc_rtsp_auth_enabled(Some("on")));      // on     → ON
+/// assert!(go2rtc_rtsp_auth_enabled(Some("nonsense"))); // typo  → ON (safe)
+/// assert!(!go2rtc_rtsp_auth_enabled(Some("off")));    // off    → OFF
+/// assert!(!go2rtc_rtsp_auth_enabled(Some("  OFF ")));  // trimmed/case → OFF
+/// ```
+#[must_use]
+pub fn go2rtc_rtsp_auth_enabled(raw: Option<&str>) -> bool {
+    !matches!(raw, Some(v) if v.trim().eq_ignore_ascii_case(GO2RTC_AUTH_OFF_TOKEN))
+}
+
+/// Read the [`go2rtc_rtsp_auth_enabled`] posture from the process environment
+/// (`GO2RTC_AUTH`). Convenience wrapper for the api/recorder startup paths.
+#[must_use]
+pub fn go2rtc_rtsp_auth_enabled_env() -> bool {
+    go2rtc_rtsp_auth_enabled(env::var("GO2RTC_AUTH").ok().as_deref())
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 /// Read a secret from `{key}_FILE` (a file path — e.g. a Docker secret mounted
@@ -543,7 +586,40 @@ fn parse_bool_env(key: &str, default: bool) -> Result<bool> {
 
 #[cfg(test)]
 mod tests {
-    use super::{optional_env, parse_env, parse_tz_env};
+    use super::{go2rtc_rtsp_auth_enabled, optional_env, parse_env, parse_tz_env};
+
+    /// Issue #398 — secure by default: auth is ON for every input except the
+    /// explicit `off` token. Unset, empty, and unrecognized values MUST all keep
+    /// auth ON so a typo or blank `${VAR:-}` expansion can never open the
+    /// LAN-facing restream. Only the documented off token disables it.
+    #[test]
+    fn go2rtc_auth_is_secure_by_default() {
+        // Auth stays ON:
+        assert!(go2rtc_rtsp_auth_enabled(None), "unset must keep auth ON");
+        assert!(
+            go2rtc_rtsp_auth_enabled(Some("")),
+            "empty must keep auth ON"
+        );
+        assert!(
+            go2rtc_rtsp_auth_enabled(Some("   ")),
+            "whitespace-only must keep auth ON"
+        );
+        assert!(go2rtc_rtsp_auth_enabled(Some("on")));
+        assert!(go2rtc_rtsp_auth_enabled(Some("true")));
+        assert!(go2rtc_rtsp_auth_enabled(Some("1")));
+        assert!(
+            go2rtc_rtsp_auth_enabled(Some("offf")),
+            "a near-miss token must NOT disable auth"
+        );
+        assert!(
+            go2rtc_rtsp_auth_enabled(Some("disabled")),
+            "an unrecognized value must fall back to the safe direction (ON)"
+        );
+        // Auth turns OFF only on the explicit token (case/whitespace tolerant):
+        assert!(!go2rtc_rtsp_auth_enabled(Some("off")));
+        assert!(!go2rtc_rtsp_auth_enabled(Some("OFF")));
+        assert!(!go2rtc_rtsp_auth_enabled(Some("  Off  ")));
+    }
 
     /// Audit #84: an invalid TZ value must fall back (non-fatal, now loudly
     /// logged) to the caller's default when that parses — never panic, never

--- a/services/recorder/src/go2rtc_embed.rs
+++ b/services/recorder/src/go2rtc_embed.rs
@@ -97,7 +97,119 @@ pub fn spawn(shutdown: CancellationToken) -> Option<tokio::task::JoinHandle<()>>
         return None;
     }
 
-    Some(tokio::spawn(supervise(bin, config, shutdown)))
+    // Issue #398: the LAN-facing RTSP restream (:8554, published as :18554) is
+    // authenticated by default. An operator may opt the LAN restream out of auth
+    // with the explicit, documented token `GO2RTC_AUTH=off`. Secure by default:
+    // anything else (unset / empty / unrecognized) keeps auth ON. The internal
+    // go2rtc REST API (:1984, never host-published) stays authenticated in BOTH
+    // postures — only the `rtsp:` listener's credentials are ever removed.
+    let effective_config = resolve_effective_config(&config);
+
+    Some(tokio::spawn(supervise(bin, effective_config, shutdown)))
+}
+
+/// Decide which go2rtc config file to launch, honoring the `GO2RTC_AUTH` posture
+/// (issue #398) and logging the posture LOUDLY at startup.
+///
+/// * Auth ON (default): returns `template_path` UNCHANGED — go2rtc reads the
+///   tracked, read-only-mounted config exactly as before, so the default path is
+///   byte-for-byte identical to prior behavior.
+/// * Auth OFF (`GO2RTC_AUTH=off`): renders an effective config with ONLY the
+///   `rtsp:` listener's `username`/`password` removed and returns that writable
+///   path. If rendering fails for any reason, falls back to `template_path`
+///   (auth stays ON) — a failure to open the restream must never silently open
+///   it, and must never open it by accident either.
+fn resolve_effective_config(template_path: &str) -> String {
+    if crumb_common::config::go2rtc_rtsp_auth_enabled_env() {
+        info!(
+            config = %template_path,
+            "go2rtc RTSP restream auth is ENABLED (default); off-container LAN clients must \
+             authenticate to pull streams"
+        );
+        return template_path.to_owned();
+    }
+
+    match render_auth_off(template_path) {
+        Ok(rendered) => {
+            warn!(
+                rendered = %rendered,
+                "go2rtc RTSP restream auth is DISABLED (GO2RTC_AUTH=off): any LAN client can pull \
+                 every camera from rtsp://<host>:18554/<name> WITHOUT credentials. This is the \
+                 operator's explicit opt-out; the internal go2rtc REST API (:1984) stays \
+                 authenticated"
+            );
+            rendered
+        }
+        Err(e) => {
+            // Secure fallback: keep the authenticated template so a rendering
+            // failure leaves the restream LOCKED rather than in an unknown state.
+            warn!(
+                error = %e,
+                config = %template_path,
+                "GO2RTC_AUTH=off was requested but rendering the auth-off go2rtc config failed; \
+                 falling back to the AUTHENTICATED config (restream stays locked, secure by default)"
+            );
+            template_path.to_owned()
+        }
+    }
+}
+
+/// Render an effective go2rtc config with the LAN `rtsp:` listener's auth
+/// removed, written to a recorder-writable path (the tracked template is mounted
+/// read-only, so it cannot be edited in place).
+///
+/// Only the `rtsp:` block's `username`/`password` keys are stripped; the `api:`
+/// block keeps its credentials so the internal REST API (:1984) stays
+/// authenticated. Returns the path go2rtc should be launched with.
+fn render_auth_off(template_path: &str) -> std::io::Result<String> {
+    let template = std::fs::read_to_string(template_path)?;
+    let rendered = strip_rtsp_auth(&template);
+    // A dedicated writable filename next to the OS temp dir. Regenerated on every
+    // boot from the current template, so it never drifts. `GO2RTC_RENDERED_CONFIG`
+    // overrides the location for hardened deployments with an unusual temp dir.
+    let out_path = std::env::var("GO2RTC_RENDERED_CONFIG")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::env::temp_dir().join("crumb-go2rtc.effective.yaml"));
+    std::fs::write(&out_path, rendered)?;
+    Ok(out_path.to_string_lossy().into_owned())
+}
+
+/// Remove the `username`/`password` keys from ONLY the top-level `rtsp:` block of
+/// a go2rtc YAML config, leaving every other block (notably `api:`) untouched.
+///
+/// go2rtc treats a listener with no `username`/`password` as open, so this is the
+/// clean "no auth" state for the LAN RTSP listener (issue #398). The transform is
+/// block-aware (it tracks the current top-level section by column-0 `key:` lines)
+/// and comment-safe, so it survives key reordering and never touches the
+/// identically-named keys under `api:`.
+fn strip_rtsp_auth(template: &str) -> String {
+    let mut out = String::with_capacity(template.len());
+    // The top-level section the current line belongs to (`api`, `rtsp`, …).
+    let mut section: Option<String> = None;
+
+    // `split_inclusive` keeps each line's trailing newline so the rewritten file
+    // preserves the original line endings exactly.
+    for line in template.split_inclusive('\n') {
+        let body = line.trim_end_matches(['\r', '\n']);
+        let is_top_level = !body.is_empty()
+            && !body.starts_with(char::is_whitespace)
+            && !body.starts_with('#')
+            && body.contains(':');
+        if is_top_level {
+            let key = body.split(':').next().unwrap_or("").trim();
+            section = Some(key.to_owned());
+        }
+
+        if section.as_deref() == Some("rtsp") {
+            let keyish = body.trim_start();
+            if keyish.starts_with("username:") || keyish.starts_with("password:") {
+                // Drop this credential line — opens ONLY the rtsp listener.
+                continue;
+            }
+        }
+        out.push_str(line);
+    }
+    out
 }
 
 /// Supervision loop: run the child, restart with exponential backoff, exit on
@@ -256,7 +368,99 @@ async fn terminate(child: &mut Child) {
 
 #[cfg(test)]
 mod tests {
-    use super::drain_pipe;
+    use super::{drain_pipe, strip_rtsp_auth};
+
+    /// The shipped go2rtc config layout (issue #398). Mirrors
+    /// `go2rtc/go2rtc.yaml`: `api:` and `rtsp:` both carry
+    /// `username`/`password`, and `api:` additionally has `local_auth: true`.
+    const SAMPLE: &str = "\
+api:
+  listen: \":1984\"
+  username: \"${GO2RTC_USER}\"
+  password: \"${GO2RTC_PASS}\"
+  local_auth: true
+
+rtsp:
+  listen: \":8554\"
+  # credential lines follow; stripped when the operator opts out
+  username: \"${GO2RTC_USER}\"
+  password: \"${GO2RTC_PASS}\"
+
+webrtc:
+  listen: \":8556\"
+
+streams: {}
+";
+
+    /// Auth-off render: ONLY the rtsp block's credentials are removed. The api
+    /// block's credentials (defense-in-depth for the internal :1984 REST API)
+    /// MUST remain, and no other content may be lost.
+    #[test]
+    fn strip_rtsp_auth_removes_only_rtsp_credentials() {
+        let out = strip_rtsp_auth(SAMPLE);
+
+        // The rtsp listener is now open: its credential KEYS are gone.
+        let rtsp_block = out
+            .split_once("rtsp:")
+            .expect("rtsp block present")
+            .1
+            .split("webrtc:")
+            .next()
+            .expect("content before webrtc");
+        assert!(
+            !rtsp_block.contains("username:"),
+            "rtsp username must be stripped, got:\n{rtsp_block}"
+        );
+        assert!(
+            !rtsp_block.contains("password:"),
+            "rtsp password must be stripped, got:\n{rtsp_block}"
+        );
+        // Non-credential content in the rtsp block (comments, other keys) is
+        // preserved — only the two credential lines are removed.
+        assert!(rtsp_block.contains("# credential lines follow"));
+
+        // The api block KEEPS its credentials + local_auth (internal REST stays
+        // authenticated in both postures).
+        let api_block = out
+            .split_once("api:")
+            .expect("api block present")
+            .1
+            .split("rtsp:")
+            .next()
+            .expect("content before rtsp");
+        assert!(api_block.contains("username: \"${GO2RTC_USER}\""));
+        assert!(api_block.contains("password: \"${GO2RTC_PASS}\""));
+        assert!(api_block.contains("local_auth: true"));
+
+        // Unrelated blocks survive intact.
+        assert!(out.contains("webrtc:"));
+        assert!(out.contains("streams: {}"));
+        assert!(out.contains("listen: \":8554\""));
+    }
+
+    /// Byte-for-byte guard on the auth-ON path is enforced by
+    /// `resolve_effective_config` returning the template unchanged; here we
+    /// prove the transform itself only ever REMOVES the two rtsp credential
+    /// lines and changes nothing else (line count drops by exactly 2).
+    #[test]
+    fn strip_rtsp_auth_removes_exactly_two_lines() {
+        let before = SAMPLE.lines().count();
+        let out = strip_rtsp_auth(SAMPLE);
+        assert_eq!(
+            out.lines().count(),
+            before - 2,
+            "exactly the rtsp username + password lines are removed"
+        );
+    }
+
+    /// A config with no rtsp credentials (already open, or a hand-edited file)
+    /// is returned unchanged — the transform is idempotent and never errors.
+    #[test]
+    fn strip_rtsp_auth_is_idempotent() {
+        let once = strip_rtsp_auth(SAMPLE);
+        let twice = strip_rtsp_auth(&once);
+        assert_eq!(once, twice);
+    }
 
     /// Audit #76 regression: the old UTF-8-strict `next_line()` drain returned
     /// `InvalidData` on the first non-UTF-8 byte and silently exited, closing


### PR DESCRIPTION
Closes #398. Makes running the embedded go2rtc restream without auth a supported CONFIG choice instead of a tracked-file edit, while keeping the secure default.

## Behavior
| state | restream auth |
|---|---|
| `GO2RTC_AUTH` unset / any value but the off token | ON, unchanged default |
| `GO2RTC_AUTH=off` (explicit) | OFF on the LAN-facing RTSP listener only |

Secure by default: unset, empty, whitespace, and unrecognized values all keep auth ON (unit-tested). The only way to disable is the documented off token.

## Scope of the opt-out (deliberately narrow)
`GO2RTC_AUTH=off` opens ONLY the LAN-facing RTSP listener (`:8554`, published as `18554`). The internal go2rtc REST API (`:1984`) stays authenticated in both postures. `:1984` is never host-published (reachable only as `recorder:1984` over the compose bridge), and the api container + reconcile loop depend on that auth, so there is no reason to weaken it and every reason not to.

## Mechanism
The tracked `go2rtc/go2rtc.yaml` is mounted read-only, so it cannot be edited in place. The recorder already supervises go2rtc (`services/recorder/src/go2rtc_embed.rs`). On startup it now resolves the effective config:
- Auth ON: returns the mounted template path UNCHANGED, so the default is byte-for-byte identical to today.
- Auth OFF: reads the template and strips ONLY the `rtsp:` block's `username`/`password` (block-aware, comment-safe, key-order-safe), writes the result to a recorder-writable path (`GO2RTC_RENDERED_CONFIG` overrides), and launches go2rtc with it. The `api:` block keeps its credentials.
- Render failure: falls back to the AUTHENTICATED template, so a failure leaves the restream locked, never in an unknown state.

No secret is written to disk: the rendered file keeps the literal `${GO2RTC_USER}` placeholder (go2rtc expands it from the recorder's env).

## Loud
- Recorder logs the posture at startup (WARN when open, naming the exact exposure).
- API logs the posture at startup.
- Admin console (Server page) shows an `Authenticated` vs `OPEN, no auth` badge with a danger note when open, sourced from `GET /config/server`.

## URL handout
`GET /cameras/{id}/streams` (`services/api/src/playback.rs`) hands out `rtsp://host:18554/<name>` with NO embedded credentials when auth is off; unchanged credential injection when on.

## Docs / decision log
`docs/AI-INSTALL.md`, `docs/COMPOSE.md`, the docs-site environment reference, `.env.example`, and `scripts/setup-env.sh` document `GO2RTC_AUTH` (optional, default authenticated, with the security warning; deliberately NOT generated by setup-env.sh). `docs/DECISIONS.md` records the decision, the rejected alternatives (flip default to off; rely on empty-username magic; per-file edit), and revisit triggers.

Note: this branch and #416 both prepend a `docs/DECISIONS.md` entry, so whichever merges second needs a trivial rebase.

## Testing
Unit tests: secure-by-default parser (on/off/unset/empty/unknown), the config strip (removes exactly the two rtsp credential lines, keeps the api block + local_auth, idempotent), and URL construction with/without creds. `node --check` on the admin.html script passed. Full gate runs in CI.

## Suggested live confirm (post-merge, on a real stack)
With `GO2RTC_AUTH=off`, verify `rtsp://<host>:18554/<name>` opens without credentials and `:1984` still rejects unauthenticated calls.