### PR TITLE
feat(ios): show operator-assigned plate name in LPR reads + watchlist (#363)

### DIFF
--- a/apps/ios/Crumb/Features/Plates/PlatesView.swift
+++ b/apps/ios/Crumb/Features/Plates/PlatesView.swift
@@ -584,7 +584,7 @@ struct PlatesView: View {
             cameraId: read.cameraId,
             cameraName: vm.cameraName(read.cameraId),
             kind: "detection",
-            label: read.plate.isEmpty ? "license_plate" : read.plate,
+            label: read.resolvedName ?? (read.plate.isEmpty ? "license_plate" : read.plate),
             iconKey: "car",
             score: read.confidence.map(Float.init),
             startTs: iso.string(from: ts.addingTimeInterval(-8)),
@@ -601,6 +601,27 @@ struct PlatesView: View {
             try? await Task.sleep(nanoseconds: 2_000_000_000)
             withAnimation { toast = nil }
         }
+    }
+}
+
+// MARK: - Plate name
+
+private extension PlateRead {
+    /// The operator-assigned plate name, trimmed; nil when absent or blank so
+    /// the UI falls back to the raw plate exactly as before.
+    var resolvedName: String? {
+        guard let n = displayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !n.isEmpty else { return nil }
+        return n
+    }
+}
+
+private extension WatchlistEntry {
+    /// The operator-assigned plate name, trimmed; nil when absent or blank.
+    var resolvedName: String? {
+        guard let n = displayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !n.isEmpty else { return nil }
+        return n
     }
 }
 
@@ -627,9 +648,21 @@ private struct PlateRow: View {
             thumbnail
             VStack(alignment: .leading, spacing: 3) {
                 HStack(spacing: 6) {
-                    Text(read.plate.isEmpty ? "—" : read.plate)
-                        .font(.system(size: 17, weight: .bold, design: .monospaced))
-                        .foregroundColor(CrumbColors.textPrimary)
+                    if let name = read.resolvedName {
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(name)
+                                .font(.system(size: 16, weight: .bold))
+                                .foregroundColor(CrumbColors.textPrimary)
+                                .lineLimit(1)
+                            Text(read.plate.isEmpty ? "—" : read.plate)
+                                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                                .foregroundColor(CrumbColors.textSecondary)
+                        }
+                    } else {
+                        Text(read.plate.isEmpty ? "—" : read.plate)
+                            .font(.system(size: 17, weight: .bold, design: .monospaced))
+                            .foregroundColor(CrumbColors.textPrimary)
+                    }
                     if count > 1 {
                         Text("×\(count)")
                             .font(.caption2.weight(.bold).monospacedDigit())
@@ -745,9 +778,20 @@ private struct PlateCard: View {
             }
             VStack(alignment: .leading, spacing: 3) {
                 HStack {
-                    Text(read.plate.isEmpty ? "—" : read.plate)
-                        .font(.system(size: 15, weight: .bold, design: .monospaced))
-                        .foregroundColor(CrumbColors.textPrimary).lineLimit(1)
+                    if let name = read.resolvedName {
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(name)
+                                .font(.system(size: 14, weight: .bold))
+                                .foregroundColor(CrumbColors.textPrimary).lineLimit(1)
+                            Text(read.plate.isEmpty ? "—" : read.plate)
+                                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                                .foregroundColor(CrumbColors.textSecondary).lineLimit(1)
+                        }
+                    } else {
+                        Text(read.plate.isEmpty ? "—" : read.plate)
+                            .font(.system(size: 15, weight: .bold, design: .monospaced))
+                            .foregroundColor(CrumbColors.textPrimary).lineLimit(1)
+                    }
                     Spacer()
                     ConfidenceChip(confidence: read.confidence)
                 }
@@ -960,9 +1004,18 @@ private struct WatchlistRow: View {
                 Circle().fill(c).frame(width: 10, height: 10)
             }
             VStack(alignment: .leading, spacing: 2) {
-                Text(entry.plate)
-                    .font(.system(.body, design: .monospaced).weight(.semibold))
-                    .foregroundColor(CrumbColors.textPrimary)
+                if let name = entry.resolvedName {
+                    Text(name)
+                        .font(.body.weight(.semibold))
+                        .foregroundColor(CrumbColors.textPrimary)
+                    Text(entry.plate)
+                        .font(.system(.caption, design: .monospaced).weight(.semibold))
+                        .foregroundColor(CrumbColors.textSecondary)
+                } else {
+                    Text(entry.plate)
+                        .font(.system(.body, design: .monospaced).weight(.semibold))
+                        .foregroundColor(CrumbColors.textPrimary)
+                }
                 if let label = entry.label, !label.isEmpty {
                     Text(label).font(.caption).foregroundColor(CrumbColors.textSecondary)
                 }
@@ -1026,9 +1079,16 @@ private struct WatchlistEditSheet: View {
         NavigationStack {
             List {
                 Section("Plate") {
-                    Text(entry.plate)
-                        .font(.system(.body, design: .monospaced).weight(.semibold))
-                        .foregroundColor(CrumbColors.textSecondary)
+                    VStack(alignment: .leading, spacing: 2) {
+                        if let name = entry.resolvedName {
+                            Text(name)
+                                .font(.body.weight(.semibold))
+                                .foregroundColor(CrumbColors.textPrimary)
+                        }
+                        Text(entry.plate)
+                            .font(.system(.body, design: .monospaced).weight(.semibold))
+                            .foregroundColor(CrumbColors.textSecondary)
+                    }
                 }
                 Section("Details") {
                     TextField("Label (optional)", text: $label)

--- a/apps/ios/Crumb/Models/Models.swift
+++ b/apps/ios/Crumb/Models/Models.swift
@@ -358,6 +358,10 @@ struct PlateRead: Decodable, Identifiable {
     let confidence: Double?
     let region: String?
     let sourceId: String
+    /// Operator-assigned, human-readable name for this plate (e.g. "Mom's car"),
+    /// resolved server-side. Optional: older servers omit the key, which decodes
+    /// as nil, and the UI then falls back to the raw plate.
+    let displayName: String?
     /// Sibling detection event, when present — drives the "open playback" jump.
     let eventId: String?
     let snapshotUrl: String?
@@ -370,6 +374,7 @@ struct PlateRead: Decodable, Identifiable {
         case cameraId = "camera_id"
         case plateRaw = "plate_raw"
         case sourceId = "source_id"
+        case displayName = "display_name"
         case eventId = "event_id"
         case snapshotUrl = "snapshot_url"
     }
@@ -398,10 +403,15 @@ struct WatchlistEntry: Decodable, Identifiable {
     let notify: Bool
     /// `"watch"` (alert on sighting) or `"ignore"` (suppress). Default watch.
     let kind: String
+    /// Operator-assigned, human-readable name for this plate, resolved
+    /// server-side. Optional: older servers omit the key (decodes as nil) and
+    /// the UI falls back to the raw plate.
+    let displayName: String?
     let createdAt: String
 
     enum CodingKeys: String, CodingKey {
         case id, plate, label, note, color, notify, kind
+        case displayName = "display_name"
         case createdAt = "created_at"
     }
 
@@ -414,6 +424,7 @@ struct WatchlistEntry: Decodable, Identifiable {
         color = try c.decodeIfPresent(String.self, forKey: .color)
         notify = try c.decodeIfPresent(Bool.self, forKey: .notify) ?? true
         kind = try c.decodeIfPresent(String.self, forKey: .kind) ?? "watch"
+        displayName = try c.decodeIfPresent(String.self, forKey: .displayName)
         createdAt = try c.decodeIfPresent(String.self, forKey: .createdAt) ?? ""
     }
 }


### PR DESCRIPTION
Client half of #363 for iOS/macOS. Renders the server-resolved plate name (backend #418) wherever a raw plate is shown.

## What
- `PlateRead` and `WatchlistEntry` (Models.swift) gain an optional `displayName` decoded from JSON `display_name`. `PlateRead` uses the existing complete CodingKeys enum (one case added); `WatchlistEntry`'s custom `init(from:)` uses `decodeIfPresent`, so an older server that omits the key still decodes (nil).
- `PlatesView.swift`: a shared `resolvedName` helper (trims whitespace, nil when blank) drives rendering in the list rows, gallery cards, watchlist rows, the watchlist edit sheet, and the plate-hit clip label. When a name is present it is the primary label with the raw plate small/monospaced beneath; when absent the raw plate shows exactly as before (no visual regression).

## Verification
No iOS CI exists, so this needs a macmini Xcode build to confirm the SwiftUI view branches type-check. Draft until that build passes. Backward-compatible: reads an optional field, so it works against both current and #418-updated servers.

Part of the #363 client rollout (sibling PRs: desktop, Android). COMPONENT-MAP updated centrally once all three land.