### PR TITLE
feat(android): HA control (single-tap actuate; card for cover/lock) (#187, #428)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/data/CrumbApi.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/CrumbApi.kt
@@ -206,6 +206,19 @@ interface CrumbApi {
     suspend fun haStates(): HaStatesResponse
 
     /**
+     * Fire a Home Assistant service call for a linked entity. Requires the
+     * `actuators` capability (admin implies it); the server enforces its own
+     * per-domain action allowlist and returns `{ "ok": true }` on success. A
+     * missing capability is 403, a rejected/unknown link 400/404, HA unreachable
+     * 502 — all surfaced to the caller as a [retrofit2.HttpException].
+     */
+    @POST("cameras/{camera_id}/ha/action")
+    suspend fun haAction(
+        @Path("camera_id") cameraId: String,
+        @Body body: HaActionRequest,
+    ): HaActionResponse
+
+    /**
      * License-plate reads (LPR) for the Plates tab — newest-first over
      * [cameraIds] (further viewer-scoped server-side; the route requires
      * `camera_ids`). [query]/[match] filter by plate text

--- a/apps/android/app/src/main/java/video/crumb/app/data/CrumbRepository.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/CrumbRepository.kt
@@ -231,6 +231,16 @@ class CrumbRepository(private val container: AppContainer) {
     suspend fun haStates(): Result<HaStatesResponse> =
         runCatchingCancellable { api.haStates() }
 
+    /**
+     * Fire an HA service call ([action], e.g. "toggle"/"open_cover"/"unlock") for
+     * a linked entity ([linkId]) on [cameraId]. Success is a bare 200 `{ok:true}`;
+     * we don't flip state locally — the `/ha/states` poll converges the shown
+     * state. A capability/validation/HA-unreachable rejection is a [Result.failure]
+     * the UI turns into a compact error via [toUserMessage].
+     */
+    suspend fun haAction(cameraId: String, linkId: String, action: String): Result<Unit> =
+        runCatchingCancellable { api.haAction(cameraId, HaActionRequest(linkId, action)); Unit }
+
     // ── motion tuner ───────────────────────────────────────────────────────────
     /** Latest live per-cell motion heatmap (null when none published yet). */
     suspend fun motionGrid(cameraId: String): Result<MotionGridDto?> =

--- a/apps/android/app/src/main/java/video/crumb/app/data/HaModels.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/HaModels.kt
@@ -15,6 +15,10 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class HaLinkDto(
     val id: String,
+    // The link's stable uuid as the server names it in the action contract. Some
+    // server builds emit only `id` (which is the same uuid); decode either and
+    // resolve through [actionLinkId] so POST /ha/action always has the id.
+    @SerialName("link_id") val linkId: String? = null,
     @SerialName("entity_id") val entityId: String,
     val role: String,
     @SerialName("device_class") val deviceClass: String? = null,
@@ -43,7 +47,51 @@ data class HaLinkDto(
 
     /** Placed on the video frame (both coordinates present) → draw an on-video badge. */
     val hasPlacement: Boolean get() = overlayX != null && overlayY != null
+
+    /** The uuid POST /ha/action expects for this link (`link_id`, else `id`). */
+    val actionLinkId: String get() = linkId ?: id
+
+    /** This link controls (not just observes) its entity — controls render only for these. */
+    val isActuator: Boolean get() = role == "actuator"
 }
+
+/** Body for POST /cameras/{id}/ha/action — fire one HA service call for a link. */
+@Serializable
+data class HaActionRequest(
+    @SerialName("link_id") val linkId: String,
+    val action: String,
+)
+
+/** Response for the HA action call: `{ "ok": true }` on success. */
+@Serializable
+data class HaActionResponse(val ok: Boolean = false)
+
+// ── HA control interaction model (issue #428) ────────────────────────────────
+// One place for the domain → interaction split, shared by the on-video badges
+// and the entity sheet so both clients behave identically. `domain` is the part
+// of `entity_id` before the first dot (e.g. `light` in `light.porch`).
+
+/**
+ * The single "primary" action a DIRECT TAP fires on a controllable actuator
+ * badge — no dialog. `null` = this domain is NOT a direct-tap control: it either
+ * needs the multi-action control sheet (see [haNeedsSheet]) or is not actuable.
+ * Mirrors the server's per-domain action allowlist for the single-tap cases.
+ */
+fun haPrimaryAction(domain: String): String? = when (domain) {
+    "light", "switch", "fan", "siren" -> "toggle"
+    "button", "input_button" -> "press"
+    "scene", "script" -> "turn_on"
+    else -> null
+}
+
+/**
+ * Domains whose control opens the detail/control SHEET instead of a single tap,
+ * because they are multi-action and/or physical-security devices that must
+ * confirm before firing: `cover` (open/stop/close) and `lock` (lock/unlock).
+ * A future value-setting control (dimmer/position) will also route here; the
+ * backend is on/off/toggle-only today, so there is no such UI yet.
+ */
+fun haNeedsSheet(domain: String): Boolean = domain == "cover" || domain == "lock"
 
 /** One entity's live state in the GET /ha/states feed. */
 @Serializable

--- a/apps/android/app/src/main/java/video/crumb/app/data/Models.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/Models.kt
@@ -78,6 +78,12 @@ data class CapabilitiesDto(
     val ptz: Boolean = false,
     /** May create/edit custom camera views. */
     @SerialName("manage_views") val manageViews: Boolean = false,
+    /**
+     * May actuate (control) linked Home Assistant devices — turn lights/switches
+     * on/off, open/close covers, lock/unlock, press buttons. Physical-security
+     * privileged, so default-off; absent on older servers → false (controls hide).
+     */
+    val actuators: Boolean = false,
     /** Bookmark access level: "none", "own", or "all". */
     val bookmarks: String = "none",
 )
@@ -122,6 +128,7 @@ data class UserDto(
             clips = true,
             ptz = true,
             manageViews = true,
+            actuators = true,
             bookmarks = "all",
         )
     } else {

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaBadgeOverlay.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaBadgeOverlay.kt
@@ -2,9 +2,10 @@
 
 package video.crumb.app.feature.live
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -37,6 +38,7 @@ import androidx.compose.material.icons.filled.Sensors
 import androidx.compose.material.icons.filled.Thermostat
 import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material.icons.filled.WaterDrop
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -258,6 +260,13 @@ private fun badgeSize(link: HaLinkDto, ps: Float): FloatArray {
  * gated by the caller on video-size-known and not-digitally-zoomed. Only the
  * badge hit-boxes are interactive — the rest of the layer passes touches through
  * to the video/PTZ beneath.
+ *
+ * Interaction (issue #428): [onBadgeTap] is the PRIMARY gesture (the caller
+ * decides direct-fire vs control sheet vs read-only detail from the link's
+ * domain/role/capability); [onBadgeLongPress] always opens the read-only detail
+ * so an actuator can be inspected without actuating. [inFlightLinkIds] holds the
+ * [HaLinkDto.actionLinkId]s of actions currently posting, shown as a brief
+ * in-flight spinner on the badge — state is never flipped locally.
  */
 @Composable
 fun HaBadgeOverlayLayer(
@@ -270,7 +279,9 @@ fun HaBadgeOverlayLayer(
     // server's own `stale` flag so a badge greys when EITHER Crumb->HA or
     // phone->Crumb has gone quiet. (#371)
     clientStale: Boolean = false,
+    inFlightLinkIds: Set<String> = emptySet(),
     onBadgeTap: (HaLinkDto) -> Unit,
+    onBadgeLongPress: (HaLinkDto) -> Unit = onBadgeTap,
 ) {
     if (videoWidth <= 0 || videoHeight <= 0) return
     val placed = remember(links) { links.filter { it.hasPlacement } }
@@ -294,21 +305,29 @@ fun HaBadgeOverlayLayer(
             val (bw, bh) = badgeSize(link, ps)
             val x = (fx + (link.overlayX ?: 0.0).toFloat() * fw).coerceIn(fx, (fx + fw - bw).coerceAtLeast(fx))
             val y = (fy + (link.overlayY ?: 0.0).toFloat() * fh).coerceIn(fy, (fy + fh - bh).coerceAtLeast(fy))
-            HaBadge(link, states, clientStale, x, y, bw, bh, onBadgeTap)
+            HaBadge(
+                link, states, clientStale,
+                inFlight = link.actionLinkId in inFlightLinkIds,
+                xDp = x, yDp = y, wDp = bw, hDp = bh,
+                onTap = onBadgeTap, onLongPress = onBadgeLongPress,
+            )
         }
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun HaBadge(
     link: HaLinkDto,
     states: HaStatesResponse?,
     clientStale: Boolean,
+    inFlight: Boolean,
     xDp: Float,
     yDp: Float,
     wDp: Float,
     hDp: Float,
     onTap: (HaLinkDto) -> Unit,
+    onLongPress: (HaLinkDto) -> Unit,
 ) {
     val st = states?.stateFor(link.entityId)
     // Stale when the server says so OR this client has missed >= 2 polls (#371).
@@ -316,6 +335,7 @@ private fun HaBadge(
     val visual = badgeVisual(link, st?.state, stale)
     val bg = parseHexColor(link.overlayBgColor) ?: BadgeDefaultBg
     val opacity = (link.overlayOpacity?.toFloat() ?: 1f).coerceIn(0.05f, 1f)
+    val isPill = link.overlayShape == "pill"
 
     Column(
         modifier = Modifier
@@ -326,17 +346,40 @@ private fun HaBadge(
         Box(
             modifier = Modifier
                 .size(width = wDp.dp, height = hDp.dp)
-                .clickable { onTap(link) },
+                // Tap = primary gesture (fire/sheet/detail, decided by the caller);
+                // long-press = read-only inspect. Both consumed here so the touch
+                // does not fall through to the video/PTZ beneath. (#428)
+                .combinedClickable(
+                    onClick = { onTap(link) },
+                    onLongClick = { onLongPress(link) },
+                ),
         ) {
             HaBadgeChip(
                 visual = visual,
-                isPill = link.overlayShape == "pill",
+                isPill = isPill,
                 pillLabel = link.displayName,
                 bgColor = bg,
                 outline = link.overlayOutline,
                 heightDp = hDp,
                 modifier = Modifier.fillMaxSize(),
             )
+            // Brief in-flight spinner while an action posts — we never flip the
+            // shown state locally; the `/ha/states` poll converges it. (#428)
+            if (inFlight) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clip(if (isPill) RoundedCornerShape(percent = 50) else CircleShape)
+                        .background(Color.Black.copy(alpha = 0.45f)),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.fillMaxSize(0.6f),
+                        color = Color.White,
+                        strokeWidth = 2.dp,
+                    )
+                }
+            }
         }
 
         val caption = buildString {

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaEntitiesSheet.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaEntitiesSheet.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import video.crumb.app.data.HaLinkDto
 import video.crumb.app.data.HaStatesResponse
+import video.crumb.app.data.haPrimaryAction
 import java.time.Duration
 import java.time.Instant
 import java.time.OffsetDateTime
@@ -144,9 +145,12 @@ private fun changedAgo(iso: String?): String? {
 }
 
 /**
- * The Home Assistant entity sheet for one camera. Read-only (Phase 1): shows the
- * camera's linked HA entities as HA-style tile cards with live state; tapping a
- * tile opens an HA "more-info"-style detail. Control lands in Phase 2.
+ * The Home Assistant entity sheet for one camera. Shows the camera's linked HA
+ * entities as HA-style tile cards with live state; tapping a tile opens an HA
+ * "more-info"-style detail. Phase 2 (#187): when [canActuate] and the link is an
+ * actuator, that detail also carries controls (with a confirm on cover/lock);
+ * every other case stays read-only. [onAction] fires one service call for a link;
+ * [inFlightLinkIds] holds the [HaLinkDto.actionLinkId]s currently posting.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -155,6 +159,9 @@ fun HaEntitiesSheet(
     links: List<HaLinkDto>,
     states: HaStatesResponse?,
     onDismiss: () -> Unit,
+    canActuate: Boolean = false,
+    inFlightLinkIds: Set<String> = emptySet(),
+    onAction: (HaLinkDto, String) -> Unit = { _, _ -> },
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var selected by remember { mutableStateOf<HaLinkDto?>(null) }
@@ -204,7 +211,13 @@ fun HaEntitiesSheet(
 
     selected?.let { link ->
         val st = states?.stateFor(link.entityId)
-        HaMoreInfoDialog(link, st?.state, st?.lastChanged, onDismiss = { selected = null })
+        HaMoreInfoDialog(
+            link, st?.state, st?.lastChanged,
+            canActuate = canActuate && link.isActuator,
+            inFlight = link.actionLinkId in inFlightLinkIds,
+            onAction = { action -> onAction(link, action) },
+            onDismiss = { selected = null },
+        )
     }
 }
 
@@ -249,16 +262,30 @@ private fun HaTile(link: HaLinkDto, state: String?, onClick: () -> Unit) {
     }
 }
 
-/** HA "more-info"-style detail dialog (read-only). Also opened by tapping an
- *  on-video badge in [HaBadgeOverlayLayer]. */
+/**
+ * HA "more-info"-style detail dialog. Read-only by default (also opened by
+ * long-pressing an on-video badge in [HaBadgeOverlayLayer], or tapping a
+ * non-controllable one). When [canActuate] is true and the link is an actuator it
+ * grows a control row: a single primary action for simple domains (fired
+ * directly), and confirm-guarded multi-action buttons for `cover`/`lock`. A
+ * future value-setting control (dimmer/position) will render here too; the
+ * backend is on/off/toggle-only today, so there is no such UI yet (#428).
+ */
 @Composable
 internal fun HaMoreInfoDialog(
     link: HaLinkDto,
     state: String?,
     lastChanged: String?,
     onDismiss: () -> Unit,
+    canActuate: Boolean = false,
+    inFlight: Boolean = false,
+    onAction: (String) -> Unit = {},
 ) {
     val v = haVisual(link, state)
+    // Pending confirm-guarded action (action verb -> human prompt), for cover/lock.
+    var pendingConfirm by remember { mutableStateOf<Pair<String, String>?>(null) }
+    val showControls = canActuate && link.isActuator
+
     androidx.compose.ui.window.Dialog(onDismissRequest = onDismiss) {
         Column(
             modifier = Modifier
@@ -281,9 +308,120 @@ internal fun HaMoreInfoDialog(
                 Spacer(Modifier.height(4.dp))
                 Text(it, color = HaSecondaryText, fontSize = 12.5.sp)
             }
+
+            if (showControls) {
+                Spacer(Modifier.height(18.dp))
+                HaControlRow(
+                    domain = link.domain,
+                    inFlight = inFlight,
+                    // Simple domains fire directly; cover/lock route through the
+                    // confirm prompt (physical-security guard).
+                    onFire = { action -> onAction(action) },
+                    onConfirm = { action, prompt -> pendingConfirm = action to prompt },
+                    entityName = link.displayName,
+                )
+            }
+
             Spacer(Modifier.height(16.dp))
             HaAttrRow("Device class", link.deviceClass?.replace('_', ' ') ?: "—")
             HaAttrRow("Entity", link.entityId)
+        }
+    }
+
+    pendingConfirm?.let { (action, prompt) ->
+        HaConfirmDialog(
+            prompt = prompt,
+            onConfirm = {
+                pendingConfirm = null
+                onAction(action)
+            },
+            onCancel = { pendingConfirm = null },
+        )
+    }
+}
+
+/**
+ * The control row for an actuator detail: one button for simple domains (toggle/
+ * press/activate, fired directly via [onFire]), Open/Stop/Close for `cover` and
+ * Lock/Unlock for `lock` (routed through [onConfirm] with a human prompt). While
+ * [inFlight], buttons are disabled and a spinner shows.
+ */
+@Composable
+private fun HaControlRow(
+    domain: String,
+    inFlight: Boolean,
+    entityName: String,
+    onFire: (String) -> Unit,
+    onConfirm: (String, String) -> Unit,
+) {
+    if (inFlight) {
+        androidx.compose.material3.CircularProgressIndicator(
+            modifier = Modifier.size(26.dp),
+            color = HaBlue,
+            strokeWidth = 2.5.dp,
+        )
+        return
+    }
+    when (domain) {
+        "cover" -> Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            HaActionButton("Open", HaBlue) { onConfirm("open_cover", "Open $entityName?") }
+            HaActionButton("Stop", HaGrey) { onConfirm("stop_cover", "Stop $entityName?") }
+            HaActionButton("Close", HaAmber) { onConfirm("close_cover", "Close $entityName?") }
+        }
+        "lock" -> Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            HaActionButton("Lock", HaBlue) { onConfirm("lock", "Lock $entityName?") }
+            HaActionButton("Unlock", HaRed) { onConfirm("unlock", "Unlock $entityName?") }
+        }
+        else -> {
+            // Simple direct-fire actuators (light/switch/fan/siren/button/scene/...).
+            val primary = haPrimaryAction(domain) ?: return
+            val label = when (primary) {
+                "toggle" -> "Toggle"
+                "press" -> "Press"
+                "turn_on" -> "Activate"
+                else -> primary.replaceFirstChar { it.uppercase() }
+            }
+            HaActionButton(label, HaBlue) { onFire(primary) }
+        }
+    }
+}
+
+/** A rounded pill action button in the HA sheet's dark theme. */
+@Composable
+private fun HaActionButton(label: String, accent: Color, onClick: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(accent.copy(alpha = 0.18f))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 18.dp, vertical = 10.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(label, color = accent, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
+    }
+}
+
+/** Confirmation prompt shown before any cover/lock action fires (#428). */
+@Composable
+private fun HaConfirmDialog(prompt: String, onConfirm: () -> Unit, onCancel: () -> Unit) {
+    androidx.compose.ui.window.Dialog(onDismissRequest = onCancel) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(16.dp))
+                .background(HaCard)
+                .padding(horizontal = 22.dp, vertical = 22.dp),
+        ) {
+            Text(prompt, color = HaPrimaryText, fontSize = 17.sp, fontWeight = FontWeight.Medium)
+            Spacer(Modifier.height(20.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                HaActionButton("Cancel", HaGrey, onClick = onCancel)
+                Spacer(Modifier.size(10.dp))
+                HaActionButton("Confirm", HaBlue, onClick = onConfirm)
+            }
         }
     }
 }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
@@ -2,6 +2,7 @@
 
 package video.crumb.app.feature.live
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -59,6 +60,9 @@ import video.crumb.app.ui.KeepScreenOn
 import video.crumb.app.data.HaLinkDto
 import video.crumb.app.data.HaStatesResponse
 import video.crumb.app.data.PtzPresetDto
+import video.crumb.app.data.haNeedsSheet
+import video.crumb.app.data.haPrimaryAction
+import video.crumb.app.data.toUserMessage
 import video.crumb.app.di.appContainer
 import video.crumb.app.ui.player.MediaFactory
 import video.crumb.app.ui.player.PlayerSurface
@@ -132,11 +136,57 @@ fun LiveFullscreenScreen(
     var haStates by remember { mutableStateOf<HaStatesResponse?>(null) }
     var haSheetOpen by remember { mutableStateOf(false) }
     var haBadgeSelected by remember { mutableStateOf<HaLinkDto?>(null) }
+    // The cover/lock badge tapped for control (opens the confirm-guarded control
+    // dialog); distinct from [haBadgeSelected], which is the read-only detail. (#428)
+    var haControlSelected by remember { mutableStateOf<HaLinkDto?>(null) }
+    // actionLinkIds of HA actions currently posting — drives the in-flight spinner
+    // on the badge / control buttons. We never flip state locally (#428).
+    var haInFlight by remember { mutableStateOf<Set<String>>(emptySet()) }
     LaunchedEffect(currentCameraId) {
         haLinks = emptyList()
         haSheetOpen = false
         haBadgeSelected = null
+        haControlSelected = null
         repo.haLinks(currentCameraId).onSuccess { haLinks = it }
+    }
+    // May this user actuate linked HA devices? Physical-security privileged and
+    // default-off; admins imply it. Older servers omit the capability → false, so
+    // controls hide and every badge stays read-only (#187).
+    val actuatorCapable = store.isAdmin || store.capabilities.actuators
+    // Fire one HA service call. Optimistic ONLY in the spinner sense; the shown
+    // state converges via the `/ha/states` poll (never a local flip). A rejection
+    // (no capability / bad link / HA unreachable) shows a compact toast.
+    val fireHaAction: (HaLinkDto, String) -> Unit = { link, action ->
+        val id = link.actionLinkId
+        haInFlight = haInFlight + id
+        scope.launch {
+            val res = repo.haAction(currentCameraId, id, action)
+            haInFlight = haInFlight - id
+            res.onFailure {
+                Toast.makeText(
+                    context,
+                    "Couldn't control ${link.displayName}: ${it.toUserMessage()}",
+                    Toast.LENGTH_LONG,
+                ).show()
+            }.onSuccess {
+                // Nudge an immediate refresh so the badge catches up fast; the
+                // periodic poll then keeps it converged.
+                repo.haStates().onSuccess { haStates = it }
+            }
+        }
+    }
+    // A single tap on a badge: fire the primary action directly for simple
+    // actuators, open the confirm-guarded control dialog for cover/lock, else
+    // fall back to the read-only detail (non-actuator, no capability, or a domain
+    // we can't actuate). Long-press always opens the read-only detail. (#428)
+    val onHaBadgeTap: (HaLinkDto) -> Unit = { link ->
+        val canActuate = actuatorCapable && link.isActuator
+        val primary = haPrimaryAction(link.domain)
+        when {
+            canActuate && primary != null -> fireHaAction(link, primary)
+            canActuate && haNeedsSheet(link.domain) -> haControlSelected = link
+            else -> haBadgeSelected = link
+        }
     }
     // Poll HA states while this camera has linked entities (to keep the on-video
     // badges live) or the sheet is open. Server demand-caches with a ~2s TTL.
@@ -152,8 +202,11 @@ fun LiveFullscreenScreen(
     // matching desktop (`live_status_controller.haStale`) and iOS
     // (`HomeAssistant` missStreak >= 2). (#371)
     var haMissStreak by remember { mutableStateOf(0) }
-    LaunchedEffect(currentCameraId, haHasPlaced, haSheetOpen) {
-        if (!haHasPlaced && !haSheetOpen) return@LaunchedEffect
+    // Keep polling while any detail/control dialog is open too, so a fired action
+    // converges the shown state even when no badge is placed on this camera (#428).
+    val haDialogOpen = haBadgeSelected != null || haControlSelected != null
+    LaunchedEffect(currentCameraId, haHasPlaced, haSheetOpen, haDialogOpen) {
+        if (!haHasPlaced && !haSheetOpen && !haDialogOpen) return@LaunchedEffect
         lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
             while (true) {
                 val res = repo.haStates().onSuccess { haStates = it }
@@ -619,9 +672,11 @@ fun LiveFullscreenScreen(
                 links = haLinks,
                 states = haStates,
                 clientStale = haStale,
+                inFlightLinkIds = haInFlight,
                 videoWidth = videoSize.width,
                 videoHeight = videoSize.height,
-                onBadgeTap = { haBadgeSelected = it },
+                onBadgeTap = onHaBadgeTap,
+                onBadgeLongPress = { haBadgeSelected = it },
             )
         }
 
@@ -894,15 +949,32 @@ fun LiveFullscreenScreen(
                 cameraName = cameraNames[currentCameraId] ?: "Camera",
                 links = haLinks,
                 states = haStates,
+                canActuate = actuatorCapable,
+                inFlightLinkIds = haInFlight,
+                onAction = { link, action -> fireHaAction(link, action) },
                 onDismiss = { haSheetOpen = false },
             )
         }
 
-        // Tapping an on-video HA badge opens the same read-only detail dialog the
-        // list sheet uses (issue #263).
+        // Long-pressing an on-video badge (or tapping a non-controllable one) opens
+        // the read-only detail dialog the list sheet uses (issue #263) — inspect
+        // without actuating (#428).
         haBadgeSelected?.let { link ->
             val st = haStates?.stateFor(link.entityId)
             HaMoreInfoDialog(link, st?.state, st?.lastChanged, onDismiss = { haBadgeSelected = null })
+        }
+
+        // Tapping a controllable cover/lock badge opens the confirm-guarded control
+        // dialog (multi-action, physical-security) (#428).
+        haControlSelected?.let { link ->
+            val st = haStates?.stateFor(link.entityId)
+            HaMoreInfoDialog(
+                link, st?.state, st?.lastChanged,
+                canActuate = true,
+                inFlight = link.actionLinkId in haInFlight,
+                onAction = { action -> fireHaAction(link, action) },
+                onDismiss = { haControlSelected = null },
+            )
         }
 
         // ── In-view PTZ controls — wheel (joystick ring) OR edge-pinned arrows ──


### PR DESCRIPTION
Adds HA control to the Android client (it previously had only the read-only badges/sheet), built directly with the refined #428 interaction model.

## What
- New `actuators` capability parsed from `/auth/me` (`CapabilitiesDto`, default false; admin implies). Controls render only when `canActuate && role=='actuator'`.
- Action POST (`POST /cameras/{id}/ha/action` `{link_id, action}`) via CrumbApi/CrumbRepository; `HaLinkDto` gains `link_id` (falls back to `id`).
- Single tap fires the primary action directly (light/switch/fan/siren -> toggle, button -> press, scene/script -> turn_on) with an on-badge spinner; state converges via the `/ha/states` poll. Split in `haPrimaryAction`/`haNeedsSheet`.
- Cover/lock open a control dialog with a confirmation ("Open Garage Door?", "Unlock Front Door?"). Long-press opens read-only detail.
- Read-only / no-capability badges unchanged. Controls also reachable from the per-camera entity sheet.

## Verification
Compiles via the `android (debug build)` CI job. Same server contract the desktop model was live-verified against real HA (#429).