### PR TITLE
feat(ios): value slider for HA percent controls (#442 Slice 1)

### DIFF
--- a/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
+++ b/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
@@ -433,11 +433,14 @@ final class HAController: ObservableObject {
     /// Deliberately does NOT mutate the shown state: the `/ha/states` poll is the
     /// only source of truth (state-honesty invariant above), so a call that HA
     /// silently drops can never leave the badge lying about the device.
-    func perform(link: HaLink, action: String) async throws {
+    ///
+    /// `value` carries the single numeric a value action needs (issue #442
+    /// Slice 1); nil for every discrete action, unchanged from before.
+    func perform(link: HaLink, action: String, value: Double? = nil) async throws {
         // Unreachable in practice (links only exist after `activate`), but a
         // missing camera must read as a failure, never as a silent success.
         guard let cameraId else { throw HAActionError.noCamera }
-        try await container.api.haAction(cameraId: cameraId, linkId: link.id, action: action)
+        try await container.api.haAction(cameraId: cameraId, linkId: link.id, action: action, value: value)
         // Nudge the poll so the real new state lands sooner than the next tick.
         await pollOnce()
     }
@@ -675,6 +678,9 @@ struct HAStateCard: View {
     @State private var inFlight: String?
     /// Awaiting confirmation (lock/cover only).
     @State private var pending: HAAction?
+    /// A value-slider commit awaiting confirmation (`require_confirm` or a
+    /// cover, issue #442 Slice 1) — the target value it would send.
+    @State private var pendingValue: PendingValueCommit?
     @State private var errorText: String?
 
     private var state: HaEntityState? { controller.state(for: link.entityId) }
@@ -691,6 +697,20 @@ struct HAStateCard: View {
         return HA.allActions(for: link.domain).filter { allowed.contains($0.action) }
     }
 
+    /// The value-setting slider's descriptor, or nil when none applies. Value
+    /// words (`set_brightness`/`set_position`/`set_speed`) are not buttons —
+    /// this slider is their entire UI (issue #442 Slice 1). Same actuate gate
+    /// as `actions`, plus the live `control` descriptor the state poll carries,
+    /// plus (when the link restricts actions) the descriptor's action word must
+    /// be one of the allowed ones — the same `allowed_actions` intersection the
+    /// button set already applies.
+    private var valueControl: HaControlDescriptor? {
+        guard controller.canActuate, link.isActuator else { return nil }
+        guard let control = state?.control else { return nil }
+        guard link.actionAllowed(control.action) else { return nil }
+        return control
+    }
+
     var body: some View {
         let v = HA.visual(for: link, state: state, stale: stale)
         NavigationStack {
@@ -700,6 +720,11 @@ struct HAStateCard: View {
                 Text(v.stateText).font(.title3.weight(.semibold)).foregroundColor(v.color)
                 if let age = HA.relativeAgo(state?.lastChanged) {
                     Text("Changed \(age)").font(.caption).foregroundColor(CrumbColors.textSecondary)
+                }
+                if let control = valueControl {
+                    HAValueSlider(control: control, disabled: inFlight != nil) { target in
+                        commitValue(control, target)
+                    }
                 }
                 if !actions.isEmpty {
                     controlsRow
@@ -742,6 +767,39 @@ struct HAStateCard: View {
                 }
             }
             Button("Cancel", role: .cancel) { pending = nil }
+        }
+        .confirmationDialog(
+            pendingValue.map { "Set \(link.displayName) to \($0.displayValue)?" } ?? "",
+            isPresented: Binding(get: { pendingValue != nil }, set: { if !$0 { pendingValue = nil } }),
+            titleVisibility: .visible
+        ) {
+            if let commit = pendingValue {
+                Button("Set") {
+                    pendingValue = nil
+                    Task { await fireValue(commit.control, commit.value) }
+                }
+            }
+            Button("Cancel", role: .cancel) { pendingValue = nil }
+        }
+    }
+
+    /// A value-slider commit awaiting confirmation, and the label the
+    /// confirmation dialog interpolates it into.
+    private struct PendingValueCommit {
+        let control: HaControlDescriptor
+        let value: Double
+        var displayValue: String { HAValueSlider.label(for: value, control: control) }
+    }
+
+    /// Route a slider commit through the same confirm gate as a button action:
+    /// the link's own `require_confirm`, or (physical-security parity with
+    /// cover's open/close buttons) the entity being a cover. Everything else
+    /// fires immediately, exactly like a light/fan toggle.
+    private func commitValue(_ control: HaControlDescriptor, _ value: Double) {
+        if link.requireConfirm || link.domain == "cover" {
+            pendingValue = PendingValueCommit(control: control, value: value)
+        } else {
+            Task { await fireValue(control, value) }
         }
     }
 
@@ -794,6 +852,20 @@ struct HAStateCard: View {
         inFlight = nil
     }
 
+    /// One value-setting service call (issue #442 Slice 1), with the slider
+    /// disabled for its duration. Same pattern as `fire`: the shown value is
+    /// left alone either way, the 3s poll converges it.
+    private func fireValue(_ control: HaControlDescriptor, _ value: Double) async {
+        errorText = nil
+        inFlight = control.action
+        do {
+            try await controller.perform(link: link, action: control.action, value: value)
+        } catch {
+            errorText = HA.actionMessage(for: error)
+        }
+        inFlight = nil
+    }
+
     private func detailRow(_ label: String, _ value: String) -> some View {
         HStack {
             Text(label).font(.caption).foregroundColor(CrumbColors.textTertiary)
@@ -801,6 +873,70 @@ struct HAStateCard: View {
             Text(value).font(.caption.monospaced()).foregroundColor(CrumbColors.textSecondary)
                 .lineLimit(1).truncationMode(.middle)
         }
+    }
+}
+
+/// A value-setting slider for `HAStateCard` (issue #442 Slice 1). Kind-agnostic
+/// — driven entirely by the descriptor's `min`/`max`/`step`/`unit`, never a
+/// hardcoded 0...100, so Slice 2's temperature control reuses this unchanged.
+///
+/// Interaction is identical to the desktop/Android sliders: commits on
+/// release, exactly ONE `onCommit` call per gesture, via `onEditingChanged`
+/// going false. The shown value never flips optimistically on commit — it
+/// only advances when the descriptor's own `value` changes (i.e. when the next
+/// `/ha/states` poll lands), and only while the user isn't mid-drag.
+struct HAValueSlider: View {
+    let control: HaControlDescriptor
+    var disabled: Bool = false
+    /// Fired once per gesture, on release, with the rounded target value.
+    let onCommit: (Double) -> Void
+
+    @State private var value: Double
+    @State private var dragging = false
+
+    private var lowerBound: Double { control.min ?? 0 }
+    private var upperBound: Double { max(control.max ?? 100, lowerBound) }
+    private var stepSize: Double { max(control.step ?? 1, 0.01) }
+
+    init(control: HaControlDescriptor, disabled: Bool = false, onCommit: @escaping (Double) -> Void) {
+        self.control = control
+        self.disabled = disabled
+        self.onCommit = onCommit
+        _value = State(initialValue: control.value ?? control.min ?? 0)
+    }
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Slider(
+                value: $value,
+                in: lowerBound...upperBound,
+                step: stepSize,
+                onEditingChanged: { editing in
+                    dragging = editing
+                    if !editing { onCommit(value) }
+                }
+            )
+            .disabled(disabled)
+            Text(Self.label(for: value, control: control))
+                .font(.caption).foregroundColor(CrumbColors.textSecondary)
+        }
+        .padding(.top, 2)
+        // Re-seed from the live descriptor only while the user isn't actively
+        // dragging — a mid-drag poll tick must never yank the thumb (the
+        // state-honesty invariant applies to the drag gesture too).
+        .onChange(of: control.value) { newValue in
+            guard !dragging, let newValue else { return }
+            value = newValue
+        }
+    }
+
+    /// "62%" for the percent kind (every Slice 1 word); "72 °F" for a future
+    /// kind that carries a `unit`.
+    static func label(for value: Double, control: HaControlDescriptor) -> String {
+        let rounded = Int(value.rounded())
+        if control.kind == "percent" { return "\(rounded)%" }
+        if let unit = control.unit, !unit.isEmpty { return "\(rounded) \(unit)" }
+        return "\(rounded)"
     }
 }
 

--- a/apps/ios/Crumb/Models/Models.swift
+++ b/apps/ios/Crumb/Models/Models.swift
@@ -588,12 +588,48 @@ struct HaEntityState: Decodable {
     /// decoder treats this optional as `decodeIfPresent`, so a payload from an
     /// older server that omits `unit` still decodes.
     let unit: String?
+    /// Value-control capability descriptor (issue #442 Slice 1, PR #460).
+    /// Present only when the entity currently exposes a settable value (a
+    /// dimmable light, a positionable cover, a speed-controllable fan); absent
+    /// otherwise, and absent entirely on an older server. The synthesized
+    /// decoder treats this optional as `decodeIfPresent`, so it decodes to nil
+    /// rather than failing when the key is missing — that absence is exactly
+    /// the client's cue to render no slider.
+    let control: HaControlDescriptor?
 
     enum CodingKeys: String, CodingKey {
-        case state, unit
+        case state, unit, control
         case entityId = "entity_id"
         case lastChanged = "last_changed"
     }
+}
+
+/// A value-setting control capability on an `HaEntityState` (issue #442 Slice
+/// 1, PR #460). Mirrors the server's `ControlDescriptor`: kept KIND-AGNOSTIC
+/// (`min`/`max`/`step`/`unit` rather than a hardcoded 0...100) so a future
+/// value kind (Slice 2's climate `set_temperature`) reuses this shape and the
+/// `HAValueSlider` view unchanged — only `kind`/`unit` would differ.
+///
+/// Every numeric field decodes via `decodeIfPresent` (the synthesized
+/// decoder's default for an Optional), so a leaner payload degrades to sane
+/// percent defaults at the call site rather than failing to decode the whole
+/// entity state.
+struct HaControlDescriptor: Decodable {
+    /// The value action word to send back on `POST /cameras/:id/ha/action`
+    /// (`set_brightness`, `set_position`, `set_speed`, ...).
+    let action: String
+    /// The value kind. `"percent"` for every Slice 1 word; a future kind (e.g.
+    /// `"temperature"`) would pair with a non-nil `unit`.
+    let kind: String
+    /// Current value in the descriptor's own units, or nil if HA hasn't
+    /// reported one yet.
+    let value: Double?
+    let min: Double?
+    let max: Double?
+    let step: Double?
+    /// Unit label for a non-percent kind; nil for percent (the client renders
+    /// a bare "%" for that case instead).
+    let unit: String?
 }
 
 /// `GET /ha/states` response. `stale` ⇒ HA was unreachable and this is the
@@ -620,12 +656,27 @@ struct HaStatesResponse: Decodable {
 struct HaActionRequest: Encodable {
     let linkId: String
     /// One of the server's per-domain allow-list: `turn_on`/`turn_off`/`toggle`,
-    /// `open_cover`/`close_cover`/`stop_cover`, `lock`/`unlock`, `press`.
+    /// `open_cover`/`close_cover`/`stop_cover`, `lock`/`unlock`, `press`, or a
+    /// value word (`set_brightness`/`set_position`/`set_speed`, issue #442
+    /// Slice 1) paired with `value`.
     let action: String
+    /// The single numeric value a value action carries (0...100 for every
+    /// Slice 1 word; the server rounds and validates the range). Nil for a
+    /// discrete action. The synthesized encoder treats an Optional as
+    /// `encodeIfPresent`, so the key is omitted entirely rather than sent as
+    /// `null` — required, since the server 400s a discrete action that
+    /// carries a `value` key at all.
+    let value: Double?
 
     enum CodingKeys: String, CodingKey {
-        case action
+        case action, value
         case linkId = "link_id"
+    }
+
+    init(linkId: String, action: String, value: Double? = nil) {
+        self.linkId = linkId
+        self.action = action
+        self.value = value
     }
 }
 

--- a/apps/ios/Crumb/Networking/CrumbAPI.swift
+++ b/apps/ios/Crumb/Networking/CrumbAPI.swift
@@ -298,10 +298,15 @@ final class CrumbAPI {
     /// `400`/`404` (rejected link/action) or `502` (Home Assistant unreachable).
     /// The caller does NOT flip local state on success: the `/ha/states` poll
     /// stays the only source of truth for what the device is actually doing.
+    ///
+    /// `value` carries the single numeric a value action needs (issue #442
+    /// Slice 1: `set_brightness`/`set_position`/`set_speed`, 0...100). Pass it
+    /// ONLY for a value action — the server 400s a discrete action sent with a
+    /// value, or a value action sent without one.
     @discardableResult
-    func haAction(cameraId: String, linkId: String, action: String) async throws -> HaActionResponse {
+    func haAction(cameraId: String, linkId: String, action: String, value: Double? = nil) async throws -> HaActionResponse {
         try await post("cameras/\(cameraId)/ha/action",
-                       body: HaActionRequest(linkId: linkId, action: action))
+                       body: HaActionRequest(linkId: linkId, action: action, value: value))
     }
 
     // MARK: - Saved Views (server-backed, per-user; shared with desktop/android/web)

--- a/apps/ios/CrumbTests/HaValueControlTests.swift
+++ b/apps/ios/CrumbTests/HaValueControlTests.swift
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import XCTest
+@testable import Crumb
+
+/// Value-control descriptor decoding + offered-slider gating (issue #442
+/// Slice 1, PR #460): `HaEntityState.control` must decode defensively (an
+/// older server that omits it decodes exactly as today via the synthesized
+/// `decodeIfPresent`), and the slider is offered only when the descriptor is
+/// present AND (allowed_actions is nil OR includes the descriptor's action
+/// word) — mirroring `HaControlConfigTests`' button-gating pattern.
+final class HaValueControlTests: XCTestCase {
+
+    private func decodeState(_ jsonBody: String) throws -> HaEntityState {
+        try JSONDecoder().decode(HaEntityState.self, from: Data(jsonBody.utf8))
+    }
+
+    private func decodeLink(_ jsonBody: String) throws -> HaLink {
+        try JSONDecoder().decode(HaLink.self, from: Data(jsonBody.utf8))
+    }
+
+    /// Mirrors `HAStateCard.valueControl`'s derivation without the SwiftUI view:
+    /// present iff the state carries a `control` descriptor and, when the link
+    /// restricts actions, the descriptor's action word is one of them.
+    private func offeredControl(link: HaLink, state: HaEntityState) -> HaControlDescriptor? {
+        guard let control = state.control else { return nil }
+        guard link.actionAllowed(control.action) else { return nil }
+        return control
+    }
+
+    // MARK: - Decoding
+
+    func testOlderServerPayloadOmittingControlDecodesToNil() throws {
+        let state = try decodeState(
+            #"{"entity_id":"light.kitchen","state":"on"}"#
+        )
+        XCTAssertNil(state.control)
+    }
+
+    func testControlDescriptorDecodesFullPayload() throws {
+        let state = try decodeState(
+            #"""
+            {"entity_id":"light.kitchen","state":"on",
+             "control":{"action":"set_brightness","kind":"percent","value":62,"min":0,"max":100,"step":1,"unit":null}}
+            """#
+        )
+        let control = try XCTUnwrap(state.control)
+        XCTAssertEqual(control.action, "set_brightness")
+        XCTAssertEqual(control.kind, "percent")
+        XCTAssertEqual(control.value, 62)
+        XCTAssertEqual(control.min, 0)
+        XCTAssertEqual(control.max, 100)
+        XCTAssertEqual(control.step, 1)
+        XCTAssertNil(control.unit)
+    }
+
+    func testControlDescriptorWithMissingSubfieldsDecodesDefensively() throws {
+        // A leaner payload than the frozen contract promises — every numeric
+        // field is individually optional, so this must still decode rather
+        // than fail the whole entity state.
+        let state = try decodeState(
+            #"{"entity_id":"cover.garage","state":"open","control":{"action":"set_position","kind":"percent"}}"#
+        )
+        let control = try XCTUnwrap(state.control)
+        XCTAssertEqual(control.action, "set_position")
+        XCTAssertNil(control.value)
+        XCTAssertNil(control.min)
+        XCTAssertNil(control.max)
+        XCTAssertNil(control.step)
+    }
+
+    // MARK: - Offered-slider gating
+
+    func testNoControlDescriptorMeansNoSlider() throws {
+        let link = try decodeLink(
+            #"{"id":"l1","entity_id":"light.kitchen","role":"actuator","sort_order":0}"#
+        )
+        let state = try decodeState(#"{"entity_id":"light.kitchen","state":"on"}"#)
+        XCTAssertNil(offeredControl(link: link, state: state))
+    }
+
+    func testControlDescriptorOfferedWhenAllowedActionsIsNil() throws {
+        let link = try decodeLink(
+            #"{"id":"l2","entity_id":"light.kitchen","role":"actuator","sort_order":0}"#
+        )
+        let state = try decodeState(
+            #"""
+            {"entity_id":"light.kitchen","state":"on",
+             "control":{"action":"set_brightness","kind":"percent","value":40,"min":0,"max":100,"step":1,"unit":null}}
+            """#
+        )
+        XCTAssertEqual(offeredControl(link: link, state: state)?.action, "set_brightness")
+    }
+
+    func testControlDescriptorOfferedWhenAllowedActionsIncludesTheValueWord() throws {
+        let link = try decodeLink(
+            #"""
+            {"id":"l3","entity_id":"cover.garage","role":"actuator","sort_order":0,
+             "allowed_actions":["open_cover","close_cover","set_position"]}
+            """#
+        )
+        let state = try decodeState(
+            #"""
+            {"entity_id":"cover.garage","state":"open",
+             "control":{"action":"set_position","kind":"percent","value":75,"min":0,"max":100,"step":1,"unit":null}}
+            """#
+        )
+        XCTAssertEqual(offeredControl(link: link, state: state)?.action, "set_position")
+    }
+
+    func testControlDescriptorSuppressedWhenAllowedActionsExcludesTheValueWord() throws {
+        // A link restricted to exactly open/close (no set_position) must not
+        // offer the slider, even though the state carries a descriptor.
+        let link = try decodeLink(
+            #"""
+            {"id":"l4","entity_id":"cover.garage","role":"actuator","sort_order":0,
+             "allowed_actions":["open_cover","close_cover"]}
+            """#
+        )
+        let state = try decodeState(
+            #"""
+            {"entity_id":"cover.garage","state":"open",
+             "control":{"action":"set_position","kind":"percent","value":75,"min":0,"max":100,"step":1,"unit":null}}
+            """#
+        )
+        XCTAssertNil(offeredControl(link: link, state: state))
+    }
+
+    // MARK: - Slider label formatting (mirrors HAValueSlider.label)
+
+    func testPercentLabelFormatting() throws {
+        let state = try decodeState(
+            #"""
+            {"entity_id":"fan.bedroom","state":"on",
+             "control":{"action":"set_speed","kind":"percent","value":33,"min":0,"max":100,"step":25,"unit":null}}
+            """#
+        )
+        let control = try XCTUnwrap(state.control)
+        XCTAssertEqual(HAValueSlider.label(for: 33, control: control), "33%")
+    }
+}


### PR DESCRIPTION
## Summary

SwiftUI/macOS counterpart to the merged `POST /cameras/:id/ha/action` value contract (#460, epic #445, issue #442 Slice 1): a slider for the three percent value words — `light.set_brightness`, `cover.set_position`, `fan.set_speed`. Climate `set_temperature` is Slice 2 and not touched.

- `HaEntityState` gains an optional, kind-agnostic `control` descriptor (`action`/`kind`/`value`/`min`/`max`/`step`/`unit`), decoded defensively (`decodeIfPresent`) so an older server without the `control` key renders exactly as today — absent descriptor means no slider.
- `HAStateCard` gains an `HAValueSlider`, driven entirely by the descriptor's `min`/`max`/`step` (never a hardcoded 0...100), so a future value kind (Slice 2 temperature) reuses it unchanged. It commits exactly once per gesture, on release (`onEditingChanged(false)`), never optimistically flips the shown value, and re-seeds from the poll only while the user isn't mid-drag — the existing ~3s `/ha/states` poll is what converges it.
- `require_confirm` on the link, or a `cover` domain, routes the commit through the same `confirmationDialog` the button actions already use, with the target value interpolated ("Set Garage Door to 40%?"). Everything else fires immediately, matching the light/fan toggle behavior.
- The slider is offered only when the descriptor is present AND (`allowed_actions` is nil OR includes the descriptor's action word) — the same intersection the button set already applies. Value words are not buttons; the slider is their entire UI.
- `HaActionRequest`/`CrumbAPI.haAction` gain an optional `value: Double?`, encoded only when present via the synthesized `encodeIfPresent` (omitted entirely for a discrete action, never sent as `null`).

Only `apps/ios/Crumb/` and its test target were touched — backend, desktop, and Android are untouched.

## Test plan

- [x] `HaValueControlTests.swift` added (mirrors `HaControlConfigTests.swift`): `control` descriptor decoding (present, absent → nil, partial payload defensive decode) + offered-slider gating (nil `allowed_actions`, restricted-but-included, restricted-and-excluded) + label formatting.
- [x] Built `Crumb-mac` scheme on macOS via `xcodegen generate` + `xcodebuild -scheme Crumb-mac -destination 'platform=macOS' build` — **BUILD SUCCEEDED**, no warnings in the changed files.
- [x] Ran `HaValueControlTests` + the existing `HaControlConfigTests` on an iOS Simulator (`Crumb` scheme) — 12/12 passed.