### PR TITLE
feat(desktop): show operator-assigned plate name in LPR UI (#363)

### DIFF
--- a/apps/desktop-flutter/lib/api/plates_api.dart
+++ b/apps/desktop-flutter/lib/api/plates_api.dart
@@ -41,6 +41,7 @@ class PlateRead {
     required this.sourceId,
     required this.eventId,
     required this.snapshotUrl,
+    required this.displayName,
     required this.bbox,
   });
 
@@ -54,6 +55,7 @@ class PlateRead {
   final String? sourceId;
   final String? eventId; // sibling detection event, or null
   final String? snapshotUrl; // provider snapshot path, or null
+  final String? displayName; // operator-given plate name, or null (older servers omit)
   final List<double>? bbox; // [x,y,w,h] fractions 0..1 of snapshot, or null
 
   factory PlateRead.fromJson(Map<String, dynamic> j) => PlateRead(
@@ -67,6 +69,7 @@ class PlateRead {
     sourceId: j['source_id'] as String?,
     eventId: j['event_id'] as String?,
     snapshotUrl: j['snapshot_url'] as String?,
+    displayName: j['display_name'] as String?,
     bbox: _parseBbox(j['bbox']),
   );
 }
@@ -125,6 +128,7 @@ class PlateWatchlistEntry {
     required this.color,
     required this.notify,
     required this.kind,
+    required this.displayName,
     required this.createdAt,
   });
 
@@ -135,6 +139,7 @@ class PlateWatchlistEntry {
   final String? color; // "#rrggbb", or null
   final bool notify; // alert on sighting
   final String kind; // "watch" | "ignore"
+  final String? displayName; // server-resolved plate name, or null (older servers omit)
   final DateTime? createdAt;
 
   /// True when this entry drops matching reads rather than alerting on them.
@@ -149,6 +154,7 @@ class PlateWatchlistEntry {
         color: j['color'] as String?,
         notify: (j['notify'] as bool?) ?? true,
         kind: (j['kind'] as String?) == 'ignore' ? 'ignore' : 'watch',
+        displayName: j['display_name'] as String?,
         createdAt: DateTime.tryParse((j['created_at'] as String?) ?? ''),
       );
 }

--- a/apps/desktop-flutter/lib/ui/plates/plates_screen.dart
+++ b/apps/desktop-flutter/lib/ui/plates/plates_screen.dart
@@ -1075,6 +1075,69 @@ class _CameraPickerDialogState extends State<_CameraPickerDialog> {
   }
 }
 
+// ─── plate headline (name + raw plate) ─────────────────────────────────────
+
+/// A plate read's headline. When the server resolved a human-readable name for
+/// the plate ([name], from `display_name`), it's the primary label with the raw
+/// [plate] shown small/mono beneath. With no name, renders just the plate in
+/// [plateStyle] exactly as before — so older servers (which omit the name) see
+/// no change. `—` stands in for an empty plate, matching the rest of this file.
+class _PlateHeadline extends StatelessWidget {
+  const _PlateHeadline({
+    required this.name,
+    required this.plate,
+    required this.plateStyle,
+  });
+
+  final String? name; // display_name, or null/empty
+  final String plate; // normalized plate (shown as-is when there's no name)
+  final TextStyle plateStyle; // the call site's existing plate text style
+
+  @override
+  Widget build(BuildContext context) {
+    final n = name?.trim() ?? '';
+    final plateText = plate.isEmpty ? '—' : plate;
+    if (n.isEmpty) {
+      return Text(
+        plateText,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: plateStyle,
+      );
+    }
+    // Raw plate demoted to a compact secondary line, keeping the call site's
+    // mono family/color so it still reads as a plate.
+    final secondaryStyle = plateStyle.copyWith(
+      fontSize: (plateStyle.fontSize ?? 14) * 0.62,
+      fontWeight: FontWeight.w600,
+      letterSpacing: 1.0,
+      color: Colors.white54,
+    );
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          n,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: TextStyle(
+            color: Colors.white,
+            fontSize: plateStyle.fontSize,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        Text(
+          plateText,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: secondaryStyle,
+        ),
+      ],
+    );
+  }
+}
+
 // ─── plate row + lazy snapshot ─────────────────────────────────────────────
 
 class _PlateRow extends StatelessWidget {
@@ -1204,9 +1267,10 @@ class _PlateRow extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Text(
-                    read.plate.isEmpty ? '—' : read.plate,
-                    style: const TextStyle(
+                  _PlateHeadline(
+                    name: read.displayName,
+                    plate: read.plate,
+                    plateStyle: const TextStyle(
                       color: Colors.white,
                       fontSize: 18,
                       fontWeight: FontWeight.w700,
@@ -1786,11 +1850,10 @@ class _PlateGalleryCard extends StatelessWidget {
                   Row(
                     children: [
                       Expanded(
-                        child: Text(
-                          read.plate.isEmpty ? '—' : read.plate,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: const TextStyle(
+                        child: _PlateHeadline(
+                          name: read.displayName,
+                          plate: read.plate,
+                          plateStyle: const TextStyle(
                             color: Colors.white,
                             fontSize: 16,
                             fontWeight: FontWeight.w700,
@@ -1939,9 +2002,12 @@ class _PlateGroupedList extends StatelessWidget {
               width: imageMode == PlateImageDisplay.both ? 200 : 110,
               height: 64,
             ),
-            title: Text(
-              g.plate,
-              style: const TextStyle(
+            title: _PlateHeadline(
+              // All reads in a group share the normalized plate, so they share
+              // the server-resolved name; the newest read is representative.
+              name: sorted.isNotEmpty ? sorted.first.displayName : null,
+              plate: g.plate,
+              plateStyle: const TextStyle(
                 color: Colors.white,
                 fontSize: 16,
                 fontWeight: FontWeight.w700,
@@ -2052,11 +2118,10 @@ class _PlateTimeline extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        Text(
-                          p.plate.isEmpty ? '—' : p.plate,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: const TextStyle(
+                        _PlateHeadline(
+                          name: p.displayName,
+                          plate: p.plate,
+                          plateStyle: const TextStyle(
                             color: Colors.white,
                             fontSize: 24,
                             fontWeight: FontWeight.w700,
@@ -2381,9 +2446,13 @@ class _PlateClipPlayerState extends State<_PlateClipPlayer> {
   Widget build(BuildContext context) {
     final read = widget.read;
     final plate = read.plate.isEmpty ? '—' : read.plate;
+    // Lead the title with the operator-given name when the server resolved one,
+    // keeping the raw plate alongside it; otherwise the plate stands alone.
+    final name = read.displayName?.trim() ?? '';
+    final heading = name.isEmpty ? plate : '$name ($plate)';
     return Positioned.fill(
       child: ClipPlayerShell(
-        title: '$plate — ${widget.cameraName}',
+        title: '$heading — ${widget.cameraName}',
         titleStyle: const TextStyle(
           color: Colors.white,
           fontSize: 15,
@@ -3643,11 +3712,10 @@ class _WatchlistTile extends StatelessWidget {
                 Row(
                   children: [
                     Flexible(
-                      child: Text(
-                        entry.plate.isEmpty ? '—' : entry.plate,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(
+                      child: _PlateHeadline(
+                        name: entry.displayName,
+                        plate: entry.plate,
+                        plateStyle: const TextStyle(
                           color: Colors.white,
                           fontSize: 14,
                           fontWeight: FontWeight.w700,

--- a/apps/desktop-flutter/test/plate_collapse_test.dart
+++ b/apps/desktop-flutter/test/plate_collapse_test.dart
@@ -33,6 +33,7 @@ PlateRead _read(
     sourceId: source,
     eventId: null,
     snapshotUrl: null,
+    displayName: null,
     bbox: null,
   );
 }


### PR DESCRIPTION
Client half of #363 for the desktop (Flutter) client. Renders the server-resolved plate name (backend #418) wherever a raw plate is shown.

## What
- `PlateRead` and `PlateWatchlistEntry` (plates_api.dart) gain a nullable `displayName` parsed from JSON `display_name` (`as String?`, matching the sibling nullable fields), null on older servers so parsing never errors.
- New shared `_PlateHeadline` widget: name prominent with the raw plate demoted to a compact monospaced line beneath when a name is present; falls back to the raw plate exactly as before (same style, same empty-plate placeholder) when null/blank. Applied to the reads list, gallery, grouped + timeline views, the clip-player detail title, and the watchlist tiles.
- The watchlist entry's own `label` line is left intact (distinct server field), so a named watchlist tile can show name / raw plate / label.

## Verification
No Flutter CI exists, so this needs a dev-box `flutter analyze` / build to confirm. All three constructor call sites (both fromJson factories + the test factory) were updated for the new param. Draft until that build passes.

Backward-compatible (optional field). Part of the #363 client rollout (sibling PRs: Android, iOS); COMPONENT-MAP updated centrally once all three land.