### PR TITLE
feat(apple): adaptive live-wall quality (thermalState backpressure + decode guardrail) (#383)

### DIFF
--- a/apps/ios/Crumb/App/AppSettings.swift
+++ b/apps/ios/Crumb/App/AppSettings.swift
@@ -18,6 +18,22 @@ final class AppSettings: ObservableObject {
     @Published var liveGridLayout: Int { didSet { defaults.set(liveGridLayout, forKey: Keys.liveGridLayout) } }
     @Published var ptzStyle: String { didSet { defaults.set(ptzStyle, forKey: Keys.ptzStyle) } }
     @Published var lowBandwidthMode: Bool { didSet { defaults.set(lowBandwidthMode, forKey: Keys.lowBandwidthMode) } }
+    /// Opt-in "high quality" live wall: decode every tile's full-resolution main
+    /// stream instead of the lighter sub. Off by default (the wall stays
+    /// sub-preferring). This is the config-time knob the Stage-1 decode guardrail
+    /// warns about and the Stage-2 backpressure net manages (issue #383).
+    @Published var wallHighQuality: Bool { didSet { defaults.set(wallHighQuality, forKey: Keys.wallHighQuality) } }
+    /// Stage-2 reactive backpressure: when the device gets too warm (thermalState,
+    /// CPU fallback) automatically shed the least-important tiles to a lighter
+    /// stream and restore them when it cools. On by default.
+    @Published var adaptiveWallQuality: Bool { didSet { defaults.set(adaptiveWallQuality, forKey: Keys.adaptiveWallQuality) } }
+    /// Stage-1 preventive guardrail: warn before showing a wall that would run
+    /// more full-resolution streams than this device can comfortably decode. On
+    /// by default; advisory, never blocks.
+    @Published var wallDecodeGuardrail: Bool { didSet { defaults.set(wallDecodeGuardrail, forKey: Keys.wallDecodeGuardrail) } }
+    /// Per-device "Don't warn on this device" latch for the decode guardrail.
+    /// Off by default; set when the operator dismisses the nudge permanently.
+    @Published var guardrailSuppressed: Bool { didSet { defaults.set(guardrailSuppressed, forKey: Keys.guardrailSuppressed) } }
     @Published var motionTunerEnabled: Bool { didSet { defaults.set(motionTunerEnabled, forKey: Keys.motionTunerEnabled) } }
     @Published var bookmarksButtonEnabled: Bool { didSet { defaults.set(bookmarksButtonEnabled, forKey: Keys.bookmarksButtonEnabled) } }
     /// Whether the built-in "All cameras" quick-view chip is shown. Off lets an
@@ -40,6 +56,10 @@ final class AppSettings: ObservableObject {
         liveGridLayout = defaults.object(forKey: Keys.liveGridLayout) as? Int ?? 1
         ptzStyle = defaults.string(forKey: Keys.ptzStyle) ?? "wheel"
         lowBandwidthMode = defaults.object(forKey: Keys.lowBandwidthMode) as? Bool ?? false
+        wallHighQuality = defaults.object(forKey: Keys.wallHighQuality) as? Bool ?? false
+        adaptiveWallQuality = defaults.object(forKey: Keys.adaptiveWallQuality) as? Bool ?? true
+        wallDecodeGuardrail = defaults.object(forKey: Keys.wallDecodeGuardrail) as? Bool ?? true
+        guardrailSuppressed = defaults.object(forKey: Keys.guardrailSuppressed) as? Bool ?? false
         motionTunerEnabled = defaults.object(forKey: Keys.motionTunerEnabled) as? Bool ?? true
         bookmarksButtonEnabled = defaults.object(forKey: Keys.bookmarksButtonEnabled) as? Bool ?? true
         showAllCamerasView = defaults.object(forKey: Keys.showAllCamerasView) as? Bool ?? true
@@ -69,6 +89,10 @@ final class AppSettings: ObservableObject {
         static let audioEnabledPrefix = "audio_enabled_"
         static let ptzStyle = "ptz_style"
         static let lowBandwidthMode = "low_bandwidth_mode"
+        static let wallHighQuality = "wall_high_quality"
+        static let adaptiveWallQuality = "adaptive_wall_quality"
+        static let wallDecodeGuardrail = "wall_decode_guardrail"
+        static let guardrailSuppressed = "wall_guardrail_suppressed"
         static let motionTunerEnabled = "motion_tuner_enabled"
         static let bookmarksButtonEnabled = "bookmarks_button_enabled"
         static let showAllCamerasView = "show_all_cameras_view"

--- a/apps/ios/Crumb/Features/Live/CameraTileView.swift
+++ b/apps/ios/Crumb/Features/Live/CameraTileView.swift
@@ -12,8 +12,16 @@ struct CameraTileView: View {
     /// requires an async `GET /media-token` round trip (see
     /// `MediaUrls.cameraFrameUrl`). Re-resolved whenever `camera.id` changes.
     let mediaUrls: MediaUrls
-    /// When true, show ~1fps snapshots instead of live WebRTC (low-bandwidth mode).
-    let lowBandwidth: Bool
+    /// The stream rung this tile should decode, already folding low-bandwidth
+    /// mode, the high-quality-wall choice, and any reactive shed together (see
+    /// `WallLoadController.effectiveQuality`). `.snapshot` == the ~1 fps still
+    /// path; `.sub` / `.main` == live sub / main video.
+    var quality: TileQuality = .sub
+    /// True when the adaptive backpressure net downgraded this tile (as opposed
+    /// to a rung the operator chose). Drives the amber "SD" badge so an
+    /// auto-downgrade reads as "the app protected this device," not a fault; it
+    /// self-restores silently when the device cools.
+    var degraded: Bool = false
     /// When true (default) the tile locks to 16:9; when false it fills its
     /// container (used by custom layouts whose panes are arbitrary aspect ratios).
     var lockAspect: Bool = true
@@ -23,33 +31,42 @@ struct CameraTileView: View {
 
     var body: some View {
         ZStack(alignment: .topLeading) {
-            if lowBandwidth {
-                // Own long-lived poll loop (low-bandwidth mode) — re-resolves
-                // its own scoped URL every tick rather than reusing the
-                // `frameUrl` snapshot-backdrop state above, since a ~1.2s
+            switch quality {
+            case .snapshot:
+                // Still-frame path (low-bandwidth, or shed all the way down when
+                // there is no sub to fall back to). Own long-lived poll loop —
+                // re-resolves its own scoped URL every tick rather than reusing
+                // the `frameUrl` snapshot-backdrop state above, since a ~1.2s
                 // poll easily outlives the ~15 min scoped-token TTL.
                 SnapshotTile(cameraId: camera.id, mediaUrls: mediaUrls)
-            } else {
+            case .sub, .main:
+                let sub = (quality == .sub)
                 #if canImport(WebRTC)
-                // iOS: native WebRTC sub-stream (sub-second), snapshot backdrop until first frame.
-                // [iOS] C3 fix: `LiveViewModel.loadCameras()` publishes `cameras`
-                // before `resolveStreams` finishes, so this tile can first render
-                // with `whepURL == nil` (the `WebRTCManager` init falls back to the
-                // `http://invalid.local` placeholder) and never retry once the real
-                // URL resolves a moment later — the `@StateObject` manager is only
-                // built once, at this view's first construction. Keying identity on
-                // the URL forces SwiftUI to tear down and rebuild the view (and thus
-                // the manager) whenever whepURL changes from nil → real or between
-                // cameras, mirroring the macOS Fmp4VideoView's `.onChange(of:
-                // streamURL)` rebuild-on-change behavior.
-                WebRTCVideoView(cameraId: camera.id, mediaUrls: mediaUrls, hasSub: camera.hasSubStream, fill: true)
+                // iOS: native WebRTC (sub-second), snapshot backdrop until first
+                // frame. `hasSub: true` prefers the light sub stream (main
+                // fallback); `false` forces the full-res main.
+                //
+                // [iOS] C3 fix + adaptive rung: `LiveViewModel.loadCameras()`
+                // publishes `cameras` before `resolveStreams` finishes, so this
+                // tile can first render with `whepURL == nil` (the
+                // `WebRTCManager` init falls back to the `http://invalid.local`
+                // placeholder) and never retry once the real URL resolves a
+                // moment later — the `@StateObject` manager is built once, at
+                // construction. Keying identity on the chosen rung forces SwiftUI
+                // to tear down and rebuild the manager whenever the rung flips
+                // (nil → real, sub ⇄ main on a shed/restore, or between cameras),
+                // mirroring the macOS Fmp4VideoView's rebuild-on-change behavior.
+                WebRTCVideoView(cameraId: camera.id, mediaUrls: mediaUrls, hasSub: sub, fill: true)
+                    .id(sub)
                 #else
                 // macOS: the cross-platform fMP4 / VideoToolbox player (no WebRTC).
-                // Wall tiles pull the SUB stream when present (lighter); the stream
-                // URL is minted per connect through the authenticated /live proxy.
+                // The stream URL is minted per connect through the authenticated
+                // /live proxy; the `streamKey` carries the rung so a shed/restore
+                // reconnects onto the other stream (Fmp4VideoView reconnects on a
+                // `streamKey` change).
                 Fmp4VideoView(
-                    streamKey: "\(camera.id):\(camera.hasSubStream ? "sub" : "main")",
-                    streamProvider: { await mediaUrls.liveFmp4URL(cameraId: camera.id, sub: camera.hasSubStream) },
+                    streamKey: "\(camera.id):\(sub ? "sub" : "main")",
+                    streamProvider: { await mediaUrls.liveFmp4URL(cameraId: camera.id, sub: sub) },
                     snapshotURL: frameUrl
                 )
                 #endif
@@ -86,6 +103,23 @@ struct CameraTileView: View {
                     .frame(width: 6, height: 6)
                     .padding(6)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+            }
+
+            // "SD" badge (bottom-right): only while the adaptive net has this
+            // tile shed. Amber (not error red) so it reads as "the app lightened
+            // this tile to protect the device," and clears itself on restore.
+            if degraded {
+                VStack {
+                    Spacer()
+                    Text("SD")
+                        .font(.caption2.bold())
+                        .foregroundColor(.black)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(CrumbColors.motionDot, in: Capsule())
+                        .padding(6)
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                }
             }
 
             VStack {

--- a/apps/ios/Crumb/Features/Live/LiveWallView.swift
+++ b/apps/ios/Crumb/Features/Live/LiveWallView.swift
@@ -27,6 +27,9 @@ enum GridLayout: Int, CaseIterable {
 struct LiveWallView: View {
 
     @StateObject private var vm: LiveViewModel
+    /// Adaptive live-wall quality (issue #383): thermalState-driven backpressure
+    /// plus the config-time decode guardrail. Scoped to the wall's lifetime.
+    @StateObject private var wallLoad: WallLoadController
     @State private var selectedCameraId: String?
     @State private var playbackCameraId: String?
     @State private var playbackStartTime: Date?
@@ -59,6 +62,7 @@ struct LiveWallView: View {
         _updateChecker = ObservedObject(wrappedValue: container.updateChecker)
         let vm = LiveViewModel(container: container)
         _vm = StateObject(wrappedValue: vm)
+        _wallLoad = StateObject(wrappedValue: WallLoadController(settings: container.settings))
         _selectedCameraId = State(initialValue: container.store.lastLiveCameraId)
     }
 
@@ -189,12 +193,76 @@ struct LiveWallView: View {
         }
         .onDisappear {
             vm.stopStatusPolling()
+            wallLoad.stop()
         }
         // Proactive update-available notice, pinned above the wall content
         // (pushes content down rather than covering it). Renders nothing —
         // and reserves no space — unless there's an un-dismissed newer
         // version, so it stays out of the way the rest of the time.
         .safeAreaInset(edge: .top, spacing: 0) { updateBanner }
+        // Feed the adaptive-quality controller the current wall composition. A
+        // single signature covers camera-set / view / focus / quality changes.
+        .onAppear { syncWallLoad() }
+        .onChange(of: wallSignature) { _ in syncWallLoad() }
+        // Stage-1 guardrail nudge (advisory; never blocks). Presented here so
+        // "Keep sub" can revert the wall-quality setting in place.
+        .alert(
+            "Heavy live wall",
+            isPresented: Binding(
+                get: { wallLoad.warning != nil },
+                set: { if !$0 { wallLoad.warning = nil } }
+            ),
+            presenting: wallLoad.warning
+        ) { warning in
+            if warning.revertable {
+                Button("Keep sub") {
+                    settings.wallHighQuality = false
+                    wallLoad.warning = nil
+                }
+                Button("Proceed anyway") { wallLoad.warning = nil }
+            } else {
+                Button("OK") { wallLoad.warning = nil }
+            }
+            Button("Don't warn on this device", role: .cancel) {
+                settings.guardrailSuppressed = true
+                wallLoad.warning = nil
+            }
+        } message: { warning in
+            Text(warning.message)
+        }
+    }
+
+    // MARK: - Adaptive wall quality (issue #383)
+
+    /// Compact signature of everything that changes the wall's decode load, so a
+    /// single `.onChange` re-feeds the controller.
+    private var wallSignature: String {
+        visibleCameras.map(\.id).joined(separator: ",")
+            + "|\(settings.wallHighQuality)|\(selectedCameraId ?? "")"
+    }
+
+    /// Push the current visible wall composition + focused tile to the controller.
+    private func syncWallLoad() {
+        wallLoad.configure(
+            cameras: visibleCameras.map { (id: $0.id, hasSub: $0.hasSubStream) },
+            focusedId: selectedCameraId
+        )
+    }
+
+    /// Effective stream rung for a tile, folding user prefs + any reactive shed.
+    private func tileQuality(_ camera: CameraDto) -> TileQuality {
+        WallLoadController.effectiveQuality(
+            hasSub: camera.hasSubStream,
+            highQuality: settings.wallHighQuality,
+            lowBandwidth: settings.lowBandwidthMode,
+            degraded: wallLoad.shedCameraIds.contains(camera.id)
+        )
+    }
+
+    /// Whether the tile carries the auto-downgrade "SD" badge (a reactive shed,
+    /// not a user-chosen low rung).
+    private func tileDegraded(_ camera: CameraDto) -> Bool {
+        !settings.lowBandwidthMode && wallLoad.shedCameraIds.contains(camera.id)
     }
 
     // MARK: - Update banner (issue #7 / task C4)
@@ -524,7 +592,8 @@ struct LiveWallView: View {
                     status: vm.cameraStatuses[cam.id],
                     detectionKeys: vm.activeDetections[cam.id] ?? [],
                     mediaUrls: urls,
-                    lowBandwidth: settings.lowBandwidthMode,
+                    quality: tileQuality(cam),
+                    degraded: tileDegraded(cam),
                     lockAspect: false,
                     onTap: {
                         selectedCameraId = cam.id
@@ -724,7 +793,8 @@ struct LiveWallView: View {
                         status: vm.cameraStatuses[camera.id],
                         detectionKeys: vm.activeDetections[camera.id] ?? [],
                         mediaUrls: urls,
-                        lowBandwidth: settings.lowBandwidthMode,
+                        quality: tileQuality(camera),
+                        degraded: tileDegraded(camera),
                         onTap: {
                             selectedCameraId = camera.id
                             vm.store.lastLiveCameraId = camera.id

--- a/apps/ios/Crumb/Features/Live/WallLoadController.swift
+++ b/apps/ios/Crumb/Features/Live/WallLoadController.swift
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import Foundation
+import Combine
+#if canImport(UIKit)
+import UIKit
+#endif
+
+// MARK: - Tile quality rungs
+
+/// The stream rung a wall tile decodes. `main` is full resolution (heaviest),
+/// `sub` is the camera's low-res sub stream (light), `snapshot` is the ~1 fps
+/// still path (no live decode at all). On Apple the wall baseline is already
+/// sub-preferring (see `CameraTileView`), so the only rung below a live tile
+/// with no sub stream is the snapshot still — there is no separate "main wall"
+/// stream to drop off of, unlike the desktop client (#382). That asymmetry is
+/// why reactive backpressure sheds `main -> sub` where a sub exists and
+/// `main/sub -> snapshot` where it does not.
+enum TileQuality: Equatable {
+    case main
+    case sub
+    case snapshot
+}
+
+// MARK: - Guardrail nudge
+
+/// A pending Stage-1 guardrail nudge (issue #383 / sibling of #382). Advisory
+/// only: it never blocks the wall, it warns that the projected full-resolution
+/// decode load would exceed this device's headroom before anything saturates.
+struct WallGuardrailWarning: Identifiable, Equatable {
+    let id = UUID()
+    /// How many tiles would decode a full-resolution main stream.
+    let mainTileCount: Int
+    /// True when the heaviness is because the operator turned on the
+    /// high-quality wall (so "Keep sub" can revert it); false when it is just an
+    /// inherently heavy set of main-only cameras (nothing to revert).
+    let revertable: Bool
+
+    var message: String {
+        let base = "This wall would run \(mainTileCount) full resolution "
+            + "\(mainTileCount == 1 ? "stream" : "streams"), more than this device "
+            + "can comfortably decode at once."
+        if revertable {
+            return base + " Keep the wall on the lighter sub stream and use "
+                + "the fullscreen view for detail?"
+        }
+        return base + " Crumb will automatically lighten the least important "
+            + "tiles if the device gets too warm."
+    }
+}
+
+// MARK: - Controller
+
+/// Adaptive live-wall quality for the Apple client (iOS / iPadOS / macOS).
+///
+/// Ports the shared two-stage policy from #382 (the desktop sibling) to
+/// Apple-native signals, since VideoToolbox exposes no NVML-style decode-util %:
+///
+///  * **Stage 1, guardrail (preventive, config time):** a resolution-weighted
+///    count projection. Each tile that would decode a main stream is weighted
+///    heavier than a sub tile; if the projected load crosses ~75% of this
+///    device's decode budget, `warning` is published so the wall can show a
+///    dismissible nudge. Advisory, never blocks.
+///  * **Stage 2, backpressure (reactive, runtime):** driven primarily by
+///    `ProcessInfo.processInfo.thermalState` (the real SoC-over-budget signal on
+///    fanless iPads / Macs), with aggregate CPU utilisation as a fallback when
+///    thermalState stays uninformative. `.serious` begins shedding, `.critical`
+///    sheds aggressively, and a return to `.nominal` restores, all with the same
+///    shed-fast / restore-slow hysteresis discipline as #382 (shed after a 4s
+///    hold, restore only after a 20s calm, one tile at a time).
+///
+/// All thresholds are client-local (a phone and an M-series Mac have very
+/// different budgets) and both stages are user-toggleable, defaulting on.
+@MainActor
+final class WallLoadController: ObservableObject {
+
+    /// Tiles the reactive net has currently downgraded (shed). Observed by the
+    /// wall so each tile recomputes its effective quality and shows the "SD"
+    /// badge. Restores clear silently.
+    @Published private(set) var shedCameraIds: Set<String> = []
+
+    /// A pending guardrail nudge, or `nil`. The wall binds an alert to this.
+    @Published var warning: WallGuardrailWarning?
+
+    private let settings: AppSettings
+
+    /// One entry per visible wall tile, in wall order. `heavy` == would decode a
+    /// full-resolution main stream (either the high-quality wall is on, or the
+    /// camera has no sub stream to fall back to).
+    private struct WallTile { let id: String; let heavy: Bool }
+    private var wall: [WallTile] = []
+    private var focusedId: String?
+
+    // Reactive shedding state.
+    /// Number of peripheral tiles currently shed (0 == none). Moved toward a
+    /// thermal-derived target with directional rate limits (shed fast, restore
+    /// slow) so the wall never flaps between quality rungs.
+    private var shedCount = 0
+    private var pressureSince: Date?
+    private var calmSince: Date?
+    private var lastRestoreAt: Date?
+    private let cpu = CpuLoadSampler()
+
+    // Guardrail bookkeeping: fire once per distinct heavy composition so a
+    // static heavy wall nags exactly once, not every re-render.
+    private var lastWarnedSignature: String?
+
+    private var tickTask: Task<Void, Never>?
+    private var cancellables = Set<AnyCancellable>()
+
+    // Timing / threshold constants (client-local; the "60/85 + 4s/20s" of #382
+    // re-expressed against thermalState bands).
+    private let tickInterval: UInt64 = 3_000_000_000 // 3s
+    private let shedHold: TimeInterval = 4           // sustain pressure before first shed
+    private let restoreHold: TimeInterval = 20       // sustain calm before restoring
+    private let restoreStep: TimeInterval = 5        // min gap between restores
+    private let mainWeight = 3.5                      // a main tile ~= 3.5 sub tiles of decode
+    private let guardrailCeiling = 0.75              // warn above 75% of budget
+    /// CPU fallback high-water mark: only consulted when thermalState is
+    /// uninformative (`.nominal` / `.fair`) so a well-cooled Mac that never
+    /// reports thermal pressure still gets a reactive net.
+    private let cpuHighWater = 0.85
+
+    init(settings: AppSettings) {
+        self.settings = settings
+        // PRIMARY signal: react immediately to thermal transitions (the tick
+        // loop also re-reads thermalState, but the notification makes a spike
+        // actionable without waiting up to a full tick).
+        NotificationCenter.default
+            .publisher(for: ProcessInfo.thermalStateDidChangeNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in Task { @MainActor in self?.tick() } }
+            .store(in: &cancellables)
+    }
+
+    /// Feed the current visible wall composition. Recomputes the shed set (so it
+    /// tracks a changed camera list) and runs the Stage-1 guardrail projection.
+    func configure(cameras: [(id: String, hasSub: Bool)], focusedId: String?) {
+        let high = settings.wallHighQuality
+        wall = cameras.map { WallTile(id: $0.id, heavy: high || !$0.hasSub) }
+        self.focusedId = focusedId
+        recomputeShedSet()
+        runGuardrail()
+        startTicking()
+    }
+
+    /// Stop the reactive loop (wall disappeared).
+    func stop() {
+        tickTask?.cancel()
+        tickTask = nil
+    }
+
+    // MARK: - Effective quality (pure; shared by the wall's tile builders)
+
+    /// The rung a tile should actually decode, folding together the user's
+    /// wall-quality choice, low-bandwidth mode, and any reactive shed.
+    ///
+    /// Base rung: low-bandwidth forces snapshots for everything; otherwise the
+    /// high-quality wall forces main, and the default wall prefers sub when the
+    /// camera has one (matching the pre-existing tile behaviour). A shed drops
+    /// that rung one step: `main -> sub` when a sub exists, else `-> snapshot`.
+    static func effectiveQuality(hasSub: Bool, highQuality: Bool,
+                                 lowBandwidth: Bool, degraded: Bool) -> TileQuality {
+        if lowBandwidth { return .snapshot }
+        let base: TileQuality = highQuality ? .main : (hasSub ? .sub : .main)
+        guard degraded else { return base }
+        switch base {
+        case .main:     return hasSub ? .sub : .snapshot
+        case .sub:      return .snapshot
+        case .snapshot: return .snapshot
+        }
+    }
+
+    // MARK: - Stage 1: guardrail projection
+
+    private func deviceDecodeBudget() -> Double {
+        // Sub-tile-equivalents this device can decode at ~100%. Deliberately
+        // conservative on mobile: iPads and phones have weaker decoders and
+        // tighter thermal ceilings than an M-series Mac (issue #383). Tunable;
+        // client-local by design.
+        #if os(macOS)
+        return 18
+        #else
+        return UIDevice.current.userInterfaceIdiom == .pad ? 10 : 6
+        #endif
+    }
+
+    private func runGuardrail() {
+        guard settings.wallDecodeGuardrail, !settings.guardrailSuppressed else { return }
+        let mainCount = wall.filter(\.heavy).count
+        // Resolution-weighted count projection: main tiles cost `mainWeight`
+        // sub-equivalents each (Apple exposes no per-stream decode cost, and the
+        // viewer camera payload carries no per-camera resolution, so main-vs-sub
+        // is the resolution proxy — a main stream is the camera's full-res feed).
+        let projected = Double(mainCount) * mainWeight
+            + Double(wall.count - mainCount)
+        let ceiling = guardrailCeiling * deviceDecodeBudget()
+        guard projected > ceiling, mainCount > 0 else {
+            // Not heavy (any more) — clear the "already warned" latch so a later
+            // heavy composition warns afresh.
+            lastWarnedSignature = nil
+            return
+        }
+        let signature = "\(wall.count)|\(mainCount)|\(settings.wallHighQuality)"
+        guard signature != lastWarnedSignature, warning == nil else { return }
+        lastWarnedSignature = signature
+        warning = WallGuardrailWarning(mainTileCount: mainCount,
+                                       revertable: settings.wallHighQuality)
+    }
+
+    // MARK: - Stage 2: reactive backpressure
+
+    private func startTicking() {
+        guard tickTask == nil else { return }
+        tickTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                self.tick()
+                try? await Task.sleep(nanoseconds: self.tickInterval)
+            }
+        }
+    }
+
+    private func tick() {
+        guard settings.adaptiveWallQuality else {
+            // Feature off: make sure nothing stays shed.
+            if shedCount != 0 { shedCount = 0; recomputeShedSet() }
+            pressureSince = nil; calmSince = nil
+            return
+        }
+
+        let thermal = ProcessInfo.processInfo.thermalState
+        // CPU fallback is only consulted when thermalState is uninformative
+        // (a well-cooled Mac can peg the decoder while still reporting nominal).
+        let cpuBusy = cpu.sample() ?? 0
+        let cpuHigh = cpuBusy >= cpuHighWater
+
+        let sheddable = sheddableCount()
+        let target = targetShed(for: thermal, cpuHigh: cpuHigh, sheddable: sheddable)
+        let now = Date()
+
+        if target > shedCount {
+            // Rising: require sustained pressure before the first shed, then
+            // step in (aggressively under `.critical`).
+            calmSince = nil
+            if pressureSince == nil { pressureSince = now }
+            if now.timeIntervalSince(pressureSince!) >= shedHold {
+                let step = (thermal == .critical) ? (target - shedCount) : 1
+                shedCount = min(shedCount + step, target)
+                recomputeShedSet()
+            }
+        } else if target < shedCount {
+            // Falling: restore slowly, and only after a calm hold, one tile at a
+            // time, aborting the moment pressure returns (handled by re-entry).
+            pressureSince = nil
+            if calmSince == nil { calmSince = now }
+            if now.timeIntervalSince(calmSince!) >= restoreHold,
+               lastRestoreAt == nil || now.timeIntervalSince(lastRestoreAt!) >= restoreStep {
+                shedCount -= 1
+                lastRestoreAt = now
+                recomputeShedSet()
+            }
+        } else {
+            // Hold (hysteresis band, e.g. thermal `.fair`): neither grow nor
+            // shrink, so the wall does not flap around the threshold.
+            pressureSince = nil
+        }
+    }
+
+    /// Target shed level for a thermal band. `.fair` holds (returns the current
+    /// level) so the serious<->fair boundary does not oscillate.
+    private func targetShed(for thermal: ProcessInfo.ThermalState,
+                            cpuHigh: Bool, sheddable: Int) -> Int {
+        switch thermal {
+        case .critical: return sheddable                 // shed everything peripheral
+        case .serious:  return (sheddable + 1) / 2       // begin shedding (~half)
+        case .fair:     return cpuHigh ? (sheddable + 1) / 2 : shedCount
+        case .nominal:  return cpuHigh ? (sheddable + 1) / 2 : 0
+        @unknown default: return shedCount
+        }
+    }
+
+    /// Peripheral tiles eligible to shed: everything except the focused tile and
+    /// the leading (most-visible / primary) tile, which are never shed.
+    private func sheddableOrder() -> [String] {
+        guard !wall.isEmpty else { return [] }
+        var protected: Set<String> = []
+        if let focusedId { protected.insert(focusedId) }
+        protected.insert(wall[0].id) // keep the primary tile live
+        // Shed order: end-of-wall first. True on/off-screen state is not cheap
+        // to observe inside a LazyVGrid, so trailing wall order is the
+        // off-screen proxy (later tiles scroll below the fold first); leading
+        // tiles (the primary view area) are preserved.
+        return Array(wall.map(\.id).filter { !protected.contains($0) }.reversed())
+    }
+
+    private func sheddableCount() -> Int { sheddableOrder().count }
+
+    private func recomputeShedSet() {
+        let order = sheddableOrder()
+        shedCount = max(0, min(shedCount, order.count))
+        shedCameraIds = Set(order.prefix(shedCount))
+    }
+}
+
+// MARK: - CPU load sampler (fallback signal)
+
+/// Aggregate system CPU utilisation from successive `host_statistics`
+/// (`HOST_CPU_LOAD_INFO`) snapshots. Cumulative tick counters, so the first
+/// sample only primes the baseline and returns `nil`; subsequent samples return
+/// the busy fraction (0...1) since the previous call. Cross-platform (iOS +
+/// macOS) via the Mach host port.
+final class CpuLoadSampler {
+    private var previous: (busy: UInt64, total: UInt64)?
+
+    func sample() -> Double? {
+        var info = host_cpu_load_info_data_t()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<host_cpu_load_info_data_t>.stride / MemoryLayout<integer_t>.stride)
+        let kr = withUnsafeMutablePointer(to: &info) { ptr -> kern_return_t in
+            ptr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { rebound in
+                host_statistics(mach_host_self(), HOST_CPU_LOAD_INFO, rebound, &count)
+            }
+        }
+        guard kr == KERN_SUCCESS else { return nil }
+        // cpu_ticks indices: 0 user, 1 system, 2 idle, 3 nice.
+        let user = UInt64(info.cpu_ticks.0)
+        let system = UInt64(info.cpu_ticks.1)
+        let idle = UInt64(info.cpu_ticks.2)
+        let nice = UInt64(info.cpu_ticks.3)
+        let busy = user &+ system &+ nice
+        let total = busy &+ idle
+        defer { previous = (busy, total) }
+        guard let prev = previous else { return nil }
+        let dBusy = Double(busy &- prev.busy)
+        let dTotal = Double(total &- prev.total)
+        guard dTotal > 0 else { return nil }
+        return max(0, min(1, dBusy / dTotal))
+    }
+}

--- a/apps/ios/Crumb/Features/Settings/SettingsView.swift
+++ b/apps/ios/Crumb/Features/Settings/SettingsView.swift
@@ -145,8 +145,26 @@ struct SettingsView: View {
             rowDivider
             settingToggle(
                 "Low-bandwidth mode",
-                "Drop the live wall to still snapshots (~1 fps) instead of live video — for weak or metered connections.",
+                "Drop the live wall to still snapshots (~1 fps) instead of live video, for weak or metered connections.",
                 $settings.lowBandwidthMode
+            )
+            rowDivider
+            settingToggle(
+                "High-quality wall",
+                "Decode every tile at full resolution instead of the lighter sub stream. Uses much more decoding power on large walls.",
+                $settings.wallHighQuality
+            )
+            rowDivider
+            settingToggle(
+                "Adaptive quality",
+                "If this device gets too warm, automatically lighten the least-important tiles, then restore them when it cools.",
+                $settings.adaptiveWallQuality
+            )
+            rowDivider
+            settingToggle(
+                "Decode guardrail",
+                "Warn before a wall would run more full-resolution streams than this device can comfortably decode at once.",
+                $settings.wallDecodeGuardrail
             )
             rowDivider
             settingToggle(

--- a/apps/ios/Crumb/Video/Fmp4/Fmp4Player.swift
+++ b/apps/ios/Crumb/Video/Fmp4/Fmp4Player.swift
@@ -312,6 +312,14 @@ final class Fmp4StreamController: NSObject, ObservableObject {
 
     private func enqueue(_ sample: CMSampleBuffer) {
         guard !stopped else { return }
+        // TODO(#383, follow-up): AVSampleBufferDisplayLayer frame-delivery-health
+        // refinement, deferred as the lower-priority Stage-2 signal. Sample
+        // `displayLayer.isReadyForMoreMediaData` stalls + enqueue backlog here
+        // (late/dropped access units under decoder over-subscription) and surface
+        // it to `WallLoadController` as a per-tile pressure input alongside the
+        // shipped thermalState/CPU signals. Intentionally NOT wired yet: it must
+        // not perturb the recorder-shielded decode path, and thermalState +
+        // guardrail already cover the failure mode.
         if displayLayer.status == .failed { displayLayer.flush() }
         displayLayer.enqueue(sample)
         if !displaying {


### PR DESCRIPTION
Apple (iOS/iPadOS/macOS) sibling of #382 (canonical policy + DECISIONS entry land with the desktop PR). Protects the VideoToolbox decoder when a heavy live wall over-subscribes it.

## What
- **Stage 1 guardrail (config-time):** `WallLoadController` projects load as a resolution-weighted tile count (main weight 3.5, sub 1.0) against a client-local device budget (Mac 18 / iPad 10 / iPhone 6 sub-equivalents); warns when projected > 75% of budget, once per composition. Dismissible alert: Keep sub / Proceed anyway / Don't warn on this device.
- **Stage 2 backpressure (runtime):** primary signal is `ProcessInfo.thermalState` (nominal/fair/serious/critical) via notification + a 3s tick; `.serious` begins shedding, `.critical` sheds aggressively, `.fair` holds (the hysteresis band), `.nominal` restores. CPU fallback (`host_statistics`) when thermalState is uninformative. Shed-fast (4s hold) / restore-slow (20s hold, one tile per 5s). Shed order: trailing wall-order first, never the focused or primary tile. Shed tiles drop a rung (main->sub, or ->snapshot) and show an amber "SD" badge, restoring silently.
- Three client-local Live settings: "High-quality wall" (default off - the opt-in heavy mode), "Adaptive quality" (default on), "Decode guardrail" (default on), plus a per-device suppress latch. No server change.

## Platform divergences from #382 (called out)
- The viewer payload has no per-camera resolution and the server must not change, so main-vs-sub is used as the resolution proxy for the guardrail projection.
- The wall is already sub-preferring, so the lower rung for a sub-less tile is the existing ~1fps snapshot path (there is no separate all-main wall stream to drop off of).

## Deferred (per the issue)
`AVSampleBufferDisplayLayer` frame-delivery-health refinement (enqueue backlog / stalls / late frames) is a `TODO(#383, follow-up)` in `Fmp4Player.swift`; thermalState + guardrail cover the failure mode.

## Verification
Built on the macmini (Crumb-mac scheme, shared sources): BUILD SUCCEEDED. Runtime shedding under real thermal load needs on-device testing (fanless iPad / older iPhone exercise .serious/.critical fastest); thresholds are first-pass.