### PR TITLE
feat(ha): render numeric-sensor units on badge + detail (all clients) (#449)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/data/HaModels.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/HaModels.kt
@@ -99,6 +99,10 @@ data class HaEntityState(
     @SerialName("entity_id") val entityId: String,
     val state: String,
     @SerialName("last_changed") val lastChanged: String? = null,
+    // HA `attributes.unit_of_measurement` for numeric sensors ("°F", "%", "W",
+    // ...); null when the entity has no unit (issue #449). Default null so an
+    // older server that omits the field still decodes.
+    @SerialName("unit") val unit: String? = null,
 )
 
 /** GET /ha/states response: the entity states plus cache freshness. */

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaBadgeOverlay.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaBadgeOverlay.kt
@@ -236,7 +236,7 @@ private fun HaBadge(
         }
 
         val caption = buildString {
-            if (link.overlayShowState) append(visual.label)
+            if (link.overlayShowState) append(haStateDisplay(visual, st?.state, st?.unit))
             if (link.overlayShowAge) {
                 relativeAgo(st?.lastChanged)?.let {
                     if (isNotEmpty()) append(" · ")

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaEntitiesSheet.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaEntitiesSheet.kt
@@ -141,7 +141,7 @@ fun HaEntitiesSheet(
         ) {
             items(sorted, key = { it.id }) { link ->
                 val st = states?.stateFor(link.entityId)
-                HaTile(link, st?.state, stale, onClick = { selected = link })
+                HaTile(link, st?.state, st?.unit, stale, onClick = { selected = link })
             }
         }
     }
@@ -150,6 +150,7 @@ fun HaEntitiesSheet(
         val st = states?.stateFor(link.entityId)
         HaMoreInfoDialog(
             link, st?.state, st?.lastChanged, stale,
+            unit = st?.unit,
             canActuate = canActuate && link.isActuator,
             inFlight = link.actionLinkId in inFlightLinkIds,
             onAction = { action -> onAction(link, action) },
@@ -167,7 +168,7 @@ private fun HaGrabber() {
 
 /** One HA tile card: state-colored icon in a tinted circle, name + state. */
 @Composable
-private fun HaTile(link: HaLinkDto, state: String?, stale: Boolean, onClick: () -> Unit) {
+private fun HaTile(link: HaLinkDto, state: String?, unit: String?, stale: Boolean, onClick: () -> Unit) {
     val v = badgeVisual(link, state, stale)
     Row(
         modifier = Modifier
@@ -193,7 +194,7 @@ private fun HaTile(link: HaLinkDto, state: String?, stale: Boolean, onClick: () 
                 fontWeight = FontWeight.Medium,
                 maxLines = 1,
             )
-            Text(v.label, color = v.color, fontSize = 13.sp)
+            Text(haStateDisplay(v, state, unit), color = v.color, fontSize = 13.sp)
         }
         Text("›", color = Color(0xFF4C4C4C), fontSize = 20.sp)
     }
@@ -215,6 +216,7 @@ internal fun HaMoreInfoDialog(
     lastChanged: String?,
     stale: Boolean,
     onDismiss: () -> Unit,
+    unit: String? = null,
     canActuate: Boolean = false,
     inFlight: Boolean = false,
     onAction: (String) -> Unit = {},
@@ -241,7 +243,7 @@ internal fun HaMoreInfoDialog(
             }
             Spacer(Modifier.height(12.dp))
             Text(link.displayName, color = HaPrimaryText, fontSize = 19.sp, fontWeight = FontWeight.Medium)
-            Text(v.label, color = v.color, fontSize = 15.sp)
+            Text(haStateDisplay(v, state, unit), color = v.color, fontSize = 15.sp)
             changedAgo(lastChanged)?.let {
                 Spacer(Modifier.height(4.dp))
                 Text(it, color = HaSecondaryText, fontSize = 12.5.sp)

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaVisual.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaVisual.kt
@@ -163,6 +163,28 @@ internal fun badgeVisual(link: HaLinkDto, state: String?, stale: Boolean): Badge
     return BadgeVisual(color, overrideIcon ?: base.icon, base.label)
 }
 
+/**
+ * The state text to show on a badge caption / entity sheet (issue #449): the
+ * visual's friendly label ("Open"/"On"), with the entity's
+ * `unit_of_measurement` appended when the reading is a real value — a
+ * numeric/plain state (`edgeOn == null`) that is not an indeterminate
+ * placeholder — and a unit is known: "72" -> "72 °F", "48" -> "48 %". An
+ * on/off/open/closed label never takes a unit. Returns exactly today's label
+ * when [unit] is null, so an un-updated server renders unchanged. Mirrors the
+ * desktop `haStateDisplay`.
+ */
+internal fun haStateDisplay(visual: BadgeVisual, state: String?, unit: String?): String {
+    val base = visual.label
+    val u = unit?.trim()
+    if (u.isNullOrEmpty() || state == null) return base
+    val s = state.trim()
+    if (s.isEmpty() || edgeOn(s) != null) return base
+    when (s.lowercase(Locale.US)) {
+        "unavailable", "unknown", "none" -> return base
+    }
+    return "$base $u"
+}
+
 /** Parse `#RRGGBB` -> opaque [Color], or null if absent/malformed. */
 internal fun parseHexColor(hex: String?): Color? {
     val h = hex?.trim()?.removePrefix("#") ?: return null

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
@@ -963,7 +963,7 @@ fun LiveFullscreenScreen(
             val st = haStates?.stateFor(link.entityId)
             // Same combined staleness the on-video badge uses (server OR client).
             val stale = haStates?.stale == true || haStale
-            HaMoreInfoDialog(link, st?.state, st?.lastChanged, stale, onDismiss = { haBadgeSelected = null })
+            HaMoreInfoDialog(link, st?.state, st?.lastChanged, stale, onDismiss = { haBadgeSelected = null }, unit = st?.unit)
         }
 
         // Tapping a controllable cover/lock badge opens the confirm-guarded control
@@ -974,6 +974,7 @@ fun LiveFullscreenScreen(
             val stale = haStates?.stale == true || haStale
             HaMoreInfoDialog(
                 link, st?.state, st?.lastChanged, stale,
+                unit = st?.unit,
                 canActuate = true,
                 inFlight = link.actionLinkId in haInFlight,
                 onAction = { action -> fireHaAction(link, action) },

--- a/apps/desktop-flutter/lib/api/ha_models.dart
+++ b/apps/desktop-flutter/lib/api/ha_models.dart
@@ -215,7 +215,7 @@ class HaLinkInput {
 
 /// One entity's current reading from `GET /ha/states`.
 class HaEntityState {
-  HaEntityState({required this.state, this.lastChanged});
+  HaEntityState({required this.state, this.lastChanged, this.unit});
 
   /// Raw HA state string (e.g. `"on"`, `"open"`, `"unavailable"`). Never
   /// reinterpret this as a boolean directly — use `ha_overlay/ha_icons.dart`'s
@@ -226,9 +226,15 @@ class HaEntityState {
   /// HA `last_changed` (RFC3339), passed through verbatim for "N ago" display.
   final DateTime? lastChanged;
 
+  /// HA `attributes.unit_of_measurement` for numeric sensors ("°F", "%", "W",
+  /// ...), or null when the entity has no unit (issue #449). Parsed with a
+  /// null default so an older server that omits the field still decodes.
+  final String? unit;
+
   factory HaEntityState.fromJson(Map<String, dynamic> j) => HaEntityState(
     state: (j['state'] as String?) ?? '',
     lastChanged: DateTime.tryParse((j['last_changed'] as String?) ?? ''),
+    unit: j['unit'] as String?,
   );
 }
 

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_icons.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_icons.dart
@@ -178,6 +178,37 @@ Color? parseOverlayColorHex(String? hex) {
   return Color(0xFF000000 | v);
 }
 
+/// The text to show for an entity's current reading on a badge caption / state
+/// card (issue #449). The visual's semantic label ("Open"/"On"/"Closed") when
+/// there is one, else the raw state, with the entity's
+/// `unit_of_measurement` appended when the reading is a real value — i.e. a
+/// numeric/plain state (`edgeOn == null`) that is not an indeterminate
+/// placeholder — and a unit is known: "72" + "°F" -> "72 °F", "48" + "%" ->
+/// "48 %". An on/off/open/closed label never gets a unit appended. Falls back
+/// to exactly today's text ("Open", "Unknown", the bare value) when `unit` is
+/// null.
+String haStateDisplay({
+  required HaVisual visual,
+  required String? state,
+  String? unit,
+}) {
+  final base = visual.label ?? (state ?? 'Unknown');
+  final u = unit?.trim();
+  if (u == null || u.isEmpty || state == null) return base;
+  final s = state.trim();
+  if (s.isEmpty) return base;
+  // Only a real value takes a unit: skip on/off style states (edgeOn known)
+  // and the indeterminate placeholders, which are not measurements.
+  if (edgeOn(s) != null) return base;
+  switch (s.toLowerCase()) {
+    case 'unavailable':
+    case 'unknown':
+    case 'none':
+      return base;
+  }
+  return '$base $u';
+}
+
 /// Relative "N ago" for a badge caption / state card, from HA `last_changed`.
 String haRelativeAgo(DateTime t) {
   final d = DateTime.now().difference(t);

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_layer.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_layer.dart
@@ -451,7 +451,7 @@ class HaBadgeCaptions extends StatelessWidget {
         ),
       if (showState)
         Text(
-          visual.label ?? (state?.state ?? 'Unknown'),
+          haStateDisplay(visual: visual, state: state?.state, unit: state?.unit),
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
           style: TextStyle(

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_state_card.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_state_card.dart
@@ -215,7 +215,11 @@ class _HaStateCardState extends State<HaStateCard> {
               ),
               const SizedBox(height: 6),
               Text(
-                visual.label ?? (state?.state ?? 'Unknown'),
+                haStateDisplay(
+                  visual: visual,
+                  state: state?.state,
+                  unit: state?.unit,
+                ),
                 style: TextStyle(
                   color: visual.color,
                   fontSize: 13,

--- a/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
+++ b/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
@@ -78,9 +78,11 @@ enum HA {
         }
 
         // Indeterminate (unknown/unavailable/stale) → grey, honest state text.
+        // A numeric sensor ("72", "48") lands here too (its state is not an
+        // on/off edge), so this is where its unit_of_measurement is appended.
         if stale || state == nil || (on == nil && domain != "light" && domain != "switch") {
             let sym = baseSymbol(domain: domain, deviceClass: link.deviceClass, on: false)
-            let text = raw.isEmpty ? "Unknown" : raw.capitalized
+            let text = raw.isEmpty ? "Unknown" : stateTextWithUnit(raw, unit: state?.unit)
             return HAVisual(symbol: overrideSymbol(link) ?? sym, color: grey, stateText: text, indeterminate: true)
         }
 
@@ -98,6 +100,21 @@ enum HA {
             base = classVisual(HA.classForDeviceClass(link.deviceClass), on: isOn)
         }
         return applyOverrides(link, base: base, on: isOn)
+    }
+
+    /// Append the entity's `unit_of_measurement` to a real numeric/plain reading
+    /// (issue #449): "72" + "°F" -> "72 °F", "48" + "%" -> "48 %". Never appended
+    /// to an on/off/open/closed edge label (those never reach this path) nor to
+    /// an indeterminate placeholder. Falls back to today's capitalized text when
+    /// there is no unit, so a payload from an older server renders unchanged.
+    private static func stateTextWithUnit(_ raw: String, unit: String?) -> String {
+        let base = raw.capitalized
+        guard let u = unit?.trimmingCharacters(in: .whitespaces), !u.isEmpty else { return base }
+        if edgeOn(raw) != nil { return base }
+        switch raw.lowercased() {
+        case "unavailable", "unknown", "none": return base
+        default: return "\(raw) \(u)"
+        }
     }
 
     private static func classVisual(_ cls: String, on: Bool) -> HAVisual {

--- a/apps/ios/Crumb/Models/Models.swift
+++ b/apps/ios/Crumb/Models/Models.swift
@@ -562,9 +562,14 @@ struct HaEntityState: Decodable {
     let entityId: String
     let state: String
     let lastChanged: String?
+    /// HA `attributes.unit_of_measurement` for numeric sensors ("°F", "%", "W",
+    /// ...); nil when the entity has no unit (issue #449). The synthesized
+    /// decoder treats this optional as `decodeIfPresent`, so a payload from an
+    /// older server that omits `unit` still decodes.
+    let unit: String?
 
     enum CodingKeys: String, CodingKey {
-        case state
+        case state, unit
         case entityId = "entity_id"
         case lastChanged = "last_changed"
     }


### PR DESCRIPTION
Closes #449 (with the backend sibling #452 that adds the `unit` field). HA management overhaul (epic #445), Tier 1. Renders the optional `/ha/states` `unit` as `<state> <unit>` ("72 °F", "48 %") on the badge caption + entity detail/sheet across desktop, Android, iOS; unit is only appended to real measurements (never to on/off/open/closed), and null unit renders exactly as today. Each client's HA-state model gains an optional `unit` parsed defensively so old-server payloads still decode. Gated via winbuild analyze / android CI / macmini build.