### PR TITLE
feat(ha): widen entity picker to all controllable + numeric-sensor domains (#433, #436)

### DIFF
--- a/apps/desktop-flutter/lib/ui/ha_link/ha_link_dialog.dart
+++ b/apps/desktop-flutter/lib/ui/ha_link/ha_link_dialog.dart
@@ -2,9 +2,12 @@
 // console's camera-editor flow (services/api/src/admin.html ~4810-4960:
 // `loadCameraHaLinks`/`renderHaLinks`/`haOpenPicker`/`renderHaResults`/
 // `haPick`/`removeHaLink`/`saveHaLinks`, issue #52). Lets an admin link this
-// camera's HA motion/door sensors (role `motion`, domain `binary_sensor`)
-// and lights/switches/scenes (role `actuator`, domain `controls`) without
-// leaving the desktop app. The desktop's separate "Edit HA overlay…" editor
+// camera's HA motion/door sensors (role `motion`, domain `binary_sensor`),
+// numeric value sensors like temperature/humidity (role `sensor`, domain
+// `sensors`), and controllable entities — lights, switches, fans, sirens,
+// covers, locks, buttons, scenes, scripts (role `actuator`, domain `controls`,
+// the server's widened action-allowlist set) — without leaving the desktop
+// app. The desktop's separate "Edit HA overlay…" editor
 // (issue #170) then places any of these linked entities as an on-video
 // badge — this dialog only manages WHICH entities are linked, not where
 // they're drawn.
@@ -14,7 +17,7 @@
 //     `HA_SENSOR_CLASSES`) grouped first (sorted), the rest bucketed under
 //     "Other sensors" — hidden unless "Show all binary sensors" is checked
 //     or there's a search query.
-//   - Controls: grouped by entity_id domain (light/switch/scene), sorted.
+//   - Values / controls: grouped by entity_id domain, sorted.
 //   - A search box filters both by friendly_name/entity_id substring.
 //   - An already-linked-for-this-role entity is shown dimmed "(linked)" but
 //     stays tappable (a no-op re-pick, matching `haPick`'s guard).
@@ -105,7 +108,7 @@ class _HaLinkDialogState extends State<_HaLinkDialog> {
   String? _saveError;
 
   // ── picker state (mirrors HA_PICKER/HA_PICKER_SEARCH/HA_PICKER_SHOWALL) ──
-  String? _pickerRole; // 'motion' | 'actuator' | null (closed)
+  String? _pickerRole; // 'motion' | 'sensor' | 'actuator' | null (closed)
   final TextEditingController _searchCtrl = TextEditingController();
   String _pickerSearch = '';
   bool _pickerShowAll = false;
@@ -153,6 +156,16 @@ class _HaLinkDialogState extends State<_HaLinkDialog> {
     }
   }
 
+  /// Server domain/alias behind each link role: motion binary sensors, numeric
+  /// value sensors, or the widened controls set (every actuatable domain). The
+  /// server owns the real domain list; the client just asks by role. Mirrors
+  /// admin.html's `haPickerDomain`.
+  String _pickerDomain(String role) {
+    if (role == 'motion') return 'binary_sensor';
+    if (role == 'sensor') return 'sensors';
+    return 'controls';
+  }
+
   Future<void> _openPicker(String role) async {
     setState(() {
       _pickerRole = role;
@@ -161,7 +174,7 @@ class _HaLinkDialogState extends State<_HaLinkDialog> {
       _pickerError = null;
     });
     _searchCtrl.clear();
-    final domain = role == 'motion' ? 'binary_sensor' : 'controls';
+    final domain = _pickerDomain(role);
     if (_entityCache.containsKey(domain)) return;
     setState(() => _pickerLoading = true);
     try {
@@ -316,6 +329,11 @@ class _HaLinkDialogState extends State<_HaLinkDialog> {
             ),
             const SizedBox(width: 8),
             OutlinedButton(
+              onPressed: () => _openPicker('sensor'),
+              child: const Text('+ Add value'),
+            ),
+            const SizedBox(width: 8),
+            OutlinedButton(
               onPressed: () => _openPicker('actuator'),
               child: const Text('+ Add control'),
             ),
@@ -378,7 +396,11 @@ class _HaLinkDialogState extends State<_HaLinkDialog> {
 
   Widget _pickerPanel(ColorScheme scheme) {
     final role = _pickerRole!;
-    final kind = role == 'motion' ? 'sensors' : 'controls';
+    final kind = role == 'motion'
+        ? 'sensors'
+        : role == 'sensor'
+        ? 'values'
+        : 'controls';
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -418,7 +440,7 @@ class _HaLinkDialogState extends State<_HaLinkDialog> {
   }
 
   Widget _pickerResults(ColorScheme scheme, String role) {
-    final domain = role == 'motion' ? 'binary_sensor' : 'controls';
+    final domain = _pickerDomain(role);
     final all = _entityCache[domain] ?? const <HaEntity>[];
     final q = _pickerSearch.trim().toLowerCase();
     bool match(HaEntity e) =>

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -5187,8 +5187,10 @@ async function saveCameraDeviceInfo(id) {
 }
 
 /* ── Camera <-> Home Assistant entity links (issue #52, Phase 1) ──
-   Link this camera to HA motion/door sensors (role 'motion') and lights/switches
-   /scenes (role 'actuator'). Edited as a set and saved via PUT .../ha/links. */
+   Link this camera to HA motion/door sensors (role 'motion'), numeric value
+   sensors like temperature/humidity (role 'sensor'), and controllable entities
+   like lights, switches, fans, covers, locks, scenes and scripts (role
+   'actuator'). Edited as a set and saved via PUT .../ha/links. */
 let HA_LINKS = [];        // working set for the open camera
 let HA_CAM_ID = null;
 let HA_ENT_CACHE = {};    // domain -> [{entity_id, friendly_name, device_class}], per camera open
@@ -5532,6 +5534,7 @@ function renderHaLinks(configured) {
     <div>${rows}</div>
     <div style="display:flex;gap:8px;margin-top:10px;flex-wrap:wrap;align-items:center">
       <button class="ghost sm" onclick="haOpenPicker('motion')">+ Add sensor</button>
+      <button class="ghost sm" onclick="haOpenPicker('sensor')">+ Add value</button>
       <button class="ghost sm" onclick="haOpenPicker('actuator')">+ Add control</button>
       <button class="primary sm" onclick="saveHaLinks()" style="margin-left:auto">Save links</button>
     </div>
@@ -5541,11 +5544,22 @@ function renderHaLinks(configured) {
 }
 
 /* Reusable search + grouped entity picker (avoids a wall-of-entities select).
-   Sensors: whitelist device_classes grouped first, rest under a collapsed
-   "Other sensors" bucket + a Show-all toggle. Controls: grouped by domain. */
+   Motion sensors: whitelist device_classes grouped first, rest under a collapsed
+   "Other sensors" bucket + a Show-all toggle. Values (numeric sensors) and
+   controls: grouped by domain. The role maps to a server domain/alias via
+   haPickerDomain(); the server owns the actual domain list. */
+/* Server domain/alias behind each link role: motion binary sensors, numeric
+   value sensors, or the widened controls set (every actuatable domain). The
+   server owns the real domain list; the client just asks by role. */
+function haPickerDomain(role) {
+  if (role === 'motion') return 'binary_sensor';
+  if (role === 'sensor') return 'sensors';
+  return 'controls';
+}
+
 async function haOpenPicker(role) {
   HA_PICKER = role; HA_PICKER_SEARCH = ''; HA_PICKER_SHOWALL = false;
-  const domain = role === 'motion' ? 'binary_sensor' : 'controls';
+  const domain = haPickerDomain(role);
   if (!HA_ENT_CACHE[domain]) {
     const box = $('ce-ha-picker'); if (box) box.innerHTML = '<div class="card-hint" style="margin-top:8px">Loading entities from Home Assistant&hellip;</div>';
     try { HA_ENT_CACHE[domain] = await api('/ha/entities?domain=' + domain); }
@@ -5560,7 +5574,7 @@ function haToggleShowAll() { HA_PICKER_SHOWALL = !HA_PICKER_SHOWALL; renderHaRes
 
 function renderHaPicker() {
   const box = $('ce-ha-picker'); if (!box || !HA_PICKER) return;
-  const kind = HA_PICKER === 'motion' ? 'sensors' : 'controls';
+  const kind = HA_PICKER === 'motion' ? 'sensors' : (HA_PICKER === 'sensor' ? 'values' : 'controls');
   box.innerHTML = `
     <div class="policy-section" style="margin-top:8px">
       <div style="display:flex;gap:8px;align-items:center">
@@ -5578,7 +5592,7 @@ function renderHaResults() {
   const results = $('ha-pick-results'); const extra = $('ha-pick-extra');
   if (!results || !HA_PICKER) return;
   const role = HA_PICKER;
-  const domain = role === 'motion' ? 'binary_sensor' : 'controls';
+  const domain = haPickerDomain(role);
   const all = HA_ENT_CACHE[domain] || [];
   const q = HA_PICKER_SEARCH.trim().toLowerCase();
   const match = e => !q || e.entity_id.toLowerCase().includes(q) || (e.friendly_name || '').toLowerCase().includes(q);
@@ -5608,7 +5622,7 @@ function renderHaResults() {
 
 function haPick(entity_id) {
   const role = HA_PICKER; if (!role) return;
-  const domain = role === 'motion' ? 'binary_sensor' : 'controls';
+  const domain = haPickerDomain(role);
   const ent = (HA_ENT_CACHE[domain] || []).find(e => e.entity_id === entity_id);
   if (!ent) return;
   if (HA_LINKS.some(l => l.entity_id === entity_id && l.role === role)) return;

--- a/services/api/src/config_routes.rs
+++ b/services/api/src/config_routes.rs
@@ -965,7 +965,7 @@ async fn create_camera(
     let motion_source = match body.motion_source.as_deref() {
         Some(s) => normalize_motion_source(s).ok_or_else(|| {
             ApiError::BadRequest(format!(
-                "motion_source must be 'pixel' or 'frigate', got '{s}'"
+                "motion_source must be 'pixel', 'frigate', or 'ha', got '{s}'"
             ))
         })?,
         None => "pixel",
@@ -1231,7 +1231,7 @@ async fn update_camera(
         Some(s) => normalize_motion_source(s)
             .ok_or_else(|| {
                 ApiError::BadRequest(format!(
-                    "motion_source must be 'pixel' or 'frigate', got '{s}'"
+                    "motion_source must be 'pixel', 'frigate', or 'ha', got '{s}'"
                 ))
             })?
             .to_owned(),

--- a/services/api/src/ha.rs
+++ b/services/api/src/ha.rs
@@ -106,6 +106,14 @@ fn allowed_service(domain: &str, action: &str) -> Option<&'static str> {
     actions.iter().copied().find(|s| *s == action)
 }
 
+/// Every entity domain Crumb can actuate, derived straight from
+/// [`HA_ACTION_ALLOWLIST`] so the "controls" entity-picker set can never drift
+/// from the domains the action endpoint will actually accept. Order follows the
+/// allowlist.
+fn control_domains() -> Vec<&'static str> {
+    HA_ACTION_ALLOWLIST.iter().map(|(d, _)| *d).collect()
+}
+
 // ─── HTTP: shared client + picker filter ──────────────────────────────────────
 
 /// Build the shared `crumb_common::ha` client from stored settings, mapping the
@@ -198,8 +206,12 @@ struct HaEntity {
 
 #[derive(Deserialize)]
 struct EntitiesQuery {
-    /// `binary_sensor`, `light`, `switch`, `scene`, or `controls`
-    /// (light+switch+scene). Omitted ⇒ all of the above.
+    /// A single HA domain (e.g. `binary_sensor`, `sensor`, `light`, `cover`), or
+    /// one of the role aliases: `controls` (every actuatable domain from
+    /// `HA_ACTION_ALLOWLIST`: light, switch, fan, siren, cover, lock, button,
+    /// `input_button`, scene, script) or `sensors` (numeric `sensor`). Omitted ⇒
+    /// the union of all of the above (motion binary sensors + numeric sensors +
+    /// every controllable domain).
     domain: Option<String>,
 }
 
@@ -439,9 +451,20 @@ async fn get_entities(
 ) -> Result<Json<Vec<HaEntity>>, ApiError> {
     let s = effective_settings(&state).await?;
     let domains: Vec<&str> = match q.domain.as_deref() {
-        Some("controls") => vec!["light", "switch", "scene"],
+        // Actuator role: every domain the action endpoint can drive (light,
+        // switch, fan, siren, cover, lock, button, input_button, scene, script),
+        // derived from the allowlist so the two can never diverge.
+        Some("controls") => control_domains(),
+        // Numeric-sensor role (temperature/humidity/... display links).
+        Some("sensors") => vec!["sensor"],
         Some(d) => vec![d],
-        None => vec!["binary_sensor", "light", "switch", "scene"],
+        // Omitted ⇒ the union of every pickable role: motion binary sensors,
+        // numeric sensors, and every controllable domain.
+        None => {
+            let mut all = vec!["binary_sensor", "sensor"];
+            all.extend(control_domains());
+            all
+        }
     };
     let states = ha_client(&s)?
         .get_states()
@@ -889,6 +912,60 @@ mod tests {
         let controls = entities_from_states(arr, &["light", "switch", "scene"]);
         assert_eq!(controls.len(), 1);
         assert_eq!(controls[0].entity_id, "light.kitchen");
+
+        // Numeric-sensor picker set surfaces `sensor.*` only.
+        let sensors = entities_from_states(arr, &["sensor"]);
+        assert_eq!(sensors.len(), 1);
+        assert_eq!(sensors[0].entity_id, "sensor.temperature");
+    }
+
+    #[test]
+    fn control_domains_match_the_action_allowlist() {
+        // The picker's "controls" set is derived from HA_ACTION_ALLOWLIST, so
+        // every domain the action endpoint can drive is reachable through the
+        // picker, and nothing else leaks in. This guards against the two lists
+        // silently diverging.
+        let picker = control_domains();
+        let allow: Vec<&str> = HA_ACTION_ALLOWLIST.iter().map(|(d, _)| *d).collect();
+        assert_eq!(picker, allow);
+        for d in [
+            "light",
+            "switch",
+            "fan",
+            "siren",
+            "cover",
+            "lock",
+            "button",
+            "input_button",
+            "scene",
+            "script",
+        ] {
+            assert!(picker.contains(&d), "control picker missing {d}");
+        }
+        // Motion + numeric-sensor domains are NOT controls (separate roles).
+        assert!(!picker.contains(&"binary_sensor"));
+        assert!(!picker.contains(&"sensor"));
+    }
+
+    #[test]
+    fn control_domains_filter_covers_lock_and_cover() {
+        // A cover and a lock must both be pickable via the widened controls set
+        // (the flagship confirm-gated garage/lock control had buttons but no
+        // pick path before issue #433).
+        let states = json!([
+            {"entity_id": "cover.garage", "attributes": {"friendly_name": "Garage Door"}},
+            {"entity_id": "lock.front", "attributes": {"friendly_name": "Front Lock"}},
+            {"entity_id": "fan.attic", "attributes": {"friendly_name": "Attic Fan"}},
+            {"entity_id": "binary_sensor.motion", "attributes": {"friendly_name": "Motion"}}
+        ]);
+        let arr = states.as_array().unwrap();
+        let controls = entities_from_states(arr, &control_domains());
+        let ids: Vec<&str> = controls.iter().map(|e| e.entity_id.as_str()).collect();
+        assert!(ids.contains(&"cover.garage"));
+        assert!(ids.contains(&"lock.front"));
+        assert!(ids.contains(&"fan.attic"));
+        // binary_sensor is a motion entity, not a control.
+        assert!(!ids.contains(&"binary_sensor.motion"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #433, closes #436. HA management overhaul (epic #445), Tier 1 flagship.

## #433 — picker widening
The entity picker only offered light/switch/scene for control and binary_sensor for sensing, so cover/lock/fan/siren/button/scene and numeric sensors were unpickable even though the backend + allowlist support them (the confirm-gated lock/garage control had buttons wired but no way to create the link). Now:
- Backend derives the control domain set from `HA_ACTION_ALLOWLIST` (`control_domains()`), so it can't drift; a regression test asserts they match. `controls` alias = light/switch/fan/siren/cover/lock/button/input_button/scene/script; new `sensors` alias = numeric `sensor`; default = union of all pickable roles.
- Console + desktop request by role alias through one helper (the widened list lives only server-side; clients group whatever comes back). "+ Add control" now surfaces covers/locks/fans/etc; a new "+ Add value" path links numeric sensors.

## #436 — motion_source error
Error text now reads "must be 'pixel', 'frigate', or 'ha'" to match `normalize_motion_source` (accepted values unchanged).

## Verification
`node --check` on the admin.html script passed. Rust gate + desktop `flutter analyze` run via CI / the build box.