### PR TITLE
feat(desktop): HA value-setting slider for #442 Slice 1

### DIFF
--- a/apps/desktop-flutter/lib/api/ha_api.dart
+++ b/apps/desktop-flutter/lib/api/ha_api.dart
@@ -44,15 +44,26 @@
 //                                                       authenticated user;
 //                                                       RBAC-projected to the
 //                                                       caller's cameras)
-//   POST /cameras/{id}/ha/action  body {link_id,action} -> {ok:true}. Requires
-//                                                       the `actuators`
+//   POST /cameras/{id}/ha/action  body {link_id,action,value?} -> {ok:true}.
+//                                                       Requires the
+//                                                       `actuators`
 //                                                       capability (issue
 //                                                       #187); 403 without
 //                                                       it, 400/404 on a
 //                                                       rejected action or
 //                                                       unknown link, 502
 //                                                       when HA is
-//                                                       unreachable.
+//                                                       unreachable. `value`
+//                                                       (0..100) is REQUIRED
+//                                                       for a value action
+//                                                       (`set_brightness`,
+//                                                       `set_position`,
+//                                                       `set_speed`, #442
+//                                                       Slice 1, PR #460) and
+//                                                       must be omitted for
+//                                                       every other action —
+//                                                       either mismatch is a
+//                                                       400.
 
 import 'dart:convert';
 
@@ -315,6 +326,12 @@ extension HaApi on CrumbApi {
   /// - `400`/`404` — the server rejected the action or the link is gone.
   /// - `502` — Home Assistant is unreachable.
   ///
+  /// [value] is the value-slider's target (#442 Slice 1) — REQUIRED for a
+  /// value action (`set_brightness`/`set_position`/`set_speed`, from the
+  /// state feed's `HaControlDescriptor.action`) and must stay null for every
+  /// discrete action; the server 400s either mismatch, so callers must only
+  /// pass it alongside a value action.
+  ///
   /// Returns normally on success. Callers must NOT flip the badge locally:
   /// the 3s `/ha/states` poll is what converges the displayed state.
   Future<void> haAction(
@@ -322,6 +339,7 @@ extension HaApi on CrumbApi {
     String cameraId, {
     required String linkId,
     required String action,
+    double? value,
   }) async {
     final resp = await sharedHttpClient.post(
       Uri.parse('${s.base}/cameras/$cameraId/ha/action'),
@@ -329,7 +347,11 @@ extension HaApi on CrumbApi {
         'authorization': 'Bearer ${s.token}',
         'content-type': 'application/json',
       },
-      body: jsonEncode({'link_id': linkId, 'action': action}),
+      body: jsonEncode({
+        'link_id': linkId,
+        'action': action,
+        if (value != null) 'value': value,
+      }),
     );
     if (resp.statusCode == 200) return;
     final detail = _errorDetail(resp).trim();

--- a/apps/desktop-flutter/lib/api/ha_models.dart
+++ b/apps/desktop-flutter/lib/api/ha_models.dart
@@ -248,9 +248,85 @@ class HaLinkInput {
   };
 }
 
+/// A value-control capability descriptor on a `GET /ha/states` entry (#442
+/// Slice 1, backend contract frozen in PR #460). Present only when the entity
+/// currently exposes a settable value (a dimmable light, a positionable
+/// cover, a speed-controllable fan); absent (null) is how a client decides
+/// whether to draw a slider at all — an older server simply never sends the
+/// field, so [HaEntityState.control] stays null and behavior is unchanged.
+///
+/// Deliberately KIND-AGNOSTIC (`min`/`max`/`step`/`unit`, raw JSON numbers) so
+/// Slice 2's `climate.set_temperature` reuses this shape unchanged: a client
+/// must drive the slider's bounds from THESE fields, never hardcode 0..100.
+class HaControlDescriptor {
+  HaControlDescriptor({
+    required this.action,
+    required this.kind,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.step,
+    this.unit,
+  });
+
+  /// The value action word to send back as `action` in
+  /// `POST /cameras/:id/ha/action` together with the chosen `value`
+  /// (`set_brightness`, `set_position`, `set_speed`, ...).
+  final String action;
+
+  /// `"percent"` in this slice; a future kind (e.g. a temperature control)
+  /// reuses the rest of the shape unchanged.
+  final String kind;
+
+  /// Current value, then the slider bounds/step, all in the descriptor's own
+  /// units (integers for percent).
+  final double value;
+  final double min;
+  final double max;
+  final double step;
+
+  /// Unit label for non-percent kinds; null for percent.
+  final String? unit;
+
+  /// Parses a `control` object defensively: any missing/malformed required
+  /// field (not just outright absence) yields null rather than throwing, so
+  /// one odd entity can never take down the whole `/ha/states` decode.
+  static HaControlDescriptor? tryParse(dynamic j) {
+    if (j is! Map<String, dynamic>) return null;
+    final action = j['action'];
+    final kind = j['kind'];
+    final value = j['value'];
+    final min = j['min'];
+    final max = j['max'];
+    final step = j['step'];
+    if (action is! String ||
+        kind is! String ||
+        value is! num ||
+        min is! num ||
+        max is! num ||
+        step is! num) {
+      return null;
+    }
+    return HaControlDescriptor(
+      action: action,
+      kind: kind,
+      value: value.toDouble(),
+      min: min.toDouble(),
+      max: max.toDouble(),
+      step: step.toDouble(),
+      unit: j['unit'] as String?,
+    );
+  }
+}
+
 /// One entity's current reading from `GET /ha/states`.
 class HaEntityState {
-  HaEntityState({required this.state, this.lastChanged, this.unit});
+  HaEntityState({
+    required this.state,
+    this.lastChanged,
+    this.unit,
+    this.control,
+  });
 
   /// Raw HA state string (e.g. `"on"`, `"open"`, `"unavailable"`). Never
   /// reinterpret this as a boolean directly — use `ha_overlay/ha_icons.dart`'s
@@ -266,10 +342,15 @@ class HaEntityState {
   /// null default so an older server that omits the field still decodes.
   final String? unit;
 
+  /// Value-control capability (#442 Slice 1) — null means no settable value,
+  /// so a client renders no slider. See [HaControlDescriptor].
+  final HaControlDescriptor? control;
+
   factory HaEntityState.fromJson(Map<String, dynamic> j) => HaEntityState(
     state: (j['state'] as String?) ?? '',
     lastChanged: DateTime.tryParse((j['last_changed'] as String?) ?? ''),
     unit: j['unit'] as String?,
+    control: HaControlDescriptor.tryParse(j['control']),
   );
 }
 

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_actions.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_actions.dart
@@ -24,6 +24,8 @@
 
 import 'package:flutter/material.dart';
 
+import '../../api/ha_models.dart';
+
 /// One button on the badge detail card's control row.
 class HaControlAction {
   const HaControlAction({
@@ -206,12 +208,54 @@ HaControlAction? haPrimaryAction(String domain) {
 
 /// Domains whose control needs the detail CARD rather than a single click:
 /// `cover` (open / stop / close — three distinct actions) and `lock` (which
-/// also keeps its confirm dialog). A future value-setting control (a dimmer /
-/// position slider) would join this bucket once the backend action allow-list
-/// grows past on/off/toggle; today those two are the only card domains.
+/// also keeps its confirm dialog). Left-click routing is unchanged by the
+/// value-setting slider (#442 Slice 1): a dimmable light/fan still one-tap
+/// toggles on left-click exactly as before, it just ALSO gains a slider,
+/// reachable via a right-click open of the card (`ha_overlay_layer.dart`'s
+/// `onSecondaryTapItem`) rather than by joining this set.
 bool haNeedsCard(String domain) => domain == 'cover' || domain == 'lock';
 
 /// The confirm-step prompt for a physical-security action, e.g.
 /// "Unlock Front Door?" / "Close Garage Door?".
 String haConfirmPrompt(HaControlAction action, String friendlyName) =>
     '${action.label} $friendlyName?';
+
+/// The value slider's row caption for a value action word (#442 Slice 1),
+/// e.g. "Brightness" for `set_brightness` — mirrors [HaControlAction.label]'s
+/// role for the button row. Falls back to a generic caption for a future
+/// value word (e.g. Slice 2's `set_temperature`) this client doesn't know
+/// about yet, rather than showing nothing.
+String haValueActionLabel(String action) {
+  switch (action) {
+    case 'set_brightness':
+      return 'Brightness';
+    case 'set_position':
+      return 'Position';
+    case 'set_speed':
+      return 'Speed';
+    default:
+      return 'Value';
+  }
+}
+
+/// Whether a value slider's OWN commit should confirm first, independent of
+/// the link's `require_confirm` (migration 0075) — mirrors
+/// [HaControlAction.confirm]'s per-button flag for the discrete cover/lock
+/// actions, extended to the value slider: `cover.set_position` is a physical-
+/// security action exactly like open/stop/close, so it confirms the same way.
+bool haValueActionNeedsConfirm(String domain) =>
+    domain == 'cover' || domain == 'lock';
+
+/// Render a value slider's current/target reading for display (row caption,
+/// confirm-dialog prompt), from the descriptor's OWN `kind`/`unit` — never
+/// hardcoded to "%" — so Slice 2's non-percent kind formats correctly without
+/// this function changing. `"percent"` (this slice) always has a null [unit]
+/// and renders as e.g. `"62%"`; any other kind renders the rounded number
+/// plus its unit when present (e.g. `"72 degF"`), matching
+/// `ha_icons.dart`'s `haStateDisplay` convention for a numeric sensor.
+String haFormatControlValue(HaControlDescriptor control, double value) {
+  final rounded = value.round();
+  if (control.kind == 'percent') return '$rounded%';
+  final unit = control.unit;
+  return (unit != null && unit.isNotEmpty) ? '$rounded $unit' : '$rounded';
+}

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_layer.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_layer.dart
@@ -26,6 +26,13 @@
 //   Every read-only / non-controllable badge opens the read-only card on click
 //   exactly as before. The card is placed beside the badge, flipped/clamped
 //   away from the pane edges.
+// * right-click (#442 Slice 1): a simple domain's left-click direct-fires and
+//   never reaches the card, so a dimmable light/fan (no dedicated card domain
+//   of its own) had no gesture to reach a value slider. A right-click on any
+//   controllable badge opens the detail card regardless of domain, alongside
+//   left-click, which keeps firing its primary action unchanged. The card
+//   itself decides whether to draw a slider (its live state's `control`
+//   descriptor, gated the same way as the button row).
 //
 // Purely a display widget: everything comes via the constructor, no
 // controller/global lookups (it builds its own private, ephemeral
@@ -595,6 +602,10 @@ class _HaOverlayLayerState extends State<HaOverlayLayer> {
   /// Extra estimated height once the card carries a control row (issue #187).
   static const double _cardControlsEstHeight = 52;
 
+  /// Extra estimated height once the card carries a value slider row (#442
+  /// Slice 1) — caption/value line + the `Slider` itself.
+  static const double _cardValueEstHeight = 54;
+
   @override
   void dispose() {
     for (final t in _settleTimers.values) {
@@ -650,6 +661,8 @@ class _HaOverlayLayerState extends State<HaOverlayLayer> {
                 ),
                 onTapItem: (item) =>
                     _handleTap((item as HaOverlayBadgeItem).link),
+                onSecondaryTapItem: (item) =>
+                    _handleSecondaryTap((item as HaOverlayBadgeItem).link),
                 onHoverItem: (item, hovering) {
                   final next = hovering
                       ? item.id
@@ -736,6 +749,17 @@ class _HaOverlayLayerState extends State<HaOverlayLayer> {
     setState(() => _openLinkId = _openLinkId == link.id ? null : link.id);
   }
 
+  /// Right-click routing (#442 Slice 1): open the detail card for ANY
+  /// controllable badge, regardless of domain — the one gesture that reaches
+  /// a value slider on a simple domain (light/fan) whose left-click already
+  /// direct-fires and so never falls through to the card. A no-op on a
+  /// non-controllable badge (nothing to show beyond the read-only card
+  /// left-click already offers).
+  void _handleSecondaryTap(HaLink link) {
+    if (!_canControl(link)) return;
+    setState(() => _openLinkId = link.id);
+  }
+
   /// POST a direct-click action and show a brief in-flight spinner on the badge
   /// itself (issue #428). Reuses [_runAction]'s optimistic-never-flip-locally +
   /// toast-on-failure behavior; the spinner rides the settle window, then the
@@ -775,11 +799,28 @@ class _HaOverlayLayerState extends State<HaOverlayLayer> {
         .toList();
   }
 
+  /// The value slider's capability descriptor for [link] (#442 Slice 1), or
+  /// null to draw no slider at all. Gated exactly like [_actionsFor]: this
+  /// account must be able to control the link AND (`allowed_actions` null, or
+  /// it names the descriptor's own value word — migration 0075's existing
+  /// per-link restriction, reused as-is for the value word). The descriptor
+  /// itself comes from the live state feed, so it is null whenever the entity
+  /// currently has nothing settable (e.g. a non-dimmable light).
+  HaControlDescriptor? _controlFor(HaLink link) {
+    if (!_canControl(link)) return null;
+    final control = widget.stateFor(link.entityId)?.control;
+    if (control == null || !link.actionAllowed(control.action)) return null;
+    return control;
+  }
+
   /// POST the action and surface any failure as a toast. Never throws; returns
   /// whether the server accepted it, which is all the card needs to decide
   /// between "settling" and "hand the buttons back". Deliberately does NOT
   /// flip the badge locally: the 3s `/ha/states` poll converges the state.
-  Future<bool> _runAction(HaLink link, String action) async {
+  ///
+  /// [value] carries a value slider's committed target (#442 Slice 1,
+  /// `HaControlDescriptor.action`) — null for every discrete button action.
+  Future<bool> _runAction(HaLink link, String action, {double? value}) async {
     final api = widget.api;
     final session = widget.session;
     final cameraId = widget.cameraId;
@@ -790,6 +831,7 @@ class _HaOverlayLayerState extends State<HaOverlayLayer> {
         cameraId,
         linkId: link.id,
         action: action,
+        value: value,
       );
       return true;
     } on CrumbApiException catch (e) {
@@ -835,8 +877,10 @@ class _HaOverlayLayerState extends State<HaOverlayLayer> {
       left = (x - 8 - _cardWidth).clamp(4.0, double.infinity).toDouble();
     }
     final actions = _actionsFor(open);
-    final estHeight =
-        _cardEstHeight + (actions.isEmpty ? 0.0 : _cardControlsEstHeight);
+    final control = _controlFor(open);
+    final estHeight = _cardEstHeight +
+        (actions.isEmpty ? 0.0 : _cardControlsEstHeight) +
+        (control == null ? 0.0 : _cardValueEstHeight);
     final top = y
         .clamp(4.0, (paneH - estHeight).clamp(4.0, double.infinity))
         .toDouble();
@@ -858,6 +902,10 @@ class _HaOverlayLayerState extends State<HaOverlayLayer> {
         onAction: actions.isEmpty
             ? null
             : (action) => _runAction(open, action),
+        control: control,
+        onValueAction: control == null
+            ? null
+            : (action, value) => _runAction(open, action, value: value),
       ),
     );
   }

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_state_card.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_state_card.dart
@@ -20,6 +20,16 @@
 //   contracted never to throw, and resolves false on failure so the buttons
 //   come straight back.
 //
+// #442 Slice 1 adds an optional VALUE row below the button row: a `Slider`
+// driven entirely by the state feed's `HaControlDescriptor` (min/max/step/
+// unit — never hardcoded), for value-setting entities (a dimmable light, a
+// positionable cover, a speed-controllable fan). It commits on release with
+// exactly one `onValueAction` call per drag gesture, never while dragging;
+// the same never-flip-locally / settle-window contract as the buttons above
+// applies, and `cover.set_position` (like the discrete cover actions) or a
+// `require_confirm` link confirms with the target value in the prompt before
+// sending.
+//
 // This widget is just the card's CONTENT (plus swallowing taps on itself so
 // a host's tap-away scrim underneath doesn't dismiss when the card itself is
 // tapped) — the caller (`ha_overlay_layer.dart`) owns showing/hiding it and
@@ -53,6 +63,8 @@ class HaStateCard extends StatefulWidget {
     this.onDismiss,
     this.actions = const [],
     this.onAction,
+    this.control,
+    this.onValueAction,
     this.requireConfirm = false,
   });
 
@@ -82,6 +94,19 @@ class HaStateCard extends StatefulWidget {
   /// convergence window. Null (or an empty [actions]) means no controls.
   final Future<bool> Function(String action)? onAction;
 
+  /// The value-slider's capability descriptor (#442 Slice 1) — null (the
+  /// default) draws no slider at all. The host decides whether to pass one
+  /// (capability + role gate, same as [actions]/[onAction]) and drives its
+  /// bounds/step/unit from the descriptor, never hardcoded.
+  final HaControlDescriptor? control;
+
+  /// Fires the slider's committed value, by [control]'s wire action string,
+  /// and resolves to whether the server accepted it — same contract as
+  /// [onAction] (never throws, resolves false on failure). Called exactly
+  /// once per drag gesture, on release, never while dragging. Null (or a null
+  /// [control]) means no slider.
+  final Future<bool> Function(String action, double value)? onValueAction;
+
   /// Per-link control config (migration 0075, issue #440). When true, EVERY
   /// action confirms first, not just the hardcoded cover/lock cases — so an
   /// operator can require a deliberate tap on any device. Default false keeps
@@ -93,12 +118,21 @@ class HaStateCard extends StatefulWidget {
 }
 
 class _HaStateCardState extends State<HaStateCard> {
-  /// The action currently in flight or settling, or null when idle.
+  /// The action currently in flight or settling, or null when idle. Shared
+  /// between the button row and the value slider — only one of either kind
+  /// can be in flight at a time (both gate on this being null).
   String? _pending;
 
   /// True once the POST returned and we are just waiting for the state poll
   /// to catch up (spinner becomes a check).
   bool _sent = false;
+
+  /// The slider's live drag position, or the value it was released/sent at
+  /// while `_pending` holds it through the settle window. Null means "follow
+  /// the polled `control.value`" — the normal idle state. Never used to
+  /// optimistically report a NEW value as accepted; it only reflects what the
+  /// operator is doing with the thumb right now (or just released).
+  double? _dragValue;
 
   Timer? _settle;
 
@@ -158,6 +192,74 @@ class _HaStateCardState extends State<HaStateCard> {
       setState(() {
         _pending = null;
         _sent = false;
+      });
+    });
+  }
+
+  /// Commit the value slider's released position (#442 Slice 1). One POST per
+  /// drag gesture, called only from `onChangeEnd` — never while dragging.
+  /// Mirrors [_fire]'s confirm / pending / settle / never-flip-locally
+  /// contract exactly, just with a numeric payload instead of a bare action.
+  Future<void> _fireValue(HaControlDescriptor control, double value) async {
+    final run = widget.onValueAction;
+    if (run == null || _pending != null) return;
+    if (widget.requireConfirm || haValueActionNeedsConfirm(widget.domain)) {
+      final ok = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: Text(
+            'Set ${widget.friendlyName} to ${haFormatControlValue(control, value)}?',
+          ),
+          content: Text(
+            'This controls a real device through Home Assistant.',
+            style: TextStyle(color: Theme.of(ctx).hintColor, fontSize: 12.5),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(true),
+              child: const Text('Set'),
+            ),
+          ],
+        ),
+      );
+      if (ok != true || !mounted) {
+        // Snap the thumb back to the last polled value — the operator backed
+        // out of the confirm, nothing was sent.
+        setState(() => _dragValue = null);
+        return;
+      }
+    }
+    setState(() {
+      _dragValue = value;
+      _pending = control.action;
+      _sent = false;
+    });
+    final ok = await run(control.action, value);
+    if (!mounted) return;
+    if (!ok) {
+      // The host already surfaced the failure; hand the slider straight back
+      // so the operator can retry.
+      setState(() {
+        _pending = null;
+        _sent = false;
+        _dragValue = null;
+      });
+      return;
+    }
+    // Accepted: hold the released position for the convergence window, then
+    // let the polled `control.value` speak for itself.
+    setState(() => _sent = true);
+    _settle?.cancel();
+    _settle = Timer(_kSettleWindow, () {
+      if (!mounted) return;
+      setState(() {
+        _pending = null;
+        _sent = false;
+        _dragValue = null;
       });
     });
   }
@@ -260,11 +362,13 @@ class _HaStateCardState extends State<HaStateCard> {
                   ),
                 ),
               ],
-              if (widget.actions.isNotEmpty && widget.onAction != null) ...[
+              if (_hasActions || _hasControl) ...[
                 const SizedBox(height: 8),
                 const Divider(height: 1, color: Colors.white12),
                 const SizedBox(height: 8),
-                _controlRow(),
+                if (_hasActions) _controlRow(),
+                if (_hasActions && _hasControl) const SizedBox(height: 10),
+                if (_hasControl) _valueRow(),
               ],
             ],
           ),
@@ -272,6 +376,12 @@ class _HaStateCardState extends State<HaStateCard> {
       ),
     );
   }
+
+  bool get _hasActions =>
+      widget.actions.isNotEmpty && widget.onAction != null;
+
+  bool get _hasControl =>
+      widget.control != null && widget.onValueAction != null;
 
   /// The control buttons (issue #187). Wrapped so a three-button cover row
   /// still fits the card's 260px cap on a narrow layout.
@@ -290,6 +400,83 @@ class _HaStateCardState extends State<HaStateCard> {
             sent: _pending == a.action && _sent,
             onPressed: busy ? null : () => unawaited(_fire(a)),
           ),
+      ],
+    );
+  }
+
+  /// The value slider row (#442 Slice 1): a caption ("Brightness"), the
+  /// live/dragged value, and a `Slider` driven entirely by [control]'s
+  /// min/max/step — never hardcoded — so a future non-percent kind (Slice
+  /// 2's temperature) drops in unchanged. Disabled (greyed, non-interactive)
+  /// while ANY action (button or slider) is pending, same busy gate as
+  /// [_controlRow].
+  Widget _valueRow() {
+    final control = widget.control!;
+    final busy = _pending != null;
+    final display = (_dragValue ?? control.value)
+        .clamp(control.min, control.max)
+        .toDouble();
+    final divisions = control.max > control.min && control.step > 0
+        ? ((control.max - control.min) / control.step)
+            .round()
+            .clamp(1, 1000)
+            .toInt()
+        : null;
+    final pendingThis = _pending == control.action;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                haValueActionLabel(control.action),
+                style: const TextStyle(
+                  color: Colors.white70,
+                  fontSize: 11.5,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            if (pendingThis && !_sent)
+              const SizedBox(
+                width: 11,
+                height: 11,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            else if (pendingThis)
+              const Icon(Icons.check, size: 13, color: Colors.white70)
+            else
+              Text(
+                haFormatControlValue(control, display),
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 11.5,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+          ],
+        ),
+        SliderTheme(
+          data: SliderTheme.of(context).copyWith(
+            trackHeight: 3,
+            thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 7),
+            overlayShape: const RoundSliderOverlayShape(overlayRadius: 14),
+          ),
+          child: Slider(
+            value: display,
+            min: control.min,
+            max: control.max,
+            divisions: divisions,
+            onChanged: busy
+                ? null
+                : (v) => setState(() => _dragValue = v),
+            // Commit exactly once, on release — never a POST per drag tick.
+            onChangeEnd: busy
+                ? null
+                : (v) => unawaited(_fireValue(control, v)),
+          ),
+        ),
       ],
     );
   }

--- a/apps/desktop-flutter/lib/ui/overlay_editor/overlay_editor_layer.dart
+++ b/apps/desktop-flutter/lib/ui/overlay_editor/overlay_editor_layer.dart
@@ -69,6 +69,7 @@ class OverlayEditorLayer extends StatefulWidget {
     this.videoW,
     this.videoH,
     this.onTapItem,
+    this.onSecondaryTapItem,
     this.onHoverItem,
     this.emptyEditHint,
   });
@@ -96,6 +97,13 @@ class OverlayEditorLayer extends StatefulWidget {
   /// View-mode tap dispatch (e.g. show a state card). Edit-mode taps select
   /// the item instead and never call this.
   final void Function(OverlayItem item)? onTapItem;
+
+  /// View-mode right-click (secondary tap) dispatch — e.g. the HA host's
+  /// right-click-to-open-card gesture (#442 Slice 1) for a controllable badge
+  /// whose left-click already fires its primary action, so the card (and any
+  /// value slider) still has a way in. Null adds no secondary-tap handling at
+  /// all, same as [onTapItem]. Edit-mode never calls this.
+  final void Function(OverlayItem item)? onSecondaryTapItem;
 
   /// View-mode hover dispatch (mouse enter/leave over an item's hit target) —
   /// e.g. the HA host's hover-reveal of the badge's live state. Null adds no
@@ -184,6 +192,7 @@ class _OverlayEditorLayerState extends State<OverlayEditorLayer> {
                         controller.primarySelectedId == item.id,
                     buildItem: widget.buildItem,
                     onTap: widget.onTapItem,
+                    onSecondaryTap: widget.onSecondaryTapItem,
                     onHover: widget.onHoverItem,
                   ),
                 if (widget.editing)
@@ -319,6 +328,7 @@ class _OverlayItemWidget extends StatelessWidget {
     required this.isReference,
     required this.buildItem,
     required this.onTap,
+    this.onSecondaryTap,
     required this.onHover,
   });
 
@@ -333,6 +343,7 @@ class _OverlayItemWidget extends StatelessWidget {
   final bool isReference;
   final OverlayItemBuilder buildItem;
   final void Function(OverlayItem item)? onTap;
+  final void Function(OverlayItem item)? onSecondaryTap;
   final void Function(OverlayItem item, bool hovering)? onHover;
 
   static const double _handle = 16;
@@ -522,6 +533,8 @@ class _OverlayItemWidget extends StatelessWidget {
     final Widget body = GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: onTap == null ? null : () => onTap!(item),
+      onSecondaryTap:
+          onSecondaryTap == null ? null : () => onSecondaryTap!(item),
       child: _withOpacity(buildItem(item, editing: false, selected: false)),
     );
     final hover = onHover;


### PR DESCRIPTION
## Summary

Part of #442

Desktop client (Flutter) implementation of #442 Slice 1's HA value-setting controls (dimmable light brightness, cover position, fan speed), consuming the backend contract frozen in #460 (still open, not yet merged into `main` — the contract's shape was confirmed directly against that branch's `services/api/src/ha.rs`).

- `lib/api/ha_models.dart`: new `HaControlDescriptor` (`action`/`kind`/`value`/`min`/`max`/`step`/`unit`), parsed defensively off `HaEntityState.control` — any missing/malformed field yields `null` rather than throwing, so an older server (or an odd entity) never breaks the whole `/ha/states` decode.
- `lib/api/ha_api.dart`: `haAction()` gains an optional `value` param, sent only when non-null.
- `lib/ui/ha_overlay/ha_actions.dart`: `haValueActionLabel` (row caption), `haValueActionNeedsConfirm` (cover/lock parity with the discrete button confirms), `haFormatControlValue` (kind-agnostic display, e.g. `"62%"`).
- `lib/ui/ha_overlay/ha_state_card.dart`: a value row (`Slider` + caption) below the existing button row, shown only when the host passes a `control` descriptor. Bounds/step/unit come entirely from the descriptor — never hardcoded — so Slice 2's `climate.set_temperature` can reuse the same widget. Commits on release with exactly one POST per drag gesture (never while dragging), never optimistically flips the displayed value (same settle-window/in-flight-spinner convention as the button row), and confirms first (with the target value in the prompt, e.g. "Set Garage Door to 20%?") for `cover.set_position` or a `require_confirm` link.
- `lib/ui/ha_overlay/ha_overlay_layer.dart`: gates the slider like the button row (`actuators` capability + `actuator` role + the link's `allowed_actions`), wires it to `POST /ha/action`, and adds a **right-click (secondary-tap) gesture** on any controllable badge to open the detail card. This was needed because a controllable "simple" domain (light/fan) already direct-fires its primary action on left-click and never reaches the card (issue #428) — so a dimmable light had no gesture to reach its slider. Left-click behavior is unchanged.
- `lib/ui/overlay_editor/overlay_editor_layer.dart`: adds an optional `onSecondaryTapItem` callback to the shared view-mode gesture layer (used only by the HA overlay; the PTZ panel's usage is edit-mode only and unaffected).

Backend, Android, and iOS were not touched.

## Verify

- [x] Manual review: null-safety, every referenced symbol exists, imports correct, brace/paren balance checked.
- [x] Caught and fixed two `num.clamp()` return-type pitfalls (`clamp()` returns `num` even when called on an `int`/`double`, so `Slider`'s `divisions`/`value` need an explicit `.toInt()`/`.toDouble()`).
- [ ] `flutter analyze` — **BLOCKED**: winbuild (10.1.10.90), the only Windows Flutter box, is offline (SSH connection timed out). dev1/dev2/macmini were also checked and have no Flutter toolchain. Did not build/run on this Windows workstation per policy.

## Test plan

- [ ] Run `flutter analyze` on winbuild once it's back online; fix any ERRORS.
- [ ] Manual smoke test against a server on #460's branch: dimmable light shows a slider on right-click, drag-and-release sets brightness with one POST, cover position slider confirms before sending, fan speed slider respects its `percentage_step`.