### PR TITLE
feat(android): HA value slider for brightness/position/speed (#442 Slice 1)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/data/CrumbApi.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/CrumbApi.kt
@@ -210,7 +210,10 @@ interface CrumbApi {
      * `actuators` capability (admin implies it); the server enforces its own
      * per-domain action allowlist and returns `{ "ok": true }` on success. A
      * missing capability is 403, a rejected/unknown link 400/404, HA unreachable
-     * 502 — all surfaced to the caller as a [retrofit2.HttpException].
+     * 502 — all surfaced to the caller as a [retrofit2.HttpException]. The
+     * body's `value` (#442, Slice 1) carries the one numeric a value action
+     * needs (`set_brightness`/`set_position`/`set_speed`, 0..100); a value on a
+     * discrete action, or a missing value on a value action, is a 400.
      */
     @POST("cameras/{camera_id}/ha/action")
     suspend fun haAction(

--- a/apps/android/app/src/main/java/video/crumb/app/data/CrumbRepository.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/CrumbRepository.kt
@@ -233,13 +233,16 @@ class CrumbRepository(private val container: AppContainer) {
 
     /**
      * Fire an HA service call ([action], e.g. "toggle"/"open_cover"/"unlock") for
-     * a linked entity ([linkId]) on [cameraId]. Success is a bare 200 `{ok:true}`;
-     * we don't flip state locally — the `/ha/states` poll converges the shown
-     * state. A capability/validation/HA-unreachable rejection is a [Result.failure]
-     * the UI turns into a compact error via [toUserMessage].
+     * a linked entity ([linkId]) on [cameraId]. [value] is the one numeric a
+     * value action carries (#442, Slice 1: `set_brightness`/`set_position`/
+     * `set_speed`, a 0..100 percent the server validates and rounds) — omit it
+     * for discrete actions. Success is a bare 200 `{ok:true}`; we don't flip
+     * state locally — the `/ha/states` poll converges the shown state. A
+     * capability/validation/HA-unreachable rejection is a [Result.failure] the
+     * UI turns into a compact error via [toUserMessage].
      */
-    suspend fun haAction(cameraId: String, linkId: String, action: String): Result<Unit> =
-        runCatchingCancellable { api.haAction(cameraId, HaActionRequest(linkId, action)); Unit }
+    suspend fun haAction(cameraId: String, linkId: String, action: String, value: Double? = null): Result<Unit> =
+        runCatchingCancellable { api.haAction(cameraId, HaActionRequest(linkId, action, value)); Unit }
 
     // ── motion tuner ───────────────────────────────────────────────────────────
     /** Latest live per-cell motion heatmap (null when none published yet). */

--- a/apps/android/app/src/main/java/video/crumb/app/data/HaModels.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/HaModels.kt
@@ -70,11 +70,20 @@ data class HaLinkDto(
     val isActuator: Boolean get() = role == "actuator"
 }
 
-/** Body for POST /cameras/{id}/ha/action — fire one HA service call for a link. */
+/**
+ * Body for POST /cameras/{id}/ha/action — fire one HA service call for a link.
+ * [value] is the ONE numeric a value action carries (#442, Slice 1: a dimmer
+ * level, a cover position, a fan speed — a plain 0..100 percent the server
+ * validates and rounds before HA). Omit it for discrete actions: the JSON
+ * layer has `explicitNulls = false` (see `Network.kt`), so a null [value]
+ * drops the key entirely rather than sending `"value":null`, matching the
+ * server's arity check (a value on a discrete action is a 400).
+ */
 @Serializable
 data class HaActionRequest(
     @SerialName("link_id") val linkId: String,
     val action: String,
+    val value: Double? = null,
 )
 
 /** Response for the HA action call: `{ "ok": true }` on success. */
@@ -103,10 +112,41 @@ fun haPrimaryAction(domain: String): String? = when (domain) {
  * Domains whose control opens the detail/control SHEET instead of a single tap,
  * because they are multi-action and/or physical-security devices that must
  * confirm before firing: `cover` (open/stop/close) and `lock` (lock/unlock).
- * A future value-setting control (dimmer/position) will also route here; the
- * backend is on/off/toggle-only today, so there is no such UI yet.
+ * The value slider (#442, Slice 1) also lives in that sheet — it rides the
+ * existing long-press/detail gesture, so it needs no entry here of its own.
  */
 fun haNeedsSheet(domain: String): Boolean = domain == "cover" || domain == "lock"
+
+// ── HA value-setting control (#442, Slice 1) ─────────────────────────────────
+// A dimmable light, a positionable cover, and a speed-controllable fan each get
+// a slider in the detail sheet alongside their action pills, instead of just an
+// on/off tap. The value words below mirror the server's `HA_ACTION_ALLOWLIST`
+// exactly (`services/api/src/ha.rs`) — climate `set_temperature` is Slice 2,
+// deliberately not here yet.
+
+/**
+ * The value-setting action word for a domain, Slice 1 (#442): the three
+ * already-trusted percent domains only. `null` for every other domain
+ * (including the discrete-only `light`-adjacent ones like `switch`/`siren`).
+ */
+fun haValueAction(domain: String): String? = when (domain) {
+    "light" -> "set_brightness"
+    "cover" -> "set_position"
+    "fan" -> "set_speed"
+    else -> null
+}
+
+/**
+ * Whether [this] link should offer a value slider given its current-state
+ * [control] descriptor: the descriptor must be present (the server says the
+ * entity currently exposes a settable value) AND its action must be permitted
+ * by the link's own `allowed_actions` gate (migration 0075) — `null` ⇒ every
+ * action including value words, matching [actionAllowed]. Capability/role
+ * gating (the `actuators` capability, [HaLinkDto.isActuator]) is the caller's
+ * job, same as the existing action-pill control row.
+ */
+fun HaLinkDto.showsSlider(control: HaControlDescriptor?): Boolean =
+    control != null && actionAllowed(control.action)
 
 /** One control action: its wire verb + human caption. */
 data class HaAction(val verb: String, val label: String)
@@ -157,6 +197,30 @@ fun HaLinkDto.controlActions(): List<HaAction> {
     return haFullActions(domain).filter { it.verb in allowed }
 }
 
+/**
+ * Value-control capability descriptor on a `GET /ha/states` entry (#442, Slice
+ * 1). Present only when the entity currently exposes a settable value (a
+ * dimmable light, a positionable cover, a speed-controllable fan); absent ⇒
+ * the client draws no slider — see [HaEntityState.control]. Kind-agnostic
+ * (min/max/step/unit as plain numbers, not hardcoded 0..100) so a future
+ * non-percent kind (Slice 2 temperature) decodes into the same shape
+ * unchanged; a client that does not recognize [kind] can still render a
+ * generic min..max/step slider with [unit] appended.
+ */
+@Serializable
+data class HaControlDescriptor(
+    /** The value action word to send back to POST .../ha/action (`set_brightness`, ...). */
+    val action: String,
+    /** `"percent"` in Slice 1; a future kind reuses the rest of this shape. */
+    val kind: String,
+    val value: Double,
+    val min: Double,
+    val max: Double,
+    val step: Double,
+    /** Unit label for non-percent kinds; `null` for percent. */
+    val unit: String? = null,
+)
+
 /** One entity's live state in the GET /ha/states feed. */
 @Serializable
 data class HaEntityState(
@@ -167,6 +231,9 @@ data class HaEntityState(
     // ...); null when the entity has no unit (issue #449). Default null so an
     // older server that omits the field still decodes.
     @SerialName("unit") val unit: String? = null,
+    // Value-control capability (#442, Slice 1). Nullable + defaulted so an
+    // older server that omits the field decodes exactly as today (no slider).
+    val control: HaControlDescriptor? = null,
 )
 
 /** GET /ha/states response: the entity states plus cache freshness. */

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaEntitiesSheet.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaEntitiesSheet.kt
@@ -23,9 +23,12 @@ import androidx.compose.material.icons.filled.Home
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -37,12 +40,15 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import video.crumb.app.data.HaControlDescriptor
 import video.crumb.app.data.HaLinkDto
 import video.crumb.app.data.HaStatesResponse
 import video.crumb.app.data.controlActions
+import video.crumb.app.data.showsSlider
 import java.time.Duration
 import java.time.Instant
 import java.time.OffsetDateTime
+import kotlin.math.roundToInt
 
 // Home Assistant default (dark) theme tokens — the sheet renders in HA's own
 // look regardless of the app theme, so it feels like an extension of the HA app.
@@ -84,8 +90,12 @@ private fun changedAgo(iso: String?): String? {
  * entities as HA-style tile cards with live state; tapping a tile opens an HA
  * "more-info"-style detail. Phase 2 (#187): when [canActuate] and the link is an
  * actuator, that detail also carries controls (with a confirm on cover/lock);
- * every other case stays read-only. [onAction] fires one service call for a link;
- * [inFlightLinkIds] holds the [HaLinkDto.actionLinkId]s currently posting.
+ * every other case stays read-only. Actuator links whose current state carries a
+ * `control` descriptor (#442, Slice 1: a dimmable light, a positionable cover, a
+ * speed-controllable fan) also get a value slider alongside the action pills.
+ * [onAction] fires one service call for a link — [value] is non-null only for a
+ * value action (a slider commit); [inFlightLinkIds] holds the
+ * [HaLinkDto.actionLinkId]s currently posting.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -96,7 +106,7 @@ fun HaEntitiesSheet(
     onDismiss: () -> Unit,
     canActuate: Boolean = false,
     inFlightLinkIds: Set<String> = emptySet(),
-    onAction: (HaLinkDto, String) -> Unit = { _, _ -> },
+    onAction: (HaLinkDto, String, Double?) -> Unit = { _, _, _ -> },
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var selected by remember { mutableStateOf<HaLinkDto?>(null) }
@@ -151,9 +161,10 @@ fun HaEntitiesSheet(
         HaMoreInfoDialog(
             link, st?.state, st?.lastChanged, stale,
             unit = st?.unit,
+            control = st?.control,
             canActuate = canActuate && link.isActuator,
             inFlight = link.actionLinkId in inFlightLinkIds,
-            onAction = { action -> onAction(link, action) },
+            onAction = { action, value -> onAction(link, action, value) },
             onDismiss = { selected = null },
         )
     }
@@ -205,9 +216,11 @@ private fun HaTile(link: HaLinkDto, state: String?, unit: String?, stale: Boolea
  * long-pressing an on-video badge in [HaBadgeOverlayLayer], or tapping a
  * non-controllable one). When [canActuate] is true and the link is an actuator it
  * grows a control row: a single primary action for simple domains (fired
- * directly), and confirm-guarded multi-action buttons for `cover`/`lock`. A
- * future value-setting control (dimmer/position) will render here too; the
- * backend is on/off/toggle-only today, so there is no such UI yet (#428).
+ * directly), and confirm-guarded multi-action buttons for `cover`/`lock`. When
+ * [control] is also present (a dimmable light, a positionable cover, a
+ * speed-controllable fan — #442, Slice 1) it additionally grows a value slider
+ * beneath the control row, gated the same way (`allowed_actions`, migration
+ * 0075).
  */
 @Composable
 internal fun HaMoreInfoDialog(
@@ -217,14 +230,20 @@ internal fun HaMoreInfoDialog(
     stale: Boolean,
     onDismiss: () -> Unit,
     unit: String? = null,
+    control: HaControlDescriptor? = null,
     canActuate: Boolean = false,
     inFlight: Boolean = false,
-    onAction: (String) -> Unit = {},
+    // [value] is non-null only when this call is a slider commit (a value
+    // action); every discrete action call passes null.
+    onAction: (String, Double?) -> Unit = { _, _ -> },
 ) {
     val v = badgeVisual(link, state, stale)
-    // Pending confirm-guarded action (action verb -> human prompt), for cover/lock.
+    // Pending confirm-guarded discrete action (action verb -> human prompt),
+    // for cover/lock. The slider owns its own confirm state (it also needs to
+    // revert the thumb on cancel) — see [HaValueSlider].
     var pendingConfirm by remember { mutableStateOf<Pair<String, String>?>(null) }
     val showControls = canActuate && link.isActuator
+    val needsConfirm = haNeedsConfirm(link)
 
     androidx.compose.ui.window.Dialog(onDismissRequest = onDismiss) {
         Column(
@@ -254,13 +273,25 @@ internal fun HaMoreInfoDialog(
                 HaControlRow(
                     link = link,
                     inFlight = inFlight,
+                    needsConfirm = needsConfirm,
                     // Simple domains fire directly; cover/lock (and any link with
                     // require_confirm, migration 0075) route through the confirm
                     // prompt (physical-security guard).
-                    onFire = { action -> onAction(action) },
+                    onFire = { action -> onAction(action, null) },
                     onConfirm = { action, prompt -> pendingConfirm = action to prompt },
                     entityName = link.displayName,
                 )
+                // `control != null` re-stated (on top of `showsSlider`'s own check) so
+                // the compiler smart-casts `control` to non-null below.
+                if (!inFlight && control != null && link.showsSlider(control)) {
+                    HaValueSlider(
+                        link = link,
+                        control = control,
+                        entityName = link.displayName,
+                        needsConfirm = needsConfirm,
+                        onFire = { value -> onAction(control.action, value) },
+                    )
+                }
             }
 
             Spacer(Modifier.height(16.dp))
@@ -274,12 +305,22 @@ internal fun HaMoreInfoDialog(
             prompt = prompt,
             onConfirm = {
                 pendingConfirm = null
-                onAction(action)
+                onAction(action, null)
             },
             onCancel = { pendingConfirm = null },
         )
     }
 }
+
+/**
+ * Whether [link]'s controls (discrete actions AND the value slider) must
+ * confirm before firing: the link's own `require_confirm` (migration 0075), or
+ * a physical-security domain (`cover`/`lock`) regardless of that flag. Shared
+ * by [HaControlRow] and [HaValueSlider] so a cover's Open/Close pills and its
+ * position slider confirm identically.
+ */
+private fun haNeedsConfirm(link: HaLinkDto): Boolean =
+    link.requireConfirm || link.domain == "cover" || link.domain == "lock"
 
 /**
  * The control row for an actuator detail. The button set is derived from the
@@ -296,6 +337,7 @@ private fun HaControlRow(
     link: HaLinkDto,
     inFlight: Boolean,
     entityName: String,
+    needsConfirm: Boolean,
     onFire: (String) -> Unit,
     onConfirm: (String, String) -> Unit,
 ) {
@@ -307,7 +349,6 @@ private fun HaControlRow(
         )
         return
     }
-    val needsConfirm = link.requireConfirm || link.domain == "cover" || link.domain == "lock"
     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
         for (action in link.controlActions()) {
             HaActionButton(action.label, haActionAccent(action.verb)) {
@@ -319,6 +360,103 @@ private fun HaControlRow(
             }
         }
     }
+}
+
+/**
+ * The value slider for a link's current [HaControlDescriptor] (#442, Slice 1):
+ * a dimmable light's brightness, a cover's position, a fan's speed. Drives
+ * [min]/[max]/[step] straight from the descriptor — never hardcoded 0..100 —
+ * so a future non-percent kind (Slice 2 temperature) renders correctly with no
+ * client change.
+ *
+ * Tracks the drag locally in [localValue] and re-syncs to the server-reported
+ * [HaControlDescriptor.value] whenever it changes AND the user is not mid-drag
+ * or mid-confirm, so the `/ha/states` poll converges the thumb exactly like the
+ * action buttons/badge — never an optimistic local flip on commit. Commits on
+ * release ([Slider]'s `onValueChangeFinished`): exactly ONE call per gesture,
+ * never continuously mid-drag. When [needsConfirm] (the link's own
+ * `require_confirm`, or a physical-security domain — same gate as
+ * [HaControlRow]), the release opens a confirm prompt with the target value
+ * baked in instead of firing immediately; cancelling reverts the thumb.
+ */
+@Composable
+private fun HaValueSlider(
+    link: HaLinkDto,
+    control: HaControlDescriptor,
+    entityName: String,
+    needsConfirm: Boolean,
+    onFire: (Double) -> Unit,
+) {
+    var dragging by remember(link.actionLinkId) { mutableStateOf(false) }
+    var pendingTarget by remember(link.actionLinkId) { mutableStateOf<Double?>(null) }
+    var localValue by remember(link.actionLinkId) { mutableStateOf(control.value) }
+    LaunchedEffect(control.value) {
+        if (!dragging && pendingTarget == null) localValue = control.value
+    }
+
+    val label = haValueLabel(control.action)
+    val unitSuffix = control.unit ?: if (control.kind == "percent") "%" else ""
+    val range = (control.max - control.min).coerceAtLeast(0.0)
+    val step = control.step.takeIf { it > 0.0 } ?: 1.0
+    val steps = ((range / step).roundToInt() - 1).coerceAtLeast(0)
+
+    Column(Modifier.fillMaxWidth().padding(top = 14.dp)) {
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Text(label, color = HaSecondaryText, fontSize = 13.sp)
+            Text(
+                "${localValue.roundToInt()}$unitSuffix",
+                color = HaPrimaryText,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+        Slider(
+            value = localValue.toFloat(),
+            onValueChange = { dragging = true; localValue = it.toDouble() },
+            onValueChangeFinished = {
+                dragging = false
+                val target = localValue.coerceIn(control.min, control.max)
+                if (needsConfirm) {
+                    pendingTarget = target
+                } else {
+                    onFire(target)
+                }
+            },
+            valueRange = control.min.toFloat()..control.max.toFloat(),
+            steps = steps,
+            colors = SliderDefaults.colors(
+                thumbColor = HaBlue,
+                activeTrackColor = HaBlue,
+                inactiveTrackColor = HaDivider,
+            ),
+        )
+    }
+
+    pendingTarget?.let { target ->
+        HaConfirmDialog(
+            prompt = "Set $label for $entityName to ${target.roundToInt()}$unitSuffix?",
+            onConfirm = {
+                pendingTarget = null
+                onFire(target)
+            },
+            onCancel = {
+                pendingTarget = null
+                localValue = control.value
+            },
+        )
+    }
+}
+
+/**
+ * Human label for a value action word — shown above the slider only (the
+ * discrete action pills read fine raw, see `HA_ACTION_LABELS` in admin.html
+ * for the same words with a "Set " prefix suited to a checkbox list).
+ */
+private fun haValueLabel(action: String): String = when (action) {
+    "set_brightness" -> "Brightness"
+    "set_position" -> "Position"
+    "set_speed" -> "Speed"
+    else -> action.removePrefix("set_").replaceFirstChar { it.uppercaseChar() }
 }
 
 /** Accent color for a control button, preserving the cover/lock/simple palette. */

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
@@ -154,13 +154,15 @@ fun LiveFullscreenScreen(
     // controls hide and every badge stays read-only (#187).
     val actuatorCapable = store.isAdmin || store.capabilities.actuators
     // Fire one HA service call. Optimistic ONLY in the spinner sense; the shown
-    // state converges via the `/ha/states` poll (never a local flip). A rejection
-    // (no capability / bad link / HA unreachable) shows a compact toast.
-    val fireHaAction: (HaLinkDto, String) -> Unit = { link, action ->
+    // state converges via the `/ha/states` poll (never a local flip). [value] is
+    // non-null only for a value action (a slider commit, #442 Slice 1) — every
+    // discrete action passes null. A rejection (no capability / bad link / HA
+    // unreachable / out-of-range value) shows a compact toast.
+    val fireHaAction: (HaLinkDto, String, Double?) -> Unit = { link, action, value ->
         val id = link.actionLinkId
         haInFlight = haInFlight + id
         scope.launch {
-            val res = repo.haAction(currentCameraId, id, action)
+            val res = repo.haAction(currentCameraId, id, action, value)
             haInFlight = haInFlight - id
             res.onFailure {
                 Toast.makeText(
@@ -188,7 +190,7 @@ fun LiveFullscreenScreen(
         // dialog (which confirms and/or shows only the permitted actions).
         val directOk = primary != null && !link.requireConfirm && link.actionAllowed(primary)
         when {
-            canActuate && directOk -> fireHaAction(link, primary!!)
+            canActuate && directOk -> fireHaAction(link, primary!!, null)
             canActuate && link.controlActions().isNotEmpty() -> haControlSelected = link
             else -> haBadgeSelected = link
         }
@@ -956,7 +958,7 @@ fun LiveFullscreenScreen(
                 states = haStates,
                 canActuate = actuatorCapable,
                 inFlightLinkIds = haInFlight,
-                onAction = { link, action -> fireHaAction(link, action) },
+                onAction = { link, action, value -> fireHaAction(link, action, value) },
                 onDismiss = { haSheetOpen = false },
             )
         }
@@ -980,9 +982,10 @@ fun LiveFullscreenScreen(
             HaMoreInfoDialog(
                 link, st?.state, st?.lastChanged, stale,
                 unit = st?.unit,
+                control = st?.control,
                 canActuate = true,
                 inFlight = link.actionLinkId in haInFlight,
-                onAction = { action -> fireHaAction(link, action) },
+                onAction = { action, value -> fireHaAction(link, action, value) },
                 onDismiss = { haControlSelected = null },
             )
         }

--- a/apps/android/app/src/test/java/video/crumb/app/data/HaControlDescriptorTest.kt
+++ b/apps/android/app/src/test/java/video/crumb/app/data/HaControlDescriptorTest.kt
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.data
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Value-control descriptor decode + gating (#442, Slice 1: `set_brightness`/
+ * `set_position`/`set_speed`). The Android client must decode the optional
+ * `control` object on a `GET /ha/states` entry defensively (an older server
+ * that omits it decodes exactly as today via the nullable default — no
+ * slider), drive min/max/step/unit FROM the descriptor rather than hardcoding
+ * 0..100, and gate the slider on `allowed_actions` the same way the existing
+ * action pills do (migration 0075). Also covers the wire shape of
+ * [HaActionRequest.value]: present only for a value action, per
+ * `Network.kt`'s `explicitNulls = false`.
+ */
+class HaControlDescriptorTest {
+
+    // Mirror the production decoder: tolerant of unknown keys.
+    private val json = Json { ignoreUnknownKeys = true }
+
+    // Mirror the production encoder (Network.kt): omit null fields entirely
+    // rather than sending `"value":null`.
+    private val wireJson = Json { ignoreUnknownKeys = true; explicitNulls = false }
+
+    @Test
+    fun `a states entry without control decodes to no slider (older server)`() {
+        val st = json.decodeFromString(
+            HaEntityState.serializer(),
+            """{"entity_id":"light.kitchen","state":"on"}""",
+        )
+        assertNull(st.control)
+    }
+
+    @Test
+    fun `a dimmable light's control descriptor decodes with server-driven bounds`() {
+        val st = json.decodeFromString(
+            HaEntityState.serializer(),
+            """{"entity_id":"light.kitchen","state":"on","control":
+                {"action":"set_brightness","kind":"percent","value":62,"min":0,"max":100,"step":1,"unit":null}}""",
+        )
+        val c = st.control!!
+        assertEquals("set_brightness", c.action)
+        assertEquals("percent", c.kind)
+        assertEquals(62.0, c.value, 0.0)
+        assertEquals(0.0, c.min, 0.0)
+        assertEquals(100.0, c.max, 0.0)
+        assertEquals(1.0, c.step, 0.0)
+        assertNull(c.unit)
+    }
+
+    @Test
+    fun `a fan's control descriptor may carry a coarser step than 1`() {
+        val st = json.decodeFromString(
+            HaEntityState.serializer(),
+            """{"entity_id":"fan.bedroom","state":"on","control":
+                {"action":"set_speed","kind":"percent","value":50,"min":0,"max":100,"step":25,"unit":null}}""",
+        )
+        assertEquals(25.0, st.control!!.step, 0.0)
+    }
+
+    @Test
+    fun `an unrestricted link (allowed_actions null) shows the slider whenever a descriptor is present`() {
+        val link = json.decodeFromString(
+            HaLinkDto.serializer(),
+            """{"id":"l1","entity_id":"light.kitchen","role":"actuator","sort_order":0}""",
+        )
+        val control = HaControlDescriptor("set_brightness", "percent", 40.0, 0.0, 100.0, 1.0, null)
+        assertTrue(link.showsSlider(control))
+    }
+
+    @Test
+    fun `a link restricted away from the value word hides the slider`() {
+        val link = json.decodeFromString(
+            HaLinkDto.serializer(),
+            """{"id":"l2","entity_id":"light.kitchen","role":"actuator","sort_order":0,
+                "allowed_actions":["turn_on","turn_off","toggle"]}""",
+        )
+        val control = HaControlDescriptor("set_brightness", "percent", 40.0, 0.0, 100.0, 1.0, null)
+        assertFalse(link.showsSlider(control))
+    }
+
+    @Test
+    fun `a link explicitly restricted to include the value word shows the slider`() {
+        val link = json.decodeFromString(
+            HaLinkDto.serializer(),
+            """{"id":"l3","entity_id":"cover.garage","role":"actuator","sort_order":0,
+                "allowed_actions":["open_cover","close_cover","set_position"]}""",
+        )
+        val control = HaControlDescriptor("set_position", "percent", 40.0, 0.0, 100.0, 1.0, null)
+        assertTrue(link.showsSlider(control))
+    }
+
+    @Test
+    fun `no descriptor means no slider regardless of allowed_actions`() {
+        val link = json.decodeFromString(
+            HaLinkDto.serializer(),
+            """{"id":"l4","entity_id":"light.kitchen","role":"actuator","sort_order":0}""",
+        )
+        assertFalse(link.showsSlider(null))
+    }
+
+    @Test
+    fun `haValueAction mirrors the server's Slice 1 percent domains`() {
+        assertEquals("set_brightness", haValueAction("light"))
+        assertEquals("set_position", haValueAction("cover"))
+        assertEquals("set_speed", haValueAction("fan"))
+        // Slice 2 (climate set_temperature) is deliberately not offered yet.
+        assertNull(haValueAction("climate"))
+        assertNull(haValueAction("switch"))
+        assertNull(haValueAction("lock"))
+    }
+
+    @Test
+    fun `a discrete action request omits value on the wire`() {
+        val body = wireJson.encodeToString(HaActionRequest.serializer(), HaActionRequest("l1", "toggle"))
+        assertFalse(body.contains("value"))
+    }
+
+    @Test
+    fun `a value action request carries its numeric value on the wire`() {
+        val body = wireJson.encodeToString(
+            HaActionRequest.serializer(),
+            HaActionRequest("l1", "set_brightness", 42.0),
+        )
+        assertTrue(body.contains("\"value\":42.0"))
+    }
+}


### PR DESCRIPTION
Part of #442

Android client for the #442 Slice 1 value-setting HA controls (brightness,
position, speed), against the contract frozen in #460.

## What changed

- `data/HaModels.kt`: decodes the optional `control` capability descriptor
  on a `GET /ha/states` entry (`action`/`kind`/`value`/`min`/`max`/`step`/
  `unit`) — nullable + defaulted so an older server that omits it decodes
  exactly as today (no slider). Kept kind-agnostic so a future non-percent
  kind (Slice 2 temperature) reuses the shape unchanged. `HaActionRequest`
  gains an optional `value` sent only for value actions (the JSON layer's
  `explicitNulls = false` drops the key entirely for discrete actions).
  Added `haValueAction(domain)` and `HaLinkDto.showsSlider(control)`, the
  latter gating on the descriptor being present AND the value word being
  permitted by the link's own `allowed_actions` (migration 0075) — same
  rule the existing action pills use.
- `feature/live/HaEntitiesSheet.kt`: `HaMoreInfoDialog` (the detail reached
  from both the list sheet and a long-pressed/tapped on-video badge) grows
  a `HaValueSlider` beneath the existing action-pill row whenever a link is
  an actuator, canActuate, and its current state carries a permitted
  `control` descriptor. Min/max/step/unit come from the descriptor, never
  hardcoded 0–100. Commits on release (`Slider`'s `onValueChangeFinished`)
  — exactly one `POST .../ha/action` per gesture, never mid-drag. Never
  optimistically flips the shown value; the existing ~3s `/ha/states` poll
  converges the thumb, matching the badge/action-button pattern. Routes
  through the same confirm gate as discrete actions (`require_confirm`, or
  domain `cover`/`lock`) with the target value baked into the prompt, and
  reverts the thumb if the user cancels.
- `feature/live/LiveFullscreenScreen.kt`, `data/CrumbRepository.kt`,
  `data/CrumbApi.kt`: thread the optional value through
  `fireHaAction` → `repo.haAction` → the POST body.
- `test/.../HaControlDescriptorTest.kt`: descriptor decode (present /
  absent-on-older-server), slider gating against `allowed_actions`,
  `haValueAction` mirrors the server's Slice 1 domains, and the wire shape
  of `HaActionRequest.value` (omitted for discrete actions, present for
  value actions).

On-video badges (`HaBadgeOverlay.kt`) are untouched — tap/long-press only,
per the existing interaction model. The slider lives in the shared detail
sheet both entry points already open into, so no new gesture was needed.

## Verify

- `./gradlew :app:assembleDebug --console=plain --stacktrace` on dev2
  (JDK 17, SDK 34, mirrors the CI android job) — `BUILD SUCCESSFUL`, no
  warnings from the changed files.
- `./gradlew :app:testDebugUnitTest --tests "video.crumb.app.data.HaControlDescriptorTest"` — new tests pass.

## Test plan

- [x] `:app:assembleDebug` green on the CI toolchain (dev2)
- [x] New unit tests for descriptor decode + slider gating + wire shape
- [ ] Manual on-device check against a real HA dimmable light / positionable
      cover / speed fan (deferred to reviewer / follow-up, no live HA rig
      in this session)