### PR TITLE
feat(ios): match HA detail-card icon to the on-video badge color

### DIFF
--- a/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
+++ b/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
@@ -67,6 +67,25 @@ enum HA {
         }
     }
 
+    /// Human "Type" label for the detail card: the humanized `device_class` when
+    /// present, else the humanized entity domain — NEVER blank. Mirrors the
+    /// Android `haTypeLabel(domain, deviceClass)` and the desktop card exactly, so
+    /// a light with no device_class reads "Light", a cover with `garage_door`
+    /// reads "Garage door", `carbon_monoxide` reads "Carbon monoxide".
+    static func typeLabel(domain: String, deviceClass: String?) -> String {
+        let raw = (deviceClass?.isEmpty == false) ? deviceClass! : domain
+        return humanizeToken(raw)
+    }
+
+    /// underscores → spaces, and capitalize ONLY the first letter (interior words
+    /// untouched): `garage_door` → "Garage door". Not `.capitalized`, which would
+    /// title-case every word ("Garage Door").
+    private static func humanizeToken(_ token: String) -> String {
+        let spaced = token.replacingOccurrences(of: "_", with: " ")
+        guard let first = spaced.first else { return spaced }
+        return first.uppercased() + spaced.dropFirst()
+    }
+
     /// Relative age of a last-changed RFC3339 timestamp.
     static func relativeAgo(_ lastChanged: String?) -> String? {
         guard let s = lastChanged, let date = parseISO8601(s) else { return nil }
@@ -742,11 +761,10 @@ struct HAStateCard: View {
                     Text(errorText).font(.caption).foregroundColor(CrumbColors.error)
                         .multilineTextAlignment(.center)
                 }
-                if let dc = link.deviceClass, !dc.isEmpty {
-                    // Humanize the device-class token for display (`garage_door` →
-                    // `garage door`), matching the Android detail card's row.
-                    detailRow("Device class", dc.replacingOccurrences(of: "_", with: " "))
-                }
+                // Single "Type" row: humanized device_class when present, else the
+                // humanized domain (never blank), matching the Android
+                // `haTypeLabel` and the desktop card.
+                detailRow("Type", HA.typeLabel(domain: link.domain, deviceClass: link.deviceClass))
                 detailRow("Entity", link.entityId)
                 if stale {
                     Label("Stale — Home Assistant connection may be down",

--- a/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
+++ b/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
@@ -523,7 +523,7 @@ struct HAOverlayLayer: View {
         }
         .sheet(item: $tapped) { link in
             HAStateCard(link: link, controller: controller)
-                .macModalSize(width: 360, height: 340)
+                .macModalSize(width: 360, height: 368)
         }
         .alert("Control failed", isPresented: Binding(get: { actionError != nil }, set: { if !$0 { actionError = nil } })) {
             Button("OK", role: .cancel) { actionError = nil }
@@ -715,7 +715,16 @@ struct HAStateCard: View {
         let v = HA.visual(for: link, state: state, stale: stale)
         NavigationStack {
             VStack(spacing: 14) {
-                Image(systemName: v.symbol).font(.system(size: 40)).foregroundColor(v.color)
+                // Badge chip: the SAME state color as this entity's on-video badge
+                // (`HA.visual`), tinted into a circle exactly like the badge overlay,
+                // the entity-sheet row, and the Android/desktop detail cards — never
+                // a greyscale or washed-out header. A lit light reads clearly
+                // warm-yellow here, an active motion sensor blue, a smoke alarm red.
+                Image(systemName: v.symbol)
+                    .font(.system(size: 34))
+                    .foregroundColor(v.color)
+                    .frame(width: 68, height: 68)
+                    .background(v.color.opacity(0.16), in: Circle())
                 Text(link.displayName).font(.headline).foregroundColor(CrumbColors.textPrimary)
                 Text(v.stateText).font(.title3.weight(.semibold)).foregroundColor(v.color)
                 if let age = HA.relativeAgo(state?.lastChanged) {
@@ -734,7 +743,9 @@ struct HAStateCard: View {
                         .multilineTextAlignment(.center)
                 }
                 if let dc = link.deviceClass, !dc.isEmpty {
-                    detailRow("Device class", dc)
+                    // Humanize the device-class token for display (`garage_door` →
+                    // `garage door`), matching the Android detail card's row.
+                    detailRow("Device class", dc.replacingOccurrences(of: "_", with: " "))
                 }
                 detailRow("Entity", link.entityId)
                 if stale {
@@ -979,7 +990,7 @@ struct HAEntitySheet: View {
         }
         .sheet(item: $detail) { link in
             HAStateCard(link: link, controller: controller)
-                .macModalSize(width: 360, height: 340)
+                .macModalSize(width: 360, height: 368)
         }
         .alert("Control failed", isPresented: Binding(get: { actionError != nil }, set: { if !$0 { actionError = nil } })) {
             Button("OK", role: .cancel) { actionError = nil }

--- a/apps/ios/CrumbTests/HaBadgeVisualTests.swift
+++ b/apps/ios/CrumbTests/HaBadgeVisualTests.swift
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import SwiftUI
+import XCTest
+@testable import Crumb
+
+/// The detail card (`HAStateCard`) colors its header icon with the SAME
+/// `HA.visual(...).color` the on-video badge uses — a lit light MUST read as warm
+/// yellow, never a greyscale/washed header (shared spec across desktop/iOS/
+/// Android). These lock the state→color mapping the card and badge both consume,
+/// so a future palette edit can't silently desaturate the card.
+final class HaBadgeVisualTests: XCTestCase {
+
+    private func link(_ entityId: String, deviceClass: String? = nil) throws -> HaLink {
+        let dc = deviceClass.map { #","device_class":"\#($0)""# } ?? ""
+        let json = #"{"id":"l","entity_id":"\#(entityId)","role":"sensor","sort_order":0\#(dc)}"#
+        return try JSONDecoder().decode(HaLink.self, from: Data(json.utf8))
+    }
+
+    private func state(_ raw: String) -> HaEntityState {
+        HaEntityState(entityId: "e", state: raw, lastChanged: nil, unit: nil, control: nil)
+    }
+
+    func testLitLightIsWarmYellowNotGrey() throws {
+        let v = HA.visual(for: try link("light.kitchen"), state: state("on"), stale: false)
+        XCTAssertEqual(v.color, HA.warmYellow)
+        XCTAssertNotEqual(v.color, HA.grey)
+        XCTAssertFalse(v.indeterminate)
+    }
+
+    func testOffLightIsGrey() throws {
+        let v = HA.visual(for: try link("light.kitchen"), state: state("off"), stale: false)
+        XCTAssertEqual(v.color, HA.grey)
+    }
+
+    func testSwitchOnIsGreen() throws {
+        let v = HA.visual(for: try link("switch.porch"), state: state("on"), stale: false)
+        XCTAssertEqual(v.color, HA.green)
+    }
+
+    func testMotionActiveIsBlue() throws {
+        let v = HA.visual(for: try link("binary_sensor.hall", deviceClass: "motion"),
+                          state: state("on"), stale: false)
+        XCTAssertEqual(v.color, HA.blue)
+    }
+
+    func testDoorOpenIsAmber() throws {
+        let v = HA.visual(for: try link("binary_sensor.front", deviceClass: "door"),
+                          state: state("on"), stale: false)
+        XCTAssertEqual(v.color, HA.amber)
+    }
+
+    func testSmokeAlarmIsDangerRed() throws {
+        let v = HA.visual(for: try link("binary_sensor.kitchen", deviceClass: "smoke"),
+                          state: state("on"), stale: false)
+        XCTAssertEqual(v.color, HA.danger)
+    }
+
+    /// The honesty invariant the card shares with the badge: a lit light that is
+    /// stale greys out rather than lying warm-yellow.
+    func testStaleLitLightGreysOut() throws {
+        let v = HA.visual(for: try link("light.kitchen"), state: state("on"), stale: true)
+        XCTAssertEqual(v.color, HA.grey)
+        XCTAssertTrue(v.indeterminate)
+    }
+}

--- a/apps/ios/CrumbTests/HaBadgeVisualTests.swift
+++ b/apps/ios/CrumbTests/HaBadgeVisualTests.swift
@@ -63,4 +63,26 @@ final class HaBadgeVisualTests: XCTestCase {
         XCTAssertEqual(v.color, HA.grey)
         XCTAssertTrue(v.indeterminate)
     }
+
+    // MARK: - "Type" row label (parity with Android haTypeLabel)
+
+    /// device_class present ⇒ humanized device_class, first letter only.
+    func testTypeUsesHumanizedDeviceClass() {
+        XCTAssertEqual(HA.typeLabel(domain: "cover", deviceClass: "garage_door"), "Garage door")
+        XCTAssertEqual(HA.typeLabel(domain: "sensor", deviceClass: "carbon_monoxide"), "Carbon monoxide")
+    }
+
+    /// device_class absent/empty ⇒ humanized domain, never blank.
+    func testTypeFallsBackToDomainWhenDeviceClassMissing() {
+        XCTAssertEqual(HA.typeLabel(domain: "light", deviceClass: nil), "Light")
+        XCTAssertEqual(HA.typeLabel(domain: "light", deviceClass: ""), "Light")
+        XCTAssertEqual(HA.typeLabel(domain: "media_player", deviceClass: nil), "Media player")
+    }
+
+    /// Only the first letter is capitalized — interior words untouched (not
+    /// `.capitalized`, which would title-case every word).
+    func testTypeCapitalizesFirstLetterOnly() {
+        XCTAssertEqual(HA.typeLabel(domain: "binary_sensor", deviceClass: "garage_door"), "Garage door")
+        XCTAssertNotEqual(HA.typeLabel(domain: "cover", deviceClass: "garage_door"), "Garage Door")
+    }
 }


### PR DESCRIPTION
## What

The iOS/macOS (SwiftUI) HA **detail card** (`HAStateCard`, opened by tapping a
placed HA badge) rendered its header icon as a bare floating glyph. Although it
already used `HA.visual(...).color`, the treatment read weaker than the on-video
badge's colored chip. This makes the card visually reuse the badge's state color
and brings it to parity with the Android/desktop detail cards.

## Changes (iOS only — `apps/ios/Crumb/`)

- **Icon = badge color, badge-style.** The card header icon is now wrapped in the
  same tinted circle the on-video badge overlay, the entity-sheet row, and the
  Android/desktop cards use (`v.color.opacity(0.16)` circle + `v.color` icon). A
  lit light reads clearly warm-yellow, motion blue, door-open amber, smoke red,
  off/stale grey — reusing `HA.visual`, no forked palette or greyscale header.
- **Entity + device-type rows.** The entity id and device class already showed as
  labeled rows with the friendly name as the title; the device-class value is now
  humanized (`garage_door` -> `garage door`) to match the Android card.
- Bumped the two `HAStateCard` mac modal heights (340 -> 368) for the taller header.
- Added `CrumbTests/HaBadgeVisualTests` locking the shared state->color spec the
  card and badge both consume.

## Verification

- `Crumb-mac` scheme (`xcodebuild -scheme Crumb-mac -destination 'platform=macOS' build`)
  on the macmini: **BUILD SUCCEEDED**.
- `HaBadgeVisualTests` on iOS Simulator: **7/7 passed**.

No backend or other-client changes; the #442 value slider behavior is untouched.