### PR TITLE
feat(ha): per-link control config — require_confirm + allowed_actions (#440)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/data/HaModels.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/HaModels.kt
@@ -38,9 +38,24 @@ data class HaLinkDto(
     @SerialName("overlay_shape") val overlayShape: String? = null,
     @SerialName("overlay_bg_color") val overlayBgColor: String? = null,
     @SerialName("overlay_outline") val overlayOutline: Boolean = false,
+    // ── Per-link control config (migration 0075, issue #440). Both default to
+    // today's behavior, so an older server that omits them decodes unchanged
+    // (kotlinx nullable + default; JSON layer also ignores unknown keys).
+    // require_confirm: prompt a confirm before EVERY action on this link.
+    // allowed_actions: when non-null, offer/allow ONLY these actions.
+    @SerialName("require_confirm") val requireConfirm: Boolean = false,
+    @SerialName("allowed_actions") val allowedActions: List<String>? = null,
 ) {
     /** The HA domain — the part before the dot in `light.porch`. */
     val domain: String get() = entityId.substringBefore('.', "")
+
+    /**
+     * Whether [action] is permitted by this link's [allowedActions] gate
+     * (migration 0075). A null list means "all of the domain's actions"
+     * (today's behavior).
+     */
+    fun actionAllowed(action: String): Boolean =
+        allowedActions == null || action in allowedActions
 
     /** Display caption: the operator's label, else the entity id. */
     val displayName: String get() = label?.takeIf { it.isNotBlank() } ?: entityId
@@ -92,6 +107,55 @@ fun haPrimaryAction(domain: String): String? = when (domain) {
  * backend is on/off/toggle-only today, so there is no such UI yet.
  */
 fun haNeedsSheet(domain: String): Boolean = domain == "cover" || domain == "lock"
+
+/** One control action: its wire verb + human caption. */
+data class HaAction(val verb: String, val label: String)
+
+/**
+ * The FULL action set for a domain, mirroring the server allowlist. A SUPERSET
+ * of the default control row: the simple on/off domains include `toggle` (which
+ * the default row expresses as a single primary tap), so a link restricted via
+ * `allowed_actions` (migration 0075) to exactly `toggle` can still render. Used
+ * only for the restricted case; intersected with the link's allowed_actions.
+ */
+fun haFullActions(domain: String): List<HaAction> = when (domain) {
+    "light", "switch", "fan", "siren" -> listOf(
+        HaAction("turn_on", "On"),
+        HaAction("turn_off", "Off"),
+        HaAction("toggle", "Toggle"),
+    )
+    "cover" -> listOf(
+        HaAction("open_cover", "Open"),
+        HaAction("stop_cover", "Stop"),
+        HaAction("close_cover", "Close"),
+    )
+    "lock" -> listOf(HaAction("lock", "Lock"), HaAction("unlock", "Unlock"))
+    "button", "input_button" -> listOf(HaAction("press", "Press"))
+    "scene" -> listOf(HaAction("turn_on", "Activate"))
+    "script" -> listOf(HaAction("turn_on", "Run"))
+    else -> emptyList()
+}
+
+/**
+ * Today's DEFAULT control set for a domain (unrestricted link): the simple
+ * domains collapse to the single primary tap ([haPrimaryAction]); cover/lock and
+ * the rest show their full set. Preserves the exact pre-0075 control row.
+ */
+fun haDefaultActions(domain: String): List<HaAction> {
+    val primary = haPrimaryAction(domain)
+    val full = haFullActions(domain)
+    return if (primary != null) full.filter { it.verb == primary } else full
+}
+
+/**
+ * The control actions to present for [this] link, honoring `allowed_actions`
+ * (migration 0075): null ⇒ today's default set; non-null ⇒ the full domain set
+ * intersected with the permitted verbs (present ONLY those).
+ */
+fun HaLinkDto.controlActions(): List<HaAction> {
+    val allowed = allowedActions ?: return haDefaultActions(domain)
+    return haFullActions(domain).filter { it.verb in allowed }
+}
 
 /** One entity's live state in the GET /ha/states feed. */
 @Serializable

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaEntitiesSheet.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaEntitiesSheet.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import video.crumb.app.data.HaLinkDto
 import video.crumb.app.data.HaStatesResponse
-import video.crumb.app.data.haPrimaryAction
+import video.crumb.app.data.controlActions
 import java.time.Duration
 import java.time.Instant
 import java.time.OffsetDateTime
@@ -252,10 +252,11 @@ internal fun HaMoreInfoDialog(
             if (showControls) {
                 Spacer(Modifier.height(18.dp))
                 HaControlRow(
-                    domain = link.domain,
+                    link = link,
                     inFlight = inFlight,
-                    // Simple domains fire directly; cover/lock route through the
-                    // confirm prompt (physical-security guard).
+                    // Simple domains fire directly; cover/lock (and any link with
+                    // require_confirm, migration 0075) route through the confirm
+                    // prompt (physical-security guard).
                     onFire = { action -> onAction(action) },
                     onConfirm = { action, prompt -> pendingConfirm = action to prompt },
                     entityName = link.displayName,
@@ -281,14 +282,18 @@ internal fun HaMoreInfoDialog(
 }
 
 /**
- * The control row for an actuator detail: one button for simple domains (toggle/
- * press/activate, fired directly via [onFire]), Open/Stop/Close for `cover` and
- * Lock/Unlock for `lock` (routed through [onConfirm] with a human prompt). While
- * [inFlight], buttons are disabled and a spinner shows.
+ * The control row for an actuator detail. The button set is derived from the
+ * link's [HaLinkDto.controlActions] (migration 0075): today's default single
+ * primary for simple domains, Open/Stop/Close for `cover`, Lock/Unlock for
+ * `lock`, or exactly the permitted subset when the link restricts
+ * `allowed_actions`. A button routes through [onConfirm] (a prompt) when the
+ * link requires a confirm or the domain is a physical-security one (cover/lock),
+ * else fires directly via [onFire]. While [inFlight], buttons are replaced by a
+ * spinner.
  */
 @Composable
 private fun HaControlRow(
-    domain: String,
+    link: HaLinkDto,
     inFlight: Boolean,
     entityName: String,
     onFire: (String) -> Unit,
@@ -302,28 +307,26 @@ private fun HaControlRow(
         )
         return
     }
-    when (domain) {
-        "cover" -> Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            HaActionButton("Open", HaBlue) { onConfirm("open_cover", "Open $entityName?") }
-            HaActionButton("Stop", HaGrey) { onConfirm("stop_cover", "Stop $entityName?") }
-            HaActionButton("Close", HaAmber) { onConfirm("close_cover", "Close $entityName?") }
-        }
-        "lock" -> Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            HaActionButton("Lock", HaBlue) { onConfirm("lock", "Lock $entityName?") }
-            HaActionButton("Unlock", HaRed) { onConfirm("unlock", "Unlock $entityName?") }
-        }
-        else -> {
-            // Simple direct-fire actuators (light/switch/fan/siren/button/scene/...).
-            val primary = haPrimaryAction(domain) ?: return
-            val label = when (primary) {
-                "toggle" -> "Toggle"
-                "press" -> "Press"
-                "turn_on" -> "Activate"
-                else -> primary.replaceFirstChar { it.uppercase() }
+    val needsConfirm = link.requireConfirm || link.domain == "cover" || link.domain == "lock"
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        for (action in link.controlActions()) {
+            HaActionButton(action.label, haActionAccent(action.verb)) {
+                if (needsConfirm) {
+                    onConfirm(action.verb, "${action.label} $entityName?")
+                } else {
+                    onFire(action.verb)
+                }
             }
-            HaActionButton(label, HaBlue) { onFire(primary) }
         }
     }
+}
+
+/** Accent color for a control button, preserving the cover/lock/simple palette. */
+private fun haActionAccent(verb: String): Color = when (verb) {
+    "turn_off", "close_cover" -> HaAmber
+    "unlock" -> HaRed
+    "stop_cover" -> HaGrey
+    else -> HaBlue // turn_on, toggle, open_cover, lock, press
 }
 
 /** A rounded pill action button in the HA sheet's dark theme. */

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
@@ -60,7 +60,7 @@ import video.crumb.app.ui.KeepScreenOn
 import video.crumb.app.data.HaLinkDto
 import video.crumb.app.data.HaStatesResponse
 import video.crumb.app.data.PtzPresetDto
-import video.crumb.app.data.haNeedsSheet
+import video.crumb.app.data.controlActions
 import video.crumb.app.data.haPrimaryAction
 import video.crumb.app.data.toUserMessage
 import video.crumb.app.di.appContainer
@@ -182,9 +182,14 @@ fun LiveFullscreenScreen(
     val onHaBadgeTap: (HaLinkDto) -> Unit = { link ->
         val canActuate = actuatorCapable && link.isActuator
         val primary = haPrimaryAction(link.domain)
+        // Direct-fire only when the link neither requires a confirm nor restricts
+        // its primary action away (migration 0075, issue #440). A require_confirm
+        // link, or one whose control set the primary is not in, opens the control
+        // dialog (which confirms and/or shows only the permitted actions).
+        val directOk = primary != null && !link.requireConfirm && link.actionAllowed(primary)
         when {
-            canActuate && primary != null -> fireHaAction(link, primary)
-            canActuate && haNeedsSheet(link.domain) -> haControlSelected = link
+            canActuate && directOk -> fireHaAction(link, primary!!)
+            canActuate && link.controlActions().isNotEmpty() -> haControlSelected = link
             else -> haBadgeSelected = link
         }
     }

--- a/apps/android/app/src/test/java/video/crumb/app/data/HaControlConfigTest.kt
+++ b/apps/android/app/src/test/java/video/crumb/app/data/HaControlConfigTest.kt
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.data
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Per-link control config (migration 0075, issue #440): the Android client must
+ * decode `require_confirm` + `allowed_actions` defensively (an older server that
+ * omits them decodes exactly as today via the nullable + default fields) and
+ * derive the offered action set from `allowed_actions` when present.
+ */
+class HaControlConfigTest {
+
+    // Mirror the production decoder: tolerant of unknown keys.
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `an older server payload without the fields defaults to today behavior`() {
+        val link = json.decodeFromString(
+            HaLinkDto.serializer(),
+            """{"id":"l1","entity_id":"light.kitchen","role":"actuator","sort_order":0}""",
+        )
+        assertFalse(link.requireConfirm)
+        assertNull(link.allowedActions)
+        // Null allowed_actions ⇒ every action permitted; default control set.
+        assertTrue(link.actionAllowed("turn_on"))
+        // Simple domain collapses to the single primary tap (Toggle), unchanged.
+        assertEquals(listOf("toggle"), link.controlActions().map { it.verb })
+    }
+
+    @Test
+    fun `present fields parse and restrict the offered actions`() {
+        val link = json.decodeFromString(
+            HaLinkDto.serializer(),
+            """{"id":"l2","entity_id":"light.kitchen","role":"actuator","sort_order":0,
+                "require_confirm":true,"allowed_actions":["turn_on"]}""",
+        )
+        assertTrue(link.requireConfirm)
+        assertEquals(listOf("turn_on"), link.allowedActions)
+        assertTrue(link.actionAllowed("turn_on"))
+        assertFalse(link.actionAllowed("turn_off"))
+        // Restricted ⇒ present ONLY the permitted verbs (from the full domain set).
+        assertEquals(listOf("turn_on"), link.controlActions().map { it.verb })
+    }
+
+    @Test
+    fun `a light may be restricted to exactly toggle, a default-card superset verb`() {
+        val link = json.decodeFromString(
+            HaLinkDto.serializer(),
+            """{"id":"l3","entity_id":"light.kitchen","role":"actuator","sort_order":0,
+                "allowed_actions":["toggle"]}""",
+        )
+        assertEquals(listOf("toggle"), link.controlActions().map { it.verb })
+    }
+
+    @Test
+    fun `a cover restricted to open and close drops stop`() {
+        val link = json.decodeFromString(
+            HaLinkDto.serializer(),
+            """{"id":"l4","entity_id":"cover.garage","role":"actuator","sort_order":0,
+                "allowed_actions":["open_cover","close_cover"]}""",
+        )
+        assertEquals(
+            listOf("open_cover", "close_cover"),
+            link.controlActions().map { it.verb },
+        )
+    }
+}

--- a/apps/desktop-flutter/lib/api/ha_models.dart
+++ b/apps/desktop-flutter/lib/api/ha_models.dart
@@ -25,6 +25,8 @@ class HaLink {
     this.overlayShape,
     this.overlayBgColor,
     this.overlayOutline = false,
+    this.requireConfirm = false,
+    this.allowedActions,
   });
 
   /// The link's own UUID — this is the `link_id` the control endpoint takes
@@ -82,7 +84,24 @@ class HaLink {
   /// (migration 0062; default off).
   final bool overlayOutline;
 
+  /// Per-link control config (migration 0075, issue #440). When true, EVERY
+  /// action on this link prompts a confirmation first (on top of the hardcoded
+  /// cover/lock safety confirm). Parsed with a false default so an older server
+  /// that omits it behaves exactly as today.
+  final bool requireConfirm;
+
+  /// Per-link control config (migration 0075, issue #440). When non-null, only
+  /// these actions are offered (intersected with the domain set) and the server
+  /// refuses anything else. Null (the default, and what an older server sends)
+  /// means every domain action is offered, exactly as today.
+  final List<String>? allowedActions;
+
   bool get hasPlacement => overlayX != null && overlayY != null;
+
+  /// Whether [action] is permitted by this link's [allowedActions] gate. A null
+  /// [allowedActions] means "all of the domain's actions" (today's behavior).
+  bool actionAllowed(String action) =>
+      allowedActions == null || allowedActions!.contains(action);
 
   /// The entity_id's domain prefix (`binary_sensor`, `light`, `switch`,
   /// `scene`, ...); empty string if [entityId] has no dot.
@@ -117,6 +136,10 @@ class HaLink {
     overlayShape: j['overlay_shape'] as String?,
     overlayBgColor: j['overlay_bg_color'] as String?,
     overlayOutline: (j['overlay_outline'] as bool?) ?? false,
+    requireConfirm: (j['require_confirm'] as bool?) ?? false,
+    allowedActions: (j['allowed_actions'] as List<dynamic>?)
+        ?.map((e) => e as String)
+        .toList(),
   );
 }
 
@@ -179,6 +202,8 @@ class HaLinkInput {
     this.deviceClass,
     this.label,
     required this.sortOrder,
+    this.requireConfirm = false,
+    this.allowedActions,
   });
 
   final String entityId;
@@ -193,6 +218,12 @@ class HaLinkInput {
   final String? label;
   final int sortOrder;
 
+  /// Per-link control config (migration 0075, issue #440). Not edited by this
+  /// UI (that is the admin console, issue #439) but carried through every
+  /// re-save so a full link-list PUT never wipes a value the console set.
+  final bool requireConfirm;
+  final List<String>? allowedActions;
+
   /// Round-trip an already-saved [HaLink] back into an editable input (e.g.
   /// loading the working set from `GET /cameras/:id/ha/links`, or carrying
   /// an unchanged link forward into the next save).
@@ -202,6 +233,8 @@ class HaLinkInput {
     deviceClass: l.deviceClass,
     label: l.label,
     sortOrder: l.sortOrder,
+    requireConfirm: l.requireConfirm,
+    allowedActions: l.allowedActions,
   );
 
   Map<String, dynamic> toJson() => {
@@ -210,6 +243,8 @@ class HaLinkInput {
     'device_class': deviceClass,
     'label': label,
     'sort_order': sortOrder,
+    'require_confirm': requireConfirm,
+    'allowed_actions': allowedActions,
   };
 }
 

--- a/apps/desktop-flutter/lib/ui/ha_link/ha_link_dialog.dart
+++ b/apps/desktop-flutter/lib/ui/ha_link/ha_link_dialog.dart
@@ -227,6 +227,8 @@ class _HaLinkDialogState extends State<_HaLinkDialog> {
         deviceClass: l.deviceClass,
         label: l.label,
         sortOrder: l.sortOrder,
+        requireConfirm: l.requireConfirm,
+        allowedActions: l.allowedActions,
       );
     });
   }
@@ -240,6 +242,8 @@ class _HaLinkDialogState extends State<_HaLinkDialog> {
       deviceClass: l.deviceClass,
       label: trimmed.isEmpty ? null : label,
       sortOrder: l.sortOrder,
+      requireConfirm: l.requireConfirm,
+      allowedActions: l.allowedActions,
     );
   }
 
@@ -252,6 +256,8 @@ class _HaLinkDialogState extends State<_HaLinkDialog> {
       deviceClass: trimmed.isEmpty ? null : deviceClass,
       label: l.label,
       sortOrder: l.sortOrder,
+      requireConfirm: l.requireConfirm,
+      allowedActions: l.allowedActions,
     );
   }
 
@@ -269,6 +275,8 @@ class _HaLinkDialogState extends State<_HaLinkDialog> {
             deviceClass: _links[i].deviceClass,
             label: _links[i].label,
             sortOrder: i,
+            requireConfirm: _links[i].requireConfirm,
+            allowedActions: _links[i].allowedActions,
           ),
       ];
       final saved = await widget.api.saveCameraHaLinks(

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_actions.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_actions.dart
@@ -151,6 +151,24 @@ List<HaControlAction> haActionsForDomain(String domain) {
   }
 }
 
+/// The FULL action set for a [domain] — a superset of [haActionsForDomain] used
+/// ONLY when a link restricts its actions (`allowed_actions` non-null, migration
+/// 0075). The simple on/off domains gain the `toggle` button their default card
+/// omits, so an operator can restrict a light to exactly `toggle` and still have
+/// it render. Every other domain equals its default set. The caller intersects
+/// this with the link's `allowedActions`.
+List<HaControlAction> haAllActionsForDomain(String domain) {
+  switch (domain) {
+    case 'light':
+    case 'switch':
+    case 'fan':
+    case 'siren':
+      return [..._kOnOffActions, _kToggleAction];
+    default:
+      return haActionsForDomain(domain);
+  }
+}
+
 /// The client interaction split for issue #428 — kept HERE (next to the
 /// server-mirroring action table) so every client and the state model agree on
 /// which domains a single click actuates directly vs which open the detail card.

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_layer.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_layer.dart
@@ -722,7 +722,13 @@ class _HaOverlayLayerState extends State<HaOverlayLayer> {
   void _handleTap(HaLink link) {
     if (_canControl(link)) {
       final primary = haPrimaryAction(link.domain);
-      if (primary != null) {
+      // Direct-fire only when the link neither requires a confirm nor restricts
+      // its primary action away (migration 0075). A require_confirm link, or one
+      // whose primary is not in its allowed_actions, falls through to the card,
+      // which confirms and/or shows only the permitted actions.
+      if (primary != null &&
+          !link.requireConfirm &&
+          link.actionAllowed(primary.action)) {
         unawaited(_fireDirect(link, primary));
         return;
       }
@@ -759,7 +765,14 @@ class _HaOverlayLayerState extends State<HaOverlayLayer> {
   /// actuate on a direct click (issue #428) and never open the card.
   List<HaControlAction> _actionsFor(HaLink link) {
     if (!_canControl(link)) return const [];
-    return haActionsForDomain(link.domain);
+    // allowed_actions null ⇒ the full default set for the domain (today's
+    // behavior). Non-null ⇒ present ONLY the permitted actions, intersected with
+    // the domain's full action set (migration 0075, issue #440).
+    final allowed = link.allowedActions;
+    if (allowed == null) return haActionsForDomain(link.domain);
+    return haAllActionsForDomain(link.domain)
+        .where((a) => allowed.contains(a.action))
+        .toList();
   }
 
   /// POST the action and surface any failure as a toast. Never throws; returns
@@ -839,6 +852,7 @@ class _HaOverlayLayerState extends State<HaOverlayLayer> {
         stale: widget.stale,
         iconOverride: open.overlayIcon,
         colorOverride: parseOverlayColorHex(open.overlayColor),
+        requireConfirm: open.requireConfirm,
         onDismiss: () => setState(() => _openLinkId = null),
         actions: actions,
         onAction: actions.isEmpty

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_state_card.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_state_card.dart
@@ -53,6 +53,7 @@ class HaStateCard extends StatefulWidget {
     this.onDismiss,
     this.actions = const [],
     this.onAction,
+    this.requireConfirm = false,
   });
 
   final String entityId;
@@ -81,6 +82,12 @@ class HaStateCard extends StatefulWidget {
   /// convergence window. Null (or an empty [actions]) means no controls.
   final Future<bool> Function(String action)? onAction;
 
+  /// Per-link control config (migration 0075, issue #440). When true, EVERY
+  /// action confirms first, not just the hardcoded cover/lock cases — so an
+  /// operator can require a deliberate tap on any device. Default false keeps
+  /// the pre-0075 behavior (only [HaControlAction.confirm] actions prompt).
+  final bool requireConfirm;
+
   @override
   State<HaStateCard> createState() => _HaStateCardState();
 }
@@ -104,7 +111,7 @@ class _HaStateCardState extends State<HaStateCard> {
   Future<void> _fire(HaControlAction action) async {
     final run = widget.onAction;
     if (run == null || _pending != null) return;
-    if (action.confirm) {
+    if (action.confirm || widget.requireConfirm) {
       final ok = await showDialog<bool>(
         context: context,
         builder: (ctx) => AlertDialog(

--- a/apps/desktop-flutter/test/ha_control_config_test.dart
+++ b/apps/desktop-flutter/test/ha_control_config_test.dart
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Per-link control config (migration 0075, issue #440): the desktop client must
+// parse `require_confirm` + `allowed_actions` defensively (an older server that
+// omits them behaves exactly as today) and derive the offered action set from
+// `allowed_actions` when present.
+//
+// Pure, headless assertions on the model + the action-set helper.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:crumb_desktop/api/ha_models.dart';
+import 'package:crumb_desktop/ui/ha_overlay/ha_actions.dart';
+
+void main() {
+  group('HaLink control config parsing', () {
+    test('an older server payload (no fields) defaults to today behavior', () {
+      final l = HaLink.fromJson({
+        'id': 'l1',
+        'entity_id': 'light.kitchen',
+        'role': 'actuator',
+        'sort_order': 0,
+      });
+      expect(l.requireConfirm, isFalse);
+      expect(l.allowedActions, isNull);
+      // Null allowed_actions ⇒ every action is permitted.
+      expect(l.actionAllowed('turn_on'), isTrue);
+      expect(l.actionAllowed('turn_off'), isTrue);
+    });
+
+    test('present fields are parsed and gate actions', () {
+      final l = HaLink.fromJson({
+        'id': 'l2',
+        'entity_id': 'light.kitchen',
+        'role': 'actuator',
+        'sort_order': 0,
+        'require_confirm': true,
+        'allowed_actions': ['turn_on'],
+      });
+      expect(l.requireConfirm, isTrue);
+      expect(l.allowedActions, ['turn_on']);
+      expect(l.actionAllowed('turn_on'), isTrue);
+      expect(l.actionAllowed('turn_off'), isFalse);
+      expect(l.actionAllowed('toggle'), isFalse);
+    });
+  });
+
+  group('offered action set honors allowed_actions', () {
+    // Mirror the layer's _actionsFor logic without the widget: null ⇒ default
+    // set, non-null ⇒ full domain set intersected with the permitted verbs.
+    List<String> offered(String domain, List<String>? allowed) {
+      final actions = allowed == null
+          ? haActionsForDomain(domain)
+          : haAllActionsForDomain(domain)
+              .where((a) => allowed.contains(a.action))
+              .toList();
+      return actions.map((a) => a.action).toList();
+    }
+
+    test('null keeps the default light set (On/Off), unchanged from today', () {
+      expect(offered('light', null), ['turn_on', 'turn_off']);
+    });
+
+    test('a light restricted to turn_on offers only On', () {
+      expect(offered('light', ['turn_on']), ['turn_on']);
+    });
+
+    test('a light may be restricted to exactly toggle (superset button)', () {
+      expect(offered('light', ['toggle']), ['toggle']);
+    });
+
+    test('a cover restricted to open/close drops stop', () {
+      expect(
+        offered('cover', ['open_cover', 'close_cover']),
+        ['open_cover', 'close_cover'],
+      );
+    });
+  });
+}

--- a/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
+++ b/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
@@ -312,6 +312,25 @@ extension HA {
         }
     }
 
+    /// The FULL action set for a domain, a SUPERSET of `actions(for:)` used only
+    /// when a link restricts its actions (`allowed_actions` non-null, migration
+    /// 0075). The simple on/off domains gain the `toggle` button the default card
+    /// omits, so an operator can restrict a light to exactly `toggle` and still
+    /// have it render. Every other domain equals its default set. Intersected
+    /// with the link's `allowedActions` at the call site.
+    static func allActions(for domain: String) -> [HAAction] {
+        switch domain {
+        case "light", "switch", "fan", "siren":
+            return [
+                HAAction("turn_on", "On", "power"),
+                HAAction("turn_off", "Off", "power"),
+                HAAction("toggle", "Toggle", "power"),
+            ]
+        default:
+            return actions(for: domain)
+        }
+    }
+
     /// Domains whose control is genuinely multi-action or needs a safety confirm,
     /// so a single tap cannot express it: the tap opens `HAStateCard` instead of
     /// firing. Today only `cover` (open/stop/close) and `lock` (lock/unlock, which
@@ -399,7 +418,14 @@ final class HAController: ObservableObject {
     /// (tap opens `HAStateCard`, exactly as the read-only Phase 1 UI did).
     func directTapAction(for link: HaLink) -> String? {
         guard canActuate, link.isActuator, !HA.needsCard(link.domain) else { return nil }
-        return HA.primaryAction(for: link.domain)
+        // A per-link confirm requirement, or an allowed_actions restriction that
+        // excludes the primary action, routes the tap to the card instead of
+        // firing directly (migration 0075, issue #440).
+        guard !link.requireConfirm else { return nil }
+        guard let primary = HA.primaryAction(for: link.domain), link.actionAllowed(primary) else {
+            return nil
+        }
+        return primary
     }
 
     /// Fire one HA service call for a link. Throws on any non-2xx so the caller
@@ -658,7 +684,11 @@ struct HAStateCard: View {
     /// `actuators` capability. Both false ⇒ the exact Phase 1 card.
     private var actions: [HAAction] {
         guard controller.canActuate, link.isActuator else { return [] }
-        return HA.actions(for: link.domain)
+        // allowed_actions nil ⇒ today's default set. Non-null ⇒ present ONLY the
+        // permitted actions, intersected with the domain's full set (migration
+        // 0075, issue #440).
+        guard let allowed = link.allowedActions else { return HA.actions(for: link.domain) }
+        return HA.allActions(for: link.domain).filter { allowed.contains($0.action) }
     }
 
     var body: some View {
@@ -721,7 +751,10 @@ struct HAStateCard: View {
         HStack(spacing: 10) {
             ForEach(actions) { action in
                 Button {
-                    if action.confirms {
+                    // Confirm when the action itself is physical-security
+                    // (cover/lock) OR the link requires a confirm on every action
+                    // (migration 0075, issue #440).
+                    if action.confirms || link.requireConfirm {
                         pending = action
                     } else {
                         Task { await fire(action) }

--- a/apps/ios/Crumb/Models/Models.swift
+++ b/apps/ios/Crumb/Models/Models.swift
@@ -495,9 +495,26 @@ struct HaLink: Decodable, Identifiable {
     let overlayShape: String?
     let overlayBgColor: String?
     let overlayOutline: Bool
+    /// Per-link control config (migration 0075, issue #440). When true, EVERY
+    /// action on this link prompts a confirmation first (on top of the hardcoded
+    /// cover/lock safety confirm). `decodeIfPresent` with a false default, so an
+    /// older server that omits it decodes exactly as today.
+    let requireConfirm: Bool
+    /// Per-link control config (migration 0075, issue #440). When non-null, the
+    /// client presents ONLY these actions (intersected with the domain set) and
+    /// the server refuses anything else. `nil` (the default, and what an older
+    /// server sends) ⇒ every domain action is offered, exactly as today.
+    let allowedActions: [String]?
 
     /// A badge renders iff both placement coords are set.
     var hasPlacement: Bool { overlayX != nil && overlayY != nil }
+
+    /// Whether `action` is permitted by this link's `allowedActions` gate
+    /// (migration 0075). A nil list means "all of the domain's actions".
+    func actionAllowed(_ action: String) -> Bool {
+        guard let allowedActions else { return true }
+        return allowedActions.contains(action)
+    }
     /// Display caption: operator label, else the entity id minus its domain.
     var displayName: String {
         if let label, !label.isEmpty { return label }
@@ -529,6 +546,8 @@ struct HaLink: Decodable, Identifiable {
         case overlayShape = "overlay_shape"
         case overlayBgColor = "overlay_bg_color"
         case overlayOutline = "overlay_outline"
+        case requireConfirm = "require_confirm"
+        case allowedActions = "allowed_actions"
     }
 
     init(from decoder: Decoder) throws {
@@ -554,6 +573,8 @@ struct HaLink: Decodable, Identifiable {
         overlayShape = try c.decodeIfPresent(String.self, forKey: .overlayShape)
         overlayBgColor = try c.decodeIfPresent(String.self, forKey: .overlayBgColor)
         overlayOutline = try c.decodeIfPresent(Bool.self, forKey: .overlayOutline) ?? false
+        requireConfirm = try c.decodeIfPresent(Bool.self, forKey: .requireConfirm) ?? false
+        allowedActions = try c.decodeIfPresent([String].self, forKey: .allowedActions)
     }
 }
 

--- a/apps/ios/CrumbTests/HaControlConfigTests.swift
+++ b/apps/ios/CrumbTests/HaControlConfigTests.swift
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import XCTest
+@testable import Crumb
+
+/// Per-link control config (migration 0075, issue #440): the iOS client must
+/// decode `require_confirm` + `allowed_actions` defensively (an older server that
+/// omits them decodes exactly as today via `decodeIfPresent`) and derive the
+/// offered action set from `allowed_actions` when present.
+final class HaControlConfigTests: XCTestCase {
+
+    private func decodeLink(_ jsonBody: String) throws -> HaLink {
+        try JSONDecoder().decode(HaLink.self, from: Data(jsonBody.utf8))
+    }
+
+    /// Mirror `HAStateCard.actions`' derivation without the SwiftUI view.
+    private func offered(_ link: HaLink) -> [String] {
+        guard let allowed = link.allowedActions else {
+            return HA.actions(for: link.domain).map(\.action)
+        }
+        return HA.allActions(for: link.domain).filter { allowed.contains($0.action) }.map(\.action)
+    }
+
+    func testOlderServerPayloadDefaultsToTodayBehavior() throws {
+        let link = try decodeLink(
+            #"{"id":"l1","entity_id":"light.kitchen","role":"actuator","sort_order":0}"#
+        )
+        XCTAssertFalse(link.requireConfirm)
+        XCTAssertNil(link.allowedActions)
+        XCTAssertTrue(link.actionAllowed("turn_on"))
+        // Null allowed_actions ⇒ the default light card set (On/Off), unchanged.
+        XCTAssertEqual(offered(link), ["turn_on", "turn_off"])
+    }
+
+    func testPresentFieldsParseAndRestrictOfferedActions() throws {
+        let link = try decodeLink(
+            #"{"id":"l2","entity_id":"light.kitchen","role":"actuator","sort_order":0,"require_confirm":true,"allowed_actions":["turn_on"]}"#
+        )
+        XCTAssertTrue(link.requireConfirm)
+        XCTAssertEqual(link.allowedActions, ["turn_on"])
+        XCTAssertTrue(link.actionAllowed("turn_on"))
+        XCTAssertFalse(link.actionAllowed("turn_off"))
+        XCTAssertEqual(offered(link), ["turn_on"])
+    }
+
+    func testLightMayBeRestrictedToExactlyToggle() throws {
+        let link = try decodeLink(
+            #"{"id":"l3","entity_id":"light.kitchen","role":"actuator","sort_order":0,"allowed_actions":["toggle"]}"#
+        )
+        // `toggle` is a full-set superset verb the default card omits.
+        XCTAssertEqual(offered(link), ["toggle"])
+    }
+
+    func testCoverRestrictedToOpenAndCloseDropsStop() throws {
+        let link = try decodeLink(
+            #"{"id":"l4","entity_id":"cover.garage","role":"actuator","sort_order":0,"allowed_actions":["open_cover","close_cover"]}"#
+        )
+        XCTAssertEqual(offered(link), ["open_cover", "close_cover"])
+    }
+}

--- a/db/migrations/0075_ha_link_control_config.sql
+++ b/db/migrations/0075_ha_link_control_config.sql
@@ -1,0 +1,21 @@
+-- Per-link control config (Tier 2 of the HA management overhaul, epic #445,
+-- issue #440). Two additive, optional knobs an operator (via the future console
+-- editor, issue #439) can set on a camera<->HA link to constrain how its device
+-- may be actuated from a camera view. Both default to today's behavior, so this
+-- migration changes nothing until #439 lets an admin set them.
+--
+-- require_confirm: a client-side UX gate. When true, EVERY action on this link
+-- prompts a confirmation first, on top of the existing hardcoded cover/lock
+-- safety confirm. It is NOT enforced server-side (a confirm is a UI affordance);
+-- the action endpoint honors allowed_actions, not this flag.
+--
+-- allowed_actions: a server-ENFORCED restriction. NULL = every action in the
+-- link's domain allowlist is permitted (today's behavior). A non-null array
+-- restricts POST /cameras/:id/ha/action to exactly these action words; anything
+-- else is refused (see post_action in services/api/src/ha.rs). Entries are
+-- validated at write time against the entity domain's allowlist, so a DB CHECK
+-- (which would drift from the code-owned allowlist) is deliberately not used.
+
+ALTER TABLE camera_ha_links
+    ADD COLUMN IF NOT EXISTS require_confirm boolean NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS allowed_actions text[];

--- a/services/api/src/ha.rs
+++ b/services/api/src/ha.rs
@@ -1689,9 +1689,7 @@ mod tests {
             &["turn_on".to_owned(), "toggle".to_owned()]
         )
         .is_ok());
-        assert!(
-            validate_allowed_actions("cover.garage", &["open_cover".to_owned()]).is_ok()
-        );
+        assert!(validate_allowed_actions("cover.garage", &["open_cover".to_owned()]).is_ok());
         // An empty list is a valid "no actions permitted" configuration.
         assert!(validate_allowed_actions("light.kitchen", &[]).is_ok());
 

--- a/services/api/src/ha.rs
+++ b/services/api/src/ha.rs
@@ -159,6 +159,43 @@ fn validate_link_role(entity_id: &str, role: &str) -> Result<(), String> {
     }
 }
 
+/// Validate a link's authored `allowed_actions` (migration 0075, issue #440) at
+/// write time: every entry MUST be a valid action for the entity's own HA
+/// domain, i.e. present in [`HA_ACTION_ALLOWLIST`] for that domain. An entry
+/// that could never fire (wrong domain, garbage word) is a silent
+/// misconfiguration, so it is rejected at the PUT with a clear 400 rather than
+/// stored as a dead restriction. An EMPTY list is accepted: it is the explicit
+/// "no action permitted" state (control fully disabled on the link).
+///
+/// Returns the 400 message on rejection. Pure, so it is unit-testable without a
+/// DB.
+fn validate_allowed_actions(entity_id: &str, allowed: &[String]) -> Result<(), String> {
+    let domain = domain_of(entity_id);
+    for action in allowed {
+        if allowed_service(domain, action).is_none() {
+            return Err(format!(
+                "allowed_actions entry '{action}' is not a valid action for a '{domain}' entity \
+                 ('{entity_id}'); it must be one of that domain's actions"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Whether `action` is permitted by a link's `allowed_actions` restriction
+/// (migration 0075, issue #440). `None` ⇒ unrestricted: every action the domain
+/// allowlist already permits is allowed (today's behavior). `Some(list)` ⇒ the
+/// action must ALSO appear in `list`. This is the server-side enforcement
+/// `post_action` applies AFTER the domain allowlist check, so a viewer cannot
+/// fire a disallowed action even by crafting the request. Pure, so it is
+/// exhaustively unit-testable without a DB.
+fn action_permitted_by_link(allowed_actions: Option<&[String]>, action: &str) -> bool {
+    match allowed_actions {
+        None => true,
+        Some(list) => list.iter().any(|a| a.as_str() == action),
+    }
+}
+
 // ─── HTTP: shared client + picker filter ──────────────────────────────────────
 
 /// Build the shared `crumb_common::ha` client from stored settings, mapping the
@@ -296,6 +333,18 @@ struct HaLinkDto {
     overlay_bg_color: Option<String>,
     /// White outline + drop shadow (migration 0062; default false).
     overlay_outline: bool,
+    /// Per-link control config (migration 0075, issue #440). `require_confirm`
+    /// tells every client to prompt a confirmation before firing ANY action on
+    /// this link (on top of the hardcoded cover/lock safety confirm). Additive
+    /// and always present; an older client that does not know the field ignores
+    /// it and behaves exactly as today (default false).
+    require_confirm: bool,
+    /// Per-link control config (migration 0075, issue #440). When non-null, the
+    /// client presents ONLY these actions (intersected with the domain's action
+    /// set) AND the server refuses anything outside it (see `post_action`).
+    /// `null` ⇒ every domain action is offered/allowed (today's behavior). Older
+    /// clients ignore it and offer the full domain set as before.
+    allowed_actions: Option<Vec<String>>,
 }
 
 impl From<crumb_common::types::CameraHaLink> for HaLinkDto {
@@ -319,6 +368,8 @@ impl From<crumb_common::types::CameraHaLink> for HaLinkDto {
             overlay_shape: l.overlay_shape,
             overlay_bg_color: l.overlay_bg_color,
             overlay_outline: l.overlay_outline,
+            require_confirm: l.require_confirm,
+            allowed_actions: l.allowed_actions,
         }
     }
 }
@@ -539,6 +590,16 @@ struct HaLinkInput {
     label: Option<String>,
     #[serde(default)]
     sort_order: i32,
+    /// Per-link control config (migration 0075, issue #440). Omitted ⇒ false
+    /// (today's behavior). A client-side confirm gate; not server-enforced.
+    #[serde(default)]
+    require_confirm: bool,
+    /// Per-link control config (migration 0075, issue #440). Omitted / `null` ⇒
+    /// every domain action is allowed (today's behavior). When present, each
+    /// entry is validated against the entity domain's allowlist at write time
+    /// and `post_action` refuses anything outside it.
+    #[serde(default)]
+    allowed_actions: Option<Vec<String>>,
 }
 
 #[derive(Deserialize)]
@@ -667,11 +728,27 @@ async fn put_links(
         // a silent dead end (actuator that never fires, motion that never
         // triggers). Issue #434.
         validate_link_role(l.entity_id.trim(), &l.role).map_err(ApiError::BadRequest)?;
+        // allowed_actions entries must be real actions for the entity's domain,
+        // else the restriction is nonsense the operator can never satisfy
+        // (migration 0075, issue #440).
+        if let Some(allowed) = &l.allowed_actions {
+            validate_allowed_actions(l.entity_id.trim(), allowed).map_err(ApiError::BadRequest)?;
+        }
     }
     let tuples: Vec<db::HaLinkInsert> = body
         .links
         .into_iter()
-        .map(|l| (l.entity_id, l.role, l.device_class, l.label, l.sort_order))
+        .map(|l| {
+            (
+                l.entity_id,
+                l.role,
+                l.device_class,
+                l.label,
+                l.sort_order,
+                l.require_confirm,
+                l.allowed_actions,
+            )
+        })
         .collect();
     let links = db::replace_camera_ha_links(state.pool(), camera_id, &tuples)
         .await
@@ -931,6 +1008,8 @@ async fn audit_actuation(
 /// 3. `link_id` exists on THIS camera and has `role = 'actuator'` — else 404.
 /// 4. the action is allowlisted for the domain of the link's stored entity —
 ///    else 400.
+/// 5. the action is permitted by the link's own `allowed_actions` restriction
+///    (migration 0075, issue #440) — else 403. `null` ⇒ unrestricted.
 ///
 /// Returns `{"ok": true}` on an HA 2xx. No state is returned: clients converge
 /// on the existing 3s `GET /ha/states` poll, so there is one source of truth for
@@ -940,7 +1019,8 @@ async fn audit_actuation(
 ///
 /// * `400` — action not allowlisted for the entity's domain, or HA not
 ///   configured/enabled.
-/// * `403` — missing `actuators`, or the camera is outside the caller's grant.
+/// * `403` — missing `actuators`, the camera is outside the caller's grant, or
+///   the action is not in the link's `allowed_actions`.
 /// * `404` — no actuator link with that id on this camera.
 /// * `502` — Home Assistant unreachable or returned an error.
 async fn post_action(
@@ -988,6 +1068,31 @@ async fn post_action(
             None => format!("Crumb does not control '{domain}' entities"),
         }));
     };
+
+    // 5. per-link allowed_actions restriction (migration 0075, issue #440). The
+    //    domain allowlist above says the action is possible for this KIND of
+    //    entity; this narrows it to what the operator authored for THIS link. A
+    //    non-null list that omits the action is a real server-side denial (403),
+    //    not a client hint: a viewer cannot fire it by crafting the request.
+    if !action_permitted_by_link(link.allowed_actions.as_deref(), action) {
+        audit_actuation(
+            &state,
+            &user,
+            camera_id,
+            &link,
+            action,
+            "rejected: action not in link's allowed_actions",
+        )
+        .await;
+        let allowed = link
+            .allowed_actions
+            .as_deref()
+            .map(|l| l.join(", "))
+            .unwrap_or_default();
+        return Err(ApiError::Forbidden(format!(
+            "that action is not permitted on this link (allowed on this link: {allowed})"
+        )));
+    }
 
     let settings = effective_settings(&state).await?;
     if !settings.enabled {
@@ -1551,5 +1656,137 @@ mod tests {
         assert!(!canonical_icon("sensor_door")); // legacy shape-only example, not a slug.
         assert!(!canonical_icon("")); // empty is neither shape-valid nor a member.
         assert!(!canonical_icon("lightbulb2")); // near-miss of a real slug.
+    }
+
+    // ─── per-link control config (migration 0075, issue #440) ────────────────
+
+    #[test]
+    fn allowed_actions_enforcement_null_allows_all_and_list_restricts() {
+        // Null ⇒ unrestricted: every action the domain allowlist already permits
+        // still passes (today's behavior).
+        assert!(action_permitted_by_link(None, "turn_on"));
+        assert!(action_permitted_by_link(None, "turn_off"));
+        assert!(action_permitted_by_link(None, "toggle"));
+
+        // A link restricted to turn_on: turn_on passes, turn_off / toggle do not,
+        // even though they are perfectly valid LIGHT actions (this is the whole
+        // point — the restriction is tighter than the domain allowlist).
+        let only_on = [String::from("turn_on")];
+        assert!(action_permitted_by_link(Some(&only_on), "turn_on"));
+        assert!(!action_permitted_by_link(Some(&only_on), "turn_off"));
+        assert!(!action_permitted_by_link(Some(&only_on), "toggle"));
+
+        // An empty list ⇒ nothing is permitted (control fully disabled).
+        let none: [String; 0] = [];
+        assert!(!action_permitted_by_link(Some(&none), "turn_on"));
+    }
+
+    #[test]
+    fn allowed_actions_write_validation_matches_the_domain_allowlist() {
+        // A subset of the entity domain's own actions is accepted.
+        assert!(validate_allowed_actions(
+            "light.kitchen",
+            &["turn_on".to_owned(), "toggle".to_owned()]
+        )
+        .is_ok());
+        assert!(
+            validate_allowed_actions("cover.garage", &["open_cover".to_owned()]).is_ok()
+        );
+        // An empty list is a valid "no actions permitted" configuration.
+        assert!(validate_allowed_actions("light.kitchen", &[]).is_ok());
+
+        // An action from a DIFFERENT domain, or garbage, is rejected at write.
+        assert!(validate_allowed_actions("light.kitchen", &["open_cover".to_owned()]).is_err());
+        assert!(validate_allowed_actions("lock.front", &["turn_on".to_owned()]).is_err());
+        assert!(validate_allowed_actions("sensor.temp", &["turn_on".to_owned()]).is_err());
+        // The rejection names the offending action and carries no em-dash.
+        let msg = validate_allowed_actions("light.kitchen", &["explode".to_owned()]).unwrap_err();
+        assert!(msg.contains("explode"));
+        assert!(!msg.contains('\u{2014}'));
+    }
+
+    #[test]
+    fn link_input_parses_control_config_with_today_default() {
+        // Omitted ⇒ require_confirm=false, allowed_actions=None (today's behavior),
+        // so an existing admin-console/desktop payload that predates #440 keeps
+        // writing links exactly as before.
+        let bare: HaLinkInput = serde_json::from_value(json!({
+            "entity_id": "light.kitchen", "role": "actuator"
+        }))
+        .unwrap();
+        assert!(!bare.require_confirm);
+        assert_eq!(bare.allowed_actions, None);
+
+        // Present ⇒ carried through verbatim.
+        let full: HaLinkInput = serde_json::from_value(json!({
+            "entity_id": "cover.garage", "role": "actuator",
+            "require_confirm": true,
+            "allowed_actions": ["open_cover", "close_cover"]
+        }))
+        .unwrap();
+        assert!(full.require_confirm);
+        assert_eq!(
+            full.allowed_actions,
+            Some(vec!["open_cover".to_owned(), "close_cover".to_owned()])
+        );
+    }
+
+    #[test]
+    fn link_dto_exposes_control_config_for_clients() {
+        use crumb_common::types::CameraHaLink;
+        let link = CameraHaLink {
+            id: Uuid::nil(),
+            camera_id: Uuid::nil(),
+            entity_id: "cover.garage".to_owned(),
+            role: "actuator".to_owned(),
+            device_class: None,
+            label: None,
+            sort_order: 0,
+            overlay_x: None,
+            overlay_y: None,
+            overlay_size: None,
+            overlay_color: None,
+            overlay_icon: None,
+            overlay_show_state: false,
+            overlay_show_age: false,
+            overlay_opacity: None,
+            overlay_shape: None,
+            overlay_bg_color: None,
+            overlay_outline: false,
+            require_confirm: true,
+            allowed_actions: Some(vec!["open_cover".to_owned()]),
+        };
+        let dto = HaLinkDto::from(link);
+        let v = serde_json::to_value(dto).unwrap();
+        assert_eq!(v["require_confirm"], true);
+        assert_eq!(v["allowed_actions"][0], "open_cover");
+
+        // A link with the migration defaults round-trips to the "unchanged"
+        // shape: require_confirm=false, allowed_actions=null.
+        let default = CameraHaLink {
+            id: Uuid::nil(),
+            camera_id: Uuid::nil(),
+            entity_id: "light.kitchen".to_owned(),
+            role: "actuator".to_owned(),
+            device_class: None,
+            label: None,
+            sort_order: 0,
+            overlay_x: None,
+            overlay_y: None,
+            overlay_size: None,
+            overlay_color: None,
+            overlay_icon: None,
+            overlay_show_state: false,
+            overlay_show_age: false,
+            overlay_opacity: None,
+            overlay_shape: None,
+            overlay_bg_color: None,
+            overlay_outline: false,
+            require_confirm: false,
+            allowed_actions: None,
+        };
+        let v = serde_json::to_value(HaLinkDto::from(default)).unwrap();
+        assert_eq!(v["require_confirm"], false);
+        assert!(v["allowed_actions"].is_null());
     }
 }

--- a/services/api/tests/ha_action_rbac.rs
+++ b/services/api/tests/ha_action_rbac.rs
@@ -49,8 +49,40 @@ async fn seed_links(
     let mut tuples: Vec<db::HaLinkInsert> = Vec::new();
     for (i, (entity, role)) in links.iter().enumerate() {
         let order = i32::try_from(i).unwrap_or(0);
-        tuples.push(((*entity).to_owned(), (*role).to_owned(), None, None, order));
+        // Default control config (migration 0075): no confirm, no action
+        // restriction — today's behavior.
+        tuples.push((
+            (*entity).to_owned(),
+            (*role).to_owned(),
+            None,
+            None,
+            order,
+            false,
+            None,
+        ));
     }
+    db::replace_camera_ha_links(pool, camera_id, &tuples)
+        .await
+        .expect("replace_camera_ha_links")
+}
+
+/// Seed a single actuator link with an explicit `allowed_actions` restriction
+/// (migration 0075) so the server-side enforcement can be exercised end to end.
+async fn seed_link_with_allowed_actions(
+    pool: &deadpool_postgres::Pool,
+    camera_id: Uuid,
+    entity: &str,
+    allowed_actions: &[&str],
+) -> Vec<crumb_common::types::CameraHaLink> {
+    let tuples: Vec<db::HaLinkInsert> = vec![(
+        entity.to_owned(),
+        "actuator".to_owned(),
+        None,
+        None,
+        0,
+        false,
+        Some(allowed_actions.iter().map(|s| (*s).to_owned()).collect()),
+    )];
     db::replace_camera_ha_links(pool, camera_id, &tuples)
         .await
         .expect("replace_camera_ha_links")
@@ -316,6 +348,8 @@ async fn camera_links_payload_carries_the_fields_clients_need() {
         Some("garage".to_owned()),
         Some("Garage door".to_owned()),
         0,
+        false,
+        None,
     )];
     db::replace_camera_ha_links(app.pool(), cam, &tuples)
         .await
@@ -338,6 +372,71 @@ async fn camera_links_payload_carries_the_fields_clients_need() {
     // the long-standing `id`.
     assert!(link["link_id"].is_string());
     assert_eq!(link["link_id"], link["id"]);
+    // Per-link control config (migration 0075) is exposed for clients to honor;
+    // an unset link reports today's defaults: no confirm, no action restriction.
+    assert_eq!(link["require_confirm"], false);
+    assert!(link["allowed_actions"].is_null());
+}
+
+// ─── allowed_actions: the server-enforced per-link restriction (issue #440) ──
+
+#[tokio::test]
+async fn allowed_actions_lets_a_permitted_action_through_to_the_ha_call() {
+    let app = TestApp::new().await;
+    let cam = seed_camera(app.pool()).await;
+    // A light restricted to turn_on only. turn_on is BOTH domain-allowlisted and
+    // in the link's allowed_actions, so it must pass every gate and reach the HA
+    // call boundary (distinct "not enabled" 400, HA being unconfigured here).
+    let links =
+        seed_link_with_allowed_actions(app.pool(), cam, "light.kitchen", &["turn_on"]).await;
+
+    let role_id = seed_viewer_role_with_caps(app.pool(), &[cam], caps_with_actuators()).await;
+    let viewer = seed_viewer_user(app.pool(), role_id).await;
+    let token = login(&app, &viewer.username, &viewer.password).await;
+
+    let resp = app
+        .send(post_auth_json(
+            &format!("/cameras/{cam}/ha/action"),
+            &token,
+            &action_body(links[0].id, "turn_on"),
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = body_text(resp).await;
+    assert!(
+        body.contains("not enabled"),
+        "an allowed action must pass the allowed_actions gate and reach the HA call, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn allowed_actions_forbids_a_domain_valid_but_unlisted_action() {
+    let app = TestApp::new().await;
+    let cam = seed_camera(app.pool()).await;
+    // A light restricted to turn_on only. turn_off IS a valid light action
+    // (passes the domain allowlist) but is NOT in allowed_actions, so the
+    // server must refuse it with a 403 BEFORE contacting HA — a real
+    // restriction, not merely a client-side hint.
+    let links =
+        seed_link_with_allowed_actions(app.pool(), cam, "light.kitchen", &["turn_on"]).await;
+
+    let role_id = seed_viewer_role_with_caps(app.pool(), &[cam], caps_with_actuators()).await;
+    let viewer = seed_viewer_user(app.pool(), role_id).await;
+    let token = login(&app, &viewer.username, &viewer.password).await;
+
+    let resp = app
+        .send(post_auth_json(
+            &format!("/cameras/{cam}/ha/action"),
+            &token,
+            &action_body(links[0].id, "turn_off"),
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let body = body_text(resp).await;
+    assert!(
+        !body.contains("not enabled"),
+        "a forbidden action must be refused before the HA call, got: {body}"
+    );
 }
 
 // ─── the capability itself: default-false everywhere ─────────────────────────

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -1647,6 +1647,8 @@ fn ha_link_from_row(row: &tokio_postgres::Row) -> CameraHaLink {
         overlay_shape: row.get("overlay_shape"),
         overlay_bg_color: row.get("overlay_bg_color"),
         overlay_outline: row.get("overlay_outline"),
+        require_confirm: row.get("require_confirm"),
+        allowed_actions: row.get("allowed_actions"),
     }
 }
 
@@ -1662,7 +1664,8 @@ pub async fn list_camera_ha_links(pool: &Pool, camera_id: Uuid) -> Result<Vec<Ca
             "SELECT id, camera_id, entity_id, role, device_class, label, sort_order,
                     overlay_x, overlay_y, overlay_size,
                     overlay_color, overlay_icon, overlay_show_state, overlay_show_age,
-                    overlay_opacity, overlay_shape, overlay_bg_color, overlay_outline
+                    overlay_opacity, overlay_shape, overlay_bg_color, overlay_outline,
+                    require_confirm, allowed_actions
              FROM camera_ha_links WHERE camera_id = $1
              ORDER BY sort_order, entity_id",
             &[&camera_id],
@@ -1690,7 +1693,8 @@ pub async fn get_camera_ha_links(
             "SELECT id, camera_id, entity_id, role, device_class, label, sort_order,
                     overlay_x, overlay_y, overlay_size,
                     overlay_color, overlay_icon, overlay_show_state, overlay_show_age,
-                    overlay_opacity, overlay_shape, overlay_bg_color, overlay_outline
+                    overlay_opacity, overlay_shape, overlay_bg_color, overlay_outline,
+                    require_confirm, allowed_actions
              FROM camera_ha_links WHERE camera_id = $1 AND role = $2
              ORDER BY sort_order, entity_id",
             &[&camera_id, &role],
@@ -1722,7 +1726,8 @@ pub async fn get_camera_ha_link(
             "SELECT id, camera_id, entity_id, role, device_class, label, sort_order,
                     overlay_x, overlay_y, overlay_size,
                     overlay_color, overlay_icon, overlay_show_state, overlay_show_age,
-                    overlay_opacity, overlay_shape, overlay_bg_color, overlay_outline
+                    overlay_opacity, overlay_shape, overlay_bg_color, overlay_outline,
+                    require_confirm, allowed_actions
              FROM camera_ha_links WHERE camera_id = $1 AND id = $2",
             &[&camera_id, &link_id],
         )
@@ -1732,8 +1737,18 @@ pub async fn get_camera_ha_link(
 }
 
 /// One camera↔HA link to persist: `(entity_id, role, device_class, label,
-/// sort_order)`. `id` is server-assigned.
-pub type HaLinkInsert = (String, String, Option<String>, Option<String>, i32);
+/// sort_order, require_confirm, allowed_actions)`. `id` is server-assigned.
+/// `require_confirm` + `allowed_actions` are the per-link control config
+/// (migration 0075); a `None` `allowed_actions` means "every domain action".
+pub type HaLinkInsert = (
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+    i32,
+    bool,
+    Option<Vec<String>>,
+);
 
 /// Replace the full set of a camera's HA links (delete-then-insert in one
 /// transaction) and bump `ha_config.version` so consumers hot-reload.
@@ -1810,7 +1825,9 @@ pub async fn replace_camera_ha_links(
     )
     .await
     .context("replace_camera_ha_links: delete")?;
-    for (entity_id, role, device_class, label, sort_order) in links {
+    for (entity_id, role, device_class, label, sort_order, require_confirm, allowed_actions) in
+        links
+    {
         let (
             ox,
             oy,
@@ -1834,9 +1851,10 @@ pub async fn replace_camera_ha_links(
                  (camera_id, entity_id, role, device_class, label, sort_order,
                   overlay_x, overlay_y, overlay_size,
                   overlay_color, overlay_icon, overlay_show_state, overlay_show_age,
-                  overlay_opacity, overlay_shape, overlay_bg_color, overlay_outline)
+                  overlay_opacity, overlay_shape, overlay_bg_color, overlay_outline,
+                  require_confirm, allowed_actions)
              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
-                     $15, $16, $17)",
+                     $15, $16, $17, $18, $19)",
             &[
                 &camera_id,
                 entity_id,
@@ -1855,6 +1873,8 @@ pub async fn replace_camera_ha_links(
                 &oshape,
                 &obg_color,
                 &ooutline,
+                require_confirm,
+                allowed_actions,
             ],
         )
         .await
@@ -1958,7 +1978,8 @@ pub async fn update_ha_link_placement(
           RETURNING id, camera_id, entity_id, role, device_class, label, sort_order,
                     overlay_x, overlay_y, overlay_size,
                     overlay_color, overlay_icon, overlay_show_state, overlay_show_age,
-                    overlay_opacity, overlay_shape, overlay_bg_color, overlay_outline",
+                    overlay_opacity, overlay_shape, overlay_bg_color, overlay_outline,
+                    require_confirm, allowed_actions",
             &[
                 &link_id,
                 &camera_id,
@@ -10617,6 +10638,10 @@ static MIGRATIONS: &[(&str, &str)] = &[
     (
         "0074_role_actuators_capability.sql",
         include_str!("../../../db/migrations/0074_role_actuators_capability.sql"),
+    ),
+    (
+        "0075_ha_link_control_config.sql",
+        include_str!("../../../db/migrations/0075_ha_link_control_config.sql"),
     ),
 ];
 

--- a/services/common/src/types.rs
+++ b/services/common/src/types.rs
@@ -290,6 +290,17 @@ pub struct CameraHaLink {
     /// Draw a white outline + drop shadow so the badge pops on a busy scene
     /// (migration 0062; default false).
     pub overlay_outline: bool,
+    /// Per-link control config (migration 0075, issue #440). When true, every
+    /// client prompts a confirmation before firing ANY action on this link (a
+    /// UX gate, on top of the hardcoded cover/lock safety confirm). NOT enforced
+    /// server-side; `allowed_actions` is what the action endpoint enforces.
+    /// Default false ⇒ today's behavior.
+    pub require_confirm: bool,
+    /// Per-link control config (migration 0075, issue #440). `Some(list)`
+    /// restricts `POST /cameras/:id/ha/action` to exactly these action words
+    /// (server-ENFORCED, in addition to the domain allowlist); `None` ⇒ every
+    /// action in the entity's domain allowlist is permitted (today's behavior).
+    pub allowed_actions: Option<Vec<String>>,
 }
 
 // ─── recording_policies ──────────────────────────────────────────────────────


### PR DESCRIPTION
Tier 2 of the HA management overhaul (epic #445). Adds two per-link control knobs and enforces/honors them end to end.

## Schema
Migration `0075_ha_link_control_config.sql` (registered in the `MIGRATIONS` array):
- `require_confirm boolean NOT NULL DEFAULT false`
- `allowed_actions text[]` (NULL = all of the domain's actions)

Additive + idempotent; defaults reproduce today's behavior byte for byte.

## Backend
- `HaLinkInput` accepts optional `require_confirm` + `allowed_actions`; `put_links` validates each `allowed_actions` entry against the entity domain's allowlist and persists both.
- `HaLinkDto` exposes both (additive).
- `post_action` **enforces** `allowed_actions`: after the domain-allowlist check, a non-null list that omits the requested action is refused with **403 before HA is contacted**. `require_confirm` is a client UX gate (exposed, not server-enforced).

## Clients (desktop / Android / iOS)
All parse defensively, so an older server without the fields behaves exactly as today:
- Confirm when `require_confirm` OR domain is cover/lock.
- When `allowed_actions` is non-null, present only those actions (intersected with the domain set); null = full domain set.

## Tests
Rust unit + integration (403-before-HA enforcement), desktop/Android/iOS parse+offered-set tests.

The console editor to set these is deferred to #439; this change only exposes and enforces them.

Closes #440