### PR TITLE
feat(desktop): HA device controls on the on-video badge card (#187)

### DIFF
--- a/apps/desktop-flutter/lib/api/boot_api.dart
+++ b/apps/desktop-flutter/lib/api/boot_api.dart
@@ -44,6 +44,14 @@ class MeResponse {
   /// clients must NOT re-derive it from [capabilities]. Absent → false.
   final bool platesEnabled;
 
+  /// Whether this account may actuate HA entities linked to a camera
+  /// (`POST /cameras/:id/ha/action`, issue #187). Server-side truth: the
+  /// `actuators` capability is deny-by-default and admin sessions get it set
+  /// by the server, so clients read the flag rather than re-deriving it from
+  /// [isAdmin]. Absent (older server) or non-boolean → false, which simply
+  /// means no control buttons render — identical to today's read-only badges.
+  bool get canActuate => capabilities['actuators'] == true;
+
   factory MeResponse.fromJson(Map<String, dynamic> j) => MeResponse(
     id: j['id'] as String,
     username: j['username'] as String,

--- a/apps/desktop-flutter/lib/api/ha_api.dart
+++ b/apps/desktop-flutter/lib/api/ha_api.dart
@@ -44,6 +44,15 @@
 //                                                       authenticated user;
 //                                                       RBAC-projected to the
 //                                                       caller's cameras)
+//   POST /cameras/{id}/ha/action  body {link_id,action} -> {ok:true}. Requires
+//                                                       the `actuators`
+//                                                       capability (issue
+//                                                       #187); 403 without
+//                                                       it, 400/404 on a
+//                                                       rejected action or
+//                                                       unknown link, 502
+//                                                       when HA is
+//                                                       unreachable.
 
 import 'dart:convert';
 
@@ -289,6 +298,49 @@ extension HaApi on CrumbApi {
     }
     return HaStatesSnapshot.fromJson(
       jsonDecode(resp.body) as Map<String, dynamic>,
+    );
+  }
+
+  /// POST /cameras/{id}/ha/action — actuate a linked HA entity (issue #187,
+  /// HA control Phase 2). The client sends the LINK id, never a raw HA
+  /// entity_id, and `action` must be one of the server's allowed strings for
+  /// that entity's domain (`ha_overlay/ha_actions.dart` mirrors the same
+  /// table, so the UI never offers a button the server would refuse).
+  ///
+  /// Requires the `actuators` capability — deny-by-default, so a viewer who
+  /// can see a camera cannot actuate its devices unless granted. Throws
+  /// [CrumbApiException] with `statusCode` on any non-200 and a message
+  /// already suitable for an operator-facing toast:
+  /// - `403` — not permitted for this account.
+  /// - `400`/`404` — the server rejected the action or the link is gone.
+  /// - `502` — Home Assistant is unreachable.
+  ///
+  /// Returns normally on success. Callers must NOT flip the badge locally:
+  /// the 3s `/ha/states` poll is what converges the displayed state.
+  Future<void> haAction(
+    Session s,
+    String cameraId, {
+    required String linkId,
+    required String action,
+  }) async {
+    final resp = await sharedHttpClient.post(
+      Uri.parse('${s.base}/cameras/$cameraId/ha/action'),
+      headers: {
+        'authorization': 'Bearer ${s.token}',
+        'content-type': 'application/json',
+      },
+      body: jsonEncode({'link_id': linkId, 'action': action}),
+    );
+    if (resp.statusCode == 200) return;
+    final detail = _errorDetail(resp).trim();
+    throw CrumbApiException(
+      switch (resp.statusCode) {
+        403 => 'Not permitted.',
+        502 => 'Home Assistant is unreachable.',
+        400 || 404 when detail.isNotEmpty => detail,
+        _ => 'HTTP ${resp.statusCode}.',
+      },
+      statusCode: resp.statusCode,
     );
   }
 }

--- a/apps/desktop-flutter/lib/api/ha_models.dart
+++ b/apps/desktop-flutter/lib/api/ha_models.dart
@@ -27,10 +27,15 @@ class HaLink {
     this.overlayOutline = false,
   });
 
-  final String id; // UUID
+  /// The link's own UUID — this is the `link_id` the control endpoint takes
+  /// (`POST /cameras/:id/ha/action`, issue #187). The client never sends a raw
+  /// HA entity_id anywhere.
+  final String id;
+
   final String entityId;
 
-  /// `"motion" | "sensor" | "actuator"` (see migration 0048).
+  /// `"motion" | "sensor" | "actuator"` (see migration 0048). Only
+  /// `"actuator"` links can be controlled.
   final String role;
 
   /// HA `device_class` (`door`, `motion`, ...), binary_sensor links only.
@@ -92,7 +97,10 @@ class HaLink {
       (label != null && label!.trim().isNotEmpty) ? label! : entityId;
 
   factory HaLink.fromJson(Map<String, dynamic> j) => HaLink(
-    id: j['id'] as String,
+    // `id` is what the links DTO has always emitted; `link_id` is tolerated
+    // as an alias so a server that spells it that way still parses. Still
+    // throws (loudly) if neither is present.
+    id: (j['id'] ?? j['link_id']) as String,
     entityId: j['entity_id'] as String,
     role: (j['role'] as String?) ?? 'sensor',
     deviceClass: j['device_class'] as String?,

--- a/apps/desktop-flutter/lib/main.dart
+++ b/apps/desktop-flutter/lib/main.dart
@@ -538,6 +538,13 @@ class _MainShellState extends State<MainShell> with WindowListener {
   /// admin-only server-side); the server's 403 is still the authority.
   bool _isAdmin = false;
 
+  /// Server-side truth (`GET /auth/me` → `capabilities.actuators`) for whether
+  /// this account may control HA devices linked to a camera (issue #187).
+  /// Gates the on-video badge card's control buttons; false (including against
+  /// an older server that doesn't send the key) keeps the badges read-only.
+  /// The server's 403 is still the authority.
+  bool _canActuate = false;
+
   /// The applied saved view (null → the default "All Cameras" auto-grid wall),
   /// and the id used to highlight the active chip in the view-selector row.
   AppliedView? _appliedView;
@@ -610,18 +617,25 @@ class _MainShellState extends State<MainShell> with WindowListener {
     _loadCapabilities();
   }
 
-  /// Resolve the capability gate for the Plates tab. The app otherwise gates
-  /// nothing on capabilities, so this is the one `/auth/me` call the shell
-  /// makes; it stores only [MeResponse.platesEnabled]. Best-effort — a failure
-  /// leaves the tab hidden rather than surfacing an error.
+  /// Resolve the capability gates the shell owns: the Plates tab
+  /// ([MeResponse.platesEnabled]) and HA device control
+  /// ([MeResponse.canActuate], issue #187). This is the one `/auth/me` call
+  /// the shell makes. Best-effort — a failure leaves both false, so the tab
+  /// stays hidden and the HA badges stay read-only rather than surfacing an
+  /// error.
   Future<void> _loadCapabilities() async {
     try {
       final me = await widget.api.fetchMe(widget.sessionController.session);
       if (!mounted) return;
-      if (me.platesEnabled == _platesEnabled && me.isAdmin == _isAdmin) return;
+      if (me.platesEnabled == _platesEnabled &&
+          me.isAdmin == _isAdmin &&
+          me.canActuate == _canActuate) {
+        return;
+      }
       setState(() {
         _platesEnabled = me.platesEnabled;
         _isAdmin = me.isAdmin;
+        _canActuate = me.canActuate;
       });
     } catch (_) {
       // Leave _platesEnabled false — the Plates tab simply stays hidden.
@@ -1341,6 +1355,10 @@ class _MainShellState extends State<MainShell> with WindowListener {
           // (issue #52 desktop port) — `PUT /cameras/:id/ha/links` is
           // admin-enforced server-side regardless.
           isAdmin: _isAdmin,
+          // Gates the on-video HA badge card's control buttons (issue #187);
+          // `POST /cameras/:id/ha/action` enforces the capability server-side
+          // regardless.
+          canActuate: _canActuate,
           // The wall listens to client options so the per-tile header bar
           // (showInfoBar) restyles live when toggled in the Settings panel.
           clientOptions: widget.clientOptions,

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_actions.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_actions.dart
@@ -1,0 +1,145 @@
+// The HA control-action table for the on-video badge detail card (issue #187,
+// HA control Phase 2 — the epic's P3 "actuators endpoint + RBAC + buttons").
+//
+// This mirrors the server's allow-list for `POST /cameras/{id}/ha/action`
+// EXACTLY: the set of actions a client may ask for is derived from the linked
+// entity's DOMAIN (the entity_id prefix before the first dot), and the server
+// rejects anything outside its own copy of this table with a 400. Keeping the
+// client's button set derived from the same table means an operator never sees
+// a button that the server would refuse.
+//
+//   light, switch, fan, siren  -> turn_on / turn_off / toggle
+//   cover                      -> open_cover / close_cover / stop_cover
+//   lock                       -> lock / unlock
+//   button, input_button       -> press
+//   scene, script              -> turn_on
+//
+// Anything else (binary_sensor, sensor, an unknown domain from a newer HA)
+// yields NO actions, so the card stays read-only exactly as it is today.
+//
+// [HaControlAction.confirm] marks the physical-security domains (locks and
+// covers): those fire only after an explicit confirm step, because a stray
+// click on a wall tile must not unlock a door or open a garage. Lights,
+// switches, buttons and scenes fire immediately.
+
+import 'package:flutter/material.dart';
+
+/// One button on the badge detail card's control row.
+class HaControlAction {
+  const HaControlAction({
+    required this.action,
+    required this.label,
+    required this.icon,
+    this.confirm = false,
+  });
+
+  /// The wire value sent as the request's `action` field. Must be one of the
+  /// server's allowed strings for the entity's domain.
+  final String action;
+
+  /// Button caption, also used to build the confirm prompt
+  /// ("Unlock Front Door?") — see [haConfirmPrompt].
+  final String label;
+
+  final IconData icon;
+
+  /// Require an explicit confirm before firing (locks + covers).
+  final bool confirm;
+}
+
+/// light / switch / fan / siren. Two explicit intents rather than a single
+/// `toggle`: on a security console "make it on" beats "flip whatever it is",
+/// and the card already shows the live state right above these buttons.
+const List<HaControlAction> _kOnOffActions = [
+  HaControlAction(
+    action: 'turn_on',
+    label: 'On',
+    icon: Icons.power_settings_new,
+  ),
+  HaControlAction(action: 'turn_off', label: 'Off', icon: Icons.power_off),
+];
+
+/// cover — Open / Stop / Close, in the order HA itself renders them.
+const List<HaControlAction> _kCoverActions = [
+  HaControlAction(
+    action: 'open_cover',
+    label: 'Open',
+    icon: Icons.keyboard_arrow_up,
+    confirm: true,
+  ),
+  HaControlAction(
+    action: 'stop_cover',
+    label: 'Stop',
+    icon: Icons.stop,
+    confirm: true,
+  ),
+  HaControlAction(
+    action: 'close_cover',
+    label: 'Close',
+    icon: Icons.keyboard_arrow_down,
+    confirm: true,
+  ),
+];
+
+const List<HaControlAction> _kLockActions = [
+  HaControlAction(
+    action: 'lock',
+    label: 'Lock',
+    icon: Icons.lock_outline,
+    confirm: true,
+  ),
+  HaControlAction(
+    action: 'unlock',
+    label: 'Unlock',
+    icon: Icons.lock_open,
+    confirm: true,
+  ),
+];
+
+const List<HaControlAction> _kPressActions = [
+  HaControlAction(action: 'press', label: 'Press', icon: Icons.touch_app),
+];
+
+/// scene — HA's service is `turn_on`; "Activate" is what it reads as.
+const List<HaControlAction> _kSceneActions = [
+  HaControlAction(
+    action: 'turn_on',
+    label: 'Activate',
+    icon: Icons.auto_awesome,
+  ),
+];
+
+/// script — also `turn_on` on the wire.
+const List<HaControlAction> _kScriptActions = [
+  HaControlAction(action: 'turn_on', label: 'Run', icon: Icons.play_arrow),
+];
+
+/// The actions the server will accept for an entity in [domain]; empty for
+/// every domain that has no control path (the card then renders read-only).
+List<HaControlAction> haActionsForDomain(String domain) {
+  switch (domain) {
+    case 'light':
+    case 'switch':
+    case 'fan':
+    case 'siren':
+      return _kOnOffActions;
+    case 'cover':
+      return _kCoverActions;
+    case 'lock':
+      return _kLockActions;
+    case 'button':
+    case 'input_button':
+      return _kPressActions;
+    case 'scene':
+      return _kSceneActions;
+    case 'script':
+      return _kScriptActions;
+    default:
+      return const [];
+  }
+}
+
+/// The confirm-step prompt for a physical-security action, e.g.
+/// "Unlock Front Door?" / "Close Garage Door?".
+String haConfirmPrompt(HaControlAction action, String friendlyName) =>
+    '${action.label} $friendlyName?';

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_layer.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_layer.dart
@@ -14,8 +14,11 @@
 //   per the link's `overlay_show_state`/`overlay_show_age` toggles;
 // * a hover reveal — mousing over a badge shows state + age even when not
 //   pinned (desktop has a mouse; `OverlayEditorLayer.onHoverItem`);
-// * the read-only `HaStateCard` on tap, placed beside the badge and flipped/
-//   clamped away from the pane edges.
+// * the `HaStateCard` on tap, placed beside the badge and flipped/clamped away
+//   from the pane edges. Read-only by default; when the host passes the
+//   actuation plumbing (`api`/`session`/`cameraId`) AND this account holds the
+//   `actuators` capability, an `actuator`-role link's card also carries the
+//   control buttons for its domain (issue #187, HA control Phase 2).
 //
 // Purely a display widget: everything comes via the constructor, no
 // controller/global lookups (it builds its own private, ephemeral
@@ -41,10 +44,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/physics.dart';
 
+import '../../api/crumb_api.dart';
+import '../../api/ha_api.dart';
 import '../../api/ha_models.dart';
+import '../../api/models.dart';
 import '../overlay_editor/overlay_editor_controller.dart';
 import '../overlay_editor/overlay_editor_layer.dart';
 import '../overlay_editor/overlay_geometry.dart';
+import 'ha_actions.dart';
 import 'ha_icons.dart';
 import 'ha_overlay_controller.dart' show HaOverlayBadgeItem;
 import 'ha_state_card.dart';
@@ -456,6 +463,10 @@ class HaOverlayLayer extends StatefulWidget {
     this.videoW,
     this.videoH,
     this.hideBadges = false,
+    this.api,
+    this.session,
+    this.cameraId,
+    this.canActuate = false,
   });
 
   /// The camera's linked entities (incl. placement) — only the PLACED ones
@@ -484,6 +495,19 @@ class HaOverlayLayer extends StatefulWidget {
   /// `_scale > 1.01`.
   final bool hideBadges;
 
+  /// Actuation plumbing (issue #187). All three must be non-null for the tap
+  /// card to offer controls; a host that hasn't wired them keeps today's
+  /// read-only card.
+  final CrumbApi? api;
+  final Session? session;
+  final String? cameraId;
+
+  /// Server-side truth (`GET /auth/me` → `capabilities.actuators`, see
+  /// `MeResponse.canActuate`) for whether this account may actuate. False —
+  /// including against an older server that doesn't send the key — renders
+  /// the card exactly as it is today, with no hint that controls exist.
+  final bool canActuate;
+
   @override
   State<HaOverlayLayer> createState() => _HaOverlayLayerState();
 }
@@ -505,6 +529,9 @@ class _HaOverlayLayerState extends State<HaOverlayLayer> {
   /// Rough height estimates for flip/clamp decisions (the real widgets
   /// self-size; these only pick which side of the badge to render on).
   static const double _cardEstHeight = 150;
+
+  /// Extra estimated height once the card carries a control row (issue #187).
+  static const double _cardControlsEstHeight = 52;
 
   @override
   void dispose() {
@@ -611,6 +638,56 @@ class _HaOverlayLayerState extends State<HaOverlayLayer> {
     return null;
   }
 
+  /// The control buttons to offer for [link] (issue #187), or empty for the
+  /// read-only card. Both gates must pass: the account holds the `actuators`
+  /// capability AND this link is an actuator (a motion/door sensor link is
+  /// never controllable, even for an admin). The domain table then decides
+  /// the button set, mirroring the server's allow-list.
+  List<HaControlAction> _actionsFor(HaLink link) {
+    if (!widget.canActuate || link.role != 'actuator') return const [];
+    if (widget.api == null ||
+        widget.session == null ||
+        widget.cameraId == null) {
+      return const [];
+    }
+    return haActionsForDomain(link.domain);
+  }
+
+  /// POST the action and surface any failure as a toast. Never throws; returns
+  /// whether the server accepted it, which is all the card needs to decide
+  /// between "settling" and "hand the buttons back". Deliberately does NOT
+  /// flip the badge locally: the 3s `/ha/states` poll converges the state.
+  Future<bool> _runAction(HaLink link, String action) async {
+    final api = widget.api;
+    final session = widget.session;
+    final cameraId = widget.cameraId;
+    if (api == null || session == null || cameraId == null) return false;
+    try {
+      await api.haAction(
+        session,
+        cameraId,
+        linkId: link.id,
+        action: action,
+      );
+      return true;
+    } on CrumbApiException catch (e) {
+      _toast(
+        e.statusCode == 403
+            ? 'Not permitted: this account cannot control devices.'
+            : 'Action failed. ${e.message}',
+      );
+    } catch (_) {
+      _toast('Action failed. The server could not be reached.');
+    }
+    return false;
+  }
+
+  void _toast(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+      SnackBar(content: Text(message), duration: const Duration(seconds: 4)),
+    );
+  }
 
   /// The tap card, placed BESIDE the tapped badge (right by preference,
   /// flipped left near the right edge; vertically clamped into the pane) —
@@ -635,8 +712,11 @@ class _HaOverlayLayerState extends State<HaOverlayLayer> {
     if (left + _cardWidth > paneW - 4) {
       left = (x - 8 - _cardWidth).clamp(4.0, double.infinity).toDouble();
     }
+    final actions = _actionsFor(open);
+    final estHeight =
+        _cardEstHeight + (actions.isEmpty ? 0.0 : _cardControlsEstHeight);
     final top = y
-        .clamp(4.0, (paneH - _cardEstHeight).clamp(4.0, double.infinity))
+        .clamp(4.0, (paneH - estHeight).clamp(4.0, double.infinity))
         .toDouble();
     return Positioned(
       left: left,
@@ -651,6 +731,10 @@ class _HaOverlayLayerState extends State<HaOverlayLayer> {
         iconOverride: open.overlayIcon,
         colorOverride: parseOverlayColorHex(open.overlayColor),
         onDismiss: () => setState(() => _openLinkId = null),
+        actions: actions,
+        onAction: actions.isEmpty
+            ? null
+            : (action) => _runAction(open, action),
       ),
     );
   }

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_state_card.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_state_card.dart
@@ -1,7 +1,24 @@
-// Read-only detail card shown when an operator taps a placed HA badge (issue
-// #170 POC — no controls, see the desktop P0 plan §4.6/§1 locked decision
-// #3). Friendly name, current state, a relative "N ago" from `last_changed`,
-// the raw entity_id in mono-dim, and a stale note when applicable.
+// Detail ("more info") card shown when an operator taps a placed HA badge
+// (issue #170 POC). Friendly name, current state, a relative "N ago" from
+// `last_changed`, the raw entity_id in mono-dim, and a stale note when
+// applicable.
+//
+// Issue #187 (HA control Phase 2) adds an optional CONTROL row at the bottom:
+// the buttons for the entity's domain (`ha_actions.dart`, which mirrors the
+// server's allow-list). The host decides whether to pass any — it renders
+// controls only when the account holds the `actuators` capability AND the link
+// is an `actuator` role, so an unprivileged operator sees the card exactly as
+// it looked before, with no hint that controls exist.
+//
+// Control semantics:
+// * lock/cover actions ask for an explicit confirm first (a stray click on a
+//   wall tile must not unlock a door);
+// * a fired action shows an in-flight spinner, then a short "sent" settle
+//   during which the buttons stay disabled — the card NEVER flips the state
+//   locally, the host's 3s `/ha/states` poll is what converges the badge;
+// * failures are surfaced by the HOST (a toast), not inline: `onAction` is
+//   contracted never to throw, and resolves false on failure so the buttons
+//   come straight back.
 //
 // This widget is just the card's CONTENT (plus swallowing taps on itself so
 // a host's tap-away scrim underneath doesn't dismiss when the card itself is
@@ -9,12 +26,20 @@
 // wiring tap-away/Esc dismissal, matching `PtzPanelEditorBar`'s
 // plain-content-widget pattern (no Dialog/route machinery).
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../../api/ha_models.dart';
+import 'ha_actions.dart';
 import 'ha_icons.dart';
 
-class HaStateCard extends StatelessWidget {
+/// How long the buttons stay disabled after a successful action, so the
+/// operator sees the request landed while the next `/ha/states` poll (3s)
+/// brings the real state back.
+const Duration _kSettleWindow = Duration(milliseconds: 3200);
+
+class HaStateCard extends StatefulWidget {
   const HaStateCard({
     super.key,
     required this.entityId,
@@ -26,6 +51,8 @@ class HaStateCard extends StatelessWidget {
     this.iconOverride,
     this.colorOverride,
     this.onDismiss,
+    this.actions = const [],
+    this.onAction,
   });
 
   final String entityId;
@@ -42,16 +69,104 @@ class HaStateCard extends StatelessWidget {
 
   final VoidCallback? onDismiss;
 
+  /// Control buttons to offer (issue #187). Empty (the default) keeps the
+  /// card exactly read-only. The host is responsible for the capability +
+  /// role gate; this widget renders whatever it is handed.
+  final List<HaControlAction> actions;
+
+  /// Fires one action, by its wire string, and resolves to whether the server
+  /// accepted it. Contracted NOT to throw: the host performs the POST and
+  /// surfaces any failure itself (toast), resolving `false` so this card can
+  /// drop its pending state immediately instead of sitting through the
+  /// convergence window. Null (or an empty [actions]) means no controls.
+  final Future<bool> Function(String action)? onAction;
+
+  @override
+  State<HaStateCard> createState() => _HaStateCardState();
+}
+
+class _HaStateCardState extends State<HaStateCard> {
+  /// The action currently in flight or settling, or null when idle.
+  String? _pending;
+
+  /// True once the POST returned and we are just waiting for the state poll
+  /// to catch up (spinner becomes a check).
+  bool _sent = false;
+
+  Timer? _settle;
+
+  @override
+  void dispose() {
+    _settle?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _fire(HaControlAction action) async {
+    final run = widget.onAction;
+    if (run == null || _pending != null) return;
+    if (action.confirm) {
+      final ok = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: Text(haConfirmPrompt(action, widget.friendlyName)),
+          content: Text(
+            'This controls a real device through Home Assistant.',
+            style: TextStyle(color: Theme.of(ctx).hintColor, fontSize: 12.5),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(true),
+              child: Text(action.label),
+            ),
+          ],
+        ),
+      );
+      if (ok != true || !mounted) return;
+    }
+    setState(() {
+      _pending = action.action;
+      _sent = false;
+    });
+    final ok = await run(action.action);
+    if (!mounted) return;
+    if (!ok) {
+      // The host already surfaced the failure; hand the buttons straight back
+      // so the operator can retry.
+      setState(() {
+        _pending = null;
+        _sent = false;
+      });
+      return;
+    }
+    // Accepted: hold the "sent" state for the convergence window, then let the
+    // polled state speak for itself.
+    setState(() => _sent = true);
+    _settle?.cancel();
+    _settle = Timer(_kSettleWindow, () {
+      if (!mounted) return;
+      setState(() {
+        _pending = null;
+        _sent = false;
+      });
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final visual = haVisualFor(
-      domain: domain,
-      deviceClass: deviceClass,
-      state: state?.state,
-      stale: stale,
-      iconOverride: iconOverride,
-      colorOverride: colorOverride,
+      domain: widget.domain,
+      deviceClass: widget.deviceClass,
+      state: widget.state?.state,
+      stale: widget.stale,
+      iconOverride: widget.iconOverride,
+      colorOverride: widget.colorOverride,
     );
+    final onDismiss = widget.onDismiss;
+    final state = widget.state;
     return GestureDetector(
       // Swallow taps on the card so a tap-away scrim behind it (drawn by the
       // host) doesn't treat "tapping the card" as "tapping away".
@@ -77,7 +192,7 @@ class HaStateCard extends StatelessWidget {
                   const SizedBox(width: 8),
                   Expanded(
                     child: Text(
-                      friendlyName,
+                      widget.friendlyName,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: const TextStyle(
@@ -116,14 +231,14 @@ class HaStateCard extends StatelessWidget {
               ],
               const SizedBox(height: 6),
               Text(
-                entityId,
+                widget.entityId,
                 style: const TextStyle(
                   color: Colors.white38,
                   fontSize: 10.5,
                   fontFamily: 'monospace',
                 ),
               ),
-              if (stale) ...[
+              if (widget.stale) ...[
                 const SizedBox(height: 6),
                 const Text(
                   '⚠ Stale — Home Assistant connection may be down',
@@ -134,6 +249,12 @@ class HaStateCard extends StatelessWidget {
                   ),
                 ),
               ],
+              if (widget.actions.isNotEmpty && widget.onAction != null) ...[
+                const SizedBox(height: 8),
+                const Divider(height: 1, color: Colors.white12),
+                const SizedBox(height: 8),
+                _controlRow(),
+              ],
             ],
           ),
         ),
@@ -141,4 +262,72 @@ class HaStateCard extends StatelessWidget {
     );
   }
 
+  /// The control buttons (issue #187). Wrapped so a three-button cover row
+  /// still fits the card's 260px cap on a narrow layout.
+  Widget _controlRow() {
+    final busy = _pending != null;
+    return Wrap(
+      spacing: 6,
+      runSpacing: 6,
+      children: [
+        for (final a in widget.actions)
+          _ControlButton(
+            action: a,
+            // Pending on THIS button shows the progress/sent glyph; every
+            // other button just goes disabled until the settle window ends.
+            pending: _pending == a.action,
+            sent: _pending == a.action && _sent,
+            onPressed: busy ? null : () => unawaited(_fire(a)),
+          ),
+      ],
+    );
+  }
+}
+
+/// One control button: icon + caption, swapping the icon for a spinner while
+/// the request is in flight and a check for the settle window after it lands.
+class _ControlButton extends StatelessWidget {
+  const _ControlButton({
+    required this.action,
+    required this.pending,
+    required this.sent,
+    required this.onPressed,
+  });
+
+  final HaControlAction action;
+  final bool pending;
+  final bool sent;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final Widget leading;
+    if (pending && !sent) {
+      leading = const SizedBox(
+        width: 13,
+        height: 13,
+        child: CircularProgressIndicator(strokeWidth: 2),
+      );
+    } else if (pending) {
+      leading = const Icon(Icons.check, size: 15);
+    } else {
+      leading = Icon(action.icon, size: 15);
+    }
+    return TextButton.icon(
+      onPressed: onPressed,
+      icon: leading,
+      label: Text(action.label, style: const TextStyle(fontSize: 12)),
+      style: TextButton.styleFrom(
+        foregroundColor: Colors.white,
+        backgroundColor: Colors.white10,
+        disabledForegroundColor: Colors.white38,
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        minimumSize: Size.zero,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(6),
+        ),
+      ),
+    );
+  }
 }

--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -74,6 +74,7 @@ class WallScreen extends StatefulWidget {
     required this.cameras,
     required this.onLogout,
     required this.isAdmin,
+    this.canActuate = false,
     this.clientOptions,
     this.streamPrefs,
     this.view,
@@ -97,6 +98,14 @@ class WallScreen extends StatefulWidget {
   /// camera's HA links need only camera access, but writing them
   /// (`PUT /cameras/:id/ha/links`) is admin-enforced server-side regardless.
   final bool isAdmin;
+
+  /// Server-side truth (`GET /auth/me` → `capabilities.actuators`, see
+  /// `main.dart`'s `_canActuate`) for whether this account may control HA
+  /// devices (issue #187). Passed down to every tile/pane's HA badge layer:
+  /// false renders today's read-only badge card with no hint that controls
+  /// exist. `POST /cameras/:id/ha/action` enforces the capability server-side
+  /// regardless.
+  final bool canActuate;
 
   /// Play-on-focus audio controller (single audible pane). Tiles register
   /// their Player; selection/maximize pick the active pane.
@@ -660,6 +669,7 @@ class _WallScreenState extends State<WallScreen> {
                   PtzWheelCorner.bottomLeft,
               haOverlay: _haOverlay,
               isAdmin: widget.isAdmin,
+              canActuate: widget.canActuate,
               onEditHaOverlay: () => unawaited(_beginHaOverlayEdit(_maximized!)),
               onHaOverlayDone: () => unawaited(_endHaOverlayEdit()),
               onEditPtzPanel: () => unawaited(_beginPtzPanelEdit(_maximized!)),
@@ -840,6 +850,7 @@ class _WallScreenState extends State<WallScreen> {
                     onHaLinksLoaded: _onHaLinksLoaded,
                     onUnauthorized: widget.onUnauthorized,
                     isAdmin: widget.isAdmin,
+                    canActuate: widget.canActuate,
                   );
           }
           children.add(
@@ -910,6 +921,7 @@ class _WallScreenState extends State<WallScreen> {
                 onHaLinksLoaded: _onHaLinksLoaded,
                 onUnauthorized: widget.onUnauthorized,
                 isAdmin: widget.isAdmin,
+                canActuate: widget.canActuate,
               ),
             ),
           );
@@ -986,6 +998,7 @@ class _WallTile extends StatefulWidget {
     this.onHaLinksLoaded,
     this.onUnauthorized,
     this.isAdmin = false,
+    this.canActuate = false,
     this.paneIdOverride,
   });
 
@@ -1030,6 +1043,11 @@ class _WallTile extends StatefulWidget {
   /// server-side regardless; this only avoids showing an item that would
   /// 403 for a non-admin.
   final bool isAdmin;
+
+  /// Whether this account holds the `actuators` capability (issue #187) —
+  /// handed to this tile's HA badge layer so an actuator link's tap card can
+  /// offer control buttons. False keeps the card read-only.
+  final bool canActuate;
 
   /// When true, digitally zooming this tile past 100% temporarily loads its
   /// main stream (reverting to sub at 100%). From the "Zoom switches to main
@@ -1864,6 +1882,12 @@ class _WallTileState extends State<_WallTile> {
                         videoW: _videoW,
                         videoH: _videoH,
                         hideBadges: _scale > 1.01,
+                        // Actuation plumbing for the badge tap card (#187) —
+                        // inert unless the account holds `actuators`.
+                        api: widget.api,
+                        session: widget.session,
+                        cameraId: widget.camera.id,
+                        canActuate: widget.canActuate,
                       ),
                     ),
                   ),
@@ -1983,6 +2007,7 @@ class _MaximizedPane extends StatefulWidget {
     this.ptzWheelCorner = PtzWheelCorner.bottomLeft,
     this.haOverlay,
     this.isAdmin = false,
+    this.canActuate = false,
     this.onEditHaOverlay,
     this.onHaOverlayDone,
     this.onEditPtzPanel,
@@ -2003,6 +2028,10 @@ class _MaximizedPane extends StatefulWidget {
   /// entities…" item (mirrors `_WallTile.isAdmin`; the PUT is admin-enforced
   /// server-side regardless).
   final bool isAdmin;
+
+  /// Whether this account holds the `actuators` capability (issue #187) —
+  /// see `_WallTile.canActuate`; same contract.
+  final bool canActuate;
 
   /// The wall tile's live controller for this camera, if it was already
   /// decoding when we maximized. Painted full-pane (sub stream, upscaled) as
@@ -2897,6 +2926,12 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
                         videoW: _videoW,
                         videoH: _videoH,
                         hideBadges: _scale > 1.01,
+                        // Actuation plumbing for the badge tap card (#187) —
+                        // inert unless the account holds `actuators`.
+                        api: widget.api,
+                        session: widget.session,
+                        cameraId: widget.camera.id,
+                        canActuate: widget.canActuate,
                       ),
                     ),
                   ),


### PR DESCRIPTION
Desktop client half of #187 (HA control Phase 2). Server PR to follow; without it (or without the capability grant) this build renders byte-identically to today's read-only overlay.

## What
- The existing badge-tap `HaStateCard` gains a control row for `role='actuator'` links: On/Off (light, switch, fan, siren), Open/Stop/Close (cover), Lock/Unlock (lock), Press (button), Activate/Run (scene/script). The domain-to-actions table (`ha_actions.dart`) mirrors the server allowlist; unknown domains stay read-only.
- Gated on the new `actuators` capability from `/auth/me` (absent or non-boolean reads as false) AND the link role, plumbed `main.dart` -> `WallScreen` -> tile/maximized panes -> `HaOverlayLayer`, all optional-with-default so no other call sites move.
- Cover and lock actions get an AlertDialog confirm ("Close Garage Door?", body: "This controls a real device through Home Assistant."); everything else fires immediately.
- In-flight: pressed button becomes a spinner, all buttons disable; success shows a check and holds a 3.2s settle window while the 3s `/ha/states` poll converges the badge; failure re-enables immediately. State is never flipped locally.
- Sends `{link_id, action}` with the link's uuid (today's payload names it `id`; fromJson hedges `id`/`link_id`). 403 toasts as not-permitted; 502 as "Home Assistant is unreachable."

## Verification
`flutter analyze` on the Windows build box: 0 errors; only pre-existing style infos in touched files. Live tap-through needs the server PR + a real HA instance.