### PR TITLE
feat(ha): one closed icon vocabulary, server-enforced + mapped on all clients (#438)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaVisual.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaVisual.kt
@@ -3,24 +3,75 @@
 package video.crumb.app.feature.live
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AcUnit
+import androidx.compose.material.icons.filled.Air
+import androidx.compose.material.icons.filled.BatteryFull
+import androidx.compose.material.icons.filled.Blinds
+import androidx.compose.material.icons.filled.BlindsClosed
 import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.Campaign
+import androidx.compose.material.icons.filled.CleaningServices
+import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.Co2
+import androidx.compose.material.icons.filled.Curtains
+import androidx.compose.material.icons.filled.DeviceThermostat
+import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.DirectionsRun
 import androidx.compose.material.icons.filled.Doorbell
+import androidx.compose.material.icons.filled.ElectricMeter
+import androidx.compose.material.icons.filled.ElectricalServices
+import androidx.compose.material.icons.filled.EvStation
+import androidx.compose.material.icons.filled.Fence
 import androidx.compose.material.icons.filled.Garage
+import androidx.compose.material.icons.filled.GasMeter
+import androidx.compose.material.icons.filled.GppGood
+import androidx.compose.material.icons.filled.Grass
+import androidx.compose.material.icons.filled.HeatPump
+import androidx.compose.material.icons.filled.Highlight
+import androidx.compose.material.icons.filled.HotTub
+import androidx.compose.material.icons.filled.Hvac
+import androidx.compose.material.icons.filled.Inventory2
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.Kitchen
 import androidx.compose.material.icons.filled.Lightbulb
 import androidx.compose.material.icons.filled.LocalFireDepartment
+import androidx.compose.material.icons.filled.LocalLaundryService
 import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.LockOpen
+import androidx.compose.material.icons.filled.Mail
 import androidx.compose.material.icons.filled.MovieFilter
+import androidx.compose.material.icons.filled.NotificationsActive
+import androidx.compose.material.icons.filled.Opacity
+import androidx.compose.material.icons.filled.Outlet
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Pets
+import androidx.compose.material.icons.filled.Plumbing
+import androidx.compose.material.icons.filled.Pool
 import androidx.compose.material.icons.filled.Power
 import androidx.compose.material.icons.filled.PowerOff
+import androidx.compose.material.icons.filled.RollerShades
+import androidx.compose.material.icons.filled.Router
+import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.SensorDoor
+import androidx.compose.material.icons.filled.SensorOccupied
 import androidx.compose.material.icons.filled.SensorWindow
 import androidx.compose.material.icons.filled.Sensors
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.SmartButton
+import androidx.compose.material.icons.filled.SolarPower
+import androidx.compose.material.icons.filled.Speaker
+import androidx.compose.material.icons.filled.Terminal
 import androidx.compose.material.icons.filled.Thermostat
+import androidx.compose.material.icons.filled.ToggleOn
+import androidx.compose.material.icons.filled.Tv
+import androidx.compose.material.icons.filled.Vibration
 import androidx.compose.material.icons.filled.Videocam
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material.icons.filled.WaterDamage
 import androidx.compose.material.icons.filled.WaterDrop
+import androidx.compose.material.icons.filled.WbIncandescent
+import androidx.compose.material.icons.filled.WbSunny
+import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import video.crumb.app.data.HaLinkDto
@@ -33,8 +84,14 @@ import java.util.Locale
 // and the entity sheet + more-info dialog (`HaEntitiesSheet.kt`), so an entity
 // reads identically wherever Android draws it (issue #437). It is a faithful port
 // of the desktop `haVisualFor` + `edgeOn` (`ui/ha_overlay/ha_icons.dart`), which
-// keeps Android in step with the other clients. The closed-vocabulary rework is
-// tracked separately (issue #438) — do NOT widen the slug set here.
+// keeps Android in step with the other clients.
+//
+// `badgeIconSlugs` below covers the ENTIRE canonical closed icon vocabulary
+// defined once server-side in `services/api/src/ha.rs` (`CANONICAL_ICON_SLUGS`,
+// issue #438): every slug there maps to a Material glyph here, so an operator's
+// pick renders the same on Android as on desktop/iOS instead of degrading to the
+// generic `Sensors` dot. The server rejects any `overlay_icon` outside that set,
+// so the `?: base.icon` fallback in `badgeVisual` is defense-in-depth.
 
 // Palette — matches desktop `ha_icons.dart`.
 internal val BadgeGrey = Color(0xFF8E8E93)
@@ -43,6 +100,7 @@ internal val BadgeNeutral = Color(0xFFB9C2CC) // closed/off but KNOWN — not gr
 internal val BadgeBlue = Color(0xFF33C3FF) // motion / occupancy active
 internal val BadgeGreen = Color(0xFF2BA84A) // switch on
 internal val BadgeWarmYellow = Color(0xFFFFCC33) // light on
+internal val BadgeDanger = Color(0xFFE5484D) // smoke/gas alarm active — attention red
 
 /** Resolved look for one entity: state color, glyph, and a friendly state label. */
 internal data class BadgeVisual(val color: Color, val icon: ImageVector, val label: String)
@@ -62,7 +120,13 @@ private fun edgeOn(state: String): Boolean? = when (state.trim().lowercase(Local
     else -> null
 }
 
-/** device_class -> Crumb label slug (mirrors desktop `labelForDeviceClass`). */
+/**
+ * device_class -> Crumb badge-class slug. Mirrors desktop `labelForDeviceClass`
+ * exactly, including the display-only extensions (lock/smoke/gas/leak) that give
+ * problem sensors their own glyph + alert color instead of a generic dot (issue
+ * #438, restoring the richness #437 flattened). A SUPERSET of the backend's
+ * `label_for_device_class`; the shared first five cases stay aligned with it.
+ */
 private fun labelForDeviceClass(deviceClass: String?): String =
     when (deviceClass?.trim()?.lowercase(Locale.US)) {
         "motion", "moving", "vibration" -> "motion"
@@ -70,31 +134,101 @@ private fun labelForDeviceClass(deviceClass: String?): String =
         "door", "opening" -> "door"
         "window" -> "window"
         "garage_door" -> "garage"
+        // display-only extensions (badge/sheet richness, issue #438)
+        "lock" -> "lock"
+        "smoke" -> "smoke"
+        "gas", "carbon_monoxide" -> "gas"
+        "moisture" -> "leak"
         else -> "sensor"
     }
 
-/** Operator-pickable per-badge icon override (migration 0059 slug -> glyph). */
+/**
+ * Operator-pickable per-badge icon override (migration 0059 slug -> glyph),
+ * covering the ENTIRE canonical vocabulary (`CANONICAL_ICON_SLUGS`, issue #438).
+ * Each glyph is the Material equivalent of the desktop `kHaBadgeIconChoices`
+ * choice for the same slug, so the same pick reads the same across clients.
+ */
 private val badgeIconSlugs: Map<String, ImageVector> = mapOf(
+    // contact & openings
     "door" to Icons.Filled.SensorDoor,
     "window" to Icons.Filled.SensorWindow,
+    "gate" to Icons.Filled.Fence,
     "garage" to Icons.Filled.Garage,
-    "motion" to Icons.Filled.DirectionsRun,
-    "person" to Icons.Filled.Person,
-    "lightbulb" to Icons.Filled.Lightbulb,
-    "power" to Icons.Filled.Power,
-    "switch" to Icons.Filled.Power,
+    "cover" to Icons.Filled.BlindsClosed,
+    "blinds" to Icons.Filled.Blinds,
+    "curtains" to Icons.Filled.Curtains,
+    "shade" to Icons.Filled.RollerShades,
     "lock" to Icons.Filled.Lock,
-    "doorbell" to Icons.Filled.Doorbell,
-    "water" to Icons.Filled.WaterDrop,
-    "leak" to Icons.Filled.WaterDrop,
-    "fire" to Icons.Filled.LocalFireDepartment,
-    "smoke" to Icons.Filled.LocalFireDepartment,
-    "thermostat" to Icons.Filled.Thermostat,
-    "camera" to Icons.Filled.Videocam,
+    "key" to Icons.Filled.Key,
+    // motion & presence
+    "motion" to Icons.Filled.DirectionsRun,
+    "occupancy" to Icons.Filled.SensorOccupied,
+    "person" to Icons.Filled.Person,
     "pet" to Icons.Filled.Pets,
-    "scene" to Icons.Filled.MovieFilter,
-    "sensor" to Icons.Filled.Sensors,
+    "vibration" to Icons.Filled.Vibration,
+    // lighting
+    "lightbulb" to Icons.Filled.Lightbulb,
+    "floodlight" to Icons.Filled.Highlight,
+    "outdoor_light" to Icons.Filled.WbIncandescent,
+    // power & switches
+    "switch" to Icons.Filled.ToggleOn,
+    "power" to Icons.Filled.Power,
+    "plug" to Icons.Filled.ElectricalServices,
+    "outlet" to Icons.Filled.Outlet,
     "energy" to Icons.Filled.Bolt,
+    "meter" to Icons.Filled.ElectricMeter,
+    "battery" to Icons.Filled.BatteryFull,
+    "solar" to Icons.Filled.SolarPower,
+    "ev" to Icons.Filled.EvStation,
+    // climate & environment
+    "fan" to Icons.Filled.Air,
+    "ac" to Icons.Filled.AcUnit,
+    "heatpump" to Icons.Filled.HeatPump,
+    "hvac" to Icons.Filled.Hvac,
+    "thermostat" to Icons.Filled.Thermostat,
+    "temperature" to Icons.Filled.DeviceThermostat,
+    "humidity" to Icons.Filled.Opacity,
+    "sun" to Icons.Filled.WbSunny,
+    // safety & alarm
+    "smoke" to Icons.Filled.Cloud,
+    "gas" to Icons.Filled.GasMeter,
+    "co" to Icons.Filled.Co2,
+    "fire" to Icons.Filled.LocalFireDepartment,
+    "leak" to Icons.Filled.WaterDamage,
+    "water" to Icons.Filled.WaterDrop,
+    "valve" to Icons.Filled.Plumbing,
+    "siren" to Icons.Filled.Campaign,
+    "security" to Icons.Filled.Shield,
+    "armed" to Icons.Filled.GppGood,
+    "warning" to Icons.Filled.Warning,
+    "doorbell" to Icons.Filled.Doorbell,
+    "bell" to Icons.Filled.NotificationsActive,
+    // camera & media
+    "camera" to Icons.Filled.Videocam,
+    "tv" to Icons.Filled.Tv,
+    "speaker" to Icons.Filled.Speaker,
+    // network
+    "wifi" to Icons.Filled.Wifi,
+    "router" to Icons.Filled.Router,
+    // vehicles & delivery
+    "vehicle" to Icons.Filled.DirectionsCar,
+    "package" to Icons.Filled.Inventory2,
+    "mail" to Icons.Filled.Mail,
+    // appliances & outdoor
+    "vacuum" to Icons.Filled.CleaningServices,
+    "lawn" to Icons.Filled.Grass,
+    "fridge" to Icons.Filled.Kitchen,
+    "laundry" to Icons.Filled.LocalLaundryService,
+    "pool" to Icons.Filled.Pool,
+    "hottub" to Icons.Filled.HotTub,
+    // time
+    "clock" to Icons.Filled.Schedule,
+    // automation
+    "scene" to Icons.Filled.MovieFilter,
+    "script" to Icons.Filled.Terminal,
+    "button" to Icons.Filled.SmartButton,
+    // generic fallback
+    "sensor" to Icons.Filled.Sensors,
 )
 
 private fun defaultIcon(domain: String, deviceClass: String?): ImageVector = when {
@@ -107,6 +241,10 @@ private fun defaultIcon(domain: String, deviceClass: String?): ImageVector = whe
         "garage" -> Icons.Filled.Garage
         "motion" -> Icons.Filled.DirectionsRun
         "occupancy" -> Icons.Filled.Person
+        "lock" -> Icons.Filled.Lock
+        "smoke" -> Icons.Filled.LocalFireDepartment
+        "gas" -> Icons.Filled.Co2
+        "leak" -> Icons.Filled.WaterDamage
         else -> Icons.Filled.Sensors
     }
 }
@@ -139,6 +277,11 @@ private fun defaultVisual(
         "garage" -> BadgeVisual(if (on) BadgeAmber else BadgeNeutral, Icons.Filled.Garage, if (on) "Open" else "Closed")
         "motion" -> BadgeVisual(if (on) BadgeBlue else BadgeGrey, Icons.Filled.DirectionsRun, if (on) "Motion" else "Clear")
         "occupancy" -> BadgeVisual(if (on) BadgeBlue else BadgeGrey, Icons.Filled.Person, if (on) "Occupied" else "Clear")
+        // A binary_sensor lock reads on = unsecured/unlocked, off = locked.
+        "lock" -> BadgeVisual(if (on) BadgeAmber else BadgeNeutral, if (on) Icons.Filled.LockOpen else Icons.Filled.Lock, if (on) "Unlocked" else "Locked")
+        "smoke" -> BadgeVisual(if (on) BadgeDanger else BadgeNeutral, Icons.Filled.LocalFireDepartment, if (on) "Smoke" else "Clear")
+        "gas" -> BadgeVisual(if (on) BadgeDanger else BadgeNeutral, Icons.Filled.Co2, if (on) "Gas" else "Clear")
+        "leak" -> BadgeVisual(if (on) BadgeAmber else BadgeNeutral, Icons.Filled.WaterDamage, if (on) "Leak" else "Dry")
         else -> BadgeVisual(if (on) BadgeBlue else BadgeGrey, Icons.Filled.Sensors, if (on) "Active" else "Clear")
     }
 }

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_icons.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_icons.dart
@@ -14,14 +14,23 @@
 // equivalent of the footage-loss bug class (AGENTS.md golden rule 2's
 // spirit, applied to state honesty rather than footage).
 //
-// NOTE for the reviewing human: `sensor_door`, `sensor_window`, `garage`,
-// `movie_filter`, `lightbulb`, `power`, `power_off` — plus the
-// [kHaBadgeIconChoices] set below (`doorbell`, `notifications_active`,
-// `water_drop`, `local_fire_department`, `thermostat`, `lock`, `videocam`,
-// `pets`, `window`) — were written without a local Flutter SDK to verify
-// against `Icons.<name>`, so please double check these compile on
-// `flutter analyze`. `directions_run` and `sensors` ARE already used
-// elsewhere (confirmed safe).
+// This map covers the ENTIRE canonical closed icon vocabulary defined once
+// server-side in `services/api/src/ha.rs` (`CANONICAL_ICON_SLUGS`, issue #438):
+// every slug there has a real glyph here, so an operator's pick renders the same
+// on desktop, iOS, and Android instead of degrading to a generic dot. The server
+// rejects any `overlay_icon` outside that set, so the `?? Icons.sensors` fallback
+// in [haVisualFor] is defense-in-depth (e.g. a newer server slug) rather than an
+// expected path.
+//
+// NOTE for the reviewing human: the following `Icons.<name>` glyphs were written
+// without a local Flutter SDK to verify, so please confirm they compile on
+// `flutter analyze`: `sensor_door`, `sensor_window`, `garage`, `movie_filter`,
+// `lightbulb`, `power`, `power_off`, `doorbell`, `notifications_active`,
+// `water_drop`, `local_fire_department`, `thermostat`, `lock`, `lock_open`,
+// `videocam`, `pets`, `window`, `co2`, `water_damage`, and the #438 additions
+// `blinds_closed`, `outlet`, `device_thermostat`, `gas_meter`, `terminal`,
+// `smart_button`. `directions_run` and `sensors` ARE already used elsewhere
+// (confirmed safe).
 
 import 'package:flutter/material.dart';
 
@@ -48,6 +57,7 @@ const Color _kNeutral = Color(0xFFB9C2CC); // closed/off but KNOWN — not grey
 const Color _kBlue = Color(0xFF33C3FF); // matches the person-detection blue family
 const Color _kGreen = Color(0xFF2BA84A);
 const Color _kWarmYellow = Color(0xFFFFCC33);
+const Color _kDanger = Color(0xFFE5484D); // smoke/gas alarm active — attention red
 
 /// HA `state` string -> on/off/indeterminate, mirroring
 /// `services/common/src/ha.rs::edge_on` EXACTLY (including which strings map
@@ -77,8 +87,16 @@ bool? edgeOn(String state) {
   }
 }
 
-/// Device-class -> Crumb label slug, mirroring
-/// `services/common/src/ha.rs::label_for_device_class` exactly.
+/// Device-class -> Crumb badge-class slug. A SUPERSET of the backend's
+/// `services/common/src/ha.rs::label_for_device_class` (which the recorder uses
+/// for timeline/notification labels and only needs motion/occupancy/door/window/
+/// garage): the display badge additionally distinguishes lock, smoke, gas/CO,
+/// and leak/moisture problem sensors so those read as their own glyph + alert
+/// color everywhere instead of a generic sensor dot (issue #438, restoring the
+/// richness #437 flattened). The FIRST five cases stay byte-for-byte aligned
+/// with the backend so the shared classes never disagree. This ONE function
+/// backs both the on-video badge and the entity sheet; the iOS
+/// `classForDeviceClass` and Android `labelForDeviceClass` mirror it exactly.
 String labelForDeviceClass(String? deviceClass) {
   switch (deviceClass?.trim().toLowerCase()) {
     case 'motion':
@@ -95,6 +113,16 @@ String labelForDeviceClass(String? deviceClass) {
       return 'window';
     case 'garage_door':
       return 'garage';
+    // ── display-only extensions (badge/sheet richness, issue #438) ──
+    case 'lock':
+      return 'lock';
+    case 'smoke':
+      return 'smoke';
+    case 'gas':
+    case 'carbon_monoxide':
+      return 'gas';
+    case 'moisture':
+      return 'leak';
     default:
       return 'sensor';
   }
@@ -167,6 +195,13 @@ const Map<String, (IconData, String)> kHaBadgeIconChoices = {
   'warning': (Icons.warning, 'Warning'),
   'pool': (Icons.pool, 'Pool'),
   'hottub': (Icons.hot_tub, 'Hot tub'),
+  // ── completes the canonical closed vocabulary (issue #438) ──────────────────
+  'cover': (Icons.blinds_closed, 'Cover'),
+  'outlet': (Icons.outlet, 'Outlet'),
+  'temperature': (Icons.device_thermostat, 'Temperature'),
+  'gas': (Icons.gas_meter, 'Gas / CO'),
+  'script': (Icons.terminal, 'Script'),
+  'button': (Icons.smart_button, 'Button'),
 };
 
 /// Parse a stored '#RRGGBB' badge color override into a [Color] (full
@@ -340,6 +375,35 @@ HaVisual _haVisualDefault({
         label: on ? 'Occupied' : 'Clear',
         pulsing: on,
       );
+    case 'lock':
+      // A binary_sensor lock reads on = unsecured/unlocked (attention),
+      // off = locked (secure/neutral).
+      return HaVisual(
+        on ? Icons.lock_open : Icons.lock,
+        on ? _kAmber : _kNeutral,
+        label: on ? 'Unlocked' : 'Locked',
+      );
+    case 'smoke':
+      return HaVisual(
+        Icons.local_fire_department,
+        on ? _kDanger : _kNeutral,
+        label: on ? 'Smoke' : 'Clear',
+        pulsing: on,
+      );
+    case 'gas':
+      return HaVisual(
+        Icons.co2,
+        on ? _kDanger : _kNeutral,
+        label: on ? 'Gas' : 'Clear',
+        pulsing: on,
+      );
+    case 'leak':
+      return HaVisual(
+        Icons.water_damage,
+        on ? _kAmber : _kNeutral,
+        label: on ? 'Leak' : 'Dry',
+        pulsing: on,
+      );
     default:
       return HaVisual(
         Icons.sensors,
@@ -364,6 +428,14 @@ IconData _iconFor({required String domain, String? deviceClass}) {
       return Icons.directions_run;
     case 'occupancy':
       return Icons.person;
+    case 'lock':
+      return Icons.lock;
+    case 'smoke':
+      return Icons.local_fire_department;
+    case 'gas':
+      return Icons.co2;
+    case 'leak':
+      return Icons.water_damage;
     default:
       return Icons.sensors;
   }

--- a/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
+++ b/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
@@ -32,6 +32,7 @@ enum HA {
     static let blue = Color(hex: 0x33C3FF)
     static let green = Color(hex: 0x2BA84A)
     static let warmYellow = Color(hex: 0xFFCC33)
+    static let danger = Color(hex: 0xE5484D) // smoke/gas alarm active — attention red
 
     /// On/off/indeterminate edge, mirroring backend `edge_on`. Returns nil for
     /// anything not explicitly on or off (incl. unavailable/unknown/"").
@@ -43,7 +44,13 @@ enum HA {
         }
     }
 
-    /// device_class → coarse class, mirroring backend `label_for_device_class`.
+    /// device_class → coarse badge class. Mirrors desktop `labelForDeviceClass`
+    /// exactly, including the display-only extensions (lock/smoke/gas/leak) that
+    /// give problem sensors their own glyph + alert color instead of a generic
+    /// dot (issue #438, restoring the richness #437 flattened). A SUPERSET of the
+    /// backend's `label_for_device_class`; the shared first five cases stay
+    /// aligned with it. This ONE mapping backs both the badge and the entity
+    /// sheet.
     static func classForDeviceClass(_ dc: String?) -> String {
         switch (dc ?? "").lowercased() {
         case "motion", "moving", "vibration": return "motion"
@@ -51,6 +58,11 @@ enum HA {
         case "door", "opening": return "door"
         case "window": return "window"
         case "garage_door": return "garage"
+        // display-only extensions (badge/sheet richness, issue #438)
+        case "lock": return "lock"
+        case "smoke": return "smoke"
+        case "gas", "carbon_monoxide": return "gas"
+        case "moisture": return "leak"
         default: return "sensor"
         }
     }
@@ -134,6 +146,19 @@ enum HA {
         case "occupancy":
             return HAVisual(symbol: "person.fill", color: on ? blue : grey,
                             stateText: on ? "Occupied" : "Clear", indeterminate: false)
+        case "lock":
+            // A binary_sensor lock reads on = unsecured/unlocked, off = locked.
+            return HAVisual(symbol: on ? "lock.open.fill" : "lock.fill",
+                            color: on ? amber : neutral, stateText: on ? "Unlocked" : "Locked", indeterminate: false)
+        case "smoke":
+            return HAVisual(symbol: "smoke.fill", color: on ? danger : neutral,
+                            stateText: on ? "Smoke" : "Clear", indeterminate: false)
+        case "gas":
+            return HAVisual(symbol: "carbon.monoxide.cloud.fill", color: on ? danger : neutral,
+                            stateText: on ? "Gas" : "Clear", indeterminate: false)
+        case "leak":
+            return HAVisual(symbol: "drop.triangle.fill", color: on ? amber : neutral,
+                            stateText: on ? "Leak" : "Dry", indeterminate: false)
         default:
             return HAVisual(symbol: "sensor.fill", color: on ? blue : grey,
                             stateText: on ? "Active" : "Clear", indeterminate: false)
@@ -166,20 +191,59 @@ enum HA {
         return iconSlugToSymbol[slug]
     }
 
-    /// Curated overlay-icon slug → SF Symbol (subset of the desktop set; unknown
-    /// slugs fall back to the class default).
+    /// Curated overlay-icon slug → SF Symbol, covering the ENTIRE canonical closed
+    /// vocabulary defined once server-side (`CANONICAL_ICON_SLUGS` in
+    /// `services/api/src/ha.rs`, issue #438). Every slug there maps to a REAL SF
+    /// Symbol available on iOS 16 / macOS 13, so an operator's pick renders the
+    /// same on iOS as on desktop/Android instead of degrading to the generic
+    /// `sensor.fill` (the `?? classDefault` fallback in `overrideSymbol`).
+    ///
+    /// iOS has no dedicated window-covering symbol on our iOS 16 floor, so
+    /// cover/blinds/curtains/shade all resolve to `window.vertical.closed`; that
+    /// is an honest, compilable choice, not a missing glyph.
     static let iconSlugToSymbol: [String: String] = [
-        "door": "door.left.hand.closed", "garage": "door.garage.closed",
-        "window": "window.vertical.closed", "motion": "figure.run",
-        "occupancy": "person.fill", "presence": "person.fill", "person": "person.fill",
-        "doorbell": "bell.fill", "bell": "bell.fill", "lock": "lock.fill", "unlock": "lock.open.fill",
-        "lightbulb": "lightbulb.fill", "light": "lightbulb.fill", "power": "power",
-        "switch": "power", "outlet": "poweroutlet.type.b.fill", "plug": "powerplug.fill",
-        "thermostat": "thermometer", "temperature": "thermometer", "humidity": "humidity.fill",
-        "fan": "fan.fill", "camera": "video.fill", "car": "car.fill", "gate": "door.garage.closed",
-        "water": "drop.fill", "leak": "drop.fill", "smoke": "smoke.fill", "co": "carbon.dioxide.cloud.fill",
-        "fire": "flame.fill", "alarm": "alarm.fill", "shield": "shield.fill", "scene": "film",
-        "sensor": "sensor.fill", "lightswitch": "power", "sun": "sun.max.fill", "moon": "moon.fill",
+        // contact & openings
+        "door": "door.left.hand.closed", "window": "window.vertical.closed",
+        "gate": "door.left.hand.closed", "garage": "door.garage.closed",
+        "cover": "window.vertical.closed", "blinds": "window.vertical.closed",
+        "curtains": "window.vertical.closed", "shade": "window.vertical.closed",
+        "lock": "lock.fill", "key": "key.fill",
+        // motion & presence
+        "motion": "figure.run", "occupancy": "person.fill", "person": "person.fill",
+        "pet": "pawprint.fill", "vibration": "waveform",
+        // lighting
+        "lightbulb": "lightbulb.fill", "floodlight": "flashlight.on.fill",
+        "outdoor_light": "lightbulb.fill",
+        // power & switches
+        "switch": "switch.2", "power": "power", "plug": "powerplug.fill",
+        "outlet": "poweroutlet.type.b.fill", "energy": "bolt.fill", "meter": "gauge",
+        "battery": "battery.100", "solar": "sun.max.fill", "ev": "bolt.car.fill",
+        // climate & environment
+        "fan": "fanblades.fill", "ac": "snowflake", "heatpump": "thermometer.snowflake",
+        "hvac": "wind", "thermostat": "thermometer", "temperature": "thermometer",
+        "humidity": "humidity.fill", "sun": "sun.max.fill",
+        // safety & alarm
+        "smoke": "smoke.fill", "gas": "carbon.monoxide.cloud.fill",
+        "co": "carbon.dioxide.cloud.fill", "fire": "flame.fill",
+        "leak": "drop.triangle.fill", "water": "drop.fill", "valve": "drop.circle.fill",
+        "siren": "megaphone.fill", "security": "shield.fill", "armed": "checkmark.shield.fill",
+        "warning": "exclamationmark.triangle.fill", "doorbell": "bell.badge.fill",
+        "bell": "bell.fill",
+        // camera & media
+        "camera": "video.fill", "tv": "tv", "speaker": "hifispeaker.fill",
+        // network
+        "wifi": "wifi", "router": "network",
+        // vehicles & delivery
+        "vehicle": "car.fill", "package": "shippingbox.fill", "mail": "envelope.fill",
+        // appliances & outdoor
+        "vacuum": "sparkles", "lawn": "leaf.fill", "fridge": "snowflake",
+        "laundry": "tshirt.fill", "pool": "figure.pool.swim", "hottub": "water.waves",
+        // time
+        "clock": "clock.fill",
+        // automation
+        "scene": "film", "script": "curlybraces", "button": "hand.tap.fill",
+        // generic fallback
+        "sensor": "sensor.fill",
     ]
 
     static func colorFromHex(_ hex: String) -> Color? {

--- a/services/api/src/ha.rs
+++ b/services/api/src/ha.rs
@@ -386,13 +386,121 @@ fn valid_overlay_shape(s: &str) -> bool {
     matches!(s, "dot" | "pill")
 }
 
-/// Validate a curated icon-slug override: short, lowercase `[a-z0-9_]` — the
-/// clients own the slug → glyph mapping, the server only sanity-checks shape.
+/// Validate a curated icon-slug override's SHAPE: short, lowercase `[a-z0-9_]`.
+/// Shape and membership are two separate gates: a slug must pass this AND be a
+/// member of [`CANONICAL_ICON_SLUGS`] (see [`canonical_icon`]) to be accepted.
+/// Keeping shape distinct gives the two rejections distinct, actionable messages.
 fn valid_overlay_icon(i: &str) -> bool {
     !i.is_empty()
         && i.len() <= 64
         && i.chars()
             .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_')
+}
+
+/// The ONE canonical closed vocabulary of on-video badge icon slugs (issue #438,
+/// epic #445). This list is the single source of truth: `overlay_icon` is
+/// validated against it here, and ALL THREE clients map every slug below to a
+/// native glyph:
+/// - desktop `ha_overlay/ha_icons.dart` (`kHaBadgeIconChoices`)
+/// - iOS `Features/HomeAssistant/HomeAssistant.swift` (`HA.iconSlugToSymbol`)
+/// - Android `feature/live/HaVisual.kt` (`badgeIconSlugs`)
+///
+/// So an icon an operator picks renders the same glyph everywhere instead of
+/// silently degrading to a generic fallback on a client that never knew the slug.
+/// The future console icon picker (#439) draws from this same list.
+///
+/// Grouped for maintenance; order is not significant (validation is set
+/// membership). To add a slug: add it here AND give it a real glyph in every
+/// client map named above. The unit tests below assert the list is deduped and
+/// that every slug passes the shape check.
+pub const CANONICAL_ICON_SLUGS: &[&str] = &[
+    // contact & openings
+    "door",
+    "window",
+    "gate",
+    "garage",
+    "cover",
+    "blinds",
+    "curtains",
+    "shade",
+    "lock",
+    "key",
+    // motion & presence
+    "motion",
+    "occupancy",
+    "person",
+    "pet",
+    "vibration",
+    // lighting
+    "lightbulb",
+    "floodlight",
+    "outdoor_light",
+    // power & switches
+    "switch",
+    "power",
+    "plug",
+    "outlet",
+    "energy",
+    "meter",
+    "battery",
+    "solar",
+    "ev",
+    // climate & environment
+    "fan",
+    "ac",
+    "heatpump",
+    "hvac",
+    "thermostat",
+    "temperature",
+    "humidity",
+    "sun",
+    // safety & alarm (incl. smoke/gas/CO problem sensors)
+    "smoke",
+    "gas",
+    "co",
+    "fire",
+    "leak",
+    "water",
+    "valve",
+    "siren",
+    "security",
+    "armed",
+    "warning",
+    "doorbell",
+    "bell",
+    // camera & media
+    "camera",
+    "tv",
+    "speaker",
+    // network
+    "wifi",
+    "router",
+    // vehicles & delivery
+    "vehicle",
+    "package",
+    "mail",
+    // appliances & outdoor
+    "vacuum",
+    "lawn",
+    "fridge",
+    "laundry",
+    "pool",
+    "hottub",
+    // time
+    "clock",
+    // automation
+    "scene",
+    "script",
+    "button",
+    // generic fallback (every client also renders unknown slugs as this)
+    "sensor",
+];
+
+/// Whether an icon slug is a member of the closed [`CANONICAL_ICON_SLUGS`]
+/// vocabulary. Membership is the contract the clients implement: a slug that
+/// passes here is guaranteed a real glyph on every client.
+fn canonical_icon(slug: &str) -> bool {
+    CANONICAL_ICON_SLUGS.contains(&slug)
 }
 
 /// One entity's current state in the `GET /ha/states` feed.
@@ -605,6 +713,17 @@ async fn put_placement(
                     return Err(ApiError::BadRequest(
                         "placement icon must be a short lowercase [a-z0-9_] slug".to_owned(),
                     ));
+                }
+                // Membership in the closed vocabulary is what guarantees every
+                // client can render the slug (issue #438). A shape-valid but
+                // off-list slug would render fine on the client that authored it
+                // and fall back to a generic glyph on the others, which is the
+                // exact divergence this endpoint now refuses.
+                if !canonical_icon(i) {
+                    return Err(ApiError::BadRequest(format!(
+                        "placement icon '{i}' is not a known badge icon (see the closed icon \
+                         vocabulary; the console icon picker only offers valid slugs)"
+                    )));
                 }
             }
             if let Some(s) = &p.shape {
@@ -1320,5 +1439,117 @@ mod tests {
         assert!(!valid_overlay_icon("Sensor_Door")); // uppercase
         assert!(!valid_overlay_icon("door bell")); // space
         assert!(!valid_overlay_icon(&"x".repeat(65))); // too long
+    }
+
+    #[test]
+    fn canonical_icon_vocabulary_is_well_formed() {
+        // The list is deduped: a stray duplicate would silently misrepresent the
+        // contract (and a future picker would show it twice).
+        let set: std::collections::HashSet<&&str> = CANONICAL_ICON_SLUGS.iter().collect();
+        assert_eq!(
+            set.len(),
+            CANONICAL_ICON_SLUGS.len(),
+            "CANONICAL_ICON_SLUGS contains a duplicate slug"
+        );
+        // Every canonical slug is itself shape-valid, so the two gates in the
+        // handler can never contradict each other (a canonical slug that failed
+        // the shape check would be permanently unusable).
+        for slug in CANONICAL_ICON_SLUGS {
+            assert!(
+                valid_overlay_icon(slug),
+                "canonical slug '{slug}' fails the shape check"
+            );
+            assert!(canonical_icon(slug), "canonical slug '{slug}' not a member");
+        }
+        // The generic fallback every client also renders must be in the set.
+        assert!(canonical_icon("sensor"));
+    }
+
+    #[test]
+    fn canonical_icon_covers_every_desktop_picker_slug() {
+        // The desktop badge editor was the most complete slug set before #438;
+        // every slug it could already store MUST remain accepted, or a prior
+        // placement's icon would start 400ing on the next edit. This is the
+        // regression guard for that stored-data compatibility.
+        for slug in [
+            "door",
+            "window",
+            "garage",
+            "gate",
+            "motion",
+            "person",
+            "lightbulb",
+            "power",
+            "plug",
+            "lock",
+            "doorbell",
+            "bell",
+            "water",
+            "fire",
+            "thermostat",
+            "fan",
+            "camera",
+            "pet",
+            "scene",
+            "sensor",
+            "floodlight",
+            "outdoor_light",
+            "siren",
+            "security",
+            "armed",
+            "blinds",
+            "curtains",
+            "shade",
+            "ac",
+            "heatpump",
+            "hvac",
+            "humidity",
+            "smoke",
+            "co",
+            "leak",
+            "valve",
+            "battery",
+            "energy",
+            "meter",
+            "switch",
+            "vibration",
+            "occupancy",
+            "sun",
+            "vehicle",
+            "package",
+            "mail",
+            "speaker",
+            "tv",
+            "vacuum",
+            "lawn",
+            "solar",
+            "ev",
+            "fridge",
+            "laundry",
+            "wifi",
+            "router",
+            "clock",
+            "key",
+            "warning",
+            "pool",
+            "hottub",
+        ] {
+            assert!(
+                canonical_icon(slug),
+                "desktop slug '{slug}' dropped from vocabulary"
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_icon_rejects_off_list_slugs() {
+        // Shape-valid but NOT in the vocabulary: exactly the case the handler now
+        // rejects (it would otherwise render as a generic glyph on clients that
+        // did not author it).
+        assert!(valid_overlay_icon("banana_phone")); // passes shape...
+        assert!(!canonical_icon("banana_phone")); // ...but is off-list.
+        assert!(!canonical_icon("sensor_door")); // legacy shape-only example, not a slug.
+        assert!(!canonical_icon("")); // empty is neither shape-valid nor a member.
+        assert!(!canonical_icon("lightbulb2")); // near-miss of a real slug.
     }
 }


### PR DESCRIPTION
Closes #438. HA management overhaul (epic #445), Tier 2 contract.

Fixes the cross-client icon drift (an icon picked on desktop silently vanished on mobile) and restores the lock/cover/smoke richness the Android unify (#437) had flattened.

- **Canonical vocabulary defined once server-side:** `CANONICAL_ICON_SLUGS` in `ha.rs` (67 slugs, deduped + documented). A strict superset of the 62 legacy desktop slugs, so no stored `overlay_icon` is newly rejected.
- **Server-enforced:** `put_placement` rejects a shape-valid but off-list icon with a 400 (membership gate). Tests: well-formed vocabulary, covers-every-legacy-slug regression, rejects off-list.
- **All 3 clients map every canonical slug** (67/67 each, verified; per-client generic fallback kept): desktop `ha_icons.dart`, Android `HaVisual.kt` (Material), iOS `HomeAssistant.swift` (SF Symbols, all verified real at the iOS 16 floor).
- **Unified device-class defaults** across clients (badge + sheet share one derivation): smoke/gas/CO -> smoke glyph + alert red, lock -> lock/unlock, cover/garage/blinds -> matching glyphs, consistently.

Gated across rust CI + winbuild analyze + android CI (the compile gate for icon names) + macmini build.