### PR TITLE
fix(admin): clarify HA entity-link picker labels + fix stale "Motion tab" copy

### DIFF
--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -197,7 +197,7 @@ table.list-tbl tbody tr{cursor:pointer;}
 .mt-preview{position:relative;background:#000;border:1px solid var(--border,#2a2f3a);border-radius:6px;min-height:160px;max-height:46vh;display:flex;align-items:center;justify-content:center;overflow:hidden;}
 .mt-preview img{max-width:100%;max-height:46vh;display:none;}
 .mt-frame-ph{color:var(--dim2);font-size:13px;padding:24px;text-align:center;}
-/* ── Inline motion-mask painter (camera Motion tab) ── */
+/* ── Inline motion-mask painter (camera Detection tab) ── */
 .cm-stage{position:relative;background:#0a0c10;border:1px solid var(--border);border-radius:var(--radius);overflow:hidden;width:100%;aspect-ratio:16/9;max-height:46vh;margin:0 auto;}
 .cm-stage img{position:absolute;inset:0;width:100%;height:100%;object-fit:contain;display:block;user-select:none;-webkit-user-drag:none;}
 .cm-stage canvas{position:absolute;inset:0;width:100%;height:100%;cursor:crosshair;touch-action:none;}
@@ -243,7 +243,7 @@ details.detail-section .ds-body .policy-section:first-child{margin-top:0;}
 details.detail-section .ds-body>.policy-section{background:transparent;border:none;padding:0;margin-top:12px;}
 details.detail-section .ds-body>.policy-section:first-child{margin-top:0;}
 details.detail-section .ds-body>.policy-section>.policy-section-title{position:static;background:transparent;padding:0;margin-bottom:8px;line-height:1.4;}
-/* ── Motion tab two-column (live tuner pinned above, settings split below) ── */
+/* ── Detection tab two-column (live tuner pinned above, settings split below) ── */
 .mt-settings-cols{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-top:10px;}
 @media(max-width:760px){.mt-settings-cols{grid-template-columns:1fr;}}
 /* live slider for the manual triggering floor */
@@ -791,7 +791,7 @@ const stName = id => { const s = STORAGES.find(s => s.id === id); return s ? s.n
 const GB = 1e9;
 /* True when the console is embedded in the Crumb Client (loaded with
    #embed=1 → bootSSO adds body.embedded). The desktop owns its own motion-tuning
-   menu, so the camera Motion tab is hidden in embed mode (item #4). */
+   menu, so the camera Detection tab is hidden in embed mode (item #4). */
 const isEmbedded = () => document.body.classList.contains('embedded');
 
 /* ── Mobile drawer toggle ──
@@ -5647,10 +5647,11 @@ function renderHaLinks(configured) {
   }).join('') || '<div class="card-hint" style="margin:4px 0">No links yet.</div>';
   el.innerHTML = `
     <div>${rows}</div>
-    <div style="display:flex;gap:8px;margin-top:10px;flex-wrap:wrap;align-items:center">
-      <button class="ghost sm" onclick="haOpenPicker('motion')">+ Add sensor</button>
-      <button class="ghost sm" onclick="haOpenPicker('sensor')">+ Add value</button>
-      <button class="ghost sm" onclick="haOpenPicker('actuator')">+ Add control</button>
+    <div class="card-hint" style="margin-top:10px">Where does an entity go? <b>Motion sensor</b> = motion or contact binary sensors. <b>Sensor reading</b> = numeric readings (temperature, power, humidity). <b>Control</b> = anything you operate (lights, switches, covers, locks, fans, sirens).</div>
+    <div style="display:flex;gap:8px;margin-top:6px;flex-wrap:wrap;align-items:center">
+      <button class="ghost sm" onclick="haOpenPicker('motion')">+ Motion sensor</button>
+      <button class="ghost sm" onclick="haOpenPicker('sensor')">+ Sensor reading</button>
+      <button class="ghost sm" onclick="haOpenPicker('actuator')">+ Control (lights, switches, covers&hellip;)</button>
       <button class="primary sm" onclick="saveHaLinks()" style="margin-left:auto">Save links</button>
     </div>
     <div id="ce-ha-picker"></div>
@@ -5907,12 +5908,15 @@ function renderHaResults() {
     all.filter(match).forEach(e => { const d = e.entity_id.split('.')[0]; (byDom[d] = byDom[d] || []).push(e); });
     Object.keys(byDom).sort().forEach(d => groups.push({ title: d, items: byDom[d] }));
   }
+  const emptyMsg = role === 'actuator'
+    ? '<div class="card-hint" style="margin:4px 0">No matching entities.</div>'
+    : '<div class="card-hint" style="margin:4px 0">No matching entities. Not here? Switches, lights, covers and locks are under <b>Control</b>.</div>';
   results.innerHTML = groups.map(g => `
     <div style="margin-top:6px"><div style="font-size:11px;color:var(--dim2);text-transform:uppercase;letter-spacing:.04em">${esc(g.title)}</div>
       ${g.items.map(e => `<div style="display:flex;align-items:center;gap:8px;padding:3px 0;cursor:pointer;${linked.has(e.entity_id) ? 'opacity:.45' : ''}" onclick="haPick('${esc(e.entity_id)}')">
         <span style="flex:1;font-size:13px">${esc(e.friendly_name)}${linked.has(e.entity_id) ? ' (linked)' : ''}</span>
         <span class="mono" style="color:var(--dim2);font-size:11px">${esc(e.entity_id)}</span></div>`).join('')}
-    </div>`).join('') || '<div class="card-hint" style="margin:4px 0">No matching entities.</div>';
+    </div>`).join('') || emptyMsg;
 }
 
 function haPick(entity_id) {
@@ -6030,7 +6034,7 @@ async function renderHaHub() {
         <button class="ghost sm" onclick="testHa()">Test connection</button>
         <span id="ha-test" class="srv-note" style="margin-left:8px"></span>
       </div>
-      <div class="card-hint" style="margin-top:4px">Save first, then Test (Test checks the saved connection). Link individual sensors and controls to a camera from that camera's Motion tab.</div>
+      <div class="card-hint" style="margin-top:4px">Save first, then Test (Test checks the saved connection). Link individual sensors and controls to a camera from that camera's Connection tab (Home Assistant section).</div>
       <div id="ha-msg" class="form-msg"></div>
     </div>
 
@@ -6040,7 +6044,7 @@ async function renderHaHub() {
       <button class="ghost sm" onclick="loadHaHubOverview()" title="Re-fetch links and live state from every camera">Refresh</button>
     </div>
     <div class="policy-section" style="margin-top:10px">
-      <div class="card-hint" style="margin:-2px 0 10px 2px">Every Home Assistant entity linked to any camera, across the whole server. An entity flagged <b>orphaned</b> no longer exists in Home Assistant — open that camera's Motion tab to relink or remove it.</div>
+      <div class="card-hint" style="margin:-2px 0 10px 2px">Every Home Assistant entity linked to any camera, across the whole server. An entity flagged <b>orphaned</b> no longer exists in Home Assistant — open that camera's Connection tab (Home Assistant section) to relink or remove it.</div>
       <div class="export-dest-row" style="align-items:center;gap:8px;flex-wrap:wrap">
         <input id="ha-hub-q" placeholder="Filter by camera, entity id, or label…" style="max-width:280px" oninput="haHubFilterChanged()" />
         <label class="chk" style="margin:0"><input type="checkbox" id="ha-hub-orphans-only" onchange="haHubOrphansOnlyChanged()"/> Orphaned only</label>
@@ -6119,7 +6123,7 @@ function renderHaHubOverview() {
   const box = $('ha-hub-overview'); if (!box) return;
   if (!HA_HUB_LINKS) { box.innerHTML = '<div class="card-hint" style="padding:6px 2px">Loading…</div>'; return; }
   if (!HA_HUB_LINKS.length) {
-    box.innerHTML = `<div class="card-hint" style="padding:6px 2px">No cameras have any Home Assistant links yet. Open a camera&#39;s <b>Motion</b> tab to link sensors or controls.</div>`;
+    box.innerHTML = `<div class="card-hint" style="padding:6px 2px">No cameras have any Home Assistant links yet. Open a camera&#39;s <b>Connection</b> tab (Home Assistant section) to link sensors or controls.</div>`;
     return;
   }
   // entity_id → live state, only for entities GET /ha/states actually returned.
@@ -8076,7 +8080,7 @@ async function saveCamEdit() {
       if (managed) { camBody.source_url = src; camBody.source_sub_url = sub; }
       else         { camBody.main_url   = src; camBody.sub_url        = sub; }
     }
-    // Additive motion sources + (pixel) algorithm (Motion tab).
+    // Additive motion sources + (pixel) algorithm (Detection tab).
     if ($('ce-motion-pixel')) camBody.motion_pixel_enabled = $('ce-motion-pixel').checked;
     if ($('ce-motion-frigate')) camBody.motion_frigate_enabled = $('ce-motion-frigate').checked;
     if ($('ce-motion-ha')) camBody.motion_ha_enabled = $('ce-motion-ha').checked;
@@ -8109,7 +8113,7 @@ async function saveCamEdit() {
     }
 
     await api('/config/cameras/' + id, { method: 'PUT', body: JSON.stringify(camBody) });
-    // Motion tab: persist per-camera motion sensitivity/buffers as a custom policy
+    // Detection tab: persist per-camera motion sensitivity/buffers as a custom policy
     // override (copy-on-write), only when those fields were edited on the tab.
     // motion_sensitivity is sent ALONGSIDE motion_threshold so the threshold is
     // actually honored, in the default 'dynamic' mode a bare threshold is a no-op,

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -5635,7 +5635,7 @@ function renderHaLinks(configured) {
       <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
         ${haRoleSelect(i, l.role)}
         <input value="${esc(l.label || '')}" placeholder="${esc(l.entity_id)}" oninput="haSetLabel(${i}, this.value)" title="Display label" style="flex:1;min-width:140px;font-size:13px" />
-        <input value="${esc(l.device_class || '')}" placeholder="device class" oninput="haSetDeviceClass(${i}, this.value)" title="Home Assistant device class" style="width:120px;font-size:12px" />
+        <input list="ha-dev-classes" value="${esc(l.device_class || '')}" placeholder="class (optional)" oninput="haSetDeviceClass(${i}, this.value)" title="Optional. Only meaningful for binary_sensor entities; it sets the badge glyph. Auto-filled from Home Assistant when the entity reports one. Leave blank for lights, switches and covers, their icon comes from the domain or the Icon &amp; style override." style="width:120px;font-size:12px" />
         <span class="mono" style="color:var(--dim2);font-size:11px">${esc(l.entity_id)}</span>
         <button class="ghost sm" onclick="haToggleStyle(${i})" ${canStyle ? '' : 'disabled'} title="${canStyle ? 'Badge icon, shape and color for this entity on the video wall' : 'Save links first to customize this entity\'s badge'}">${HA_STYLE_OPEN === i ? 'Hide style' : 'Icon &amp; style'}</button>
         ${isActuator ? `<button class="ghost sm" onclick="haToggleCtrl(${i})" title="Confirmation + which actions this control allows">${HA_CTRL_OPEN === i ? 'Hide controls' : 'Controls'}</button>` : ''}
@@ -5645,8 +5645,12 @@ function renderHaLinks(configured) {
       ${HA_CTRL_OPEN === i ? haCtrlPanel(i, l) : ''}
     </div>`;
   }).join('') || '<div class="card-hint" style="margin:4px 0">No links yet.</div>';
+  const devClassOpts = ['door', 'garage_door', 'window', 'opening', 'motion', 'occupancy', 'presence', 'vibration', 'moisture', 'smoke', 'gas', 'carbon_monoxide', 'lock']
+    .map(c => `<option value="${c}"></option>`).join('');
   el.innerHTML = `
     <div>${rows}</div>
+    <datalist id="ha-dev-classes">${devClassOpts}</datalist>
+    <div class="card-hint" style="margin-top:10px">The <b>class</b> box on each row is optional and only affects <code>binary_sensor</code> badge glyphs; it is auto-filled from Home Assistant. Leave it blank for lights, switches and covers.</div>
     <div class="card-hint" style="margin-top:10px">Where does an entity go? <b>Motion sensor</b> = motion or contact binary sensors. <b>Sensor reading</b> = numeric readings (temperature, power, humidity). <b>Control</b> = anything you operate (lights, switches, covers, locks, fans, sirens).</div>
     <div style="display:flex;gap:8px;margin-top:6px;flex-wrap:wrap;align-items:center">
       <button class="ghost sm" onclick="haOpenPicker('motion')">+ Motion sensor</button>


### PR DESCRIPTION
## Summary

Web-console (admin.html) only. Improves the per-camera Home Assistant entity-linking UX and fixes stale copy about where linking happens.

**Supersedes #480** (which used the wrong tab name); the tab-name fix is done correctly here.

### The confusion this fixes
The HA link editor lives on a camera's **Connection** tab, "Home Assistant" section, with three role-scoped add buttons (motion / sensor / actuator). A user trying to link a HA **switch** (a smoker's power switch) searched under "+ Add sensor" and "+ Add value" and got "No matching entities," because switches only appear under the actuator picker. The old labels gave no hint which entity types belong to which button. The bare per-row "device class" field added to the confusion (no hint, no options, blank-is-correct for a switch was non-obvious).

### Changes
1. **Self-explanatory add buttons.** Relabeled `+ Add sensor` / `+ Add value` / `+ Add control` to **`+ Motion sensor`** / **`+ Sensor reading`** / **`+ Control (lights, switches, covers…)`**, with a one-line `card-hint` above the row spelling out what each role is for (motion/contact binary sensors; numeric readings like temperature/power/humidity; anything you operate like lights/switches/covers/locks/fans/sirens). Roles and `haOpenPicker('motion'|'sensor'|'actuator')` handlers are unchanged.
2. **Dead-end guidance.** When the motion or sensor picker returns no matches, the empty state now reads: *"No matching entities. Not here? Switches, lights, covers and locks are under Control."*
3. **Fixed every "Motion tab" reference.** The tabs are Connection / Detection / Recording; there is no "Motion tab." The HA hub connection blurb, orphaned-entity note, and empty state now name the camera's **Connection tab (Home Assistant section)**. Internal code comments that referred to the motion-settings tab now say "Detection tab" to match the real UI label.
4. **Guided device_class field.** The per-row "device class" box was bare free text. Added an inline `card-hint` plus a fuller title tooltip explaining it is optional, only meaningful for `binary_sensor` badge glyphs, auto-filled from Home Assistant, and should stay blank for lights/switches/covers. Backed the input with a shared `<datalist>` of the classes Crumb recognizes for badge mapping (door, garage_door, window, opening, motion, occupancy, presence, vibration, moisture, smoke, gas, carbon_monoxide, lock) so users pick instead of guess. Non-restrictive (other HA classes can still be typed); the `haSetDeviceClass` handler and value round-trip are unchanged.

Labels, hints, copy, and one datalist only. No picker/link backend behavior or role semantics changed. No em-dashes in the prose.

### Verify
- Extracted the inline `<script>` and ran `node --check` after each change → clean.
- Grep confirms **no** "Motion tab" string remains in admin.html, and every referenced `on*=` handler exists.