### PR TITLE
feat(ios): HA control Phase 2, actuator buttons on the entity detail card (#187)

### DIFF
--- a/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
+++ b/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
@@ -2,13 +2,14 @@
 
 import SwiftUI
 
-/// Home Assistant on-video overlays + read-only entity sheet, at parity with the
-/// desktop badge overlay and the Android per-camera entity sheet.
+/// Home Assistant on-video overlays + entity sheet, at parity with the desktop
+/// badge overlay and the Android per-camera entity sheet.
 ///
-/// Read-only by design (matches Android/desktop POC): the client renders linked
-/// entities and their live states; linking/placement/config is admin-only and
-/// lives in the web console / desktop editor. Both surfaces here use only the two
-/// viewer-accessible endpoints `GET /cameras/:id/ha/links` and `GET /ha/states`.
+/// Linking/placement/config stays admin-only (web console / desktop editor); the
+/// client only reads `GET /cameras/:id/ha/links` and `GET /ha/states`. Phase 2
+/// (issue #187) adds ONE write: `POST /cameras/:id/ha/action` on the detail
+/// card, gated on the `actuators` capability AND an `actuator`-role link, so a
+/// viewer without the grant sees exactly the read-only surface it saw before.
 ///
 /// State-honesty invariant (mirrors the recorder's `edge_on` rail): an
 /// `unavailable`/`unknown`/empty state, or a `stale` snapshot, is NEVER rendered
@@ -172,6 +173,76 @@ enum HA {
     }
 }
 
+// MARK: - Actions (Phase 2 controls, issue #187)
+
+/// One button on the detail card: the wire `action` the server accepts, its
+/// caption, an SF Symbol from the same vocabulary the badges use, and whether
+/// it needs a confirmation first.
+struct HAAction: Identifiable, Equatable {
+    let action: String
+    let title: String
+    let symbol: String
+    /// Physical-security domains (locks, covers) confirm before firing.
+    let confirms: Bool
+    /// Renders the confirm button in the destructive role (unlock / open).
+    let destructive: Bool
+
+    var id: String { action }
+
+    init(_ action: String, _ title: String, _ symbol: String, confirms: Bool = false, destructive: Bool = false) {
+        self.action = action
+        self.title = title
+        self.symbol = symbol
+        self.confirms = confirms
+        self.destructive = destructive
+    }
+}
+
+extension HA {
+    /// Allowed actions BY DOMAIN, mirroring the server's allow-list. An unknown
+    /// domain yields no buttons (the card stays read-only) rather than guessing
+    /// at a service call the server would reject.
+    static func actions(for domain: String) -> [HAAction] {
+        switch domain {
+        case "light", "switch", "fan", "siren":
+            return [
+                HAAction("turn_on", "On", "power"),
+                HAAction("turn_off", "Off", "power"),
+            ]
+        case "cover":
+            return [
+                HAAction("open_cover", "Open", "arrow.up.square", confirms: true, destructive: true),
+                HAAction("stop_cover", "Stop", "stop.fill", confirms: true),
+                HAAction("close_cover", "Close", "arrow.down.square", confirms: true),
+            ]
+        case "lock":
+            return [
+                HAAction("lock", "Lock", "lock.fill", confirms: true),
+                HAAction("unlock", "Unlock", "lock.open.fill", confirms: true, destructive: true),
+            ]
+        case "button", "input_button":
+            return [HAAction("press", "Press", "hand.tap.fill")]
+        case "scene":
+            return [HAAction("turn_on", "Activate", "film")]
+        case "script":
+            return [HAAction("turn_on", "Run", "play.fill")]
+        default:
+            return []
+        }
+    }
+}
+
+/// Client-side failure before an action ever reaches the server.
+enum HAActionError: LocalizedError {
+    case noCamera
+
+    var errorDescription: String? {
+        switch self {
+        case .noCamera: return "No camera selected."
+        }
+    }
+}
+
 // MARK: - Controller (per-camera links + polled states)
 
 @MainActor
@@ -193,7 +264,27 @@ final class HAController: ObservableObject {
     var placedLinks: [HaLink] { links.filter(\.hasPlacement) }
     var hasLinks: Bool { !links.isEmpty }
 
+    /// Whether this user may actuate linked devices (issue #187). Deny-by-default:
+    /// an older server omits the capability, `Capabilities` defaults it to false,
+    /// and the detail card renders byte-identically to the read-only Phase 1 UI.
+    /// Admins implicitly hold it (`Capabilities.admin`), same as every other cap.
+    var canActuate: Bool { container.isAdmin || container.capabilities.actuators }
+
     func state(for entityId: String) -> HaEntityState? { states?.state(for: entityId) }
+
+    /// Fire one HA service call for a link. Throws on any non-2xx so the caller
+    /// can surface `403` as "not permitted" and `502` as "HA unreachable".
+    /// Deliberately does NOT mutate the shown state: the `/ha/states` poll is the
+    /// only source of truth (state-honesty invariant above), so a call that HA
+    /// silently drops can never leave the badge lying about the device.
+    func perform(link: HaLink, action: String) async throws {
+        // Unreachable in practice (links only exist after `activate`), but a
+        // missing camera must read as a failure, never as a silent success.
+        guard let cameraId else { throw HAActionError.noCamera }
+        try await container.api.haAction(cameraId: cameraId, linkId: link.id, action: action)
+        // Nudge the poll so the real new state lands sooner than the next tick.
+        await pollOnce()
+    }
 
     /// Point at a camera: load its links, and (re)start state polling if it has
     /// any. Idempotent per camera id.
@@ -266,8 +357,8 @@ struct HAOverlayLayer: View {
             }
         }
         .sheet(item: $tapped) { link in
-            HAStateCard(link: link, state: controller.state(for: link.entityId), stale: controller.stale)
-                .macModalSize(width: 360, height: 300)
+            HAStateCard(link: link, controller: controller)
+                .macModalSize(width: 360, height: 340)
         }
     }
 
@@ -364,13 +455,31 @@ private struct HABadge: View {
     }
 }
 
-// MARK: - Read-only detail card (tap a badge)
+// MARK: - Detail card (tap a badge) — read-only, plus Phase 2 controls
 
 struct HAStateCard: View {
     let link: HaLink
-    let state: HaEntityState?
-    let stale: Bool
+    /// Observed (not snapshotted) so the 3s poll keeps the shown state current
+    /// while the card is open — the card never flips state locally after an
+    /// action, it waits for the poll to say so.
+    @ObservedObject var controller: HAController
     @Environment(\.dismiss) private var dismiss
+
+    /// The action currently in flight (its wire name), or nil.
+    @State private var inFlight: String?
+    /// Awaiting confirmation (lock/cover only).
+    @State private var pending: HAAction?
+    @State private var errorText: String?
+
+    private var state: HaEntityState? { controller.state(for: link.entityId) }
+    private var stale: Bool { controller.stale }
+
+    /// Controls render only for an `actuator`-role link when the user holds the
+    /// `actuators` capability. Both false ⇒ the exact Phase 1 card.
+    private var actions: [HAAction] {
+        guard controller.canActuate, link.isActuator else { return [] }
+        return HA.actions(for: link.domain)
+    }
 
     var body: some View {
         let v = HA.visual(for: link, state: state, stale: stale)
@@ -381,6 +490,13 @@ struct HAStateCard: View {
                 Text(v.stateText).font(.title3.weight(.semibold)).foregroundColor(v.color)
                 if let age = HA.relativeAgo(state?.lastChanged) {
                     Text("Changed \(age)").font(.caption).foregroundColor(CrumbColors.textSecondary)
+                }
+                if !actions.isEmpty {
+                    controlsRow
+                }
+                if let errorText {
+                    Text(errorText).font(.caption).foregroundColor(CrumbColors.error)
+                        .multilineTextAlignment(.center)
                 }
                 if let dc = link.deviceClass, !dc.isEmpty {
                     detailRow("Device class", dc)
@@ -404,6 +520,78 @@ struct HAStateCard: View {
                 }
             }
         }
+        .confirmationDialog(
+            pending.map { "\($0.title) \(link.displayName)?" } ?? "",
+            isPresented: Binding(get: { pending != nil }, set: { if !$0 { pending = nil } }),
+            titleVisibility: .visible
+        ) {
+            if let action = pending {
+                Button(action.title, role: action.destructive ? ButtonRole.destructive : nil) {
+                    pending = nil
+                    Task { await fire(action) }
+                }
+            }
+            Button("Cancel", role: .cancel) { pending = nil }
+        }
+    }
+
+    /// The per-domain button set. Buttons stay disabled while any action is in
+    /// flight so a double tap can't queue two service calls at a lock.
+    private var controlsRow: some View {
+        HStack(spacing: 10) {
+            ForEach(actions) { action in
+                Button {
+                    if action.confirms {
+                        pending = action
+                    } else {
+                        Task { await fire(action) }
+                    }
+                } label: {
+                    HStack(spacing: 6) {
+                        if inFlight == action.action {
+                            ProgressView().controlSize(.small)
+                        } else {
+                            Image(systemName: action.symbol).font(.system(size: 13))
+                        }
+                        Text(action.title).font(.subheadline.weight(.medium))
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 9)
+                    .background(CrumbColors.surfaceVariant, in: RoundedRectangle(cornerRadius: 9))
+                    .foregroundColor(CrumbColors.textPrimary)
+                }
+                .buttonStyle(.plain)
+                .disabled(inFlight != nil)
+                .opacity(inFlight != nil && inFlight != action.action ? 0.5 : 1)
+            }
+        }
+        .padding(.top, 2)
+    }
+
+    /// One service call, with the button disabled for its duration. The shown
+    /// state is left alone either way; the 3s poll converges it.
+    private func fire(_ action: HAAction) async {
+        errorText = nil
+        inFlight = action.action
+        do {
+            try await controller.perform(link: link, action: action.action)
+        } catch {
+            errorText = message(for: error)
+        }
+        inFlight = nil
+    }
+
+    /// 403 reads as a permission denial, 502 as "Crumb is up, HA isn't"; anything
+    /// else falls through to the app's shared error phrasing.
+    private func message(for error: Error) -> String {
+        if let api = error as? APIError {
+            if api.isForbidden { return "You are not permitted to control this device." }
+            if api.isBadGateway { return "Home Assistant did not respond. The device was not changed." }
+            if case .http(let code, _) = api, code == 400 || code == 404 {
+                return "Home Assistant rejected that action."
+            }
+        }
+        return error.userMessage
     }
 
     private func detailRow(_ label: String, _ value: String) -> some View {
@@ -433,7 +621,7 @@ struct HAEntitySheet: View {
                 }
                 ForEach(controller.links.sorted { $0.sortOrder < $1.sortOrder }) { link in
                     NavigationLink {
-                        HAStateCard(link: link, state: controller.state(for: link.entityId), stale: controller.stale)
+                        HAStateCard(link: link, controller: controller)
                     } label: {
                         entityRow(link)
                     }

--- a/apps/ios/Crumb/Models/Models.swift
+++ b/apps/ios/Crumb/Models/Models.swift
@@ -46,23 +46,29 @@ struct Capabilities: Codable, Equatable {
     var clips: Bool
     var ptz: Bool
     var manageViews: Bool
+    /// Controlling physical devices (HA lights/locks/covers, and later the
+    /// Reolink actuators) — deny-by-default, issue #187. Absent on servers
+    /// before HA control Phase 2 ⇒ false ⇒ the controls stay hidden.
+    var actuators: Bool
     /// Bookmark access level: "none", "own", or "all".
     var bookmarks: String
 
     /// Admins implicitly hold every capability.
-    static let admin = Capabilities(export: true, playback: true, clips: true, ptz: true, manageViews: true, bookmarks: "all")
+    static let admin = Capabilities(export: true, playback: true, clips: true, ptz: true, manageViews: true, actuators: true, bookmarks: "all")
 
     /// True when the user may see/create any bookmarks at all.
     var canBookmark: Bool { bookmarks != "none" }
 
     init(export: Bool = false, playback: Bool = false, clips: Bool = false,
-         ptz: Bool = false, manageViews: Bool = false, bookmarks: String = "none") {
+         ptz: Bool = false, manageViews: Bool = false, actuators: Bool = false,
+         bookmarks: String = "none") {
         self.export = export; self.playback = playback; self.clips = clips
-        self.ptz = ptz; self.manageViews = manageViews; self.bookmarks = bookmarks
+        self.ptz = ptz; self.manageViews = manageViews; self.actuators = actuators
+        self.bookmarks = bookmarks
     }
 
     enum CodingKeys: String, CodingKey {
-        case export, playback, clips, ptz, bookmarks
+        case export, playback, clips, ptz, actuators, bookmarks
         case manageViews = "manage_views"
     }
 
@@ -73,6 +79,7 @@ struct Capabilities: Codable, Equatable {
         clips = try c.decodeIfPresent(Bool.self, forKey: .clips) ?? false
         ptz = try c.decodeIfPresent(Bool.self, forKey: .ptz) ?? false
         manageViews = try c.decodeIfPresent(Bool.self, forKey: .manageViews) ?? false
+        actuators = try c.decodeIfPresent(Bool.self, forKey: .actuators) ?? false
         bookmarks = try c.decodeIfPresent(String.self, forKey: .bookmarks) ?? "none"
     }
 }
@@ -464,8 +471,14 @@ struct LprConfigDto: Decodable {
 /// overlay placement/style; the read-only entity sheet ignores the `overlay*`
 /// fields. Mirrors the server `HaLinkDto`.
 struct HaLink: Decodable, Identifiable {
+    /// The link id. Sent back as `link_id` on `POST /cameras/:id/ha/action` —
+    /// the client never sends a raw HA entity id (issue #52 RBAC note). Decoded
+    /// from `id`, falling back to `link_id` if a server ever names it that way.
     let id: String
     let entityId: String
+    /// `"motion"`, `"sensor"`, or `"actuator"`. Only `actuator` links get
+    /// controls (issue #187); older servers that omit it fall back to `sensor`,
+    /// which renders read-only exactly as today.
     let role: String
     let deviceClass: String?
     let label: String?
@@ -495,9 +508,13 @@ struct HaLink: Decodable, Identifiable {
     var domain: String {
         entityId.firstIndex(of: ".").map { String(entityId[..<$0]) } ?? ""
     }
+    /// Controllable link (issue #187). Controls also require the `actuators`
+    /// capability — see `HAController.canActuate`.
+    var isActuator: Bool { role.caseInsensitiveCompare("actuator") == .orderedSame }
 
     enum CodingKeys: String, CodingKey {
         case id, role, label
+        case linkId = "link_id"
         case entityId = "entity_id"
         case deviceClass = "device_class"
         case sortOrder = "sort_order"
@@ -516,7 +533,11 @@ struct HaLink: Decodable, Identifiable {
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        id = try c.decode(String.self, forKey: .id)
+        if let plainId = try c.decodeIfPresent(String.self, forKey: .id) {
+            id = plainId
+        } else {
+            id = try c.decode(String.self, forKey: .linkId)
+        }
         entityId = try c.decode(String.self, forKey: .entityId)
         role = try c.decodeIfPresent(String.self, forKey: .role) ?? "sensor"
         deviceClass = try c.decodeIfPresent(String.self, forKey: .deviceClass)
@@ -564,6 +585,37 @@ struct HaStatesResponse: Decodable {
 
     func state(for entityId: String) -> HaEntityState? {
         states.first { $0.entityId == entityId }
+    }
+}
+
+/// Body of `POST /cameras/:id/ha/action` (issue #187). The client identifies the
+/// target by LINK id, never by raw HA entity id, so the server stays the only
+/// thing that can name an entity to Home Assistant.
+struct HaActionRequest: Encodable {
+    let linkId: String
+    /// One of the server's per-domain allow-list: `turn_on`/`turn_off`/`toggle`,
+    /// `open_cover`/`close_cover`/`stop_cover`, `lock`/`unlock`, `press`.
+    let action: String
+
+    enum CodingKeys: String, CodingKey {
+        case action
+        case linkId = "link_id"
+    }
+}
+
+/// `POST /cameras/:id/ha/action` response. Any 2xx is success; `ok` is decoded
+/// defensively (absent ⇒ true) so a leaner server response can't read as a
+/// failure after the service call already went through.
+struct HaActionResponse: Decodable {
+    let ok: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case ok
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        ok = try c.decodeIfPresent(Bool.self, forKey: .ok) ?? true
     }
 }
 

--- a/apps/ios/Crumb/Networking/CrumbAPI.swift
+++ b/apps/ios/Crumb/Networking/CrumbAPI.swift
@@ -292,6 +292,18 @@ final class CrumbAPI {
         try await get("ha/states")
     }
 
+    /// `POST /cameras/:id/ha/action` — actuate a linked HA entity (issue #187).
+    /// Requires the `actuators` capability plus access to the camera; the server
+    /// enforces a per-domain action allow-list and returns `403` (not permitted),
+    /// `400`/`404` (rejected link/action) or `502` (Home Assistant unreachable).
+    /// The caller does NOT flip local state on success: the `/ha/states` poll
+    /// stays the only source of truth for what the device is actually doing.
+    @discardableResult
+    func haAction(cameraId: String, linkId: String, action: String) async throws -> HaActionResponse {
+        try await post("cameras/\(cameraId)/ha/action",
+                       body: HaActionRequest(linkId: linkId, action: action))
+    }
+
     // MARK: - Saved Views (server-backed, per-user; shared with desktop/android/web)
 
     /// All views visible to the caller (own + legacy global + shared-with-me).
@@ -463,6 +475,13 @@ enum APIError: Error, LocalizedError {
     /// A capability/role denial (e.g. a non-admin attempting a watchlist write).
     var isForbidden: Bool {
         if case .http(let code, _) = self { return code == 403 }
+        return false
+    }
+
+    /// The server reached us but could not reach the thing behind it (an HA
+    /// service call with Home Assistant down). Distinct from a Crumb failure.
+    var isBadGateway: Bool {
+        if case .http(let code, _) = self { return code == 502 }
         return false
     }
 


### PR DESCRIPTION
iOS/macOS client half of #187 (HA control Phase 2). Server PR to follow; without it (or without the capability) this build is inert and byte-identical to the read-only Phase 1 UI.

## What
- `HAStateCard` (the shared more-info surface reached from both the on-video badge tap and the per-camera sheet) gains an action row for `role='actuator'` links: On/Off (light, switch, fan, siren), Open/Stop/Close (cover), Lock/Unlock (lock), Press (button), Activate/Run (scene/script). Unknown domains stay read-only, no guessed service calls.
- Gated on the new `actuators` capability from `/auth/me` (`decodeIfPresent ?? false`, so older servers hide the controls and decoding never breaks) AND the link's role. Admin implies.
- Lock and cover actions require a confirmation dialog ("Unlock Front Door?"); Unlock/Open carry the destructive button role. Lights and buttons fire immediately.
- In-flight: tapped button becomes a spinner, all buttons disabled (no double-fire at a lock). State is never flipped locally; one immediate poll is triggered and the 3s `/ha/states` poll stays the single source of truth.
- Sends `{link_id, action}` only (explicit CodingKeys, wire-verified); the client never names a raw HA entity id to the server. Link id decodes from either `id` (today's payload) or `link_id`.
- Errors are terse and honest: 403 reads as not permitted, 502 as "Home Assistant did not respond. The device was not changed."

## Verification
Built on the Mac build host (Crumb-mac scheme, shared sources): BUILD SUCCEEDED. On-device tap-through against a real HA instance still needed once the server PR lands.