### PR TITLE
fix(android): restore UTF-8 in a LiveFullscreenScreen comment

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
@@ -984,7 +984,7 @@ fun LiveFullscreenScreen(
         // the detail dialog the list sheet uses (issue #263). For an actuator this
         // is the reachable home for its controls: the action row and, for a
         // value-capable entity (dimmable light / fan / positionable cover), the
-        // value slider (#442, Slice 1) — a simple domain toggles on tap and only
+        // value slider (#442, Slice 1) -- a simple domain toggles on tap and only
         // opens a dialog on long-press, so the slider has nowhere else to live.
         // Non-actuators (sensors) stay read-only via `showControls = canActuate &&
         // isActuator` inside the dialog. Never in PiP (#469): this Dialog is a


### PR DESCRIPTION
The #470 merge resolution left a lone CP1252 byte (`0x97`, an em-dash) in a code comment at `LiveFullscreenScreen.kt:987`, making the file invalid UTF-8. Harmless (it's in a `//` comment, so kotlinc tolerates it and the build passes) but flagged by the v0.2.0 release audit's UTF-8 scan as the only corrupted file in the HA slice. Replaced with ASCII. No behavior change.