### PR TITLE
fix(android): don't render HA entity popup inside the PiP window (#469)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
@@ -249,6 +249,21 @@ fun LiveFullscreenScreen(
     // system manages the floating window's own lifecycle).
     KeepScreenOn(enabled = !inPip)
 
+    // PiP shows ONLY the camera video. The HA read-only sheet and the badge
+    // detail/control popups are Compose `Dialog`s — separate windows that are NOT
+    // clipped into the PiP surface, so one left open renders its icon/slider inside
+    // the floating window (and can get stuck there) instead of just the video
+    // (issue #469). On the PiP-enter transition, dismiss any open transient HA UI.
+    // Clearing the state (rather than merely hiding) also guarantees a clean state
+    // — no stuck dialog — when the user returns from PiP.
+    LaunchedEffect(inPip) {
+        if (inPip) {
+            haSheetOpen = false
+            haBadgeSelected = null
+            haControlSelected = null
+        }
+    }
+
     // Resolved RTSP URLs. `rtspUrl` is the ACTIVE url fed to the player: it starts
     // as the main (HD) stream and is swapped to `subUrl` if the main can't play on
     // this device (H265-over-RTSP — see the header). `mainUrl`/`subUrl` are the two
@@ -951,7 +966,9 @@ fun LiveFullscreenScreen(
 
         // Home Assistant entity sheet (read-only status). Opens over the video
         // from the HA button; renders in HA's own dark theme so it feels native.
-        if (haSheetOpen) {
+        // Never in PiP — a Dialog window isn't clipped into the PiP surface (#469);
+        // the inPip effect above also clears haSheetOpen so it can't reappear there.
+        if (!inPip && haSheetOpen) {
             HaEntitiesSheet(
                 cameraName = cameraNames[currentCameraId] ?: "Camera",
                 links = haLinks,
@@ -965,8 +982,9 @@ fun LiveFullscreenScreen(
 
         // Long-pressing an on-video badge (or tapping a non-controllable one) opens
         // the read-only detail dialog the list sheet uses (issue #263) — inspect
-        // without actuating (#428).
-        haBadgeSelected?.let { link ->
+        // without actuating (#428). Never in PiP — this Dialog isn't clipped into
+        // the PiP surface (#469); the inPip effect above also nulls the selection.
+        if (!inPip) haBadgeSelected?.let { link ->
             val st = haStates?.stateFor(link.entityId)
             // Same combined staleness the on-video badge uses (server OR client).
             val stale = haStates?.stale == true || haStale
@@ -974,8 +992,10 @@ fun LiveFullscreenScreen(
         }
 
         // Tapping a controllable cover/lock badge opens the confirm-guarded control
-        // dialog (multi-action, physical-security) (#428).
-        haControlSelected?.let { link ->
+        // dialog (multi-action, physical-security) (#428). Never in PiP — this
+        // Dialog isn't clipped into the PiP surface (#469); the inPip effect above
+        // also nulls the selection.
+        if (!inPip) haControlSelected?.let { link ->
             val st = haStates?.stateFor(link.entityId)
             // Same combined staleness the on-video badge uses (server OR client).
             val stale = haStates?.stale == true || haStale


### PR DESCRIPTION
## The bug (#469)

On the live/fullscreen view (`LiveFullscreenScreen.kt`), if a Home Assistant detail/control popup (`HaMoreInfoDialog`) or the entities sheet was open when the app entered picture-in-picture, its icon/slider rendered inside the floating PiP window instead of only the camera video — and it could get stuck there.

## Root cause

The on-video HA badges, spinner, SD badge, top controls row, and PTZ overlay were all already `!inPip`-gated. The three HA popups were not:

- `HaEntitiesSheet` (gated only on `haSheetOpen`)
- `HaMoreInfoDialog` via `haBadgeSelected`
- `HaMoreInfoDialog` via `haControlSelected`

These are Compose `Dialog`s — separate windows that are **not** clipped into the PiP surface — so an open one leaks into the floating window.

## Fix (scoped to the PiP path)

- On the PiP-enter transition (`LaunchedEffect(inPip)`), dismiss any open HA sheet/detail/control popup by clearing its state — which also guarantees a clean state (no stuck dialog) when returning from PiP.
- Gate the three dialog composables on `!inPip` to match the surrounding pattern and avoid a one-frame flash.

No change to PiP entry policy, video behavior, or the HA feature itself.

## Gate

`:app:assembleDebug` — BUILD SUCCESSFUL on dev2 (only pre-existing deprecation warnings).

Fixes #469