### PR TITLE
feat(api): HA control Phase 2, service-call endpoint + actuators capability (#187)

### DIFF
--- a/db/migrations/0074_role_actuators_capability.sql
+++ b/db/migrations/0074_role_actuators_capability.sql
@@ -1,0 +1,23 @@
+-- 0074_role_actuators_capability.sql — the `actuators` role capability.
+--
+-- Capabilities live in the `roles.capabilities` jsonb (migration 0028), so a new
+-- capability needs no column: the Rust `Capabilities` struct reads a missing key
+-- as its serde default, and `actuators` defaults to FALSE (deny). This migration
+-- therefore changes NO effective permission. It exists to (a) make the new key
+-- explicit in stored rows so the admin console's checkbox reflects real stored
+-- state rather than an implied default, and (b) record in the schema history
+-- when the capability appeared.
+--
+-- `actuators` gates `POST /cameras/:id/ha/action` (issue #187) and, later, the
+-- Reolink actuators: operating PHYSICAL devices, garage doors, locks, sirens,
+-- linked to a camera. It is deny-by-default on purpose. Being able to SEE a
+-- camera, or even the live state of its linked entities, must never imply being
+-- able to operate them. Admin roles bypass capabilities entirely (`is_admin`),
+-- so they are left untouched here.
+--
+-- Idempotent: only rows that do not already carry the key are touched.
+
+UPDATE roles
+SET capabilities = capabilities || '{"actuators": false}'::jsonb
+WHERE NOT is_admin
+  AND NOT (capabilities ? 'actuators');

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,76 @@ revisit.
 
 ---
 
+## 2026-08-01, Home Assistant control is a strict per-domain action allowlist addressed by `link_id`, gated on a new default-off `actuators` capability
+
+**Context.** The HA integration has been read-only since Phase 1 (config
+singleton + `camera_ha_links` + an entity picker that proxies HA so the token
+never reaches a client). Issue #187 adds the control path: an operator watching
+the garage on camera should be able to close it from the same view. This is the
+only endpoint in Crumb that actuates PHYSICAL hardware, and the HA long-lived
+access token Crumb holds is unscoped, so anything a client can talk Crumb into
+asking HA for, it gets. The design question is how much of the HA service call a
+client is allowed to influence.
+
+**Decision, `POST /cameras/:id/ha/action` with a body of exactly
+`{link_id, action}`, and nothing else.** The client names a `camera_ha_links`
+row the operator authored and one action *word*. The server derives the HA
+domain from that row's stored `entity_id` (text before the first `.`), looks the
+word up in a static per-domain allowlist, and builds
+`POST <ha_base>/api/services/<domain>/<service>` with
+`{"entity_id": <the stored entity>}` itself. The allowlist is exhaustive:
+`light`/`switch`/`fan`/`siren` (`turn_on`, `turn_off`, `toggle`), `cover`
+(`open_cover`, `close_cover`, `stop_cover`), `lock` (`lock`, `unlock`),
+`button`/`input_button` (`press`), `scene`/`script` (`turn_on`). No domain,
+service, or entity id is ever accepted from a client. Verification runs in a
+fixed order and returns before HA is contacted at every step: the new
+`actuators` capability, then per-camera scope, then "this link exists on this
+camera and has `role = 'actuator'`", then the allowlist. Every attempt that
+resolves to an actuator link, including allowlist rejections and failed HA
+calls, writes a `system_events` row (`event_key = 'ha_actuation'`) naming the
+user, camera, link, entity, action and outcome, plus a tracing line.
+
+`actuators` is a role-level boolean, default FALSE in the DB (jsonb capability,
+migration 0074 makes the key explicit), in the Rust struct, and in serde (a role
+row that predates the capability deserializes to `false`, never an error, per
+the #407 lesson). Admin implies it. It is deliberately NOT a media-token claim:
+a `?token=` credential can end up in URLs and access logs, and it must never be
+able to work a lock. The same capability will gate the planned Reolink
+actuators, so an operator grants "may work the devices on their cameras" once.
+
+**Rejected:**
+- **Raw service / entity passthrough (client sends `domain`, `service`,
+  `entity_id`).** The obvious, most flexible design, and the reason this needed
+  a decision: it turns any viewer session that holds the capability into
+  arbitrary control of the operator's ENTIRE Home Assistant, `homeassistant.
+  restart`, `shell_command.*`, every alarm panel, whether or not the entity is
+  linked to any camera. Crumb's token cannot be scoped down to compensate.
+- **Per-camera actuator grants in v1.** Genuinely finer-grained, but it means a
+  new grant mechanism (a second table, new admin UI, new resolution path)
+  alongside the role's existing camera list, which already bounds which cameras,
+  and therefore which links, a role can reach. Deferred until someone actually
+  needs "can see 12 cameras, may only work the door on one".
+- **Returning the new entity state in the response.** Clients already poll
+  `GET /ha/states` every 3s and converge from it. Returning state here would
+  create a second source of truth that can disagree with the poll (HA applies a
+  service call asynchronously; the state at response time is often still the old
+  one), so the response is just `{"ok": true}`.
+- **A tracing-only audit.** Cheaper, but actuations are exactly the events an
+  operator will want to reconstruct later ("who opened the gate at 2am"), and
+  logs rotate. `system_events` is append-only, is not pruned, and has no
+  `system_alert_rules` row for this key, so the notification engine consumes and
+  skips it: a durable audit trail with no notification side effects.
+
+**Revisit triggers (any one):**
+- The Reolink actuators land: confirm they reuse `actuators` rather than
+  inventing a second capability, and that their action vocabulary gets the same
+  allowlist treatment.
+- Demand for per-camera (or per-link) actuator grants, then split a narrower
+  grant from the role-level boolean, the way `view_plates` was split from admin.
+- Home Assistant ships a scoped-token mechanism (per-entity or per-domain
+  tokens), which would let Crumb hold a credential that cannot do more than the
+  allowlist and would reopen how much of the allowlist has to live in Crumb.
+
 ## 2026-07-31, Naming a license plate is a first-class `plate_labels` table, not an extension of the watchlist; resolved via COALESCE with exact-normalized keying
 
 **Context.** Issue #363 asks that an operator name a plate once ("Mom's car",

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -9118,7 +9118,8 @@ async function delUser(id) {
    ROLES, list / create / edit / delete
    REST: GET/POST /config/roles  ·  GET/PUT/DELETE /config/roles/:id
    Role shape: { id, name, is_admin, capabilities:{export,playback,clips,ptz,
-                 manage_views,bookmarks}, camera_ids:[uuid], created_at }
+                 manage_views,bookmarks,view_plates,actuators},
+                 camera_ids:[uuid], created_at }
 ═══════════════════════════════════════════════════════════════════════════ */
 
 /* Capability checkboxes rendered in the role editor. */
@@ -9129,6 +9130,7 @@ const ROLE_CAP_FIELDS = [
   { key: 'ptz',          label: 'PTZ control',    hint: 'Operate pan / tilt / zoom on PTZ cameras.' },
   { key: 'manage_views', label: 'Manage views',   hint: 'Create, edit and delete saved live-wall views.' },
   { key: 'view_plates',  label: 'View license plates', hint: 'Sensitive: see recognised license-plate reads and search the plate database for this role’s cameras.' },
+  { key: 'actuators',    label: 'Control linked devices (locks, covers, switches) - default off', hint: 'Sensitive: operate PHYSICAL devices linked to this role’s cameras, garage doors, locks, lights, sirens. Off by default; seeing a camera never implies being able to work its devices.' },
 ];
 
 /** Build the capability checkboxes + bookmarks selector for a role form. pfx = field prefix. */

--- a/services/api/src/auth_mw.rs
+++ b/services/api/src/auth_mw.rs
@@ -153,6 +153,14 @@ impl AuthUser {
     pub fn can_view_plates(&self) -> bool {
         self.is_admin() || self.capabilities.view_plates
     }
+    /// Operate a device linked to a camera (HA actuators today, Reolink
+    /// actuators later). Deny-by-default: a role must be granted `actuators`
+    /// explicitly, and a scoped media principal never carries it (see
+    /// [`media_capabilities_from_claims`]).
+    #[inline]
+    pub fn can_actuators(&self) -> bool {
+        self.is_admin() || self.capabilities.actuators
+    }
     /// Effective bookmark visibility (admins see all).
     #[inline]
     pub fn bookmarks_scope(&self) -> BookmarkScope {
@@ -196,6 +204,9 @@ impl AuthUser {
     pub fn require_view_plates(&self) -> Result<(), ApiError> {
         Self::require(self.can_view_plates(), "viewing license plates")
     }
+    pub fn require_actuators(&self) -> Result<(), ApiError> {
+        Self::require(self.can_actuators(), "controlling linked devices")
+    }
 }
 
 /// Conservative capabilities for a token that carries no resolvable role
@@ -212,6 +223,7 @@ fn fallback_caps(role: UserRole) -> Capabilities {
             bookmarks: BookmarkScope::Own,
             manage_views: true,
             view_plates: false,
+            actuators: false,
         },
     }
 }
@@ -547,11 +559,14 @@ fn try_media_token(token: &str, state: &AppState) -> Option<AuthUser> {
 /// Reconstruct a media principal's [`Capabilities`] from a decoded
 /// [`MediaClaims`]. `export`/`playback`/`clips`/`view_plates` come straight from
 /// the token (the minting user's real capabilities — never widened); the rest
-/// (ptz, bookmark, view-management) are always denied, since a media token is
-/// only ever used to fetch media. `view_plates` is carried because plate crops
-/// (`GET /events/{id}/snapshot` crumb-alpr fallback and `GET /plates/{id}/crop`)
-/// require it and clients fetch them with a media token. Pure, so the
-/// "no amplification" property is directly unit-testable.
+/// (ptz, actuators, bookmark, view-management) are always denied, since a media
+/// token is only ever used to fetch media. `view_plates` is carried because
+/// plate crops (`GET /events/{id}/snapshot` crumb-alpr fallback and
+/// `GET /plates/{id}/crop`) require it and clients fetch them with a media
+/// token. `actuators` is deliberately NOT a media claim and hardcoded `false`
+/// here: a `?token=` media credential can appear in URLs/logs, and it must never
+/// be able to operate a lock or a garage door. Pure, so the "no amplification"
+/// property is directly unit-testable.
 fn media_capabilities_from_claims(claims: &MediaClaims) -> Capabilities {
     Capabilities {
         export: claims.export,
@@ -559,6 +574,7 @@ fn media_capabilities_from_claims(claims: &MediaClaims) -> Capabilities {
         clips: claims.clips,
         view_plates: claims.view_plates,
         ptz: false,
+        actuators: false,
         bookmarks: BookmarkScope::None,
         manage_views: false,
     }
@@ -615,6 +631,10 @@ mod media_cap_tests {
         // A media token never carries these regardless of the claim.
         assert!(!caps.ptz);
         assert!(!caps.manage_views);
+        assert!(
+            !caps.actuators,
+            "a media token must never be able to operate a physical device"
+        );
     }
 
     #[test]
@@ -624,5 +644,7 @@ mod media_cap_tests {
         // must survive, or plate crops fetched with the token render blank.
         let caps = media_capabilities_from_claims(&claims(true, true, true, true));
         assert!(caps.export && caps.playback && caps.clips && caps.view_plates);
+        // ...but still never the device-control capability.
+        assert!(!caps.actuators);
     }
 }

--- a/services/api/src/export.rs
+++ b/services/api/src/export.rs
@@ -903,7 +903,7 @@ async fn run_export_job(
         let cam_base_pct = (cam_idx * 100 / n_cameras).min(99) as u8;
         // Per-camera progress slice; at least 1% so we always make forward progress.
         #[allow(clippy::cast_possible_truncation)]
-        let cam_range_pct = (100 / n_cameras).max(1).min(100) as u8;
+        let cam_range_pct = (100 / n_cameras).clamp(1, 100) as u8;
 
         if let Some(stderr_pipe) = stderr {
             tokio::spawn(async move {
@@ -1346,7 +1346,7 @@ async fn run_batch_export_job(
         #[allow(clippy::cast_possible_truncation)]
         let cam_base_pct = (idx * 100 / n).min(99) as u8;
         #[allow(clippy::cast_possible_truncation)]
-        let cam_range_pct = (100 / n).max(1).min(100) as u8;
+        let cam_range_pct = (100 / n).clamp(1, 100) as u8;
         let seq = idx + 1;
         let cam_short: String = camera_id
             .to_string()

--- a/services/api/src/ha.rs
+++ b/services/api/src/ha.rs
@@ -1,13 +1,23 @@
-//! Home Assistant integration — Phase 1: connection config + per-camera entity
-//! links + an entity picker. REST-only (HA's `/api`), no WebSocket yet; the
-//! inbound event path (Phase 2) will consume a transport-agnostic source so WS
-//! can drop in later. See `docs/DECISIONS.md` (2026-07-10) and issue #52.
+//! Home Assistant integration — connection config + per-camera entity links + an
+//! entity picker (Phase 1), the live state feed, and the outbound control path
+//! (Phase 2, issue #187). REST-only (HA's `/api`), no WebSocket yet; the inbound
+//! event path consumes a transport-agnostic source so WS can drop in later. See
+//! `docs/DECISIONS.md` (2026-07-10, 2026-08-01) and issues #52 / #187.
 //!
 //! Security: the token is write-only (never returned; the admin DTO exposes only
 //! `has_token`) and travels in the `Authorization: Bearer` header, never a URL.
 //! The entity picker proxies HA `/api/states` so the client never sees the token.
 //! Config + links edits are admin-only; reading a camera's links needs only
 //! access to that camera.
+//!
+//! `POST /cameras/:id/ha/action` is the most privileged surface in the product:
+//! it moves physical hardware (locks, garage doors, sirens). Its whole design is
+//! "the client picks from a set the server already decided": the client sends a
+//! `link_id` the operator authored plus an action *word*, and the server derives
+//! the HA domain from the stored entity, checks the word against a static
+//! per-domain allowlist, and constructs the service call itself. There is no
+//! raw-service passthrough, and no domain / service / `entity_id` is ever accepted
+//! from a client.
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -48,6 +58,52 @@ pub fn routes() -> Router<AppState> {
             "/cameras/:id/ha/links/:link_id/placement",
             put(put_placement),
         )
+        .route("/cameras/:id/ha/action", post(post_action))
+}
+
+// ─── outbound control: the action allowlist ───────────────────────────────────
+
+/// The EXHAUSTIVE set of HA services Crumb will ever call, keyed by the linked
+/// entity's own domain. A client sends an action *word*; the server looks it up
+/// here for the domain it derived from the stored `entity_id` and calls the
+/// matching HA service. Anything not in this table is rejected with a 400.
+///
+/// Deliberately narrow: only actions an operator would plausibly want from a
+/// camera view, and only ones whose effect is obvious from the button. Adding a
+/// domain here widens what any `actuators` role can do, so it is a security
+/// decision, not a convenience one (see `docs/DECISIONS.md`, 2026-08-01).
+///
+/// The action word and the HA service name are 1:1 within a domain, so the
+/// lookup returns a `&'static str` service that the URL is built from — the
+/// client's own string never reaches the HA request.
+const HA_ACTION_ALLOWLIST: &[(&str, &[&str])] = &[
+    ("light", &["turn_on", "turn_off", "toggle"]),
+    ("switch", &["turn_on", "turn_off", "toggle"]),
+    ("fan", &["turn_on", "turn_off", "toggle"]),
+    ("siren", &["turn_on", "turn_off", "toggle"]),
+    ("cover", &["open_cover", "close_cover", "stop_cover"]),
+    ("lock", &["lock", "unlock"]),
+    ("button", &["press"]),
+    ("input_button", &["press"]),
+    ("scene", &["turn_on"]),
+    ("script", &["turn_on"]),
+];
+
+/// HA domain of an entity id: the text before the first `.` (`cover.garage` ⇒
+/// `cover`). Always derived SERVER-SIDE from the stored link, never taken from
+/// the client. An entity id with no `.` yields `""`, which matches no allowlist
+/// row and is therefore rejected.
+fn domain_of(entity_id: &str) -> &str {
+    entity_id.split_once('.').map_or("", |(d, _)| d)
+}
+
+/// Resolve `(domain, action)` to the `&'static str` HA service to call, or
+/// `None` when the pair is not allowlisted (unknown domain, unknown action, or
+/// an action that belongs to a different domain). Pure, so the allowlist is
+/// exhaustively unit-testable without HA or a DB.
+fn allowed_service(domain: &str, action: &str) -> Option<&'static str> {
+    let (_, actions) = HA_ACTION_ALLOWLIST.iter().find(|(d, _)| *d == domain)?;
+    actions.iter().copied().find(|s| *s == action)
 }
 
 // ─── HTTP: shared client + picker filter ──────────────────────────────────────
@@ -150,6 +206,12 @@ struct EntitiesQuery {
 #[derive(Serialize)]
 struct HaLinkDto {
     id: Uuid,
+    /// The same value as `id`, under the name the control endpoint's request
+    /// body uses (`POST /cameras/:id/ha/action` takes `link_id`). Additive and
+    /// redundant on purpose: clients rendering controls from this payload send
+    /// the field back verbatim, and having the two names agree removes the one
+    /// place a client could plausibly send the wrong id.
+    link_id: Uuid,
     entity_id: String,
     role: String,
     device_class: Option<String>,
@@ -183,6 +245,7 @@ impl From<crumb_common::types::CameraHaLink> for HaLinkDto {
     fn from(l: crumb_common::types::CameraHaLink) -> Self {
         Self {
             id: l.id,
+            link_id: l.id,
             entity_id: l.entity_id,
             role: l.role,
             device_class: l.device_class,
@@ -311,6 +374,19 @@ struct HaLinkInput {
 #[derive(Deserialize)]
 struct HaLinksUpdate {
     links: Vec<HaLinkInput>,
+}
+
+/// Body of `POST /cameras/:id/ha/action`.
+///
+/// Note what is NOT here: no domain, no service, no entity id. The link id
+/// addresses an operator-authored row on this camera, and `action` is a word
+/// looked up in [`HA_ACTION_ALLOWLIST`] for the domain the SERVER derives from
+/// that row's entity. Everything the HA request is built from comes from the
+/// server side of that lookup.
+#[derive(Deserialize)]
+struct HaActionRequest {
+    link_id: Uuid,
+    action: String,
 }
 
 // ─── handlers ────────────────────────────────────────────────────────────────
@@ -579,6 +655,171 @@ async fn get_states(
     }))
 }
 
+// ─── outbound control: the actuator endpoint ─────────────────────────────────
+
+/// `system_events.event_key` for the actuation audit trail. There is no
+/// `system_alert_rules` row for it, so the notification engine consumes and
+/// skips it (see `notifications.rs`): the row is an AUDIT record, not an alert.
+const HA_ACTUATION_EVENT_KEY: &str = "ha_actuation";
+
+/// Sanitize a client-supplied string for inclusion in an audit detail: keep it
+/// short and printable so a hostile `action` cannot smuggle newlines or control
+/// characters into the log / audit row.
+fn sanitize_for_audit(s: &str) -> String {
+    s.chars()
+        .take(64)
+        .map(|c| if c.is_ascii_graphic() { c } else { '?' })
+        .collect()
+}
+
+/// Record one actuation attempt: a durable `system_events` row plus a tracing
+/// line. Called for every attempt that got as far as a resolved actuator link,
+/// including allowlist rejections and failed HA calls.
+///
+/// Never fails the request: the tracing line is emitted unconditionally, so a
+/// DB hiccup degrades the audit to log-only rather than either losing the record
+/// silently or telling an operator their garage door did not move when it did.
+async fn audit_actuation(
+    state: &AppState,
+    user: &AuthUser,
+    camera_id: Uuid,
+    link: &crumb_common::types::CameraHaLink,
+    action: &str,
+    outcome: &str,
+) {
+    let username = db::get_user_by_id(state.pool(), user.user_id)
+        .await
+        .ok()
+        .flatten()
+        .map_or_else(|| "unknown".to_owned(), |u| u.username);
+    let action = sanitize_for_audit(action);
+    tracing::info!(
+        target: "crumb::audit",
+        user_id = %user.user_id,
+        username = %username,
+        camera_id = %camera_id,
+        link_id = %link.id,
+        entity_id = %link.entity_id,
+        action = %action,
+        outcome = %outcome,
+        "HA actuation"
+    );
+    let detail = format!(
+        "user={username} ({}) camera={camera_id} link={} entity={} \
+         action={action} outcome={outcome}",
+        user.user_id, link.id, link.entity_id
+    );
+    if let Err(e) = db::insert_system_event(
+        state.pool(),
+        HA_ACTUATION_EVENT_KEY,
+        Some(camera_id),
+        Some(&detail),
+    )
+    .await
+    {
+        tracing::warn!(error = %e, "ha actuation audit row insert failed (log-only audit for this attempt)");
+    }
+}
+
+/// `POST /cameras/:id/ha/action` — operate a device linked to this camera.
+///
+/// Bearer JWT only. A scoped media `?token=` principal authenticates for media
+/// but never carries the `actuators` capability (hardcoded `false` in
+/// `auth_mw::media_capabilities_from_claims`), so it is refused at the first
+/// check below.
+///
+/// Verification order, each step returning before HA is contacted:
+/// 1. `actuators` capability (admin implies) — else 403.
+/// 2. access to camera `:id` — else 403, matching every other per-camera route
+///    (`AuthUser::assert_camera_access`).
+/// 3. `link_id` exists on THIS camera and has `role = 'actuator'` — else 404.
+/// 4. the action is allowlisted for the domain of the link's stored entity —
+///    else 400.
+///
+/// Returns `{"ok": true}` on an HA 2xx. No state is returned: clients converge
+/// on the existing 3s `GET /ha/states` poll, so there is one source of truth for
+/// entity state and no chance of this response disagreeing with it.
+///
+/// # Errors
+///
+/// * `400` — action not allowlisted for the entity's domain, or HA not
+///   configured/enabled.
+/// * `403` — missing `actuators`, or the camera is outside the caller's grant.
+/// * `404` — no actuator link with that id on this camera.
+/// * `502` — Home Assistant unreachable or returned an error.
+async fn post_action(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(camera_id): Path<Uuid>,
+    Json(body): Json<HaActionRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    // 1. capability — the deny-by-default gate on moving physical hardware.
+    user.require_actuators()?;
+    // 2. camera scope.
+    user.assert_camera_access(camera_id)?;
+    // 3. the link must exist ON THIS CAMERA and be an actuator. A link id from
+    //    another camera, or a motion/sensor link, is indistinguishable from a
+    //    nonexistent one to the caller.
+    let link = db::get_camera_ha_link(state.pool(), camera_id, body.link_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .filter(|l| l.role == "actuator")
+        .ok_or_else(|| {
+            ApiError::NotFound("no actuator HA link with that id on this camera".to_owned())
+        })?;
+
+    // 4. allowlist, on the domain derived from the STORED entity id.
+    let domain = domain_of(&link.entity_id);
+    let action = body.action.trim();
+    let Some(service) = allowed_service(domain, action) else {
+        audit_actuation(
+            &state,
+            &user,
+            camera_id,
+            &link,
+            action,
+            "rejected: action not allowed for this domain",
+        )
+        .await;
+        let allowed = HA_ACTION_ALLOWLIST
+            .iter()
+            .find(|(d, _)| *d == domain)
+            .map(|(_, a)| a.join(", "));
+        return Err(ApiError::BadRequest(match allowed {
+            Some(list) => {
+                format!("that action is not allowed for a '{domain}' entity (allowed: {list})")
+            }
+            None => format!("Crumb does not control '{domain}' entities"),
+        }));
+    };
+
+    let settings = effective_settings(&state).await?;
+    if !settings.enabled {
+        return Err(ApiError::BadRequest(
+            "Home Assistant is not enabled".to_owned(),
+        ));
+    }
+    let client = ha_client(&settings)?;
+
+    // `domain` is the stored entity's own prefix and `service` is a &'static str
+    // straight out of the allowlist, so nothing client-controlled reaches the
+    // HA URL; the entity id travels in the request body.
+    match client.call_service(domain, service, &link.entity_id).await {
+        Ok(()) => {
+            audit_actuation(&state, &user, camera_id, &link, action, "ok").await;
+            Ok(Json(json!({ "ok": true })))
+        }
+        Err(e) => {
+            audit_actuation(&state, &user, camera_id, &link, action, "ha call failed").await;
+            // BadGateway logs the detail and returns a generic message to the
+            // client (see error.rs); the detail carries only a status code.
+            Err(ApiError::BadGateway(format!(
+                "Home Assistant service call failed: {e}"
+            )))
+        }
+    }
+}
+
 /// Project a raw HA `/api/states` array down to the `wanted` entity ids, keeping
 /// each entity's `state` and `last_changed`. Pure (no HA/DB), so the RBAC
 /// filtering it backs is unit-testable. Entities not in `wanted` are dropped —
@@ -740,6 +981,119 @@ mod tests {
         assert!(!valid_overlay_shape("square")); // not in the vocabulary
         assert!(!valid_overlay_shape("Dot")); // case-sensitive
         assert!(!valid_overlay_shape("")); // empty
+    }
+
+    #[test]
+    fn domain_is_derived_from_the_entity_id_prefix() {
+        assert_eq!(domain_of("cover.garage_door"), "cover");
+        assert_eq!(domain_of("lock.front_door"), "lock");
+        // Only the FIRST dot splits, so a dotted object id keeps its domain.
+        assert_eq!(domain_of("light.hall.left"), "light");
+        // No dot ⇒ no domain ⇒ matches no allowlist row.
+        assert_eq!(domain_of("garage"), "");
+        assert_eq!(domain_of(""), "");
+        assert!(allowed_service(domain_of("garage"), "turn_on").is_none());
+    }
+
+    #[test]
+    fn allowlist_accepts_every_documented_domain_action_pair() {
+        // The EXHAUSTIVE positive list. If this test needs editing, the set of
+        // things any `actuators` role can do to physical hardware changed.
+        let allowed: &[(&str, &[&str])] = &[
+            ("light", &["turn_on", "turn_off", "toggle"]),
+            ("switch", &["turn_on", "turn_off", "toggle"]),
+            ("fan", &["turn_on", "turn_off", "toggle"]),
+            ("siren", &["turn_on", "turn_off", "toggle"]),
+            ("cover", &["open_cover", "close_cover", "stop_cover"]),
+            ("lock", &["lock", "unlock"]),
+            ("button", &["press"]),
+            ("input_button", &["press"]),
+            ("scene", &["turn_on"]),
+            ("script", &["turn_on"]),
+        ];
+        for (domain, actions) in allowed {
+            for action in *actions {
+                assert_eq!(
+                    allowed_service(domain, action),
+                    Some(*action),
+                    "{domain}.{action} must be allowed and map 1:1 to its service"
+                );
+            }
+        }
+        // ...and the allowlist contains nothing beyond that set.
+        let expected: usize = allowed.iter().map(|(_, a)| a.len()).sum();
+        let actual: usize = HA_ACTION_ALLOWLIST.iter().map(|(_, a)| a.len()).sum();
+        assert_eq!(actual, expected, "allowlist grew or shrank unexpectedly");
+    }
+
+    #[test]
+    fn allowlist_rejects_wrong_domain_unknown_and_garbage_actions() {
+        // Right action word, wrong domain.
+        assert_eq!(allowed_service("lock", "turn_on"), None);
+        assert_eq!(allowed_service("light", "unlock"), None);
+        assert_eq!(allowed_service("cover", "toggle"), None);
+        assert_eq!(allowed_service("scene", "turn_off"), None);
+        assert_eq!(allowed_service("button", "turn_on"), None);
+        assert_eq!(allowed_service("script", "toggle"), None);
+        assert_eq!(allowed_service("lock", "open_cover"), None);
+
+        // Unknown domains, including HA domains Crumb deliberately won't drive.
+        assert_eq!(allowed_service("climate", "set_temperature"), None);
+        assert_eq!(allowed_service("alarm_control_panel", "alarm_disarm"), None);
+        assert_eq!(allowed_service("homeassistant", "turn_on"), None);
+        assert_eq!(allowed_service("shell_command", "turn_on"), None);
+        assert_eq!(allowed_service("", "turn_on"), None);
+
+        // Unknown / garbage actions.
+        assert_eq!(allowed_service("light", "explode"), None);
+        assert_eq!(allowed_service("light", ""), None);
+        assert_eq!(allowed_service("light", "TURN_ON"), None); // case-sensitive
+        assert_eq!(allowed_service("light", "turn_on "), None); // handler trims
+        assert_eq!(allowed_service("light", "turn_on;reboot"), None);
+        assert_eq!(
+            allowed_service("light", "../../homeassistant/restart"),
+            None
+        );
+        assert_eq!(allowed_service("light", "turn_on/../restart"), None);
+        assert_eq!(allowed_service("light/../x", "turn_on"), None);
+    }
+
+    #[test]
+    fn audit_detail_is_sanitized() {
+        assert_eq!(sanitize_for_audit("turn_on"), "turn_on");
+        // Newlines / control chars can't break out into a forged log line.
+        assert_eq!(sanitize_for_audit("turn_on\nFAKE"), "turn_on?FAKE");
+        assert_eq!(sanitize_for_audit("a\tb"), "a?b");
+        // Bounded length.
+        assert_eq!(sanitize_for_audit(&"x".repeat(300)).len(), 64);
+    }
+
+    #[test]
+    fn action_request_requires_link_id_and_action_only() {
+        let ok: HaActionRequest = serde_json::from_value(json!({
+            "link_id": "11111111-1111-1111-1111-111111111111",
+            "action": "open_cover"
+        }))
+        .unwrap();
+        assert_eq!(ok.action, "open_cover");
+        // A body trying to name a service/entity/domain is not a different
+        // request — the extra keys are simply ignored, never honoured.
+        let sneaky: HaActionRequest = serde_json::from_value(json!({
+            "link_id": "11111111-1111-1111-1111-111111111111",
+            "action": "turn_on",
+            "domain": "homeassistant",
+            "service": "restart",
+            "entity_id": "lock.front_door"
+        }))
+        .unwrap();
+        assert_eq!(sneaky.action, "turn_on");
+        // Missing fields are a deserialize failure (400), not a default.
+        let no_link = serde_json::from_value::<HaActionRequest>(json!({"action": "turn_on"}));
+        assert!(no_link.is_err());
+        let no_action = serde_json::from_value::<HaActionRequest>(
+            json!({"link_id": "11111111-1111-1111-1111-111111111111"}),
+        );
+        assert!(no_action.is_err());
     }
 
     #[test]

--- a/services/api/tests/auth_rbac.rs
+++ b/services/api/tests/auth_rbac.rs
@@ -1033,6 +1033,7 @@ async fn seed_viewer_no_plates(pool: &deadpool_postgres::Pool, cameras: &[Uuid])
         bookmarks: BookmarkScope::Own,
         manage_views: true,
         view_plates: false,
+        actuators: false,
     };
     let role = crumb_common::db::create_role(pool, &unique("noplates-role"), &caps, cameras)
         .await
@@ -1481,6 +1482,17 @@ async fn no_protected_route_is_reachable_without_credentials() {
         (Method::GET, "/stats/storage".into()),
         (Method::POST, format!("/cameras/{u}/ptz")),
         (Method::POST, format!("/cameras/{u}/imaging")),
+        // -- Home Assistant integration (config admin-only, links/states/action
+        //    authenticated); the action route operates physical hardware. --
+        (Method::GET, "/config/ha".into()),
+        (Method::PUT, "/config/ha".into()),
+        (Method::POST, "/config/ha/test".into()),
+        (Method::GET, "/ha/entities".into()),
+        (Method::GET, "/ha/states".into()),
+        (Method::GET, format!("/cameras/{u}/ha/links")),
+        (Method::PUT, format!("/cameras/{u}/ha/links")),
+        (Method::PUT, format!("/cameras/{u}/ha/links/{u}/placement")),
+        (Method::POST, format!("/cameras/{u}/ha/action")),
         (Method::GET, "/events".into()),
         // Detection snapshot proxy: despite a stale "unauthenticated opaque-UUID"
         // comment in main.rs/events.rs, get_event_snapshot actually takes AuthUser,
@@ -1867,6 +1879,7 @@ fn mk_caps(playback: bool, clips: bool, view_plates: bool) -> crumb_common::type
         bookmarks: crumb_common::types::BookmarkScope::Own,
         manage_views: false,
         view_plates,
+        actuators: false,
     }
 }
 

--- a/services/api/tests/ha_action_rbac.rs
+++ b/services/api/tests/ha_action_rbac.rs
@@ -1,0 +1,408 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! `POST /cameras/:id/ha/action` — the actuator control endpoint (issue #187).
+//!
+//! This is the one route in Crumb that moves PHYSICAL hardware (locks, garage
+//! doors, sirens), so every gate in front of it gets an explicit test: the
+//! deny-by-default `actuators` capability, per-camera scope, link ownership +
+//! role, and the per-domain action allowlist.
+//!
+//! The harness has no stand-in Home Assistant (the mock-HA server lives in
+//! `crumb_common::ha`'s own unit tests, where the real `HaClient` is exercised
+//! against it). So the route tests here assert the four verification steps and
+//! stop at the HA call BOUNDARY: with HA unconfigured, a fully-authorized,
+//! allowlisted request gets the distinct "not enabled" 400, which proves it
+//! passed capability + scope + link + allowlist and reached the call site.
+
+mod support;
+
+use axum::http::StatusCode;
+use crumb_common::{
+    db,
+    types::{BookmarkScope, Capabilities},
+};
+use support::*;
+use uuid::Uuid;
+
+/// Capabilities of a normal viewer PLUS `actuators` (what an operator role that
+/// is allowed to work the garage door looks like).
+fn caps_with_actuators() -> Capabilities {
+    Capabilities {
+        export: false,
+        playback: true,
+        clips: true,
+        ptz: false,
+        bookmarks: BookmarkScope::Own,
+        manage_views: true,
+        view_plates: false,
+        actuators: true,
+    }
+}
+
+/// Replace a camera's HA links with the given `(entity_id, role)` pairs and
+/// return them in insertion order.
+async fn seed_links(
+    pool: &deadpool_postgres::Pool,
+    camera_id: Uuid,
+    links: &[(&str, &str)],
+) -> Vec<crumb_common::types::CameraHaLink> {
+    let mut tuples: Vec<db::HaLinkInsert> = Vec::new();
+    for (i, (entity, role)) in links.iter().enumerate() {
+        let order = i32::try_from(i).unwrap_or(0);
+        tuples.push(((*entity).to_owned(), (*role).to_owned(), None, None, order));
+    }
+    db::replace_camera_ha_links(pool, camera_id, &tuples)
+        .await
+        .expect("replace_camera_ha_links")
+}
+
+fn action_body(link_id: Uuid, action: &str) -> serde_json::Value {
+    serde_json::json!({ "link_id": link_id, "action": action })
+}
+
+async fn body_text(resp: axum::http::Response<axum::body::Body>) -> String {
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+// ─── 401: no credentials ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn action_without_a_token_is_401() {
+    let app = TestApp::new().await;
+    let cam = seed_camera(app.pool()).await;
+    let req = axum::http::Request::builder()
+        .method("POST")
+        .uri(format!("/cameras/{cam}/ha/action"))
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(
+            action_body(Uuid::new_v4(), "turn_on").to_string(),
+        ))
+        .unwrap();
+    assert_eq!(app.send(req).await.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ─── 403: authenticated, but not permitted ───────────────────────────────────
+
+#[tokio::test]
+async fn action_denied_without_the_actuators_capability() {
+    let app = TestApp::new().await;
+    let cam = seed_camera(app.pool()).await;
+    let links = seed_links(app.pool(), cam, &[("light.kitchen", "actuator")]).await;
+
+    // A generous viewer (playback/clips/export/ptz/view_plates) WITH access to
+    // the camera, but no `actuators` — the whole point of the capability.
+    let viewer = seed_viewer(app.pool(), &[cam]).await;
+    let token = login(&app, &viewer.username, &viewer.password).await;
+
+    let resp = app
+        .send(post_auth_json(
+            &format!("/cameras/{cam}/ha/action"),
+            &token,
+            &action_body(links[0].id, "turn_on"),
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn action_denied_for_a_camera_outside_the_grant() {
+    let app = TestApp::new().await;
+    let mine = seed_camera(app.pool()).await;
+    let theirs = seed_camera(app.pool()).await;
+    let links = seed_links(app.pool(), theirs, &[("lock.front_door", "actuator")]).await;
+
+    // Holds `actuators`, but only for `mine`.
+    let role_id = seed_viewer_role_with_caps(app.pool(), &[mine], caps_with_actuators()).await;
+    let viewer = seed_viewer_user(app.pool(), role_id).await;
+    let token = login(&app, &viewer.username, &viewer.password).await;
+
+    let resp = app
+        .send(post_auth_json(
+            &format!("/cameras/{theirs}/ha/action"),
+            &token,
+            &action_body(links[0].id, "unlock"),
+        ))
+        .await;
+    // Matches the codebase-wide convention for a camera outside the caller's
+    // grant (`AuthUser::assert_camera_access` → 403).
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn a_media_token_can_never_actuate() {
+    // A scoped media `?token=` credential authenticates for media and can appear
+    // in URLs / access logs. It must never work the lock, even when minted by a
+    // user whose role DOES hold `actuators`.
+    let app = TestApp::new().await;
+    let cam = seed_camera(app.pool()).await;
+    let links = seed_links(app.pool(), cam, &[("lock.front_door", "actuator")]).await;
+
+    let role_id = seed_viewer_role_with_caps(app.pool(), &[cam], caps_with_actuators()).await;
+    let viewer = seed_viewer_user(app.pool(), role_id).await;
+    let token = login(&app, &viewer.username, &viewer.password).await;
+
+    let mint = app
+        .send(get_auth(&format!("/media-token?camera={cam}"), &token))
+        .await;
+    assert_eq!(mint.status(), StatusCode::OK);
+    let v: serde_json::Value = serde_json::from_str(&body_text(mint).await).expect("mint json");
+    let media_token = v["token"].as_str().expect("media token").to_owned();
+
+    let req = axum::http::Request::builder()
+        .method("POST")
+        .uri(format!("/cameras/{cam}/ha/action?token={media_token}"))
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(
+            action_body(links[0].id, "unlock").to_string(),
+        ))
+        .unwrap();
+    let resp = app.send(req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a media token must not carry the actuators capability"
+    );
+}
+
+// ─── 404: the link must exist on THIS camera and be an actuator ──────────────
+
+#[tokio::test]
+async fn action_404s_for_unknown_foreign_and_non_actuator_links() {
+    let app = TestApp::new().await;
+    let mine = seed_camera(app.pool()).await;
+    let other = seed_camera(app.pool()).await;
+
+    let mine_links = seed_links(
+        app.pool(),
+        mine,
+        &[
+            ("cover.garage", "actuator"),
+            ("binary_sensor.driveway", "motion"),
+            ("sensor.porch_temp", "sensor"),
+        ],
+    )
+    .await;
+    let other_links = seed_links(app.pool(), other, &[("lock.side_gate", "actuator")]).await;
+
+    let role_id =
+        seed_viewer_role_with_caps(app.pool(), &[mine, other], caps_with_actuators()).await;
+    let viewer = seed_viewer_user(app.pool(), role_id).await;
+    let token = login(&app, &viewer.username, &viewer.password).await;
+
+    let motion_link = mine_links
+        .iter()
+        .find(|l| l.role == "motion")
+        .expect("motion link");
+    let sensor_link = mine_links
+        .iter()
+        .find(|l| l.role == "sensor")
+        .expect("sensor link");
+
+    // A link id that does not exist at all.
+    // A link that belongs to another camera the caller CAN access (so this is
+    // about link ownership, not scope).
+    // A link on this camera whose role is not 'actuator'.
+    for (label, link_id, action) in [
+        ("unknown link", Uuid::new_v4(), "open_cover"),
+        ("link of another camera", other_links[0].id, "unlock"),
+        ("motion-role link", motion_link.id, "turn_on"),
+        ("sensor-role link", sensor_link.id, "turn_on"),
+    ] {
+        let resp = app
+            .send(post_auth_json(
+                &format!("/cameras/{mine}/ha/action"),
+                &token,
+                &action_body(link_id, action),
+            ))
+            .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND, "{label} must 404");
+    }
+}
+
+// ─── 400: the per-domain action allowlist ────────────────────────────────────
+
+#[tokio::test]
+async fn action_400s_when_the_action_is_not_allowlisted_for_the_domain() {
+    let app = TestApp::new().await;
+    let cam = seed_camera(app.pool()).await;
+    let links = seed_links(
+        app.pool(),
+        cam,
+        &[
+            ("lock.front_door", "actuator"),
+            ("climate.hallway", "actuator"),
+        ],
+    )
+    .await;
+    let lock = links
+        .iter()
+        .find(|l| l.entity_id == "lock.front_door")
+        .expect("lock link");
+    let climate = links
+        .iter()
+        .find(|l| l.entity_id == "climate.hallway")
+        .expect("climate link");
+
+    let role_id = seed_viewer_role_with_caps(app.pool(), &[cam], caps_with_actuators()).await;
+    let viewer = seed_viewer_user(app.pool(), role_id).await;
+    let token = login(&app, &viewer.username, &viewer.password).await;
+
+    for (label, link_id, action) in [
+        // Real HA service, wrong domain for this entity.
+        ("turn_on on a lock", lock.id, "turn_on"),
+        ("open_cover on a lock", lock.id, "open_cover"),
+        // A domain Crumb deliberately does not drive.
+        ("any action on a climate entity", climate.id, "turn_on"),
+        // Garbage / path-traversal shaped.
+        ("garbage action", lock.id, "../homeassistant/restart"),
+        ("empty action", lock.id, ""),
+    ] {
+        let resp = app
+            .send(post_auth_json(
+                &format!("/cameras/{cam}/ha/action"),
+                &token,
+                &action_body(link_id, action),
+            ))
+            .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "{label} must be rejected by the allowlist"
+        );
+    }
+}
+
+#[tokio::test]
+async fn an_allowlisted_action_passes_every_gate_and_stops_at_the_ha_boundary() {
+    // With HA unconfigured, the request that clears capability + scope + link +
+    // allowlist fails with the DISTINCT "not enabled" 400. That is how this
+    // suite proves the happy path reaches the HA call site without a stand-in HA
+    // (the real client's call is covered in `crumb_common::ha`'s mock-HA tests).
+    let app = TestApp::new().await;
+    let cam = seed_camera(app.pool()).await;
+    let links = seed_links(app.pool(), cam, &[("cover.garage", "actuator")]).await;
+
+    let role_id = seed_viewer_role_with_caps(app.pool(), &[cam], caps_with_actuators()).await;
+    let viewer = seed_viewer_user(app.pool(), role_id).await;
+    let token = login(&app, &viewer.username, &viewer.password).await;
+
+    let resp = app
+        .send(post_auth_json(
+            &format!("/cameras/{cam}/ha/action"),
+            &token,
+            &action_body(links[0].id, "close_cover"),
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = body_text(resp).await;
+    assert!(
+        body.contains("not enabled"),
+        "expected the HA-not-enabled 400 (proving the allowlist passed), got: {body}"
+    );
+}
+
+// ─── the viewer payload clients render controls from ─────────────────────────
+
+#[tokio::test]
+async fn camera_links_payload_carries_the_fields_clients_need() {
+    let app = TestApp::new().await;
+    let cam = seed_camera(app.pool()).await;
+    let tuples: Vec<db::HaLinkInsert> = vec![(
+        "cover.garage".to_owned(),
+        "actuator".to_owned(),
+        Some("garage".to_owned()),
+        Some("Garage door".to_owned()),
+        0,
+    )];
+    db::replace_camera_ha_links(app.pool(), cam, &tuples)
+        .await
+        .expect("replace_camera_ha_links");
+
+    let viewer = seed_viewer(app.pool(), &[cam]).await;
+    let token = login(&app, &viewer.username, &viewer.password).await;
+
+    let resp = app
+        .send(get_auth(&format!("/cameras/{cam}/ha/links"), &token))
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v: serde_json::Value = serde_json::from_str(&body_text(resp).await).expect("links json");
+    let link = &v[0];
+    assert_eq!(link["role"], "actuator");
+    assert_eq!(link["entity_id"], "cover.garage");
+    assert_eq!(link["label"], "Garage door");
+    assert_eq!(link["device_class"], "garage");
+    // `link_id` is the field name the action endpoint's body uses; it mirrors
+    // the long-standing `id`.
+    assert!(link["link_id"].is_string());
+    assert_eq!(link["link_id"], link["id"]);
+}
+
+// ─── the capability itself: default-false everywhere ─────────────────────────
+
+#[tokio::test]
+async fn actuators_defaults_to_false_for_a_new_role_and_true_for_admin() {
+    let app = TestApp::new().await;
+
+    // A role created with the default capability set does NOT get actuators.
+    let defaults = Capabilities::default();
+    let role = db::create_role(app.pool(), &unique("defaults-role"), &defaults, &[])
+        .await
+        .expect("create_role (defaults)");
+    assert!(
+        !role.capabilities.actuators,
+        "a new role must not be able to operate physical devices"
+    );
+
+    // A legacy role row persisted BEFORE this capability existed (its jsonb has
+    // no `actuators` key) must deserialize to false, not fail to load (#407).
+    {
+        let client = app.pool().get().await.expect("pool.get");
+        client
+            .execute(
+                r#"UPDATE roles
+                   SET capabilities = '{"playback": true, "clips": true,
+                                        "bookmarks": "own", "manage_views": true}'::jsonb
+                   WHERE id = $1"#,
+                &[&role.id],
+            )
+            .await
+            .expect("simulate a pre-actuators role row");
+    }
+    let legacy = db::get_role(app.pool(), role.id)
+        .await
+        .expect("get_role (legacy jsonb)")
+        .expect("role exists");
+    assert!(
+        legacy.capabilities.playback,
+        "legacy caps still deserialize"
+    );
+    assert!(
+        !legacy.capabilities.actuators,
+        "a missing claim must read as DENY, never as granted or an error"
+    );
+
+    // ...and the admin role implies it, surfaced to clients via /auth/me.
+    let admin = seed_admin(app.pool()).await;
+    let admin_token = login(&app, &admin.username, &admin.password).await;
+    let me = app.send(get_auth("/auth/me", &admin_token)).await;
+    assert_eq!(me.status(), StatusCode::OK);
+    let v: serde_json::Value = serde_json::from_str(&body_text(me).await).expect("me json");
+    assert_eq!(
+        v["capabilities"]["actuators"],
+        serde_json::Value::Bool(true),
+        "admin implies actuators"
+    );
+
+    // A plain viewer sees it as false in the same payload.
+    let viewer = seed_viewer(app.pool(), &[]).await;
+    let viewer_token = login(&app, &viewer.username, &viewer.password).await;
+    let me = app.send(get_auth("/auth/me", &viewer_token)).await;
+    let v: serde_json::Value = serde_json::from_str(&body_text(me).await).expect("me json");
+    assert_eq!(
+        v["capabilities"]["actuators"],
+        serde_json::Value::Bool(false)
+    );
+}

--- a/services/api/tests/lpr_ab.rs
+++ b/services/api/tests/lpr_ab.rs
@@ -53,6 +53,7 @@ async fn seed_viewer_no_plates(pool: &Pool, cameras: &[Uuid]) -> SeededUser {
         bookmarks: BookmarkScope::Own,
         manage_views: true,
         view_plates: false,
+        actuators: false,
     };
     let role = db::create_role(pool, &unique("role"), &caps, cameras)
         .await

--- a/services/api/tests/lpr_plates.rs
+++ b/services/api/tests/lpr_plates.rs
@@ -76,6 +76,7 @@ async fn seed_viewer_no_plates(pool: &Pool, cameras: &[Uuid]) -> SeededUser {
         bookmarks: BookmarkScope::Own,
         manage_views: true,
         view_plates: false,
+        actuators: false,
     };
     let role = db::create_role(pool, &unique("role"), &caps, cameras)
         .await

--- a/services/api/tests/notification_channel_rbac.rs
+++ b/services/api/tests/notification_channel_rbac.rs
@@ -57,6 +57,7 @@ async fn seed_viewer_no_plates(pool: &Pool, cameras: &[Uuid]) -> SeededUser {
         bookmarks: BookmarkScope::Own,
         manage_views: true,
         view_plates: false,
+        actuators: false,
     };
     let role = db::create_role(pool, &unique("role"), &caps, cameras)
         .await

--- a/services/api/tests/support/mod.rs
+++ b/services/api/tests/support/mod.rs
@@ -77,6 +77,8 @@ pub mod ffprobe;
 pub mod filmstrip;
 #[path = "../../src/go2rtc.rs"]
 pub mod go2rtc;
+#[path = "../../src/ha.rs"]
+pub mod ha;
 #[path = "../../src/plates.rs"]
 pub mod plates;
 #[path = "../../src/playback.rs"]
@@ -373,6 +375,8 @@ pub fn test_router() -> Router<AppState> {
         //    auth-invariant walk covers every route, not just the RBAC subset. --
         .merge(cameras::json_routes())
         .merge(cameras::routes())
+        // Home Assistant config/links/states + the actuator control endpoint.
+        .merge(ha::routes())
         .merge(views::routes())
         .merge(bookmarks::routes())
         .merge(timeline::routes())
@@ -458,9 +462,19 @@ pub async fn seed_admin(pool: &Pool) -> SeededUser {
 /// capabilities (defaults to a generous "can do everything a viewer can do"
 /// set — playback/clips/export/ptz all `true` — so scope-denial tests are
 /// unambiguously about camera scope, not a missing capability).
+///
+/// `actuators` is the ONE capability left `false` here: it is deny-by-default
+/// and moves physical hardware, so tests that need it opt in explicitly via
+/// [`seed_viewer_role_with_caps`]. That also keeps the "a plain viewer cannot
+/// actuate" assertion honest.
 pub async fn seed_viewer_role(pool: &Pool, camera_ids: &[Uuid]) -> Uuid {
-    let name = unique("role");
-    let caps = Capabilities {
+    seed_viewer_role_with_caps(pool, camera_ids, generous_viewer_caps()).await
+}
+
+/// The generous viewer capability set [`seed_viewer_role`] uses (everything a
+/// viewer can hold except `actuators`).
+pub fn generous_viewer_caps() -> Capabilities {
+    Capabilities {
         export: true,
         playback: true,
         clips: true,
@@ -468,7 +482,17 @@ pub async fn seed_viewer_role(pool: &Pool, camera_ids: &[Uuid]) -> Uuid {
         bookmarks: crumb_common::types::BookmarkScope::All,
         manage_views: true,
         view_plates: true,
-    };
+        actuators: false,
+    }
+}
+
+/// Create a viewer role scoped to `camera_ids` with an explicit capability set.
+pub async fn seed_viewer_role_with_caps(
+    pool: &Pool,
+    camera_ids: &[Uuid],
+    caps: Capabilities,
+) -> Uuid {
+    let name = unique("role");
     let role = db::create_role(pool, &name, &caps, camera_ids)
         .await
         .expect("create_role (viewer)");
@@ -515,6 +539,7 @@ pub async fn seed_viewer_with_bookmark_scope(
         bookmarks: scope,
         manage_views: true,
         view_plates: true,
+        actuators: false,
     };
     let role = db::create_role(pool, &name, &caps, camera_ids)
         .await

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -1700,6 +1700,37 @@ pub async fn get_camera_ha_links(
     Ok(rows.iter().map(ha_link_from_row).collect())
 }
 
+/// One HA link by id, scoped to the camera it must belong to.
+///
+/// The camera is part of the WHERE clause on purpose: the actuator endpoint
+/// (`POST /cameras/:id/ha/action`) has already authorized the caller for that
+/// camera, so a link id belonging to a different camera must read as "not
+/// found" rather than resolve. Returns `None` when no such link exists on that
+/// camera.
+///
+/// # Errors
+///
+/// Returns an error if the query fails.
+pub async fn get_camera_ha_link(
+    pool: &Pool,
+    camera_id: Uuid,
+    link_id: Uuid,
+) -> Result<Option<CameraHaLink>> {
+    let client = get_conn(pool).await?;
+    let row = client
+        .query_opt(
+            "SELECT id, camera_id, entity_id, role, device_class, label, sort_order,
+                    overlay_x, overlay_y, overlay_size,
+                    overlay_color, overlay_icon, overlay_show_state, overlay_show_age,
+                    overlay_opacity, overlay_shape, overlay_bg_color, overlay_outline
+             FROM camera_ha_links WHERE camera_id = $1 AND id = $2",
+            &[&camera_id, &link_id],
+        )
+        .await
+        .context("get_camera_ha_link")?;
+    Ok(row.as_ref().map(ha_link_from_row))
+}
+
 /// One camera↔HA link to persist: `(entity_id, role, device_class, label,
 /// sort_order)`. `id` is server-assigned.
 pub type HaLinkInsert = (String, String, Option<String>, Option<String>, i32);
@@ -10582,6 +10613,10 @@ static MIGRATIONS: &[(&str, &str)] = &[
     (
         "0073_plate_labels.sql",
         include_str!("../../../db/migrations/0073_plate_labels.sql"),
+    ),
+    (
+        "0074_role_actuators_capability.sql",
+        include_str!("../../../db/migrations/0074_role_actuators_capability.sql"),
     ),
 ];
 

--- a/services/common/src/ha.rs
+++ b/services/common/src/ha.rs
@@ -84,6 +84,44 @@ impl HaClient {
         resp.json().await.context("Home Assistant states parse")
     }
 
+    /// `POST /api/services/<domain>/<service>` with `{"entity_id": ...}` — the
+    /// outbound control path (Phase 2, issue #187).
+    ///
+    /// # Security contract (do NOT weaken)
+    ///
+    /// `domain` and `service` must be caller-chosen CONSTANTS, never strings
+    /// that came off the wire: this method builds a URL path from them. The API
+    /// obtains both from a static per-domain allowlist keyed by the linked
+    /// entity's own domain (`api/src/ha.rs::allowed_service`), so a client can
+    /// never reach an arbitrary HA service. `entity_id` is the stored link's
+    /// entity, never a client-supplied one, and travels in the JSON body.
+    ///
+    /// The token is a header (as everywhere in this client), so the error
+    /// strings below cannot leak it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if HA is unreachable, rejects the token, or answers
+    /// non-2xx. The message carries only the HTTP status, no upstream body.
+    pub async fn call_service(&self, domain: &str, service: &str, entity_id: &str) -> Result<()> {
+        let resp = self
+            .http
+            .post(format!("{}/api/services/{domain}/{service}", self.base_url))
+            .bearer_auth(&self.token)
+            .json(&serde_json::json!({ "entity_id": entity_id }))
+            .send()
+            .await
+            .context("Home Assistant service call failed")?;
+        let code = resp.status();
+        if code.is_success() {
+            Ok(())
+        } else if code.as_u16() == 401 {
+            anyhow::bail!("Home Assistant rejected the token (HTTP 401)")
+        } else {
+            anyhow::bail!("Home Assistant returned HTTP {}", code.as_u16())
+        }
+    }
+
     /// Current `(entity_id, state)` for the given entities. HA has no bulk
     /// get-by-id, so this filters the full `/api/states` read (cheap at homelab
     /// scale; the one bounded request doubles as the liveness check).
@@ -296,9 +334,13 @@ mod tests {
 
     /// Stand-in HA: serves `GET /api/` and `GET /api/states` for one sensor whose
     /// state the test can flip, and can be switched to fail (HTTP 500) mid-run.
+    /// Also accepts `POST /api/services/<domain>/<service>` and records the
+    /// request line so the control path's URL construction is assertable.
     struct MockHa {
         sensor_state: Mutex<String>,
         fail: AtomicBool,
+        /// `("<method> <path>", "<body>")` for every service call received.
+        service_calls: Mutex<Vec<(String, String)>>,
     }
 
     /// Bind a stand-in HA on a loopback port and return its base URL.
@@ -324,10 +366,36 @@ mod tests {
                             Err(_) => return,
                         }
                     }
-                    let req = String::from_utf8_lossy(&buf);
-                    let path = req.split_whitespace().nth(1).unwrap_or("/");
+                    // A POST carries a body after the head; read exactly
+                    // Content-Length more bytes so the assertion below sees it.
+                    let head = String::from_utf8_lossy(&buf).to_string();
+                    let head_end = head.find("\r\n\r\n").map_or(head.len(), |i| i + 4);
+                    let want: usize = head
+                        .lines()
+                        .filter_map(|l| l.split_once(':'))
+                        .find(|(k, _)| k.eq_ignore_ascii_case("content-length"))
+                        .and_then(|(_, v)| v.trim().parse::<usize>().ok())
+                        .unwrap_or(0);
+                    while buf.len() < head_end + want {
+                        match sock.read(&mut tmp).await {
+                            Ok(0) => break,
+                            Ok(n) => buf.extend_from_slice(&tmp[..n]),
+                            Err(_) => break,
+                        }
+                    }
+                    let req = String::from_utf8_lossy(&buf).to_string();
+                    let method = req.split_whitespace().next().unwrap_or("GET").to_owned();
+                    let path_owned = req.split_whitespace().nth(1).unwrap_or("/").to_owned();
+                    let path = path_owned.as_str();
+                    let req_body = req.get(head_end..).unwrap_or("").to_owned();
                     let (status, body) = if mock.fail.load(Ordering::SeqCst) {
                         ("500 Internal Server Error", String::new())
+                    } else if method == "POST" && path.starts_with("/api/services/") {
+                        mock.service_calls
+                            .lock()
+                            .unwrap()
+                            .push((format!("{method} {path}"), req_body));
+                        ("200 OK", "[]".to_owned())
                     } else if path == "/api/" {
                         ("200 OK", r#"{"message":"API running."}"#.to_owned())
                     } else if path == "/api/states" {
@@ -365,6 +433,7 @@ mod tests {
         let mock = Arc::new(MockHa {
             sensor_state: Mutex::new("off".to_owned()),
             fail: AtomicBool::new(false),
+            service_calls: Mutex::new(Vec::new()),
         });
         let base = spawn_mock_ha(Arc::clone(&mock)).await;
         let client = HaClient::from_settings(&settings_for(base)).expect("client builds");
@@ -398,6 +467,41 @@ mod tests {
             failed.is_err(),
             "a failed poll MUST return Err to arm fail-open, got {failed:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn call_service_posts_domain_service_and_entity_then_errors_on_failure() {
+        let mock = Arc::new(MockHa {
+            sensor_state: Mutex::new("off".to_owned()),
+            fail: AtomicBool::new(false),
+            service_calls: Mutex::new(Vec::new()),
+        });
+        let base = spawn_mock_ha(Arc::clone(&mock)).await;
+        let client = HaClient::from_settings(&settings_for(base)).expect("client builds");
+
+        client
+            .call_service("cover", "close_cover", "cover.garage")
+            .await
+            .expect("service call ok");
+
+        let calls = mock.service_calls.lock().unwrap().clone();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "POST /api/services/cover/close_cover");
+        // The entity travels in the BODY, never the URL.
+        let body: serde_json::Value = serde_json::from_str(&calls[0].1).expect("json body");
+        assert_eq!(body["entity_id"], "cover.garage");
+        assert_eq!(
+            body.as_object().map(|o| o.len()),
+            Some(1),
+            "body carries exactly entity_id, nothing else"
+        );
+
+        // A failing HA surfaces as Err (the handler maps this to a 502).
+        mock.fail.store(true, Ordering::SeqCst);
+        assert!(client
+            .call_service("lock", "unlock", "lock.front")
+            .await
+            .is_err());
     }
 
     #[tokio::test]

--- a/services/common/src/types.rs
+++ b/services/common/src/types.rs
@@ -1157,6 +1157,14 @@ pub struct Capabilities {
     /// `false` (absent ⇒ denied) — a role must be granted it explicitly.
     #[serde(default)]
     pub view_plates: bool,
+    /// Actuate devices linked to a camera (`POST /cameras/:id/ha/action`, and
+    /// the planned Reolink actuators). This is the only capability that moves
+    /// PHYSICAL hardware, locks, garage doors, sirens, so it defaults to
+    /// `false` (absent ⇒ denied) and must be granted explicitly. Seeing a
+    /// camera, and even seeing its linked entities' state, never implies being
+    /// able to operate them.
+    #[serde(default)]
+    pub actuators: bool,
 }
 
 /// Serde default for capability fields that should read as granted (not the
@@ -1178,6 +1186,7 @@ impl Capabilities {
             bookmarks: BookmarkScope::All,
             manage_views: true,
             view_plates: true,
+            actuators: true,
         }
     }
 }


### PR DESCRIPTION
Server half of #187 (HA control Phase 2), per the #52 design of record. Client PRs: #425 (iOS), #426 (desktop). Deny-by-default: no operator sees or can use any of this until an admin grants the new capability, which makes the whole set safe to merge and a natural preview feature.

## Endpoint
`POST /cameras/:id/ha/action` `{link_id, action}`, bearer JWT only. Verification order, each failing step returning before HA is contacted:
1. `actuators` capability (admin implies), else 403. Media `?token=` principals have the capability hardcoded false in `auth_mw` (with regression asserts), so a leaked media URL can never actuate.
2. Camera scope (`assert_camera_access`), else 403 (matching every other per-camera route).
3. `link_id` must exist on THIS camera with `role='actuator'`, else 404; a foreign-camera link, wrong-role link, and nonexistent link are indistinguishable to the caller.
4. Strict per-domain action allowlist on the STORED entity's domain: light/switch/fan/siren (on/off/toggle), cover (open/close/stop), lock (lock/unlock), button (press), scene/script (turn_on). No raw service/entity passthrough; the HA URL is built from a `&'static str` out of the allowlist, so no client-controlled string reaches it.

Response is `200 {"ok": true}`; clients converge state on the existing 3s `/ha/states` poll (one source of truth).

## Capability
Role-level `actuators`, default false at every layer (`#[serde(default)]`, jsonb backfill migration `0074`, registered), admin implies. Exposed at `/auth/me` `capabilities.actuators` and in the roles CRUD; roles editor checkbox added in the admin console. Reused later for Reolink actuators (#25).

## Audit
Every actuation attempt that reaches the allowlist writes a durable `system_events` row (`ha_actuation`: who, camera, link, entity, action, outcome; client strings sanitized) plus a structured tracing line. No `system_alert_rules` row, so the notification engine ignores it by design; nothing prunes `system_events`.

## Viewer payload
`GET /cameras/:id/ha/links` additionally carries `link_id` (duplicating `id`, additive) so clients address links without ever naming an HA entity.

## Tests
Exhaustive allowlist positives with a count guard; rejection tests including `homeassistant`/`shell_command` domains, case/whitespace/traversal garbage; mock-HA call-shape test; integration RBAC suite (401/403 no-capability/403 out-of-scope-camera/**media-token-can-never-actuate**/404 foreign-wrong-role-unknown links/400 disallowed actions/legacy-role-jsonb default-false); 9 new rows in the unauthenticated-route walk.

`docs/DECISIONS.md` entry included (allowlist over passthrough, role-level over per-camera in v1, poll-converged state). An adversarial security review pass runs before this leaves draft.