### PR TITLE
feat(android): adaptive live-wall quality (guardrail + thermal/decoder backpressure) (#384)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/data/SecureStore.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/SecureStore.kt
@@ -317,6 +317,29 @@ class SecureStore(context: Context) {
         set(value) = safeWrite { it.putBoolean(KEY_LOW_BW_AUTOFIX, value) }
 
     /**
+     * Adaptive live-wall quality (issue #384). When on (the default), the wall
+     * protects the device's video decoder from over-subscription: a config-time
+     * guardrail warns before a heavy wall renders, and a runtime backpressure
+     * loop sheds peripheral tiles to still-frames when dropped-frame rate or
+     * thermal pressure climbs, restoring them when it recovers. Device-local
+     * (a phone and a tablet have very different decode budgets).
+     *
+     * Default true.
+     */
+    var adaptiveWallQuality: Boolean
+        get() = safeRead(true) { it.getBoolean(KEY_ADAPTIVE_WALL, true) }
+        set(value) = safeWrite { it.putBoolean(KEY_ADAPTIVE_WALL, value) }
+
+    /**
+     * "Don't warn on this device": suppresses the Stage-1 guardrail nudge for a
+     * heavy live wall on this device only. The runtime backpressure net still
+     * runs; only the advisory heads-up is silenced. Default false.
+     */
+    var wallGuardrailSilenced: Boolean
+        get() = safeRead(false) { it.getBoolean(KEY_WALL_GUARDRAIL_SILENCED, false) }
+        set(value) = safeWrite { it.putBoolean(KEY_WALL_GUARDRAIL_SILENCED, value) }
+
+    /**
      * How the Plates tab renders its reads: "list" (dense rows, default),
      * "gallery" (snapshot grid), "grouped" (collapsed by plate), or "timeline"
      * (big chronological feed). Per-account UI residue: CLEARED on logout
@@ -417,6 +440,8 @@ class SecureStore(context: Context) {
         private const val KEY_PLAYBACK_QUALITY = "playback_quality"
         private const val KEY_LIVE_LAYOUT = "live_grid_layout"
         private const val KEY_LOW_BW_AUTOFIX = "low_bw_autofix_applied"
+        private const val KEY_ADAPTIVE_WALL = "adaptive_wall_quality"
+        private const val KEY_WALL_GUARDRAIL_SILENCED = "wall_guardrail_silenced"
         private const val KEY_PTZ_STYLE = "ptz_style"
         private const val KEY_MOTION_TUNER = "motion_tuner_enabled"
         private const val KEY_SHOW_ALL_CAMERAS_VIEW = "show_all_cameras_view"

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveCameraTile.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveCameraTile.kt
@@ -57,6 +57,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.ui.AspectRatioFrameLayout
 import video.crumb.app.data.CameraDto
 import video.crumb.app.data.DetectionIcons
@@ -121,16 +122,32 @@ fun LiveCameraTile(
     detections: List<String> = emptyList(),
     /** When true the tile renders via snapshot polling instead of RTSP. */
     lowBandwidthMode: Boolean = false,
+    /**
+     * Adaptive backpressure (#384) has shed THIS tile to the still-frame path to
+     * relieve decoder/thermal pressure on the wall. Same render path as
+     * [lowBandwidthMode] but tile-scoped and system-driven, so it carries a
+     * distinct "SD" auto badge and self-restores silently when pressure eases.
+     */
+    autoShed: Boolean = false,
     /** Called when the stall watchdog fires; forwarded to the VM for auto-fallback. */
     onStall: () -> Unit = {},
+    /**
+     * Reports this tile's Media3 dropped-frame deltas (count, elapsedMs) up to the
+     * wall's [WallDecodeMonitor] so it can aggregate the reactive decode signal.
+     * Wired only on the live RTSP path; a no-op by default.
+     */
+    onDroppedFrames: (Int, Long) -> Unit = { _, _ -> },
 ) {
+    // Either the user-selected wall-wide low-bandwidth mode OR a system-shed tile
+    // renders the still-frame path instead of an RTSP decoder.
+    val stillFramePath = lowBandwidthMode || autoShed
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(8.dp))
             .background(Color.Black)
             .clickable(onClick = onClick),
     ) {
-        if (lowBandwidthMode) {
+        if (stillFramePath) {
             // ── Snapshot-polling path ────────────────────────────────────────────
             // Independent JPEG GETs on an adaptive interval. No RTSP connection,
             // no ExoPlayer, no buffering — just a new still every tick. A single
@@ -155,14 +172,16 @@ fun LiveCameraTile(
                 streams = streams,
                 mediaUrls = mediaUrls,
                 onStall = onStall,
+                onDroppedFrames = onDroppedFrames,
             )
         }
 
         // ── Overlays common to both paths ─────────────────────────────────────
 
         // Low-bandwidth mode indicator (bottom-center, subtle) so the user
-        // always knows which render path is active.
-        if (lowBandwidthMode && mediaUrls != null) {
+        // always knows which render path is active. Only for the user-selected
+        // wall-wide mode; a system-shed tile shows the "SD" auto badge instead.
+        if (lowBandwidthMode && !autoShed && mediaUrls != null) {
             Icon(
                 imageVector = Icons.Default.SignalWifiStatusbarConnectedNoInternet4,
                 contentDescription = "Low-bandwidth mode",
@@ -171,6 +190,25 @@ fun LiveCameraTile(
                     .align(Alignment.BottomCenter)
                     .padding(bottom = 6.dp)
                     .size(14.dp),
+            )
+        }
+
+        // Adaptive-backpressure "SD" badge (#384): this tile was auto-shed to a
+        // still frame to protect the decoder. A distinct amber tint reads as
+        // "the system stepped this down", not a fault; it self-clears silently.
+        if (autoShed) {
+            Text(
+                text = "SD",
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.White,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 6.dp)
+                    .background(
+                        color = AutoShedAmber.copy(alpha = 0.85f),
+                        shape = RoundedCornerShape(4.dp),
+                    )
+                    .padding(horizontal = 5.dp, vertical = 1.dp),
             )
         }
 
@@ -260,6 +298,7 @@ private fun LiveRtspContent(
     streams: LiveStreamsResponse?,
     mediaUrls: MediaUrls?,
     onStall: () -> Unit,
+    onDroppedFrames: (Int, Long) -> Unit = { _, _ -> },
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -343,6 +382,28 @@ private fun LiveRtspContent(
             // (fullscreen) camera. Avoids a wall of overlapping audio tracks.
             exo.volume = 0f
         }
+    }
+
+    // Adaptive-wall decode signal (#384): forward this player's dropped-frame
+    // deltas to the wall's WallDecodeMonitor. Media3 calls onDroppedVideoFrames
+    // with the frames dropped since the last callback and the elapsed decode time,
+    // which is exactly the per-tile term the monitor aggregates across the wall.
+    // The listener is removed in onDispose (keyed on `player`), so it can't outlive
+    // the player instance or leak across the tile's many reconnects.
+    val onDroppedFramesState = rememberUpdatedState(onDroppedFrames)
+    DisposableEffect(player) {
+        val p = player
+        val analytics = object : AnalyticsListener {
+            override fun onDroppedVideoFrames(
+                eventTime: AnalyticsListener.EventTime,
+                droppedFrames: Int,
+                elapsedMs: Long,
+            ) {
+                onDroppedFramesState.value(droppedFrames, elapsedMs)
+            }
+        }
+        p?.addAnalyticsListener(analytics)
+        onDispose { p?.removeAnalyticsListener(analytics) }
     }
 
     // Attach a listener that updates buffering/error state and drives automatic
@@ -701,6 +762,11 @@ private fun LiveRtspContent(
         }
     }
 }
+
+/** Amber tint for the adaptive-backpressure "SD" auto badge (#384) — deliberately
+ *  distinct from the teal low-bandwidth glyph and the red motion/error accents, so
+ *  a system-shed tile reads as "stepped down to protect the device", not a fault. */
+private val AutoShedAmber = Color(0xFFFFB300)
 
 // ─── reconnect tuning ─────────────────────────────────────────────────────────
 

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveScreen.kt
@@ -5,6 +5,8 @@ package video.crumb.app.feature.live
 import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -20,6 +22,7 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AddAPhoto
 import androidx.compose.material.icons.filled.Close
@@ -27,6 +30,7 @@ import androidx.compose.material.icons.filled.Fullscreen
 import androidx.compose.material.icons.filled.FullscreenExit
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.SignalWifiStatusbarConnectedNoInternet4
+import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -45,11 +49,14 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import android.os.SystemClock
 import android.widget.Toast
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
@@ -301,6 +308,81 @@ fun LiveScreen(
     // Low-bw mode: read from the VM state (which is seeded from SecureStore on init).
     val lowBandwidthMode = state.lowBandwidthMode
 
+    // ── Adaptive wall quality (#384) ──────────────────────────────────────────────
+    // Client-local decode protection: a config-time guardrail nudge (Stage 1) plus a
+    // runtime backpressure loop (Stage 2) that sheds peripheral tiles to still frames
+    // when the device's decoder/thermal headroom runs low. Both governed by one
+    // device-local toggle (default ON). Mirrored in state so the Settings switch and
+    // the guardrail's "Don't warn on this device" take effect without leaving here.
+    var adaptiveWallQuality by remember { mutableStateOf(store.adaptiveWallQuality) }
+    var wallGuardrailSilenced by remember { mutableStateOf(store.wallGuardrailSilenced) }
+    // Session-only ack of the guardrail nudge ("Proceed anyway"): quiet until the
+    // wall drops back under budget and climbs over it again.
+    var guardrailProceeded by remember { mutableStateOf(false) }
+
+    // The reactive monitor. Remembered for the wall's lifetime; its thermal listener
+    // is registered while foregrounded and always removed on dispose (see below).
+    val decodeMonitor = remember { WallDecodeMonitor(activityContext) }
+    val shedIds by decodeMonitor.shedIds.collectAsStateWithLifecycle()
+
+    // Grid scroll state, so the shedder can prefer off-screen tiles (shed order:
+    // off-screen first, then oldest wall-order, never the focused single tile).
+    val gridState = rememberLazyGridState()
+    val visibleCameraIds by remember {
+        derivedStateOf {
+            gridState.layoutInfo.visibleItemsInfo.mapNotNull { it.key as? String }.toSet()
+        }
+    }
+
+    // Push topology (order / off-screen / focus) into the monitor on any change.
+    LaunchedEffect(shownCameras, visibleCameraIds) {
+        val ordered = shownCameras.map { it.id }
+        val offscreen = ordered.toSet() - visibleCameraIds
+        // A single-camera view is the Android analog of the focused/fullscreen tile
+        // and must never be shed.
+        val focused = shownCameras.singleOrNull()?.id
+        decodeMonitor.updateTopology(ordered, offscreen, focused)
+    }
+
+    // Stage-2 control loop: tick the monitor ~every 2s while the wall is at least
+    // STARTED and the feature is on and we're not already wall-wide low-bw (where
+    // every tile is a still anyway). Register/unregister the thermal listener around
+    // the foreground window; reset shed state whenever the loop is not running.
+    LaunchedEffect(adaptiveWallQuality, lowBandwidthMode) {
+        if (!adaptiveWallQuality || lowBandwidthMode) {
+            decodeMonitor.reset()
+            return@LaunchedEffect
+        }
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            decodeMonitor.start()
+            try {
+                var last = SystemClock.elapsedRealtime()
+                while (true) {
+                    delay(WallDecodeMonitor.WALL_TICK_MS)
+                    val now = SystemClock.elapsedRealtime()
+                    decodeMonitor.tick(now - last)
+                    last = now
+                }
+            } finally {
+                decodeMonitor.stop()
+            }
+        }
+    }
+    // Belt-and-suspenders: ensure the thermal listener is gone if the wall leaves
+    // composition outside the repeatOnLifecycle window.
+    DisposableEffect(Unit) {
+        onDispose { decodeMonitor.stop() }
+    }
+
+    // Stage-1 guardrail: warn when the live wall would render more video tiles than
+    // this device's conservative decode budget, before anything saturates. Advisory
+    // only. Suppressed in low-bw mode (no video tiles), once silenced on the device,
+    // or once acknowledged this session.
+    val liveTileCount = if (lowBandwidthMode) 0 else shownCameras.size
+    val showGuardrail = adaptiveWallQuality && !lowBandwidthMode &&
+        !wallGuardrailSilenced && !guardrailProceeded &&
+        liveTileCount > WallDecodeMonitor.GUARDRAIL_TILE_BUDGET
+
     // Snapshot (#163): grab a camera's current live frame → device gallery, then a
     // Share-able confirmation (#164). The wall tiles render on a SurfaceView (no
     // readable pixel buffer), so rather than a surface grab we fetch the camera's
@@ -434,6 +516,25 @@ fun LiveScreen(
                     LowBandwidthAutoFallbackBanner(
                         onRestore = { vm.setLowBandwidthMode(false) },
                         onDismiss = { vm.dismissAutoFallbackBadge() },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+
+                // ── Adaptive-wall guardrail nudge (#384, Stage 1) ─────────────────
+                // Advisory heads-up that this wall has enough live tiles to risk
+                // over-subscribing the device's decoder. Never blocks; three actions.
+                if (showGuardrail) {
+                    WallGuardrailNudge(
+                        tileCount = liveTileCount,
+                        onUseSnapshots = {
+                            vm.setLowBandwidthMode(true)
+                            guardrailProceeded = true
+                        },
+                        onProceed = { guardrailProceeded = true },
+                        onDontWarn = {
+                            wallGuardrailSilenced = true
+                            store.wallGuardrailSilenced = true
+                        },
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }
@@ -599,6 +700,7 @@ fun LiveScreen(
                         else -> {
                             LazyVerticalGrid(
                                 columns = GridCells.Fixed(minOf(layout.cols, maxCols)),
+                                state = gridState,
                                 contentPadding = PaddingValues(8.dp),
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                                 verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -621,7 +723,14 @@ fun LiveScreen(
                                         recording = recordingCams.contains(cam.id),
                                         detections = detectionCams[cam.id] ?: emptyList(),
                                         lowBandwidthMode = lowBandwidthMode,
+                                        // Stage-2 backpressure: this tile has been
+                                        // shed to a still to relieve decode pressure.
+                                        autoShed = adaptiveWallQuality &&
+                                            !lowBandwidthMode && shedIds.contains(cam.id),
                                         onStall = { vm.reportTileStall(cam.id) },
+                                        onDroppedFrames = { dropped, elapsedMs ->
+                                            decodeMonitor.reportDroppedVideoFrames(dropped, elapsedMs)
+                                        },
                                         modifier = Modifier
                                             .fillMaxWidth()
                                             .aspectRatio(16f / 9f),
@@ -668,6 +777,11 @@ fun LiveScreen(
             store = store,
             lowBandwidthMode = lowBandwidthMode,
             onLowBandwidthChange = { vm.setLowBandwidthMode(it) },
+            adaptiveWallQuality = adaptiveWallQuality,
+            onAdaptiveWallQualityChange = {
+                adaptiveWallQuality = it
+                store.adaptiveWallQuality = it
+            },
             showAllCamerasView = showAllCamerasView,
             onShowAllCamerasViewChange = {
                 showAllCamerasView = it
@@ -827,6 +941,75 @@ private fun LowBandwidthAutoFallbackBanner(
                 tint = TextSecondary,
                 modifier = Modifier.size(14.dp),
             )
+        }
+    }
+}
+
+// ─── adaptive-wall guardrail nudge (#384, Stage 1) ────────────────────────────
+
+/**
+ * A dismissible, non-blocking nudge shown when the live wall would render more
+ * live video tiles than this device's conservative decode budget. Advisory only,
+ * matching the desktop guardrail (#382): it warns before the wall over-subscribes
+ * the decoder, but never forbids the heavy wall. Three actions:
+ * - "Use snapshots" — drop the wall to the low-bandwidth still-frame path.
+ * - "Proceed anyway" — keep full video; quiet for this session.
+ * - "Don't warn on this device" — silence the nudge on this device for good (the
+ *   runtime backpressure net still runs).
+ */
+@Composable
+private fun WallGuardrailNudge(
+    tileCount: Int,
+    onUseSnapshots: () -> Unit,
+    onProceed: () -> Unit,
+    onDontWarn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .background(NavySurface)
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Speed,
+                contentDescription = null,
+                tint = TealAccent,
+                modifier = Modifier.size(16.dp),
+            )
+            Text(
+                text = "This wall runs $tileCount live streams, which may exceed this " +
+                    "device's video decode headroom. Use still snapshots instead?",
+                style = MaterialTheme.typography.labelMedium,
+                color = TextSecondary,
+                modifier = Modifier.weight(1f),
+            )
+        }
+        // Horizontally scrollable so all three actions stay reachable even on a
+        // narrow phone (a >12-tile wall can appear in portrait too).
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(2.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()),
+        ) {
+            TextButton(onClick = onDontWarn) {
+                Text(
+                    "Don't warn on this device",
+                    color = TextSecondary,
+                    style = MaterialTheme.typography.labelMedium,
+                )
+            }
+            TextButton(onClick = onProceed) {
+                Text("Proceed anyway", color = TextSecondary, style = MaterialTheme.typography.labelMedium)
+            }
+            TextButton(onClick = onUseSnapshots) {
+                Text("Use snapshots", color = TealAccent, style = MaterialTheme.typography.labelMedium)
+            }
         }
     }
 }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/WallDecodeMonitor.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/WallDecodeMonitor.kt
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.feature.live
+
+import android.content.Context
+import android.os.Build
+import android.os.PowerManager
+import android.os.SystemClock
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.io.File
+import kotlin.math.max
+
+/**
+ * Reactive live-wall decode-load signal + the two-stage shed/restore controller
+ * (issue #384, the Android sibling of the desktop #382 policy).
+ *
+ * ## Why this exists
+ * The live wall decodes N RTSP tiles through Media3 -> MediaCodec. On a weaker
+ * mobile SoC (a tablet or an Android TV wall), enough concurrent tiles
+ * over-subscribe the hardware decoder or push the SoC into thermal throttling —
+ * dropped frames, black tiles, stutter. The cameras themselves are shielded
+ * (go2rtc pulls each once and fans out), so this is a purely client-local
+ * resource cliff. The desktop client already sampled whole-GPU decode util and
+ * keyed off it; Android exposes no such single number, so this class *builds* the
+ * signal from Android-native sources and applies the same policy.
+ *
+ * ## Signal (highest to lowest priority)
+ * 1. **Dropped frames** — each live tile attaches a Media3 `AnalyticsListener`
+ *    whose `onDroppedVideoFrames` deltas are fed to [reportDroppedVideoFrames].
+ *    This is the direct "frames are being dropped" evidence and is available
+ *    whenever any tile is decoding. Aggregated across all tiles.
+ * 2. **Thermal** — [PowerManager.getThermalHeadroom] (API 30+) plus an
+ *    [PowerManager.OnThermalStatusChangedListener] (API 29+, cached in
+ *    [latestThermalStatus]); mobile SoCs throttle decode under thermal pressure
+ *    well before frames visibly drop, so this is the leading indicator on phones.
+ * 3. **CPU fallback** — process CPU utilization from `/proc/self/stat`, used only
+ *    when neither of the above produced a sample (e.g. no tiles decoding yet on a
+ *    pre-API-29 device). We never assume unmeasurable headroom.
+ *
+ * The three are folded into a single 0..1 `load` (max of whatever is available,
+ * CPU only as a last resort), EMA-smoothed over ~3s to ride keyframe bursts.
+ *
+ * ## Policy (mirrors #382; thresholds/timings/shed-order are shared)
+ * - **Shed** when smoothed load stays above [SHED_LINE] (0.85) for
+ *   [SHED_SUSTAIN_MS] (4s): downgrade ONE peripheral tile from RTSP video to the
+ *   still-frame snapshot path (Android's next quality tier down, since the wall is
+ *   already on the sub stream). Shed-fast.
+ * - **Restore** when smoothed load stays below [RESTORE_LINE] (0.60) for
+ *   [RESTORE_SUSTAIN_MS] (20s): promote one shed tile back to video. Restore-slow.
+ * - The 0.60/0.85 gap + shed-fast / restore-slow timing is the hysteresis that
+ *   prevents flapping.
+ * - **Shed order** (last shed = most protected): off-screen tiles first, then the
+ *   oldest-added / lowest wall-order tile, **never** the focused (single-camera)
+ *   tile. A floor of [MIN_ACTIVE_TILES] video tiles is always kept.
+ *
+ * A shed tile carries the "SD"-style auto badge (see [LiveCameraTile]) and
+ * self-restores silently. Everything here is client-local; nothing is persisted
+ * and no server call is made.
+ *
+ * ## Threading
+ * [reportDroppedVideoFrames] is called from ExoPlayer's callback threads and is
+ * synchronized. [tick]/[updateTopology]/[start]/[stop]/[reset] are called from the
+ * wall's main-thread Compose effects. The published [shedIds] is a [StateFlow].
+ */
+class WallDecodeMonitor(context: Context) {
+
+    private val appContext = context.applicationContext
+    private val powerManager = appContext.getSystemService(Context.POWER_SERVICE) as? PowerManager
+
+    // ── dropped-frame aggregation (across all live video tiles) ──────────────────
+
+    private val dropLock = Any()
+    private var droppedFramesAccum = 0L
+    private var decodeElapsedMsAccum = 0L
+
+    /**
+     * Called from each tile's `AnalyticsListener.onDroppedVideoFrames`. [dropped]
+     * is the number of frames dropped over [elapsedMs] of decode time for that
+     * tile. Thread-safe (invoked on ExoPlayer callback threads).
+     */
+    fun reportDroppedVideoFrames(dropped: Int, elapsedMs: Long) {
+        if (dropped <= 0 || elapsedMs <= 0) return
+        synchronized(dropLock) {
+            droppedFramesAccum += dropped
+            decodeElapsedMsAccum += elapsedMs
+        }
+    }
+
+    /** Drain the accumulated drop rate as a 0..1 load, or null if no decode time
+     *  was reported this window (no active video tiles). */
+    private fun drainDropLoad(): Float? {
+        val dropped: Long
+        val elapsed: Long
+        synchronized(dropLock) {
+            dropped = droppedFramesAccum
+            elapsed = decodeElapsedMsAccum
+            droppedFramesAccum = 0L
+            decodeElapsedMsAccum = 0L
+        }
+        if (elapsed <= 0L) return null
+        // Average dropped frames-per-second across the pool's tile-seconds.
+        val droppedPerSec = dropped * 1000.0 / elapsed
+        return (droppedPerSec / DROPPED_FPS_AT_FULL_LOAD).toFloat().coerceIn(0f, 1f)
+    }
+
+    // ── thermal ──────────────────────────────────────────────────────────────────
+
+    @Volatile private var latestThermalStatus: Int = -1
+    private var thermalListener: PowerManager.OnThermalStatusChangedListener? = null
+
+    /** Thermal pressure as 0..1, or null when the platform exposes nothing usable. */
+    private fun thermalLoad(): Float? {
+        val pm = powerManager ?: return null
+        // getThermalHeadroom (API 30+): 0.0 = cool, 1.0 = at the throttling
+        // threshold. NaN when the device can't forecast — fall through to status.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val hr = try {
+                pm.getThermalHeadroom(THERMAL_FORECAST_SECONDS)
+            } catch (_: Throwable) {
+                Float.NaN
+            }
+            if (!hr.isNaN()) return hr.coerceIn(0f, 1f)
+        }
+        // THERMAL_STATUS_* (API 29+), kept fresh by the registered listener.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val status = if (latestThermalStatus >= 0) latestThermalStatus else {
+                try { pm.currentThermalStatus } catch (_: Throwable) { -1 }
+            }
+            return when (status) {
+                PowerManager.THERMAL_STATUS_NONE -> 0.0f
+                PowerManager.THERMAL_STATUS_LIGHT -> 0.35f
+                PowerManager.THERMAL_STATUS_MODERATE -> 0.60f
+                PowerManager.THERMAL_STATUS_SEVERE -> 0.85f
+                -1 -> null
+                else -> 1.0f // CRITICAL / EMERGENCY / SHUTDOWN
+            }
+        }
+        return null
+    }
+
+    // ── CPU fallback (process utilization from /proc/self/stat) ──────────────────
+
+    private val cores = Runtime.getRuntime().availableProcessors().coerceAtLeast(1)
+    private var lastCpuTicks = -1L
+    private var lastCpuWallMs = 0L
+
+    /** Last-resort CPU load as 0..1, or null if it can't be measured this tick. */
+    private fun cpuLoad(): Float? {
+        return try {
+            // `comm` (field 2) can contain spaces and parentheses; everything after
+            // the final ')' is the stable, space-delimited tail starting at `state`.
+            val raw = File("/proc/self/stat").readText()
+            val rparen = raw.lastIndexOf(')')
+            if (rparen < 0) return null
+            val tail = raw.substring(rparen + 1).trim().split(Regex("\\s+"))
+            // Post-`comm` index: state=0, ... utime=11, stime=12 (fields 14/15).
+            val utime = tail.getOrNull(11)?.toLongOrNull() ?: return null
+            val stime = tail.getOrNull(12)?.toLongOrNull() ?: return null
+            val ticks = utime + stime
+            val nowMs = SystemClock.elapsedRealtime()
+            if (lastCpuTicks < 0L) {
+                lastCpuTicks = ticks
+                lastCpuWallMs = nowMs
+                return null // need a delta first
+            }
+            val dTicks = ticks - lastCpuTicks
+            val dWallMs = nowMs - lastCpuWallMs
+            lastCpuTicks = ticks
+            lastCpuWallMs = nowMs
+            if (dWallMs <= 0L) return null
+            val cpuSec = dTicks.toDouble() / CLOCK_TICKS_PER_SEC
+            val load = cpuSec / (dWallMs / 1000.0 * cores)
+            load.toFloat().coerceIn(0f, 1f)
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    /** Combined instantaneous load: max(dropped, thermal), CPU only as a fallback. */
+    private fun currentLoad(): Float? {
+        // Always drain the drop accumulator so it doesn't stale across ticks.
+        val drop = drainDropLoad()
+        val thermal = thermalLoad()
+        val primary = when {
+            drop != null && thermal != null -> max(drop, thermal)
+            drop != null -> drop
+            thermal != null -> thermal
+            else -> null
+        }
+        return primary ?: cpuLoad()
+    }
+
+    // ── shed/restore state machine ────────────────────────────────────────────────
+
+    private val _shedIds = MutableStateFlow<Set<String>>(emptySet())
+    /** Camera ids currently shed to the still-frame path. Observed by the wall. */
+    val shedIds: StateFlow<Set<String>> = _shedIds.asStateFlow()
+
+    private var smoothedLoad = 0f
+    private var overMs = 0L
+    private var underMs = 0L
+
+    // Topology, pushed by the wall each layout/scroll change.
+    @Volatile private var orderedIds: List<String> = emptyList()
+    @Volatile private var offscreenIds: Set<String> = emptySet()
+    @Volatile private var focusedId: String? = null
+
+    // Insertion order == shed order, so restore is LIFO (last shed comes back first).
+    private val shedOrder = LinkedHashSet<String>()
+
+    /**
+     * Update the wall topology so shedding respects on-screen/order/focus. Called
+     * from the wall whenever the shown set, scroll position, or focus changes.
+     * Also prunes shed entries for cameras that left the wall.
+     */
+    fun updateTopology(ordered: List<String>, offscreen: Set<String>, focused: String?) {
+        orderedIds = ordered
+        offscreenIds = offscreen
+        focusedId = focused
+        val present = ordered.toHashSet()
+        if (shedOrder.retainAll(present)) publish()
+    }
+
+    /**
+     * Advance the controller by [tickMs] of elapsed time. Reads the current load,
+     * smooths it, and sheds/restores one tile when the sustained-threshold timers
+     * fire. A no-op when no signal is available (holds the current state).
+     */
+    fun tick(tickMs: Long) {
+        val raw = currentLoad() ?: return
+        smoothedLoad += LOAD_EMA_ALPHA * (raw - smoothedLoad)
+        when {
+            smoothedLoad >= SHED_LINE -> { overMs += tickMs; underMs = 0L }
+            smoothedLoad <= RESTORE_LINE -> { underMs += tickMs; overMs = 0L }
+            else -> { overMs = 0L; underMs = 0L } // hysteresis band: hold steady
+        }
+        if (overMs >= SHED_SUSTAIN_MS) {
+            overMs = 0L
+            shedOne()
+        } else if (underMs >= RESTORE_SUSTAIN_MS) {
+            underMs = 0L
+            restoreOne()
+        }
+    }
+
+    /** Shed one peripheral tile: off-screen first, then earliest wall-order, never
+     *  the focused tile, keeping at least [MIN_ACTIVE_TILES] video tiles. */
+    private fun shedOne() {
+        val activeCount = orderedIds.count { it !in shedOrder }
+        if (activeCount <= MIN_ACTIVE_TILES) return
+        val candidates = orderedIds.filter { it != focusedId && it !in shedOrder }
+        if (candidates.isEmpty()) return
+        val pick = candidates.firstOrNull { it in offscreenIds } ?: candidates.first()
+        shedOrder.add(pick)
+        publish()
+    }
+
+    /** Restore the most-recently-shed tile (LIFO), so the wall recovers gradually. */
+    private fun restoreOne() {
+        val last = shedOrder.lastOrNull() ?: return
+        shedOrder.remove(last)
+        publish()
+    }
+
+    private fun publish() {
+        _shedIds.value = shedOrder.toSet()
+    }
+
+    /** Clear all shed state (e.g. the feature was turned off, or the wall dropped to
+     *  wall-wide low-bandwidth mode where every tile is already a still). */
+    fun reset() {
+        smoothedLoad = 0f
+        overMs = 0L
+        underMs = 0L
+        lastCpuTicks = -1L
+        synchronized(dropLock) {
+            droppedFramesAccum = 0L
+            decodeElapsedMsAccum = 0L
+        }
+        if (shedOrder.isNotEmpty()) {
+            shedOrder.clear()
+            publish()
+        }
+    }
+
+    // ── lifecycle (thermal listener registration) ────────────────────────────────
+
+    /** Register the thermal-status listener. Idempotent. Call when the wall is
+     *  foregrounded; pair with [stop]. Guarded to API 29+. */
+    fun start() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return
+        val pm = powerManager ?: return
+        if (thermalListener != null) return
+        val l = PowerManager.OnThermalStatusChangedListener { status ->
+            latestThermalStatus = status
+        }
+        try {
+            pm.addThermalStatusListener(l)
+            thermalListener = l
+            latestThermalStatus = try { pm.currentThermalStatus } catch (_: Throwable) { -1 }
+        } catch (_: Throwable) {
+            thermalListener = null
+        }
+    }
+
+    /** Remove the thermal-status listener. Idempotent; safe to call any time. */
+    fun stop() {
+        val l = thermalListener ?: return
+        thermalListener = null
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return
+        try {
+            powerManager?.removeThermalStatusListener(l)
+        } catch (_: Throwable) {
+            // ignore
+        }
+    }
+
+    companion object {
+        /** Shed above this smoothed load; mirrors desktop's 85% shed line. */
+        private const val SHED_LINE = 0.85f
+        /** Restore below this smoothed load; mirrors desktop's 60% restore line. */
+        private const val RESTORE_LINE = 0.60f
+        /** Shed-fast: load must hold above the shed line this long (ms). */
+        private const val SHED_SUSTAIN_MS = 4_000L
+        /** Restore-slow: load must hold below the restore line this long (ms). */
+        private const val RESTORE_SUSTAIN_MS = 20_000L
+        /** EMA factor at the ~2s control tick, giving a ~3s smoothing window. */
+        private const val LOAD_EMA_ALPHA = 0.5f
+        /** Average dropped frames-per-second (per tile-second) mapped to load 1.0. */
+        private const val DROPPED_FPS_AT_FULL_LOAD = 6.0
+        /** Thermal-headroom forecast horizon (s); must be within [0, 60]. */
+        private const val THERMAL_FORECAST_SECONDS = 10
+        /** Never shed below this many live video tiles. */
+        private const val MIN_ACTIVE_TILES = 2
+        /** Standard Linux USER_HZ on Android (`sysconf(_SC_CLK_TCK)`). */
+        private const val CLOCK_TICKS_PER_SEC = 100L
+
+        /** The control-loop tick used by the wall (kept here so the wall and the
+         *  smoothing constant above stay in sync). */
+        const val WALL_TICK_MS = 2_000L
+
+        /**
+         * Stage-1 guardrail: warn when this many live video tiles would render at
+         * once. A conservative COUNT budget, not the resolution-weighted budget the
+         * desktop uses — the Android client is not sent per-camera stream resolution
+         * (see #384), so it can't weight by 4K-vs-1080p without a server change.
+         * The runtime shedder ([tick]) is the real safety net; this is the advisory
+         * heads-up that fires first, before anything saturates.
+         */
+        const val GUARDRAIL_TILE_BUDGET = 12
+    }
+}

--- a/apps/android/app/src/main/java/video/crumb/app/feature/settings/SettingsDialog.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/settings/SettingsDialog.kt
@@ -59,6 +59,13 @@ fun SettingsDialog(
     lowBandwidthMode: Boolean,
     onLowBandwidthChange: (Boolean) -> Unit,
     /**
+     * Adaptive live-wall quality (#384). Mirrored from the caller (not read from
+     * [store] here) so the wall reacts the moment the switch flips. Governs both the
+     * config-time guardrail nudge and the runtime decode backpressure.
+     */
+    adaptiveWallQuality: Boolean,
+    onAdaptiveWallQualityChange: (Boolean) -> Unit,
+    /**
      * Whether the auto-built "All Cameras" quick-grid default view is offered on the
      * Live/Playback wall. Mirrored (not read straight from [store]) so the caller's
      * copy — which the wall itself reacts to live — stays in sync; see
@@ -180,6 +187,37 @@ fun SettingsDialog(
                     Switch(
                         checked = lowBandwidthMode,
                         onCheckedChange = onLowBandwidthChange,
+                        colors = crumbSwitchColors(),
+                    )
+                }
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(end = 8.dp),
+                    ) {
+                        Text(
+                            text = "Adaptive video quality",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = TextPrimary,
+                        )
+                        Text(
+                            text = "Protect this device's video decoder on big walls. " +
+                                "Warns before a heavy wall, and quietly steps busy tiles " +
+                                "down to snapshots if the decoder or the device gets hot, " +
+                                "restoring them once it recovers.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = TextSecondary,
+                        )
+                    }
+                    Switch(
+                        checked = adaptiveWallQuality,
+                        onCheckedChange = onAdaptiveWallQualityChange,
                         colors = crumbSwitchColors(),
                     )
                 }


### PR DESCRIPTION
Android sibling of #382 (canonical policy + DECISIONS entry land with the desktop PR). Protects the client decoder when a heavy live wall over-subscribes it.

## What
- **Stage 1 guardrail (config-time):** dismissible nudge ("Use snapshots / Proceed anyway / Don't warn on this device") when live tile count exceeds a budget. Advisory, never blocks.
- **Stage 2 backpressure (runtime):** new `WallDecodeMonitor` folds three signals - ExoPlayer `DecoderCounters` dropped frames (per-tile `AnalyticsListener`, aggregated), `PowerManager` thermal (`getThermalHeadroom` API>=30 + `OnThermalStatusChangedListener` API>=29, SDK-guarded), and a `/proc/self/stat` CPU fallback - EMA-smoothed. Sheds one peripheral tile when smoothed load >=0.85 for 4s, restores when <=0.60 for 20s (hysteresis). Shed order: off-screen -> earliest wall-order -> never the focused tile, floor of 2 active video tiles. Shed tiles show an amber "SD" pill and self-restore silently.
- One client-local Settings toggle ("Adaptive video quality", default ON) governs both stages; per-device silence for the nudge. No server change.
- Listener lifecycle: per-tile AnalyticsListener removed on dispose (keyed on player); thermal listener registered/removed in the lifecycle scope.

## Platform divergences from #382 (called out for review)
- The Android wall already runs the sub stream and has no all-main toggle, so there is no exact "all-main" trigger. The analog is "many live tiles", and the next tier down is the snapshot poller (the shed target), not "sub".
- Resolution-weighted guardrail projection is deferred: the Android client has no per-camera stream resolution and the server must not change, so Stage 1 uses a plain count budget. Noted as a follow-up.

## Verification
Compiles via the `android (debug build)` CI job. Runtime shedding under real thermal/decoder saturation needs on-device testing on a heavy tablet / Android-TV wall; the thresholds and the dropped-fps normalization constant are first-pass and may want tuning.