### PR TITLE
fix(android): make the HA value slider usable + popup visuals match the badge (#442 Slice 1 follow-ups)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/data/SecureStore.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/SecureStore.kt
@@ -271,6 +271,24 @@ class SecureStore(context: Context) {
         set(value) = safeWrite { it.putBoolean(KEY_SHOW_ALL_CAMERAS_VIEW, value) }
 
     /**
+     * Whether the Home Assistant "more-info" popup shows the **Entity** row (the
+     * raw `entity_id`). A device-level display preference like [ptzStyle]; NOT
+     * cleared on logout. Default true (today's behavior — the row is shown).
+     */
+    var showHaEntityId: Boolean
+        get() = safeRead(true) { it.getBoolean(KEY_SHOW_HA_ENTITY_ID, true) }
+        set(value) = safeWrite { it.putBoolean(KEY_SHOW_HA_ENTITY_ID, value) }
+
+    /**
+     * Whether the Home Assistant "more-info" popup shows the **Type** row (the
+     * humanized `device_class`, falling back to the domain). A device-level
+     * display preference like [ptzStyle]; NOT cleared on logout. Default true.
+     */
+    var showHaDeviceType: Boolean
+        get() = safeRead(true) { it.getBoolean(KEY_SHOW_HA_DEVICE_TYPE, true) }
+        set(value) = safeWrite { it.putBoolean(KEY_SHOW_HA_DEVICE_TYPE, value) }
+
+    /**
      * Last playback-timeline zoom level (visible time span, in millis) the user left
      * the Playback surfaces on. Shared by BOTH single-camera playback and the playback
      * wall, so switching between them and back restores the same scale, and it survives
@@ -445,6 +463,8 @@ class SecureStore(context: Context) {
         private const val KEY_PTZ_STYLE = "ptz_style"
         private const val KEY_MOTION_TUNER = "motion_tuner_enabled"
         private const val KEY_SHOW_ALL_CAMERAS_VIEW = "show_all_cameras_view"
+        private const val KEY_SHOW_HA_ENTITY_ID = "show_ha_entity_id"
+        private const val KEY_SHOW_HA_DEVICE_TYPE = "show_ha_device_type"
         private const val KEY_PLAYBACK_SPAN_MS = "playback_span_ms"
         private const val KEY_PLATES_VIEW_MODE = "plates_view_mode"
         private const val KEY_LPR_IMAGE_MODE = "lpr_image_mode"

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaBadgeOverlay.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaBadgeOverlay.kt
@@ -58,10 +58,10 @@ import kotlin.math.min
 // `edgeOn` EXACTLY (including the honesty rule: unknown/stale never reads as a
 // confident "off/closed").
 
-// The canonical entity visual mapping (`badgeVisual`, `BadgeVisual`, the palette,
-// `parseHexColor`) lives in `HaVisual.kt`, shared with the entity sheet + more-
-// info dialog so an entity reads identically wherever Android draws it (#437).
-private val BadgeDefaultBg = Color(0xFF17171B) // near-black opaque chip
+// The canonical entity visual mapping (`badgeVisual`, `BadgeVisual`, the palette
+// incl. `BadgeDefaultBg`, `parseHexColor`) lives in `HaVisual.kt`, shared with the
+// entity sheet + more-info dialog so an entity reads identically wherever Android
+// draws it (#437).
 
 private const val BASE_REF_PX = 22f // reference badge size at pane-scale 1.0
 private const val REF_SHORT_SIDE = 320f

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaEntitiesSheet.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaEntitiesSheet.kt
@@ -255,15 +255,35 @@ internal fun HaMoreInfoDialog(
                 .padding(horizontal = 20.dp, vertical = 22.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            // An entity that is ON/active reads as a boldly filled colored disc with
+            // a dark glyph cut out of it (HA's "lit" look), so on-vs-off is
+            // unmistakable at icon size — a warm-yellow bulb on a faint 16% disc was
+            // too weak to read as lit. Off/unknown keep the faint tinted disc +
+            // state-colored glyph. The on/off signal is the canonical `v.active`
+            // from `badgeVisual` (no forked color logic).
+            val activeOn = v.active == true
             Box(
-                modifier = Modifier.size(76.dp).clip(CircleShape).background(v.color.copy(alpha = 0.16f)),
+                modifier = Modifier
+                    .size(76.dp)
+                    .clip(CircleShape)
+                    .background(v.color.copy(alpha = if (activeOn) 1f else 0.16f)),
                 contentAlignment = Alignment.Center,
             ) {
-                Icon(v.icon, contentDescription = null, tint = v.color, modifier = Modifier.size(40.dp))
+                Icon(
+                    v.icon,
+                    contentDescription = null,
+                    tint = if (activeOn) HaBg else v.color,
+                    modifier = Modifier.size(40.dp),
+                )
             }
             Spacer(Modifier.height(12.dp))
             Text(link.displayName, color = HaPrimaryText, fontSize = 19.sp, fontWeight = FontWeight.Medium)
-            Text(haStateDisplay(v, state, unit), color = v.color, fontSize = 15.sp)
+            Text(
+                haStateDisplay(v, state, unit),
+                color = v.color,
+                fontSize = 15.sp,
+                fontWeight = if (activeOn) FontWeight.SemiBold else FontWeight.Normal,
+            )
             changedAgo(lastChanged)?.let {
                 Spacer(Modifier.height(4.dp))
                 Text(it, color = HaSecondaryText, fontSize = 12.5.sp)

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaEntitiesSheet.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaEntitiesSheet.kt
@@ -46,6 +46,7 @@ import video.crumb.app.data.HaLinkDto
 import video.crumb.app.data.HaStatesResponse
 import video.crumb.app.data.controlActions
 import video.crumb.app.data.showsSlider
+import video.crumb.app.di.appContainer
 import java.time.Duration
 import java.time.Instant
 import java.time.OffsetDateTime
@@ -239,6 +240,12 @@ internal fun HaMoreInfoDialog(
     onAction: (String, Double?) -> Unit = { _, _ -> },
 ) {
     val v = badgeVisual(link, state, stale)
+    // The Entity (entity_id) and Type rows are each user-hideable (Settings ›
+    // Home Assistant), both default-on. Read straight from the shared store, so
+    // reopening the popup reflects a toggle change (the dialog is transient).
+    val settings = appContainer().store
+    val showEntityId = settings.showHaEntityId
+    val showDeviceType = settings.showHaDeviceType
     // Pending confirm-guarded discrete action (action verb -> human prompt),
     // for cover/lock. The slider owns its own confirm state (it also needs to
     // revert the thumb on cancel) — see [HaValueSlider].
@@ -323,9 +330,14 @@ internal fun HaMoreInfoDialog(
                 }
             }
 
-            Spacer(Modifier.height(16.dp))
-            HaAttrRow("Device class", link.deviceClass?.replace('_', ' ') ?: "—")
-            HaAttrRow("Entity", link.entityId)
+            if (showDeviceType || showEntityId) {
+                Spacer(Modifier.height(16.dp))
+                // "Type" = humanized device_class, else humanized domain, so the
+                // row is never blank (a light with no device_class reads "Light") —
+                // matches the desktop detail card. Entity is the raw entity_id.
+                if (showDeviceType) HaAttrRow("Type", haTypeLabel(link.domain, link.deviceClass))
+                if (showEntityId) HaAttrRow("Entity", link.entityId)
+            }
         }
     }
 
@@ -605,6 +617,19 @@ private fun HaConfirmDialog(prompt: String, onConfirm: () -> Unit, onCancel: () 
             }
         }
     }
+}
+
+/**
+ * The "Type" row's value for the more-info popup: the humanized `device_class`
+ * when the entity has one, else the humanized `domain`, so the row is never
+ * blank (a `light` with no device_class reads "Light"; a `cover` with
+ * device_class `garage_door` reads "Garage door"). Matches the desktop detail
+ * card's `_deviceTypeLabel`/`_humanize`: underscores → spaces, first letter
+ * capitalized. Pure, so it's unit-tested.
+ */
+internal fun haTypeLabel(domain: String, deviceClass: String?): String {
+    val raw = deviceClass?.trim()?.takeIf { it.isNotEmpty() } ?: domain
+    return raw.replace('_', ' ').replaceFirstChar { it.uppercaseChar() }
 }
 
 @Composable

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaEntitiesSheet.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaEntitiesSheet.kt
@@ -388,16 +388,50 @@ private fun HaValueSlider(
     onFire: (Double) -> Unit,
 ) {
     var dragging by remember(link.actionLinkId) { mutableStateOf(false) }
-    var pendingTarget by remember(link.actionLinkId) { mutableStateOf<Double?>(null) }
+    // A value awaiting the user's confirm (cover / lock / require_confirm); non-null
+    // only while its confirm dialog is up.
+    var awaitingConfirm by remember(link.actionLinkId) { mutableStateOf<Double?>(null) }
+    // A value we just committed and hold the thumb at until the /ha/states poll
+    // reflects it. Without this hold the poll -- which for a beat still reports the
+    // device's OLD value while it transitions -- snaps the thumb back the instant
+    // you release, then jumps it to the committed value a poll later (the bounce,
+    // issue #465).
+    var committed by remember(link.actionLinkId) { mutableStateOf<Double?>(null) }
     var localValue by remember(link.actionLinkId) { mutableStateOf(control.value) }
-    LaunchedEffect(control.value) {
-        if (!dragging && pendingTarget == null) localValue = control.value
+
+    val step = control.step.takeIf { it > 0.0 } ?: 1.0
+
+    // Track the live poll ONLY when the user is neither dragging nor holding a
+    // just-committed value. Release the hold once the poll converges to within a
+    // step of the committed value (absorbs percent<->brightness rounding), or when
+    // the safety timeout below clears it.
+    LaunchedEffect(control.value, committed) {
+        if (dragging) return@LaunchedEffect
+        val c = committed
+        if (c != null && kotlin.math.abs(control.value - c) <= step + 0.5) {
+            committed = null
+        }
+        if (committed == null) localValue = control.value
+    }
+    // Never hold forever: a dropped request or a device that never reaches the
+    // target would otherwise freeze the thumb. Drop the hold after a short window
+    // so it resumes tracking the real state.
+    LaunchedEffect(committed) {
+        if (committed != null) {
+            kotlinx.coroutines.delay(6000)
+            committed = null
+        }
+    }
+
+    fun commit(target: Double) {
+        localValue = target
+        committed = target
+        onFire(target)
     }
 
     val label = haValueLabel(control.action)
     val unitSuffix = control.unit ?: if (control.kind == "percent") "%" else ""
     val range = (control.max - control.min).coerceAtLeast(0.0)
-    val step = control.step.takeIf { it > 0.0 } ?: 1.0
     val steps = ((range / step).roundToInt() - 1).coerceAtLeast(0)
 
     Column(Modifier.fillMaxWidth().padding(top = 14.dp)) {
@@ -416,11 +450,7 @@ private fun HaValueSlider(
             onValueChangeFinished = {
                 dragging = false
                 val target = localValue.coerceIn(control.min, control.max)
-                if (needsConfirm) {
-                    pendingTarget = target
-                } else {
-                    onFire(target)
-                }
+                if (needsConfirm) awaitingConfirm = target else commit(target)
             },
             valueRange = control.min.toFloat()..control.max.toFloat(),
             steps = steps,
@@ -432,15 +462,15 @@ private fun HaValueSlider(
         )
     }
 
-    pendingTarget?.let { target ->
+    awaitingConfirm?.let { target ->
         HaConfirmDialog(
             prompt = "Set $label for $entityName to ${target.roundToInt()}$unitSuffix?",
             onConfirm = {
-                pendingTarget = null
-                onFire(target)
+                awaitingConfirm = null
+                commit(target)
             },
             onCancel = {
-                pendingTarget = null
+                awaitingConfirm = null
                 localValue = control.value
             },
         )

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaEntitiesSheet.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaEntitiesSheet.kt
@@ -255,24 +255,27 @@ internal fun HaMoreInfoDialog(
                 .padding(horizontal = 20.dp, vertical = 22.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            // An entity that is ON/active reads as a boldly filled colored disc with
-            // a dark glyph cut out of it (HA's "lit" look), so on-vs-off is
-            // unmistakable at icon size — a warm-yellow bulb on a faint 16% disc was
-            // too weak to read as lit. Off/unknown keep the faint tinted disc +
-            // state-colored glyph. The on/off signal is the canonical `v.active`
-            // from `badgeVisual` (no forked color logic).
+            // The icon reads EXACTLY like the entity's on-video badge (#437): the
+            // full-strength state color as the glyph on the same near-black chip the
+            // badge uses ([BadgeDefaultBg]). So a lit light is unmistakably warm-yellow
+            // (not the washed 16% tint that read grey/white), and on-vs-off is carried
+            // by the color itself — warm-yellow vs grey, green vs grey, amber vs
+            // neutral — the same signal the badge and the desktop/iOS detail popups
+            // use. No forked palette, no inverted filled-disc/cut-out treatment that
+            // diverged from the badge. `v.active` (the canonical tri-state) only adds a
+            // little extra weight to the state text below when the entity is on.
             val activeOn = v.active == true
             Box(
                 modifier = Modifier
                     .size(76.dp)
                     .clip(CircleShape)
-                    .background(v.color.copy(alpha = if (activeOn) 1f else 0.16f)),
+                    .background(BadgeDefaultBg),
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
                     v.icon,
                     contentDescription = null,
-                    tint = if (activeOn) HaBg else v.color,
+                    tint = v.color,
                     modifier = Modifier.size(40.dp),
                 )
             }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaEntitiesSheet.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaEntitiesSheet.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -281,9 +282,14 @@ internal fun HaMoreInfoDialog(
                     onConfirm = { action, prompt -> pendingConfirm = action to prompt },
                     entityName = link.displayName,
                 )
-                // `control != null` re-stated (on top of `showsSlider`'s own check) so
-                // the compiler smart-casts `control` to non-null below.
-                if (!inFlight && control != null && link.showsSlider(control)) {
+                // The slider stays MOUNTED across the in-flight window — it is NOT
+                // gated on `!inFlight`. Unmounting it on every commit destroyed its
+                // committed-hold state (#465) and collapsed then re-expanded the
+                // dialog: the residual "bar + window bounce". It holds the committed
+                // value itself until the poll converges. `control != null` re-stated
+                // (on top of `showsSlider`'s own check) so the compiler smart-casts
+                // `control` to non-null below.
+                if (control != null && link.showsSlider(control)) {
                     HaValueSlider(
                         link = link,
                         control = control,
@@ -341,21 +347,30 @@ private fun HaControlRow(
     onFire: (String) -> Unit,
     onConfirm: (String, String) -> Unit,
 ) {
-    if (inFlight) {
-        androidx.compose.material3.CircularProgressIndicator(
-            modifier = Modifier.size(26.dp),
-            color = HaBlue,
-            strokeWidth = 2.5.dp,
-        )
-        return
-    }
-    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        for (action in link.controlActions()) {
-            HaActionButton(action.label, haActionAccent(action.verb)) {
-                if (needsConfirm) {
-                    onConfirm(action.verb, "${action.label} $entityName?")
-                } else {
-                    onFire(action.verb)
+    // Reserve a stable height whether we're showing the action pills or the
+    // in-flight spinner, so toggling `inFlight` on a commit never re-measures and
+    // re-centers the dialog — half of the "window bounce" (#442 Slice 1 residual).
+    // The pill row is ~40dp tall (10dp*2 padding + text); 44dp holds both.
+    Box(
+        modifier = Modifier.fillMaxWidth().height(44.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (inFlight) {
+            androidx.compose.material3.CircularProgressIndicator(
+                modifier = Modifier.size(26.dp),
+                color = HaBlue,
+                strokeWidth = 2.5.dp,
+            )
+        } else {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                for (action in link.controlActions()) {
+                    HaActionButton(action.label, haActionAccent(action.verb)) {
+                        if (needsConfirm) {
+                            onConfirm(action.verb, "${action.label} $entityName?")
+                        } else {
+                            onFire(action.verb)
+                        }
+                    }
                 }
             }
         }
@@ -369,12 +384,15 @@ private fun HaControlRow(
  * so a future non-percent kind (Slice 2 temperature) renders correctly with no
  * client change.
  *
- * Tracks the drag locally in [localValue] and re-syncs to the server-reported
- * [HaControlDescriptor.value] whenever it changes AND the user is not mid-drag
- * or mid-confirm, so the `/ha/states` poll converges the thumb exactly like the
- * action buttons/badge — never an optimistic local flip on commit. Commits on
- * release ([Slider]'s `onValueChangeFinished`): exactly ONE call per gesture,
- * never continuously mid-drag. When [needsConfirm] (the link's own
+ * Tracks the drag locally (a Float `sliderValue`, the Slider's native type, so a
+ * gesture never round-trips through Double) and re-syncs to the server-reported
+ * [HaControlDescriptor.value] whenever it changes AND the user is not mid-drag,
+ * mid-confirm, nor holding a just-committed value, so the `/ha/states` poll
+ * converges the thumb exactly like the action buttons/badge — never an optimistic
+ * local flip on commit. The Slider is CONTINUOUS (no discrete `steps`, which snap
+ * the thumb and read as a bounce); the released value is snapped to `step` in
+ * [haSnapToStep]. Commits on release ([Slider]'s `onValueChangeFinished`): exactly
+ * ONE call per gesture, never continuously mid-drag. When [needsConfirm] (the link's own
  * `require_confirm`, or a physical-security domain — same gate as
  * [HaControlRow]), the release opens a confirm prompt with the target value
  * baked in instead of firing immediately; cancelling reverts the thumb.
@@ -397,21 +415,24 @@ private fun HaValueSlider(
     // you release, then jumps it to the committed value a poll later (the bounce,
     // issue #465).
     var committed by remember(link.actionLinkId) { mutableStateOf<Double?>(null) }
-    var localValue by remember(link.actionLinkId) { mutableStateOf(control.value) }
+    // The thumb's live position, kept in Float (the Slider's native type) so a
+    // drag never round-trips Double<->Float and quantizes mid-gesture. Seeded from
+    // the server value; the idle effect below re-syncs it to the poll.
+    var sliderValue by remember(link.actionLinkId) { mutableFloatStateOf(control.value.toFloat()) }
 
     val step = control.step.takeIf { it > 0.0 } ?: 1.0
 
-    // Track the live poll ONLY when the user is neither dragging nor holding a
-    // just-committed value. Release the hold once the poll converges to within a
-    // step of the committed value (absorbs percent<->brightness rounding), or when
-    // the safety timeout below clears it.
+    // Track the live poll ONLY when the user is neither dragging, holding a
+    // just-committed value, nor waiting on a confirm. Release the hold once the
+    // poll converges to within a step of the committed value (absorbs
+    // percent<->brightness rounding), or when the safety timeout below clears it.
     LaunchedEffect(control.value, committed) {
-        if (dragging) return@LaunchedEffect
+        if (dragging || awaitingConfirm != null) return@LaunchedEffect
         val c = committed
-        if (c != null && kotlin.math.abs(control.value - c) <= step + 0.5) {
+        if (c != null && haHoldConverged(control.value, c, step)) {
             committed = null
         }
-        if (committed == null) localValue = control.value
+        if (committed == null) sliderValue = control.value.toFloat()
     }
     // Never hold forever: a dropped request or a device that never reaches the
     // target would otherwise freeze the thumb. Drop the hold after a short window
@@ -424,36 +445,39 @@ private fun HaValueSlider(
     }
 
     fun commit(target: Double) {
-        localValue = target
+        sliderValue = target.toFloat()
         committed = target
         onFire(target)
     }
 
     val label = haValueLabel(control.action)
     val unitSuffix = control.unit ?: if (control.kind == "percent") "%" else ""
-    val range = (control.max - control.min).coerceAtLeast(0.0)
-    val steps = ((range / step).roundToInt() - 1).coerceAtLeast(0)
+    val minF = control.min.toFloat()
+    val maxF = control.max.toFloat()
 
     Column(Modifier.fillMaxWidth().padding(top = 14.dp)) {
         Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
             Text(label, color = HaSecondaryText, fontSize = 13.sp)
             Text(
-                "${localValue.roundToInt()}$unitSuffix",
+                "${sliderValue.roundToInt()}$unitSuffix",
                 color = HaPrimaryText,
                 fontSize = 13.sp,
                 fontWeight = FontWeight.Medium,
             )
         }
+        // CONTINUOUS slider (no `steps`): a discrete slider snaps the thumb to tick
+        // positions, which combined with recomposition read as a "bar bounce". The
+        // thumb tracks the finger exactly; we snap to `step` only on release, in
+        // [haSnapToStep], so the POSTed value stays grid-aligned.
         Slider(
-            value = localValue.toFloat(),
-            onValueChange = { dragging = true; localValue = it.toDouble() },
+            value = sliderValue.coerceIn(minF, maxF),
+            onValueChange = { dragging = true; sliderValue = it },
             onValueChangeFinished = {
                 dragging = false
-                val target = localValue.coerceIn(control.min, control.max)
+                val target = haSnapToStep(sliderValue.toDouble(), control.min, control.max, step)
                 if (needsConfirm) awaitingConfirm = target else commit(target)
             },
-            valueRange = control.min.toFloat()..control.max.toFloat(),
-            steps = steps,
+            valueRange = minF..maxF,
             colors = SliderDefaults.colors(
                 thumbColor = HaBlue,
                 activeTrackColor = HaBlue,
@@ -471,11 +495,34 @@ private fun HaValueSlider(
             },
             onCancel = {
                 awaitingConfirm = null
-                localValue = control.value
+                sliderValue = control.value.toFloat()
             },
         )
     }
 }
+
+/**
+ * Snap a raw slider value onto the descriptor's grid: clamp to [min]..[max], then
+ * round to the nearest whole [step] measured from [min]. Kind-agnostic (never a
+ * hardcoded 0..100). Applied ONCE on release so the drag itself stays smooth (the
+ * Slider is continuous) while the committed/POSTed value is step-aligned.
+ */
+internal fun haSnapToStep(raw: Double, min: Double, max: Double, step: Double): Double {
+    val s = step.takeIf { it > 0.0 } ?: 1.0
+    val clamped = raw.coerceIn(min, max)
+    val snapped = min + ((clamped - min) / s).roundToInt() * s
+    return snapped.coerceIn(min, max)
+}
+
+/**
+ * Whether the just-committed [committed] value has been reflected by the poll:
+ * true once the polled [value] is within a step (plus a small margin, to absorb
+ * percent<->brightness rounding) of it. While false the slider keeps holding the
+ * committed value rather than snapping to the device's transitioning old value
+ * (#465). Pure, so it's unit-tested.
+ */
+internal fun haHoldConverged(value: Double, committed: Double, step: Double): Boolean =
+    kotlin.math.abs(value - committed) <= step + 0.5
 
 /**
  * Human label for a value action word — shown above the slider only (the

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaVisual.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaVisual.kt
@@ -102,8 +102,21 @@ internal val BadgeGreen = Color(0xFF2BA84A) // switch on
 internal val BadgeWarmYellow = Color(0xFFFFCC33) // light on
 internal val BadgeDanger = Color(0xFFE5484D) // smoke/gas alarm active — attention red
 
-/** Resolved look for one entity: state color, glyph, and a friendly state label. */
-internal data class BadgeVisual(val color: Color, val icon: ImageVector, val label: String)
+/**
+ * Resolved look for one entity: state color, glyph, and a friendly state label,
+ * plus [active] — the tri-state on/off derived once here (true = on/open/motion,
+ * false = off/closed/clear, null = unknown/stale/scene) so every surface can
+ * style "on vs off" from the SAME signal instead of re-deriving it or guessing
+ * from the color. The more-info dialog uses it to fill the icon disc boldly when
+ * an actuator is on (issue: popup icon didn't read as lit); the badge/tile ignore
+ * it and keep today's look.
+ */
+internal data class BadgeVisual(
+    val color: Color,
+    val icon: ImageVector,
+    val label: String,
+    val active: Boolean? = null,
+)
 
 /**
  * HA `state` -> on / off / indeterminate, mirroring desktop `edgeOn` (and the
@@ -256,33 +269,34 @@ private fun defaultVisual(
     state: String?,
     stale: Boolean,
 ): BadgeVisual {
-    if (domain == "scene") return BadgeVisual(BadgeNeutral, Icons.Filled.MovieFilter, "Scene")
+    if (domain == "scene") return BadgeVisual(BadgeNeutral, Icons.Filled.MovieFilter, "Scene", active = null)
     val on = if (state == null || stale) null else edgeOn(state)
     if (on == null) {
-        return BadgeVisual(BadgeGrey.copy(alpha = 0.6f), defaultIcon(domain, deviceClass), state ?: "Unknown")
+        return BadgeVisual(BadgeGrey.copy(alpha = 0.6f), defaultIcon(domain, deviceClass), state ?: "Unknown", active = null)
     }
     if (domain == "light") {
-        return BadgeVisual(if (on) BadgeWarmYellow else BadgeGrey, Icons.Filled.Lightbulb, if (on) "On" else "Off")
+        return BadgeVisual(if (on) BadgeWarmYellow else BadgeGrey, Icons.Filled.Lightbulb, if (on) "On" else "Off", active = on)
     }
     if (domain == "switch") {
         return BadgeVisual(
             if (on) BadgeGreen else BadgeGrey,
             if (on) Icons.Filled.Power else Icons.Filled.PowerOff,
             if (on) "On" else "Off",
+            active = on,
         )
     }
     return when (labelForDeviceClass(deviceClass)) {
-        "door" -> BadgeVisual(if (on) BadgeAmber else BadgeNeutral, Icons.Filled.SensorDoor, if (on) "Open" else "Closed")
-        "window" -> BadgeVisual(if (on) BadgeAmber else BadgeNeutral, Icons.Filled.SensorWindow, if (on) "Open" else "Closed")
-        "garage" -> BadgeVisual(if (on) BadgeAmber else BadgeNeutral, Icons.Filled.Garage, if (on) "Open" else "Closed")
-        "motion" -> BadgeVisual(if (on) BadgeBlue else BadgeGrey, Icons.Filled.DirectionsRun, if (on) "Motion" else "Clear")
-        "occupancy" -> BadgeVisual(if (on) BadgeBlue else BadgeGrey, Icons.Filled.Person, if (on) "Occupied" else "Clear")
+        "door" -> BadgeVisual(if (on) BadgeAmber else BadgeNeutral, Icons.Filled.SensorDoor, if (on) "Open" else "Closed", active = on)
+        "window" -> BadgeVisual(if (on) BadgeAmber else BadgeNeutral, Icons.Filled.SensorWindow, if (on) "Open" else "Closed", active = on)
+        "garage" -> BadgeVisual(if (on) BadgeAmber else BadgeNeutral, Icons.Filled.Garage, if (on) "Open" else "Closed", active = on)
+        "motion" -> BadgeVisual(if (on) BadgeBlue else BadgeGrey, Icons.Filled.DirectionsRun, if (on) "Motion" else "Clear", active = on)
+        "occupancy" -> BadgeVisual(if (on) BadgeBlue else BadgeGrey, Icons.Filled.Person, if (on) "Occupied" else "Clear", active = on)
         // A binary_sensor lock reads on = unsecured/unlocked, off = locked.
-        "lock" -> BadgeVisual(if (on) BadgeAmber else BadgeNeutral, if (on) Icons.Filled.LockOpen else Icons.Filled.Lock, if (on) "Unlocked" else "Locked")
-        "smoke" -> BadgeVisual(if (on) BadgeDanger else BadgeNeutral, Icons.Filled.LocalFireDepartment, if (on) "Smoke" else "Clear")
-        "gas" -> BadgeVisual(if (on) BadgeDanger else BadgeNeutral, Icons.Filled.Co2, if (on) "Gas" else "Clear")
-        "leak" -> BadgeVisual(if (on) BadgeAmber else BadgeNeutral, Icons.Filled.WaterDamage, if (on) "Leak" else "Dry")
-        else -> BadgeVisual(if (on) BadgeBlue else BadgeGrey, Icons.Filled.Sensors, if (on) "Active" else "Clear")
+        "lock" -> BadgeVisual(if (on) BadgeAmber else BadgeNeutral, if (on) Icons.Filled.LockOpen else Icons.Filled.Lock, if (on) "Unlocked" else "Locked", active = on)
+        "smoke" -> BadgeVisual(if (on) BadgeDanger else BadgeNeutral, Icons.Filled.LocalFireDepartment, if (on) "Smoke" else "Clear", active = on)
+        "gas" -> BadgeVisual(if (on) BadgeDanger else BadgeNeutral, Icons.Filled.Co2, if (on) "Gas" else "Clear", active = on)
+        "leak" -> BadgeVisual(if (on) BadgeAmber else BadgeNeutral, Icons.Filled.WaterDamage, if (on) "Leak" else "Dry", active = on)
+        else -> BadgeVisual(if (on) BadgeBlue else BadgeGrey, Icons.Filled.Sensors, if (on) "Active" else "Clear", active = on)
     }
 }
 
@@ -303,7 +317,9 @@ internal fun badgeVisual(link: HaLinkDto, state: String?, stale: Boolean): Badge
     } else {
         base.color
     }
-    return BadgeVisual(color, overrideIcon ?: base.icon, base.label)
+    // `on` here is the same tri-state `defaultVisual` used for `base.active`
+    // (both null out on unknown/stale/scene); keep them in lockstep.
+    return BadgeVisual(color, overrideIcon ?: base.icon, base.label, active = on)
 }
 
 /**

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaVisual.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaVisual.kt
@@ -101,6 +101,7 @@ internal val BadgeBlue = Color(0xFF33C3FF) // motion / occupancy active
 internal val BadgeGreen = Color(0xFF2BA84A) // switch on
 internal val BadgeWarmYellow = Color(0xFFFFCC33) // light on
 internal val BadgeDanger = Color(0xFFE5484D) // smoke/gas alarm active — attention red
+internal val BadgeDefaultBg = Color(0xFF17171B) // near-black opaque chip behind the glyph
 
 /**
  * Resolved look for one entity: state color, glyph, and a friendly state label,

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
@@ -964,13 +964,26 @@ fun LiveFullscreenScreen(
         }
 
         // Long-pressing an on-video badge (or tapping a non-controllable one) opens
-        // the read-only detail dialog the list sheet uses (issue #263) — inspect
-        // without actuating (#428).
+        // the detail dialog the list sheet uses (issue #263). For an actuator this
+        // is the reachable home for its controls: the action row and, for a
+        // value-capable entity (dimmable light / fan / positionable cover), the
+        // value slider (#442, Slice 1) — a simple domain toggles on tap and only
+        // opens a dialog on long-press, so the slider has nowhere else to live.
+        // Non-actuators (sensors) stay read-only via `showControls = canActuate &&
+        // isActuator` inside the dialog.
         haBadgeSelected?.let { link ->
             val st = haStates?.stateFor(link.entityId)
             // Same combined staleness the on-video badge uses (server OR client).
             val stale = haStates?.stale == true || haStale
-            HaMoreInfoDialog(link, st?.state, st?.lastChanged, stale, onDismiss = { haBadgeSelected = null }, unit = st?.unit)
+            HaMoreInfoDialog(
+                link, st?.state, st?.lastChanged, stale,
+                onDismiss = { haBadgeSelected = null },
+                unit = st?.unit,
+                control = st?.control,
+                canActuate = actuatorCapable,
+                inFlight = link.actionLinkId in haInFlight,
+                onAction = { action, value -> fireHaAction(link, action, value) },
+            )
         }
 
         // Tapping a controllable cover/lock badge opens the confirm-guarded control

--- a/apps/android/app/src/main/java/video/crumb/app/feature/settings/SettingsDialog.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/settings/SettingsDialog.kt
@@ -80,6 +80,8 @@ fun SettingsDialog(
     var motionTunerOn by remember { mutableStateOf(store.motionTunerEnabled) }
     var snapshotView by remember { mutableStateOf(store.snapshotCapturesView) }
     var lprImageMode by remember { mutableStateOf(store.lprImageMode) }
+    var haShowEntityId by remember { mutableStateOf(store.showHaEntityId) }
+    var haShowDeviceType by remember { mutableStateOf(store.showHaDeviceType) }
 
     // Security — biometric app lock.
     val context = LocalContext.current
@@ -248,6 +250,82 @@ fun SettingsDialog(
                     Switch(
                         checked = showAllCamerasView,
                         onCheckedChange = onShowAllCamerasViewChange,
+                        colors = crumbSwitchColors(),
+                    )
+                }
+
+                // ── Home Assistant section ────────────────────────────────────────
+                // What the entity "more-info" popup (opened from the HA sheet or an
+                // on-video badge) shows below the state. Both default on; read/written
+                // straight through to [store], and [HaMoreInfoDialog] reads the same
+                // flags when it next opens.
+                Text(
+                    text = "Home Assistant — entity popup",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = TextSecondary,
+                    modifier = Modifier.padding(top = 12.dp),
+                )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(end = 8.dp),
+                    ) {
+                        Text(
+                            text = "Show entity type",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = TextPrimary,
+                        )
+                        Text(
+                            text = "Show the \"Type\" row (e.g. Light, Garage door) in the " +
+                                "entity detail popup.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = TextSecondary,
+                        )
+                    }
+                    Switch(
+                        checked = haShowDeviceType,
+                        onCheckedChange = { checked ->
+                            haShowDeviceType = checked
+                            store.showHaDeviceType = checked
+                        },
+                        colors = crumbSwitchColors(),
+                    )
+                }
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(end = 8.dp),
+                    ) {
+                        Text(
+                            text = "Show entity ID",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = TextPrimary,
+                        )
+                        Text(
+                            text = "Show the raw entity_id (e.g. light.front_porch) in the " +
+                                "entity detail popup.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = TextSecondary,
+                        )
+                    }
+                    Switch(
+                        checked = haShowEntityId,
+                        onCheckedChange = { checked ->
+                            haShowEntityId = checked
+                            store.showHaEntityId = checked
+                        },
                         colors = crumbSwitchColors(),
                     )
                 }

--- a/apps/android/app/src/test/java/video/crumb/app/feature/live/HaTypeLabelTest.kt
+++ b/apps/android/app/src/test/java/video/crumb/app/feature/live/HaTypeLabelTest.kt
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.feature.live
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests for [haTypeLabel] — the "Type" row value in the HA more-info popup.
+ * Mirrors the desktop client's `_deviceTypeLabel`/`_humanize`
+ * (`apps/desktop-flutter/lib/ui/ha_overlay/ha_state_card.dart`): humanized
+ * `device_class` when present, else humanized `domain`, so the row is never
+ * blank.
+ */
+class HaTypeLabelTest {
+
+    @Test
+    fun `humanizes device_class when present`() {
+        // cover.garage with device_class garage_door -> "Garage door".
+        assertEquals("Garage door", haTypeLabel("cover", "garage_door"))
+        assertEquals("Motion", haTypeLabel("binary_sensor", "motion"))
+    }
+
+    @Test
+    fun `falls back to humanized domain when device_class absent`() {
+        // light.front_island_light (no device_class) -> "Light".
+        assertEquals("Light", haTypeLabel("light", null))
+        // Domains with underscores humanize too.
+        assertEquals("Input boolean", haTypeLabel("input_boolean", null))
+    }
+
+    @Test
+    fun `blank device_class falls back to domain`() {
+        assertEquals("Switch", haTypeLabel("switch", ""))
+        assertEquals("Switch", haTypeLabel("switch", "   "))
+    }
+
+    @Test
+    fun `capitalizes only the first letter`() {
+        // Underscores become spaces; interior words are NOT title-cased, matching
+        // the desktop _humanize (first letter only).
+        assertEquals("Carbon monoxide", haTypeLabel("sensor", "carbon_monoxide"))
+    }
+}

--- a/apps/android/app/src/test/java/video/crumb/app/feature/live/HaValueSliderLogicTest.kt
+++ b/apps/android/app/src/test/java/video/crumb/app/feature/live/HaValueSliderLogicTest.kt
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.feature.live
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure slider-math for the HA value slider (#442, Slice 1). Extracted from the
+ * composable so the two decisions that drive the anti-bounce behaviour are
+ * testable without a UI harness:
+ *  - [haSnapToStep]: the CONTINUOUS thumb is rounded onto the descriptor's grid
+ *    only ONCE, on release, so the committed/POSTed value is step-aligned while
+ *    the drag itself stays smooth (no discrete-slider snapping "bar bounce").
+ *  - [haHoldConverged]: whether a just-committed value has been reflected by the
+ *    `/ha/states` poll yet, so the thumb holds the committed value instead of
+ *    snapping back to the device's transitioning old value (#465).
+ * Both are kind-agnostic: bounds/step come from the descriptor, never a
+ * hardcoded 0..100.
+ */
+class HaValueSliderLogicTest {
+
+    // ── haSnapToStep ────────────────────────────────────────────────────────
+
+    @Test
+    fun `step 1 rounds to the nearest whole percent`() {
+        assertEquals(62.0, haSnapToStep(61.7, 0.0, 100.0, 1.0), 0.0)
+        assertEquals(0.0, haSnapToStep(0.4, 0.0, 100.0, 1.0), 0.0)
+        assertEquals(100.0, haSnapToStep(99.6, 0.0, 100.0, 1.0), 0.0)
+    }
+
+    @Test
+    fun `a coarse step snaps to the nearest multiple`() {
+        // A fan with step 25: mid-drag values land on 0/25/50/75/100.
+        assertEquals(50.0, haSnapToStep(51.0, 0.0, 100.0, 25.0), 0.0)
+        assertEquals(75.0, haSnapToStep(64.0, 0.0, 100.0, 25.0), 0.0)
+        assertEquals(0.0, haSnapToStep(10.0, 0.0, 100.0, 25.0), 0.0)
+    }
+
+    @Test
+    fun `snapping clamps into bounds and honours a non-zero minimum`() {
+        assertEquals(100.0, haSnapToStep(140.0, 0.0, 100.0, 1.0), 0.0)
+        assertEquals(0.0, haSnapToStep(-20.0, 0.0, 100.0, 1.0), 0.0)
+        // Grid measured FROM min (not from 0): min 10, step 5 -> 10,15,20,...
+        assertEquals(20.0, haSnapToStep(21.0, 10.0, 30.0, 5.0), 0.0)
+        assertEquals(10.0, haSnapToStep(9.0, 10.0, 30.0, 5.0), 0.0)
+    }
+
+    @Test
+    fun `a non-positive step is treated as 1 rather than dividing by zero`() {
+        assertEquals(43.0, haSnapToStep(42.6, 0.0, 100.0, 0.0), 0.0)
+        assertEquals(43.0, haSnapToStep(42.6, 0.0, 100.0, -5.0), 0.0)
+    }
+
+    // ── haHoldConverged ─────────────────────────────────────────────────────
+
+    @Test
+    fun `the hold releases once the poll reaches the committed value`() {
+        assertTrue(haHoldConverged(60.0, 60.0, 1.0))
+    }
+
+    @Test
+    fun `the hold releases within a step plus rounding margin`() {
+        // percent<->brightness (0..255) rounding can land the poll a hair off.
+        assertTrue(haHoldConverged(59.0, 60.0, 1.0))
+        assertTrue(haHoldConverged(61.4, 60.0, 1.0))
+        // A coarse step widens the acceptance window accordingly.
+        assertTrue(haHoldConverged(74.0, 75.0, 25.0))
+    }
+
+    @Test
+    fun `the hold persists while the poll still reports the old value`() {
+        // Committed 100, device still transitioning through its old 20 -> keep holding.
+        assertFalse(haHoldConverged(20.0, 100.0, 1.0))
+        assertFalse(haHoldConverged(0.0, 50.0, 1.0))
+    }
+}

--- a/apps/android/app/src/test/java/video/crumb/app/feature/live/HaVisualActiveTest.kt
+++ b/apps/android/app/src/test/java/video/crumb/app/feature/live/HaVisualActiveTest.kt
@@ -12,11 +12,12 @@ import video.crumb.app.data.HaLinkDto
 
 /**
  * The tri-state [BadgeVisual.active] the canonical [badgeVisual] mapping derives
- * once (on / off / unknown), and which the more-info dialog uses to fill the icon
- * disc boldly for an ON actuator (the "popup icon didn't read as lit" polish).
- * Locks that on-vs-off is honestly signalled and that an ON light really carries
- * the warm-yellow accent — no forked color logic, no reliance on the color to
- * infer state.
+ * once (on / off / unknown), plus the state color the more-info dialog tints its
+ * icon glyph with — the same near-black-chip + full-strength-color-glyph look as
+ * the on-video badge (the "popup didn't match the badge" polish, #437). Locks that
+ * on-vs-off is honestly signalled and that an ON light really carries the
+ * warm-yellow accent the popup glyph shows — no forked color logic, no reliance on
+ * the color to infer state.
  */
 class HaVisualActiveTest {
 

--- a/apps/android/app/src/test/java/video/crumb/app/feature/live/HaVisualActiveTest.kt
+++ b/apps/android/app/src/test/java/video/crumb/app/feature/live/HaVisualActiveTest.kt
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.feature.live
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import video.crumb.app.data.HaLinkDto
+
+/**
+ * The tri-state [BadgeVisual.active] the canonical [badgeVisual] mapping derives
+ * once (on / off / unknown), and which the more-info dialog uses to fill the icon
+ * disc boldly for an ON actuator (the "popup icon didn't read as lit" polish).
+ * Locks that on-vs-off is honestly signalled and that an ON light really carries
+ * the warm-yellow accent — no forked color logic, no reliance on the color to
+ * infer state.
+ */
+class HaVisualActiveTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun link(entityId: String, deviceClass: String? = null): HaLinkDto {
+        val dc = if (deviceClass != null) ",\"device_class\":\"$deviceClass\"" else ""
+        return json.decodeFromString(
+            HaLinkDto.serializer(),
+            "{\"id\":\"l\",\"entity_id\":\"$entityId\",\"role\":\"actuator\",\"sort_order\":0$dc}",
+        )
+    }
+
+    @Test
+    fun `a light that is on is active with the warm-yellow accent`() {
+        val v = badgeVisual(link("light.kitchen"), "on", stale = false)
+        assertEquals(true, v.active)
+        assertEquals(BadgeWarmYellow, v.color)
+        assertEquals("On", v.label)
+    }
+
+    @Test
+    fun `a light that is off is inactive and grey`() {
+        val v = badgeVisual(link("light.kitchen"), "off", stale = false)
+        assertEquals(false, v.active)
+        assertEquals(BadgeGrey, v.color)
+        assertEquals("Off", v.label)
+    }
+
+    @Test
+    fun `a switch that is on is active`() {
+        assertTrue(badgeVisual(link("switch.porch"), "on", stale = false).active == true)
+        assertFalse(badgeVisual(link("switch.porch"), "off", stale = false).active == true)
+    }
+
+    @Test
+    fun `an unknown or stale reading is indeterminate, never a confident off`() {
+        // Unknown state -> null (not false), so the dialog does not render a bold
+        // "on" disc nor a confident "off".
+        assertNull(badgeVisual(link("light.kitchen"), "unavailable", stale = false).active)
+        assertNull(badgeVisual(link("light.kitchen"), null, stale = false).active)
+        // A fresh "on" reading but a stale feed must not read as lit.
+        assertNull(badgeVisual(link("light.kitchen"), "on", stale = true).active)
+    }
+
+    @Test
+    fun `an open contact sensor is active`() {
+        val v = badgeVisual(link("binary_sensor.front_door", deviceClass = "door"), "on", stale = false)
+        assertEquals(true, v.active)
+        assertEquals("Open", v.label)
+    }
+}


### PR DESCRIPTION
Bundle of Android HA fixes found by live-testing #442 Slice 1 on real hardware (a dimmable light + Home Assistant). Each passed CI in isolation; the gaps only surfaced driving a real device.

## Fixes
- **#464 — value slider was unreachable for lights/fans.** The live-view long-press dialog (`haBadgeSelected`) opened `HaMoreInfoDialog` without `control`/`canActuate`, so a simple domain (which toggles on tap, dialog only on long-press) had no path to its slider. Now passes the control args; long-press opens the full control detail for actuators, read-only for sensors.
- **#465 — slider bounced back on release.** The direct path had no post-commit hold, so the ~3s poll (still reporting the old value mid-transition) snapped the thumb back. Added a commit-and-hold until the poll converges, with a 6s safety timeout. Also fixed the dominant window+bar bounce: the slider was being unmounted on every commit (`!inFlight` gate) which destroyed its hold state and collapsed the dialog; kept it mounted, reserved a fixed control-row height, made the slider continuous with snap-on-commit.
- **On/off icon state + popup color match the badge.** The detail popup rendered its icon as the inverse of the on-video badge (filled disc + cut-out glyph), so a lit light read grey/white. Now matches the badge exactly: dark disc + full-strength `v.color` glyph, on/off carried by color (warm-yellow light, green switch, amber cover, blue motion, red alarm). Unified the shared background token; added an `active` tri-state to the canonical visual.

Pure functions extracted with unit tests (`HaValueSliderLogicTest`, `HaVisualActiveTest`). Android-only; backend and other clients untouched. Verified on-device.

Closes #464
Closes #465