### PR TITLE
feat(ha): editable role/device_class/label on HA links (console + desktop) (#434, #435)

### DIFF
--- a/apps/desktop-flutter/lib/ui/ha_link/ha_link_dialog.dart
+++ b/apps/desktop-flutter/lib/ui/ha_link/ha_link_dialog.dart
@@ -214,6 +214,47 @@ class _HaLinkDialogState extends State<_HaLinkDialog> {
     setState(() => _links = [..._links]..removeAt(index));
   }
 
+  /// Replace one field on the working link at [index] without rebuilding the
+  /// whole list, so an in-row text field keeps focus while typing. The edited
+  /// set is persisted by [_save]. Empty text collapses to null (label falls
+  /// back to entityId, device_class is genuinely unset).
+  void _updateRole(int index, String role) {
+    final l = _links[index];
+    setState(() {
+      _links = [..._links]..[index] = HaLinkInput(
+        entityId: l.entityId,
+        role: role,
+        deviceClass: l.deviceClass,
+        label: l.label,
+        sortOrder: l.sortOrder,
+      );
+    });
+  }
+
+  void _updateLabel(int index, String label) {
+    final l = _links[index];
+    final trimmed = label.trim();
+    _links[index] = HaLinkInput(
+      entityId: l.entityId,
+      role: l.role,
+      deviceClass: l.deviceClass,
+      label: trimmed.isEmpty ? null : label,
+      sortOrder: l.sortOrder,
+    );
+  }
+
+  void _updateDeviceClass(int index, String deviceClass) {
+    final l = _links[index];
+    final trimmed = deviceClass.trim();
+    _links[index] = HaLinkInput(
+      entityId: l.entityId,
+      role: l.role,
+      deviceClass: trimmed.isEmpty ? null : deviceClass,
+      label: l.label,
+      sortOrder: l.sortOrder,
+    );
+  }
+
   Future<void> _save() async {
     setState(() {
       _saving = true;
@@ -245,14 +286,26 @@ class _HaLinkDialogState extends State<_HaLinkDialog> {
         const SnackBar(content: Text('Home Assistant links saved.')),
       );
     } catch (e) {
-      if (mounted) setState(() => _saveError = '$e');
+      // The server rejects a role that doesn't fit the entity's domain (e.g.
+      // marking a light as Motion) with a 400; surface that reason inline and
+      // as a snackbar rather than failing silently.
+      if (mounted) {
+        setState(() => _saveError = '$e');
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('$e')));
+      }
     } finally {
       if (mounted) setState(() => _saving = false);
     }
   }
 
-  String _rolePill(HaLinkInput l) =>
-      l.role == 'actuator' ? 'control' : (l.deviceClass ?? 'sensor');
+  /// The three link roles an operator can pick per row. "Control" is the
+  /// server's `actuator` role (an entity you can operate); the parenthetical
+  /// spells that out so it reads as controllable, not just another sensor.
+  static const List<(String, String)> _roleOptions = [
+    ('motion', 'Motion (triggers recording)'),
+    ('sensor', 'Sensor (status only)'),
+    ('actuator', 'Control (operate)'),
+  ];
 
   @override
   Widget build(BuildContext context) {
@@ -354,40 +407,82 @@ class _HaLinkDialogState extends State<_HaLinkDialog> {
 
   Widget _linkRow(ColorScheme scheme, int index) {
     final l = _links[index];
+    // Key each editable field to the entity so Flutter reattaches field state
+    // to the right row after a remove shifts indexes.
+    final rowKey = '${l.entityId}:${l.role}';
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 2),
-      child: Row(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-            decoration: BoxDecoration(
-              color: scheme.surfaceContainerHighest,
-              borderRadius: BorderRadius.circular(10),
-            ),
-            child: Text(_rolePill(l), style: const TextStyle(fontSize: 11)),
+          Row(
+            children: [
+              DropdownButton<String>(
+                value: l.role,
+                isDense: true,
+                style: TextStyle(fontSize: 12, color: scheme.onSurface),
+                items: [
+                  for (final (v, t) in _roleOptions)
+                    DropdownMenuItem(value: v, child: Text(t)),
+                ],
+                onChanged: (v) {
+                  if (v != null) _updateRole(index, v);
+                },
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: TextFormField(
+                  key: ValueKey('label:$rowKey'),
+                  initialValue: l.label ?? '',
+                  style: const TextStyle(fontSize: 13),
+                  decoration: InputDecoration(
+                    isDense: true,
+                    hintText: l.entityId,
+                    labelText: 'Label',
+                    border: const OutlineInputBorder(),
+                  ),
+                  onChanged: (v) => _updateLabel(index, v),
+                ),
+              ),
+              IconButton(
+                tooltip: 'Remove',
+                icon: const Icon(Icons.close, size: 16),
+                onPressed: () => _removeAt(index),
+              ),
+            ],
           ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              l.label ?? l.entityId,
-              style: const TextStyle(fontSize: 13),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
-          const SizedBox(width: 8),
-          Text(
-            l.entityId,
-            style: TextStyle(
-              fontFamily: 'monospace',
-              fontSize: 11,
-              color: scheme.onSurfaceVariant,
-            ),
-          ),
-          IconButton(
-            tooltip: 'Remove',
-            icon: const Icon(Icons.close, size: 16),
-            onPressed: () => _removeAt(index),
+          const SizedBox(height: 4),
+          Row(
+            children: [
+              SizedBox(
+                width: 160,
+                child: TextFormField(
+                  key: ValueKey('dc:$rowKey'),
+                  initialValue: l.deviceClass ?? '',
+                  style: const TextStyle(fontSize: 12),
+                  decoration: const InputDecoration(
+                    isDense: true,
+                    hintText: 'device class',
+                    labelText: 'Device class',
+                    border: OutlineInputBorder(),
+                  ),
+                  onChanged: (v) => _updateDeviceClass(index, v),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  l.entityId,
+                  style: TextStyle(
+                    fontFamily: 'monospace',
+                    fontSize: 11,
+                    color: scheme.onSurfaceVariant,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
           ),
         ],
       ),

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -5512,9 +5512,19 @@ async function loadCameraHaLinks(camId) {
   }
 }
 
-function haRolePill(l) {
-  if (l.role === 'actuator') return 'control';
-  return l.device_class || 'sensor';   // show the class (door/motion/...) for sensors
+/* The three link roles an operator can pick per row. "Control" is the server's
+   `actuator` role (an entity you can operate); the parenthetical spells that out
+   so it reads as controllable, not just another sensor. */
+const HA_ROLE_OPTS = [
+  ['motion', 'Motion (triggers recording)'],
+  ['sensor', 'Sensor (status only)'],
+  ['actuator', 'Control (operate)'],
+];
+
+function haRoleSelect(i, role) {
+  const opts = HA_ROLE_OPTS.map(([v, t]) =>
+    `<option value="${v}"${v === role ? ' selected' : ''}>${esc(t)}</option>`).join('');
+  return `<select onchange="haSetRole(${i}, this.value)" title="How Crumb uses this entity" style="font-size:12px">${opts}</select>`;
 }
 
 function renderHaLinks(configured) {
@@ -5524,9 +5534,10 @@ function renderHaLinks(configured) {
     return;
   }
   const rows = HA_LINKS.map((l, i) => `
-    <div style="display:flex;align-items:center;gap:8px;margin:4px 0">
-      <span class="pill">${esc(haRolePill(l))}</span>
-      <span style="flex:1;font-size:13px">${esc(l.label || l.entity_id)}</span>
+    <div style="display:flex;align-items:center;gap:8px;margin:6px 0;flex-wrap:wrap">
+      ${haRoleSelect(i, l.role)}
+      <input value="${esc(l.label || '')}" placeholder="${esc(l.entity_id)}" oninput="haSetLabel(${i}, this.value)" title="Display label" style="flex:1;min-width:140px;font-size:13px" />
+      <input value="${esc(l.device_class || '')}" placeholder="device class" oninput="haSetDeviceClass(${i}, this.value)" title="Home Assistant device class" style="width:120px;font-size:12px" />
       <span class="mono" style="color:var(--dim2);font-size:11px">${esc(l.entity_id)}</span>
       <button class="ghost sm" onclick="removeHaLink(${i})">Remove</button>
     </div>`).join('') || '<div class="card-hint" style="margin:4px 0">No links yet.</div>';
@@ -5542,6 +5553,14 @@ function renderHaLinks(configured) {
     <div id="ce-ha-msg" class="form-msg"></div>`;
   if (HA_PICKER) renderHaPicker();
 }
+
+/* Row-edit handlers: mutate the working set in place WITHOUT re-rendering, so a
+   text input keeps focus while typing. The edited set is persisted by
+   saveHaLinks(). Empty text collapses to null (label falls back to entity_id,
+   device_class is genuinely unset). */
+function haSetRole(i, v) { if (HA_LINKS[i]) HA_LINKS[i].role = v; }
+function haSetLabel(i, v) { if (HA_LINKS[i]) HA_LINKS[i].label = v.trim() ? v : null; }
+function haSetDeviceClass(i, v) { if (HA_LINKS[i]) HA_LINKS[i].device_class = v.trim() ? v : null; }
 
 /* Reusable search + grouped entity picker (avoids a wall-of-entities select).
    Motion sensors: whitelist device_classes grouped first, rest under a collapsed
@@ -5643,7 +5662,14 @@ async function saveHaLinks() {
     HA_PICKER = null;
     toast('Home Assistant links saved.');
     renderHaLinks(true);
-  } catch (e) { setMsg('ce-ha-msg', (e && e.message) || 'Save failed', 'err'); }
+  } catch (e) {
+    // The server rejects a role that doesn't fit the entity's domain (e.g.
+    // marking a light as Motion) with a 400; surface that reason inline and as
+    // a toast rather than failing silently.
+    const msg = (e && e.message) || 'Save failed';
+    setMsg('ce-ha-msg', msg, 'err');
+    toast(msg, 'err');
+  }
 }
 
 /* At-a-glance summary line for the collapsed "Camera info (probed)" section: the


### PR DESCRIPTION
Closes #434, closes #435. HA management overhaul (epic #445), Tier 1 (UI half; backend validation + the pinned model are the sibling PR).

Each linked entity's row is now editable after add, replacing the immutable implicit-by-add-button role and the read-only label:
- **Role selector** (Motion triggers recording / Sensor status-only / **Control (operate)**). "Control" = the existing `role='actuator'` (no schema flag added, per the pinned design); the "(operate)" wording makes controllable explicit, satisfying #435.
- **device_class** editable text (pre-filled from the HA-reported value; empty -> null).
- **Label** editable inline (empty -> null).

All persist through the existing `PUT /cameras/:id/ha/links` (no new endpoints). The picker (#448) is untouched. The backend's 400 on a bad role/domain pairing is surfaced inline + toast on both surfaces. Console (`admin.html`) and desktop (`ha_link_dialog.dart`); `node --check` passed.