### PR TITLE
fix(android): unify HA badge vs entity-sheet icon/color mapping (#437)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaBadgeOverlay.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaBadgeOverlay.kt
@@ -19,25 +19,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Bolt
-import androidx.compose.material.icons.filled.DirectionsRun
-import androidx.compose.material.icons.filled.Doorbell
-import androidx.compose.material.icons.filled.Garage
-import androidx.compose.material.icons.filled.Lightbulb
-import androidx.compose.material.icons.filled.LocalFireDepartment
-import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material.icons.filled.MovieFilter
-import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Pets
-import androidx.compose.material.icons.filled.Power
-import androidx.compose.material.icons.filled.PowerOff
-import androidx.compose.material.icons.filled.SensorDoor
-import androidx.compose.material.icons.filled.SensorWindow
-import androidx.compose.material.icons.filled.Sensors
-import androidx.compose.material.icons.filled.Thermostat
-import androidx.compose.material.icons.filled.Videocam
-import androidx.compose.material.icons.filled.WaterDrop
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -54,7 +35,6 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
@@ -66,7 +46,6 @@ import video.crumb.app.data.HaStatesResponse
 import java.time.Duration
 import java.time.Instant
 import java.time.OffsetDateTime
-import java.util.Locale
 import kotlin.math.min
 
 // On-video Home Assistant badge layer for the live fullscreen screen — the
@@ -79,139 +58,13 @@ import kotlin.math.min
 // `edgeOn` EXACTLY (including the honesty rule: unknown/stale never reads as a
 // confident "off/closed").
 
-// Palette — matches desktop `ha_icons.dart`.
-private val BadgeGrey = Color(0xFF8E8E93)
-private val BadgeAmber = Color(0xFFFFB143) // open (door/window/garage)
-private val BadgeNeutral = Color(0xFFB9C2CC) // closed/off but KNOWN — not grey
-private val BadgeBlue = Color(0xFF33C3FF) // motion / occupancy active
-private val BadgeGreen = Color(0xFF2BA84A) // switch on
-private val BadgeWarmYellow = Color(0xFFFFCC33) // light on
+// The canonical entity visual mapping (`badgeVisual`, `BadgeVisual`, the palette,
+// `parseHexColor`) lives in `HaVisual.kt`, shared with the entity sheet + more-
+// info dialog so an entity reads identically wherever Android draws it (#437).
 private val BadgeDefaultBg = Color(0xFF17171B) // near-black opaque chip
 
 private const val BASE_REF_PX = 22f // reference badge size at pane-scale 1.0
 private const val REF_SHORT_SIDE = 320f
-
-/** Resolved badge look: state color, glyph, and a friendly state label. */
-data class BadgeVisual(val color: Color, val icon: ImageVector, val label: String)
-
-/**
- * HA `state` -> on / off / indeterminate, mirroring desktop `edgeOn` (and the
- * server `edge_on`) EXACTLY. `null` = indeterminate (unavailable/unknown/
- * anything else) and is NEVER treated as off.
- */
-private fun edgeOn(state: String): Boolean? = when (state.trim().lowercase(Locale.US)) {
-    "on", "open", "detected", "true", "home", "motion", "occupied" -> true
-    "off", "closed", "clear", "false", "not_home", "no_motion" -> false
-    else -> null
-}
-
-/** device_class -> Crumb label slug (mirrors desktop `labelForDeviceClass`). */
-private fun labelForDeviceClass(deviceClass: String?): String =
-    when (deviceClass?.trim()?.lowercase(Locale.US)) {
-        "motion", "moving", "vibration" -> "motion"
-        "occupancy", "presence" -> "occupancy"
-        "door", "opening" -> "door"
-        "window" -> "window"
-        "garage_door" -> "garage"
-        else -> "sensor"
-    }
-
-/** Operator-pickable per-badge icon override (migration 0059 slug -> glyph). */
-private val badgeIconSlugs: Map<String, ImageVector> = mapOf(
-    "door" to Icons.Filled.SensorDoor,
-    "window" to Icons.Filled.SensorWindow,
-    "garage" to Icons.Filled.Garage,
-    "motion" to Icons.Filled.DirectionsRun,
-    "person" to Icons.Filled.Person,
-    "lightbulb" to Icons.Filled.Lightbulb,
-    "power" to Icons.Filled.Power,
-    "switch" to Icons.Filled.Power,
-    "lock" to Icons.Filled.Lock,
-    "doorbell" to Icons.Filled.Doorbell,
-    "water" to Icons.Filled.WaterDrop,
-    "leak" to Icons.Filled.WaterDrop,
-    "fire" to Icons.Filled.LocalFireDepartment,
-    "smoke" to Icons.Filled.LocalFireDepartment,
-    "thermostat" to Icons.Filled.Thermostat,
-    "camera" to Icons.Filled.Videocam,
-    "pet" to Icons.Filled.Pets,
-    "scene" to Icons.Filled.MovieFilter,
-    "sensor" to Icons.Filled.Sensors,
-    "energy" to Icons.Filled.Bolt,
-)
-
-private fun defaultIcon(domain: String, deviceClass: String?): ImageVector = when {
-    domain == "light" -> Icons.Filled.Lightbulb
-    domain == "switch" -> Icons.Filled.Power
-    domain == "scene" -> Icons.Filled.MovieFilter
-    else -> when (labelForDeviceClass(deviceClass)) {
-        "door" -> Icons.Filled.SensorDoor
-        "window" -> Icons.Filled.SensorWindow
-        "garage" -> Icons.Filled.Garage
-        "motion" -> Icons.Filled.DirectionsRun
-        "occupancy" -> Icons.Filled.Person
-        else -> Icons.Filled.Sensors
-    }
-}
-
-/** Port of desktop `_haVisualDefault` — device-class/domain + state -> look. */
-private fun defaultVisual(
-    domain: String,
-    deviceClass: String?,
-    state: String?,
-    stale: Boolean,
-): BadgeVisual {
-    if (domain == "scene") return BadgeVisual(BadgeNeutral, Icons.Filled.MovieFilter, "Scene")
-    val on = if (state == null || stale) null else edgeOn(state)
-    if (on == null) {
-        return BadgeVisual(BadgeGrey.copy(alpha = 0.6f), defaultIcon(domain, deviceClass), state ?: "Unknown")
-    }
-    if (domain == "light") {
-        return BadgeVisual(if (on) BadgeWarmYellow else BadgeGrey, Icons.Filled.Lightbulb, if (on) "On" else "Off")
-    }
-    if (domain == "switch") {
-        return BadgeVisual(
-            if (on) BadgeGreen else BadgeGrey,
-            if (on) Icons.Filled.Power else Icons.Filled.PowerOff,
-            if (on) "On" else "Off",
-        )
-    }
-    return when (labelForDeviceClass(deviceClass)) {
-        "door" -> BadgeVisual(if (on) BadgeAmber else BadgeNeutral, Icons.Filled.SensorDoor, if (on) "Open" else "Closed")
-        "window" -> BadgeVisual(if (on) BadgeAmber else BadgeNeutral, Icons.Filled.SensorWindow, if (on) "Open" else "Closed")
-        "garage" -> BadgeVisual(if (on) BadgeAmber else BadgeNeutral, Icons.Filled.Garage, if (on) "Open" else "Closed")
-        "motion" -> BadgeVisual(if (on) BadgeBlue else BadgeGrey, Icons.Filled.DirectionsRun, if (on) "Motion" else "Clear")
-        "occupancy" -> BadgeVisual(if (on) BadgeBlue else BadgeGrey, Icons.Filled.Person, if (on) "Occupied" else "Clear")
-        else -> BadgeVisual(if (on) BadgeBlue else BadgeGrey, Icons.Filled.Sensors, if (on) "Active" else "Clear")
-    }
-}
-
-/**
- * Port of desktop `haVisualFor`: the default look, then the operator's per-badge
- * icon/color overrides. The color override applies ONLY to a KNOWN reading
- * (active full-strength, inactive dimmed) — never to unknown/stale, where the
- * grey honesty treatment must win.
- */
-private fun badgeVisual(link: HaLinkDto, state: String?, stale: Boolean): BadgeVisual {
-    val base = defaultVisual(link.domain, link.deviceClass, state, stale)
-    val overrideIcon = link.overlayIcon?.let { badgeIconSlugs[it] }
-    val on = if (state == null || stale || link.domain == "scene") null else edgeOn(state)
-    val colorOverride = parseHexColor(link.overlayColor)
-    val color = if (colorOverride != null && on != null) {
-        if (on) colorOverride else colorOverride.copy(alpha = 0.45f)
-    } else {
-        base.color
-    }
-    return BadgeVisual(color, overrideIcon ?: base.icon, base.label)
-}
-
-/** Parse `#RRGGBB` -> opaque [Color], or null if absent/malformed. */
-private fun parseHexColor(hex: String?): Color? {
-    val h = hex?.trim()?.removePrefix("#") ?: return null
-    if (h.length != 6) return null
-    val v = h.toLongOrNull(16) ?: return null
-    return Color(0xFF000000L or v)
-}
 
 /** Compact "just now / 5s / 3m / 2h / 4d" from an RFC3339 timestamp. */
 private fun relativeAgo(iso: String?): String? {

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaEntitiesSheet.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaEntitiesSheet.kt
@@ -19,17 +19,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Bolt
-import androidx.compose.material.icons.filled.Garage
 import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.Lightbulb
-import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material.icons.filled.LockOpen
-import androidx.compose.material.icons.filled.MeetingRoom
-import androidx.compose.material.icons.filled.PowerSettingsNew
-import androidx.compose.material.icons.filled.Sensors
-import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material.icons.filled.Window
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
@@ -44,7 +34,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -54,7 +43,6 @@ import video.crumb.app.data.haPrimaryAction
 import java.time.Duration
 import java.time.Instant
 import java.time.OffsetDateTime
-import java.util.Locale
 
 // Home Assistant default (dark) theme tokens — the sheet renders in HA's own
 // look regardless of the app theme, so it feels like an extension of the HA app.
@@ -64,69 +52,16 @@ private val HaCardActive = Color(0xFF232323)
 private val HaPrimaryText = Color(0xFFE1E1E1)
 private val HaSecondaryText = Color(0xFF9B9B9B)
 private val HaDivider = Color(0x1FE1E1E1)
-private val HaBlue = Color(0xFF18BCF2) // HA brand mark
-private val HaAmber = Color(0xFFFFC107) // active state
-private val HaRed = Color(0xFFF44336) // problem state
-private val HaGrey = Color(0xFF7A7A7A) // inactive icon
+private val HaBlue = Color(0xFF18BCF2) // HA brand mark / primary action accent
+private val HaAmber = Color(0xFFFFC107) // cover Close accent
+private val HaRed = Color(0xFFF44336) // lock Unlock accent
+private val HaGrey = Color(0xFF7A7A7A) // neutral Stop / Cancel accent
 
-/** Resolved visual for one entity: state color, icon, and a display state text. */
-private data class HaVisual(val color: Color, val icon: ImageVector, val stateText: String)
-
-private val PROBLEM_CLASSES =
-    setOf("smoke", "gas", "safety", "moisture", "problem", "co", "carbon_monoxide", "tamper")
-
-/** Is a binary/state value "active" (on/open/detected)? */
-private fun isActive(state: String): Boolean =
-    when (state.lowercase(Locale.US)) {
-        "on", "open", "opening", "detected", "unlocked", "home", "playing", "active" -> true
-        else -> false
-    }
-
-/**
- * Map (domain, device_class, state) to HA's state color + icon + a friendly
- * state label, matching Home Assistant's own conventions: amber when active,
- * grey when inactive, red for problem-type binary sensors.
- */
-private fun haVisual(link: HaLinkDto, state: String?): HaVisual {
-    val s = state?.lowercase(Locale.US) ?: "unknown"
-    val dc = link.deviceClass?.lowercase(Locale.US)
-    val active = isActive(s)
-    val problem = dc in PROBLEM_CLASSES && active
-
-    val color = when {
-        s == "unavailable" || s == "unknown" -> HaGrey
-        problem -> HaRed
-        active -> HaAmber
-        else -> HaGrey
-    }
-
-    val icon = when {
-        link.domain == "light" -> Icons.Filled.Lightbulb
-        link.domain == "switch" || link.domain == "input_boolean" -> Icons.Filled.PowerSettingsNew
-        link.domain == "lock" -> if (s == "unlocked") Icons.Filled.LockOpen else Icons.Filled.Lock
-        dc == "garage" || dc == "garage_door" -> Icons.Filled.Garage
-        dc == "motion" || dc == "occupancy" || dc == "presence" || dc == "moving" -> Icons.Filled.Sensors
-        dc == "window" -> Icons.Filled.Window
-        dc == "door" || dc == "opening" || link.domain == "cover" -> Icons.Filled.MeetingRoom
-        problem -> Icons.Filled.Warning
-        else -> Icons.Filled.Bolt
-    }
-
-    // HA's friendly state text per device class.
-    val text = when {
-        s == "unavailable" -> "Unavailable"
-        s == "unknown" -> "Unknown"
-        dc == "motion" || dc == "occupancy" || dc == "presence" -> if (active) "Detected" else "Clear"
-        dc in PROBLEM_CLASSES -> if (active) "Detected" else "OK"
-        dc == "door" || dc == "window" || dc == "garage" || dc == "garage_door" ||
-            dc == "opening" || link.domain == "cover" -> if (active) "Open" else "Closed"
-        link.domain == "lock" -> if (s == "unlocked") "Unlocked" else "Locked"
-        link.domain == "light" || link.domain == "switch" || link.domain == "input_boolean" ->
-            if (active) "On" else "Off"
-        else -> state.orEmpty().replaceFirstChar { it.uppercase() }.ifBlank { "Unknown" }
-    }
-    return HaVisual(color, icon, text)
-}
+// The entity look (icon + state color + label) comes from the ONE canonical
+// mapping in `HaVisual.kt` (`badgeVisual`), shared with the on-video badge
+// overlay so an entity reads identically in the badge and in this sheet (#437).
+// The HaAmber/HaRed/HaGrey tokens above are the actuator control-row button
+// accents (#428) — the state-color derivation itself lives in `HaVisual.kt`.
 
 /** "Changed N ago" from an RFC3339 timestamp, HA-style. */
 private fun changedAgo(iso: String?): String? {
@@ -166,6 +101,8 @@ fun HaEntitiesSheet(
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var selected by remember { mutableStateOf<HaLinkDto?>(null) }
     val sorted = remember(links) { links.sortedBy { it.sortOrder } }
+    // Grey the icon honestly when HA is unreachable, exactly as the badge does.
+    val stale = states?.stale == true
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -204,7 +141,7 @@ fun HaEntitiesSheet(
         ) {
             items(sorted, key = { it.id }) { link ->
                 val st = states?.stateFor(link.entityId)
-                HaTile(link, st?.state, onClick = { selected = link })
+                HaTile(link, st?.state, stale, onClick = { selected = link })
             }
         }
     }
@@ -212,7 +149,7 @@ fun HaEntitiesSheet(
     selected?.let { link ->
         val st = states?.stateFor(link.entityId)
         HaMoreInfoDialog(
-            link, st?.state, st?.lastChanged,
+            link, st?.state, st?.lastChanged, stale,
             canActuate = canActuate && link.isActuator,
             inFlight = link.actionLinkId in inFlightLinkIds,
             onAction = { action -> onAction(link, action) },
@@ -230,8 +167,8 @@ private fun HaGrabber() {
 
 /** One HA tile card: state-colored icon in a tinted circle, name + state. */
 @Composable
-private fun HaTile(link: HaLinkDto, state: String?, onClick: () -> Unit) {
-    val v = haVisual(link, state)
+private fun HaTile(link: HaLinkDto, state: String?, stale: Boolean, onClick: () -> Unit) {
+    val v = badgeVisual(link, state, stale)
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -256,7 +193,7 @@ private fun HaTile(link: HaLinkDto, state: String?, onClick: () -> Unit) {
                 fontWeight = FontWeight.Medium,
                 maxLines = 1,
             )
-            Text(v.stateText, color = if (v.color == HaGrey) HaSecondaryText else v.color, fontSize = 13.sp)
+            Text(v.label, color = v.color, fontSize = 13.sp)
         }
         Text("›", color = Color(0xFF4C4C4C), fontSize = 20.sp)
     }
@@ -276,12 +213,13 @@ internal fun HaMoreInfoDialog(
     link: HaLinkDto,
     state: String?,
     lastChanged: String?,
+    stale: Boolean,
     onDismiss: () -> Unit,
     canActuate: Boolean = false,
     inFlight: Boolean = false,
     onAction: (String) -> Unit = {},
 ) {
-    val v = haVisual(link, state)
+    val v = badgeVisual(link, state, stale)
     // Pending confirm-guarded action (action verb -> human prompt), for cover/lock.
     var pendingConfirm by remember { mutableStateOf<Pair<String, String>?>(null) }
     val showControls = canActuate && link.isActuator
@@ -303,7 +241,7 @@ internal fun HaMoreInfoDialog(
             }
             Spacer(Modifier.height(12.dp))
             Text(link.displayName, color = HaPrimaryText, fontSize = 19.sp, fontWeight = FontWeight.Medium)
-            Text(v.stateText, color = if (v.color == HaGrey) HaSecondaryText else v.color, fontSize = 15.sp)
+            Text(v.label, color = v.color, fontSize = 15.sp)
             changedAgo(lastChanged)?.let {
                 Spacer(Modifier.height(4.dp))
                 Text(it, color = HaSecondaryText, fontSize = 12.5.sp)

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaVisual.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaVisual.kt
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.feature.live
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.DirectionsRun
+import androidx.compose.material.icons.filled.Doorbell
+import androidx.compose.material.icons.filled.Garage
+import androidx.compose.material.icons.filled.Lightbulb
+import androidx.compose.material.icons.filled.LocalFireDepartment
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.MovieFilter
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Pets
+import androidx.compose.material.icons.filled.Power
+import androidx.compose.material.icons.filled.PowerOff
+import androidx.compose.material.icons.filled.SensorDoor
+import androidx.compose.material.icons.filled.SensorWindow
+import androidx.compose.material.icons.filled.Sensors
+import androidx.compose.material.icons.filled.Thermostat
+import androidx.compose.material.icons.filled.Videocam
+import androidx.compose.material.icons.filled.WaterDrop
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import video.crumb.app.data.HaLinkDto
+import java.util.Locale
+
+// ── The ONE canonical Home Assistant visual mapping for the Android client. ──
+//
+// `badgeVisual` (icon slug -> glyph, state -> active/color/label) is the single
+// source of truth shared by BOTH the on-video badge overlay (`HaBadgeOverlay.kt`)
+// and the entity sheet + more-info dialog (`HaEntitiesSheet.kt`), so an entity
+// reads identically wherever Android draws it (issue #437). It is a faithful port
+// of the desktop `haVisualFor` + `edgeOn` (`ui/ha_overlay/ha_icons.dart`), which
+// keeps Android in step with the other clients. The closed-vocabulary rework is
+// tracked separately (issue #438) — do NOT widen the slug set here.
+
+// Palette — matches desktop `ha_icons.dart`.
+internal val BadgeGrey = Color(0xFF8E8E93)
+internal val BadgeAmber = Color(0xFFFFB143) // open (door/window/garage)
+internal val BadgeNeutral = Color(0xFFB9C2CC) // closed/off but KNOWN — not grey
+internal val BadgeBlue = Color(0xFF33C3FF) // motion / occupancy active
+internal val BadgeGreen = Color(0xFF2BA84A) // switch on
+internal val BadgeWarmYellow = Color(0xFFFFCC33) // light on
+
+/** Resolved look for one entity: state color, glyph, and a friendly state label. */
+internal data class BadgeVisual(val color: Color, val icon: ImageVector, val label: String)
+
+/**
+ * HA `state` -> on / off / indeterminate, mirroring desktop `edgeOn` (and the
+ * server `edge_on`). `null` = indeterminate (unavailable/unknown/anything else)
+ * and is NEVER treated as off. Beyond the desktop set, a few tokens the Android
+ * entity sheet relied on (`opening`, `unlocked`, `playing`, `active`, `locked`)
+ * are folded in here so those entities keep reading as active/inactive under the
+ * one unified mapping instead of falling back to indeterminate (issue #437).
+ */
+private fun edgeOn(state: String): Boolean? = when (state.trim().lowercase(Locale.US)) {
+    "on", "open", "opening", "detected", "true", "home", "motion", "occupied",
+    "unlocked", "playing", "active" -> true
+    "off", "closed", "clear", "false", "not_home", "no_motion", "locked" -> false
+    else -> null
+}
+
+/** device_class -> Crumb label slug (mirrors desktop `labelForDeviceClass`). */
+private fun labelForDeviceClass(deviceClass: String?): String =
+    when (deviceClass?.trim()?.lowercase(Locale.US)) {
+        "motion", "moving", "vibration" -> "motion"
+        "occupancy", "presence" -> "occupancy"
+        "door", "opening" -> "door"
+        "window" -> "window"
+        "garage_door" -> "garage"
+        else -> "sensor"
+    }
+
+/** Operator-pickable per-badge icon override (migration 0059 slug -> glyph). */
+private val badgeIconSlugs: Map<String, ImageVector> = mapOf(
+    "door" to Icons.Filled.SensorDoor,
+    "window" to Icons.Filled.SensorWindow,
+    "garage" to Icons.Filled.Garage,
+    "motion" to Icons.Filled.DirectionsRun,
+    "person" to Icons.Filled.Person,
+    "lightbulb" to Icons.Filled.Lightbulb,
+    "power" to Icons.Filled.Power,
+    "switch" to Icons.Filled.Power,
+    "lock" to Icons.Filled.Lock,
+    "doorbell" to Icons.Filled.Doorbell,
+    "water" to Icons.Filled.WaterDrop,
+    "leak" to Icons.Filled.WaterDrop,
+    "fire" to Icons.Filled.LocalFireDepartment,
+    "smoke" to Icons.Filled.LocalFireDepartment,
+    "thermostat" to Icons.Filled.Thermostat,
+    "camera" to Icons.Filled.Videocam,
+    "pet" to Icons.Filled.Pets,
+    "scene" to Icons.Filled.MovieFilter,
+    "sensor" to Icons.Filled.Sensors,
+    "energy" to Icons.Filled.Bolt,
+)
+
+private fun defaultIcon(domain: String, deviceClass: String?): ImageVector = when {
+    domain == "light" -> Icons.Filled.Lightbulb
+    domain == "switch" -> Icons.Filled.Power
+    domain == "scene" -> Icons.Filled.MovieFilter
+    else -> when (labelForDeviceClass(deviceClass)) {
+        "door" -> Icons.Filled.SensorDoor
+        "window" -> Icons.Filled.SensorWindow
+        "garage" -> Icons.Filled.Garage
+        "motion" -> Icons.Filled.DirectionsRun
+        "occupancy" -> Icons.Filled.Person
+        else -> Icons.Filled.Sensors
+    }
+}
+
+/** Port of desktop `_haVisualDefault` — device-class/domain + state -> look. */
+private fun defaultVisual(
+    domain: String,
+    deviceClass: String?,
+    state: String?,
+    stale: Boolean,
+): BadgeVisual {
+    if (domain == "scene") return BadgeVisual(BadgeNeutral, Icons.Filled.MovieFilter, "Scene")
+    val on = if (state == null || stale) null else edgeOn(state)
+    if (on == null) {
+        return BadgeVisual(BadgeGrey.copy(alpha = 0.6f), defaultIcon(domain, deviceClass), state ?: "Unknown")
+    }
+    if (domain == "light") {
+        return BadgeVisual(if (on) BadgeWarmYellow else BadgeGrey, Icons.Filled.Lightbulb, if (on) "On" else "Off")
+    }
+    if (domain == "switch") {
+        return BadgeVisual(
+            if (on) BadgeGreen else BadgeGrey,
+            if (on) Icons.Filled.Power else Icons.Filled.PowerOff,
+            if (on) "On" else "Off",
+        )
+    }
+    return when (labelForDeviceClass(deviceClass)) {
+        "door" -> BadgeVisual(if (on) BadgeAmber else BadgeNeutral, Icons.Filled.SensorDoor, if (on) "Open" else "Closed")
+        "window" -> BadgeVisual(if (on) BadgeAmber else BadgeNeutral, Icons.Filled.SensorWindow, if (on) "Open" else "Closed")
+        "garage" -> BadgeVisual(if (on) BadgeAmber else BadgeNeutral, Icons.Filled.Garage, if (on) "Open" else "Closed")
+        "motion" -> BadgeVisual(if (on) BadgeBlue else BadgeGrey, Icons.Filled.DirectionsRun, if (on) "Motion" else "Clear")
+        "occupancy" -> BadgeVisual(if (on) BadgeBlue else BadgeGrey, Icons.Filled.Person, if (on) "Occupied" else "Clear")
+        else -> BadgeVisual(if (on) BadgeBlue else BadgeGrey, Icons.Filled.Sensors, if (on) "Active" else "Clear")
+    }
+}
+
+/**
+ * The canonical entity look: the default look, then the operator's per-badge
+ * icon/color overrides. The color override applies ONLY to a KNOWN reading
+ * (active full-strength, inactive dimmed) — never to unknown/stale, where the
+ * grey honesty treatment must win (unknown/stale never reads as a confident
+ * "off/closed").
+ */
+internal fun badgeVisual(link: HaLinkDto, state: String?, stale: Boolean): BadgeVisual {
+    val base = defaultVisual(link.domain, link.deviceClass, state, stale)
+    val overrideIcon = link.overlayIcon?.let { badgeIconSlugs[it] }
+    val on = if (state == null || stale || link.domain == "scene") null else edgeOn(state)
+    val colorOverride = parseHexColor(link.overlayColor)
+    val color = if (colorOverride != null && on != null) {
+        if (on) colorOverride else colorOverride.copy(alpha = 0.45f)
+    } else {
+        base.color
+    }
+    return BadgeVisual(color, overrideIcon ?: base.icon, base.label)
+}
+
+/** Parse `#RRGGBB` -> opaque [Color], or null if absent/malformed. */
+internal fun parseHexColor(hex: String?): Color? {
+    val h = hex?.trim()?.removePrefix("#") ?: return null
+    if (h.length != 6) return null
+    val v = h.toLongOrNull(16) ?: return null
+    return Color(0xFF000000L or v)
+}

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
@@ -961,15 +961,19 @@ fun LiveFullscreenScreen(
         // without actuating (#428).
         haBadgeSelected?.let { link ->
             val st = haStates?.stateFor(link.entityId)
-            HaMoreInfoDialog(link, st?.state, st?.lastChanged, onDismiss = { haBadgeSelected = null })
+            // Same combined staleness the on-video badge uses (server OR client).
+            val stale = haStates?.stale == true || haStale
+            HaMoreInfoDialog(link, st?.state, st?.lastChanged, stale, onDismiss = { haBadgeSelected = null })
         }
 
         // Tapping a controllable cover/lock badge opens the confirm-guarded control
         // dialog (multi-action, physical-security) (#428).
         haControlSelected?.let { link ->
             val st = haStates?.stateFor(link.entityId)
+            // Same combined staleness the on-video badge uses (server OR client).
+            val stale = haStates?.stale == true || haStale
             HaMoreInfoDialog(
-                link, st?.state, st?.lastChanged,
+                link, st?.state, st?.lastChanged, stale,
                 canActuate = true,
                 inFlight = link.actionLinkId in haInFlight,
                 onAction = { action -> fireHaAction(link, action) },


### PR DESCRIPTION
Closes #437. Part of the HA management overhaul (epic #445), Tier 1.

Android's on-video badge and its entity sheet/more-info dialog used two different HA visual mappings (different palette, active-set, and glyphs), so the same entity read differently between them. Collapses both onto one canonical `HaVisual.kt` (the badge mapping, which matches the desktop port), and deletes the divergent sheet mapping. Stale honesty is now consistent too.

Tradeoff (intentional, sequenced): unifying onto the badge map means the sheet temporarily loses its dedicated lock/cover/problem-sensor icons (an active smoke sensor shows generic "Active" rather than red "Detected"). The richer, consistent icon set for all surfaces is the separate Tier-2 issue #438 (closed cross-client vocabulary); this PR only removes the internal Android inconsistency. Compiles via the android CI job.