### PR TITLE
fix(admin): always-visible guidance to link HA entities from a camera's Motion tab

### DIFF
--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -6040,7 +6040,7 @@ async function renderHaHub() {
       <button class="ghost sm" onclick="loadHaHubOverview()" title="Re-fetch links and live state from every camera">Refresh</button>
     </div>
     <div class="policy-section" style="margin-top:10px">
-      <div class="card-hint" style="margin:-2px 0 10px 2px">Every Home Assistant entity linked to any camera, across the whole server. An entity flagged <b>orphaned</b> no longer exists in Home Assistant — open that camera's Motion tab to relink or remove it.</div>
+      <div class="card-hint" style="margin:-2px 0 10px 2px">Every Home Assistant entity linked to any camera, across the whole server. <b>To link a new sensor or control, open a camera and use its Motion tab</b> (entities are linked per camera, not from this page). An entity flagged <b>orphaned</b> no longer exists in Home Assistant; relink or remove it from that camera's Motion tab.</div>
       <div class="export-dest-row" style="align-items:center;gap:8px;flex-wrap:wrap">
         <input id="ha-hub-q" placeholder="Filter by camera, entity id, or label…" style="max-width:280px" oninput="haHubFilterChanged()" />
         <label class="chk" style="margin:0"><input type="checkbox" id="ha-hub-orphans-only" onchange="haHubOrphansOnlyChanged()"/> Orphaned only</label>


### PR DESCRIPTION
On the Home Assistant hub (#441), the **Linked entities** list explained what it shows and how to handle orphaned links, but the populated view gave **no guidance on how to ADD a link** — the "open a camera's Motion tab" hint only appeared in the empty state and vanished once any entity was linked (reported while reviewing the v0.2.0 desktop client against a live server).

Surface it always: the section hint now leads with **"To link a new sensor or control, open a camera and use its Motion tab (entities are linked per camera, not from this page)."** Text-only change in the HA hub card hint; `node --check` on the extracted console script passes. Small enough to fold into v0.2.0 if you want it in the release.