### PR TITLE
feat(ha): expand canonical badge-icon vocabulary (grill/smoker/landscape + 20 more)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaVisual.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaVisual.kt
@@ -9,15 +9,21 @@ import androidx.compose.material.icons.filled.BatteryFull
 import androidx.compose.material.icons.filled.Blinds
 import androidx.compose.material.icons.filled.BlindsClosed
 import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.Campaign
 import androidx.compose.material.icons.filled.CleaningServices
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.Co2
+import androidx.compose.material.icons.filled.Coffee
+import androidx.compose.material.icons.filled.Computer
 import androidx.compose.material.icons.filled.Curtains
+import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.DeviceThermostat
 import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.DirectionsRun
+import androidx.compose.material.icons.filled.Dns
 import androidx.compose.material.icons.filled.Doorbell
+import androidx.compose.material.icons.filled.Eco
 import androidx.compose.material.icons.filled.ElectricMeter
 import androidx.compose.material.icons.filled.ElectricalServices
 import androidx.compose.material.icons.filled.EvStation
@@ -25,9 +31,11 @@ import androidx.compose.material.icons.filled.Fence
 import androidx.compose.material.icons.filled.Garage
 import androidx.compose.material.icons.filled.GasMeter
 import androidx.compose.material.icons.filled.GppGood
+import androidx.compose.material.icons.filled.Grain
 import androidx.compose.material.icons.filled.Grass
 import androidx.compose.material.icons.filled.HeatPump
 import androidx.compose.material.icons.filled.Highlight
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.HotTub
 import androidx.compose.material.icons.filled.Hvac
 import androidx.compose.material.icons.filled.Inventory2
@@ -39,9 +47,12 @@ import androidx.compose.material.icons.filled.LocalLaundryService
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.LockOpen
 import androidx.compose.material.icons.filled.Mail
+import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MovieFilter
+import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.NotificationsActive
 import androidx.compose.material.icons.filled.Opacity
+import androidx.compose.material.icons.filled.OutdoorGrill
 import androidx.compose.material.icons.filled.Outlet
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Pets
@@ -49,6 +60,7 @@ import androidx.compose.material.icons.filled.Plumbing
 import androidx.compose.material.icons.filled.Pool
 import androidx.compose.material.icons.filled.Power
 import androidx.compose.material.icons.filled.PowerOff
+import androidx.compose.material.icons.filled.Print
 import androidx.compose.material.icons.filled.RollerShades
 import androidx.compose.material.icons.filled.Router
 import androidx.compose.material.icons.filled.Schedule
@@ -56,12 +68,19 @@ import androidx.compose.material.icons.filled.SensorDoor
 import androidx.compose.material.icons.filled.SensorOccupied
 import androidx.compose.material.icons.filled.SensorWindow
 import androidx.compose.material.icons.filled.Sensors
+import androidx.compose.material.icons.filled.SettingsRemote
 import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material.icons.filled.SmartButton
+import androidx.compose.material.icons.filled.SmartDisplay
+import androidx.compose.material.icons.filled.Smartphone
 import androidx.compose.material.icons.filled.SolarPower
 import androidx.compose.material.icons.filled.Speaker
+import androidx.compose.material.icons.filled.SportsEsports
+import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.Terminal
 import androidx.compose.material.icons.filled.Thermostat
+import androidx.compose.material.icons.filled.Thunderstorm
+import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.ToggleOn
 import androidx.compose.material.icons.filled.Tv
 import androidx.compose.material.icons.filled.Vibration
@@ -70,8 +89,12 @@ import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.filled.WaterDamage
 import androidx.compose.material.icons.filled.WaterDrop
 import androidx.compose.material.icons.filled.WbIncandescent
+import androidx.compose.material.icons.filled.WbCloudy
 import androidx.compose.material.icons.filled.WbSunny
+import androidx.compose.material.icons.filled.WbTwilight
+import androidx.compose.material.icons.filled.Whatshot
 import androidx.compose.material.icons.filled.Wifi
+import androidx.compose.material.icons.filled.WindPower
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import video.crumb.app.data.HaLinkDto
@@ -178,12 +201,14 @@ private val badgeIconSlugs: Map<String, ImageVector> = mapOf(
     "motion" to Icons.Filled.DirectionsRun,
     "occupancy" to Icons.Filled.SensorOccupied,
     "person" to Icons.Filled.Person,
+    "home" to Icons.Filled.Home,
     "pet" to Icons.Filled.Pets,
     "vibration" to Icons.Filled.Vibration,
     // lighting
     "lightbulb" to Icons.Filled.Lightbulb,
     "floodlight" to Icons.Filled.Highlight,
     "outdoor_light" to Icons.Filled.WbIncandescent,
+    "landscape_light" to Icons.Filled.WbTwilight,
     // power & switches
     "switch" to Icons.Filled.ToggleOn,
     "power" to Icons.Filled.Power,
@@ -203,6 +228,12 @@ private val badgeIconSlugs: Map<String, ImageVector> = mapOf(
     "temperature" to Icons.Filled.DeviceThermostat,
     "humidity" to Icons.Filled.Opacity,
     "sun" to Icons.Filled.WbSunny,
+    // weather
+    "cloud" to Icons.Filled.WbCloudy,
+    "rain" to Icons.Filled.Grain,
+    "wind" to Icons.Filled.WindPower,
+    "storm" to Icons.Filled.Thunderstorm,
+    "moon" to Icons.Filled.DarkMode,
     // safety & alarm
     "smoke" to Icons.Filled.Cloud,
     "gas" to Icons.Filled.GasMeter,
@@ -221,9 +252,19 @@ private val badgeIconSlugs: Map<String, ImageVector> = mapOf(
     "camera" to Icons.Filled.Videocam,
     "tv" to Icons.Filled.Tv,
     "speaker" to Icons.Filled.Speaker,
-    // network
+    "media_player" to Icons.Filled.SmartDisplay,
+    "remote" to Icons.Filled.SettingsRemote,
+    "game" to Icons.Filled.SportsEsports,
+    "mic" to Icons.Filled.Mic,
+    "music" to Icons.Filled.MusicNote,
+    // network & computing
     "wifi" to Icons.Filled.Wifi,
     "router" to Icons.Filled.Router,
+    "printer" to Icons.Filled.Print,
+    "server" to Icons.Filled.Dns,
+    "computer" to Icons.Filled.Computer,
+    "storage" to Icons.Filled.Storage,
+    "phone" to Icons.Filled.Smartphone,
     // vehicles & delivery
     "vehicle" to Icons.Filled.DirectionsCar,
     "package" to Icons.Filled.Inventory2,
@@ -235,8 +276,14 @@ private val badgeIconSlugs: Map<String, ImageVector> = mapOf(
     "laundry" to Icons.Filled.LocalLaundryService,
     "pool" to Icons.Filled.Pool,
     "hottub" to Icons.Filled.HotTub,
+    "grill" to Icons.Filled.OutdoorGrill,
+    "smoker" to Icons.Filled.Whatshot,
+    "coffee" to Icons.Filled.Coffee,
+    "plant" to Icons.Filled.Eco,
     // time
     "clock" to Icons.Filled.Schedule,
+    "calendar" to Icons.Filled.CalendarToday,
+    "timer" to Icons.Filled.Timer,
     // automation
     "scene" to Icons.Filled.MovieFilter,
     "script" to Icons.Filled.Terminal,

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_icons.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_icons.dart
@@ -29,8 +29,12 @@
 // `water_drop`, `local_fire_department`, `thermostat`, `lock`, `lock_open`,
 // `videocam`, `pets`, `window`, `co2`, `water_damage`, and the #438 additions
 // `blinds_closed`, `outlet`, `device_thermostat`, `gas_meter`, `terminal`,
-// `smart_button`. `directions_run` and `sensors` ARE already used elsewhere
-// (confirmed safe).
+// `smart_button`, plus the vocabulary-expansion additions `wb_twilight`,
+// `wb_cloudy`, `grain`, `wind_power`, `thunderstorm`, `dark_mode`,
+// `smart_display`, `settings_remote`, `sports_esports`, `music_note`, `print`,
+// `dns`, `computer`, `storage`, `smartphone`, `outdoor_grill`, `whatshot`,
+// `coffee`, `eco`, `calendar_today`, `timer` (and `home`, `mic` already common).
+// `directions_run` and `sensors` ARE already used elsewhere (confirmed safe).
 
 import 'package:flutter/material.dart';
 
@@ -202,6 +206,30 @@ const Map<String, (IconData, String)> kHaBadgeIconChoices = {
   'gas': (Icons.gas_meter, 'Gas / CO'),
   'script': (Icons.terminal, 'Script'),
   'button': (Icons.smart_button, 'Button'),
+  // ── vocabulary expansion: outdoor cooking, weather, media/compute, etc. ─────
+  'home': (Icons.home, 'Home / zone'),
+  'landscape_light': (Icons.wb_twilight, 'Landscape light'),
+  'cloud': (Icons.wb_cloudy, 'Cloud / weather'),
+  'rain': (Icons.grain, 'Rain'),
+  'wind': (Icons.wind_power, 'Wind'),
+  'storm': (Icons.thunderstorm, 'Storm'),
+  'moon': (Icons.dark_mode, 'Moon / night'),
+  'media_player': (Icons.smart_display, 'Media player'),
+  'remote': (Icons.settings_remote, 'Remote'),
+  'game': (Icons.sports_esports, 'Game'),
+  'mic': (Icons.mic, 'Microphone'),
+  'music': (Icons.music_note, 'Music'),
+  'printer': (Icons.print, 'Printer'),
+  'server': (Icons.dns, 'Server'),
+  'computer': (Icons.computer, 'Computer'),
+  'storage': (Icons.storage, 'Storage / NAS'),
+  'phone': (Icons.smartphone, 'Phone'),
+  'grill': (Icons.outdoor_grill, 'Grill / BBQ'),
+  'smoker': (Icons.whatshot, 'Smoker'),
+  'coffee': (Icons.coffee, 'Coffee'),
+  'plant': (Icons.eco, 'Plant'),
+  'calendar': (Icons.calendar_today, 'Calendar'),
+  'timer': (Icons.timer, 'Timer'),
 };
 
 /// Parse a stored '#RRGGBB' badge color override into a [Color] (full

--- a/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
+++ b/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
@@ -219,7 +219,9 @@ enum HA {
     ///
     /// iOS has no dedicated window-covering symbol on our iOS 16 floor, so
     /// cover/blinds/curtains/shade all resolve to `window.vertical.closed`; that
-    /// is an honest, compilable choice, not a missing glyph.
+    /// is an honest, compilable choice, not a missing glyph. Likewise the iOS 16
+    /// floor has no grill/BBQ or kitchen-appliance symbols, so outdoor cooking
+    /// leans on flame/smoke (`grill`→`flame.fill`, `smoker`→`smoke.fill`).
     static let iconSlugToSymbol: [String: String] = [
         // contact & openings
         "door": "door.left.hand.closed", "window": "window.vertical.closed",
@@ -229,10 +231,10 @@ enum HA {
         "lock": "lock.fill", "key": "key.fill",
         // motion & presence
         "motion": "figure.run", "occupancy": "person.fill", "person": "person.fill",
-        "pet": "pawprint.fill", "vibration": "waveform",
+        "home": "house.fill", "pet": "pawprint.fill", "vibration": "waveform",
         // lighting
         "lightbulb": "lightbulb.fill", "floodlight": "flashlight.on.fill",
-        "outdoor_light": "lightbulb.fill",
+        "outdoor_light": "lightbulb.fill", "landscape_light": "light.beacon.max.fill",
         // power & switches
         "switch": "switch.2", "power": "power", "plug": "powerplug.fill",
         "outlet": "poweroutlet.type.b.fill", "energy": "bolt.fill", "meter": "gauge",
@@ -241,6 +243,9 @@ enum HA {
         "fan": "fanblades.fill", "ac": "snowflake", "heatpump": "thermometer.snowflake",
         "hvac": "wind", "thermostat": "thermometer", "temperature": "thermometer",
         "humidity": "humidity.fill", "sun": "sun.max.fill",
+        // weather
+        "cloud": "cloud.fill", "rain": "cloud.rain.fill", "wind": "wind",
+        "storm": "cloud.bolt.rain.fill", "moon": "moon.fill",
         // safety & alarm
         "smoke": "smoke.fill", "gas": "carbon.monoxide.cloud.fill",
         "co": "carbon.dioxide.cloud.fill", "fire": "flame.fill",
@@ -250,15 +255,21 @@ enum HA {
         "bell": "bell.fill",
         // camera & media
         "camera": "video.fill", "tv": "tv", "speaker": "hifispeaker.fill",
-        // network
+        "media_player": "play.tv.fill", "remote": "av.remote.fill",
+        "game": "gamecontroller.fill", "mic": "mic.fill", "music": "music.note",
+        // network & computing
         "wifi": "wifi", "router": "network",
+        "printer": "printer.fill", "server": "server.rack", "computer": "desktopcomputer",
+        "storage": "externaldrive.fill", "phone": "iphone",
         // vehicles & delivery
         "vehicle": "car.fill", "package": "shippingbox.fill", "mail": "envelope.fill",
         // appliances & outdoor
         "vacuum": "sparkles", "lawn": "leaf.fill", "fridge": "snowflake",
         "laundry": "tshirt.fill", "pool": "figure.pool.swim", "hottub": "water.waves",
+        "grill": "flame.fill", "smoker": "smoke.fill", "coffee": "cup.and.saucer.fill",
+        "plant": "leaf.circle.fill",
         // time
-        "clock": "clock.fill",
+        "clock": "clock.fill", "calendar": "calendar", "timer": "timer",
         // automation
         "scene": "film", "script": "curlybraces", "button": "hand.tap.fill",
         // generic fallback

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -5218,16 +5218,17 @@ const HA_SENSOR_CLASSES = ['motion','occupancy','presence','moving','door','wind
    not significant) or a save here will fail server-side validation. */
 const HA_ICON_SLUGS = [
   'door','window','gate','garage','cover','blinds','curtains','shade','lock','key',
-  'motion','occupancy','person','pet','vibration',
-  'lightbulb','floodlight','outdoor_light',
+  'motion','occupancy','person','home','pet','vibration',
+  'lightbulb','floodlight','outdoor_light','landscape_light',
   'switch','power','plug','outlet','energy','meter','battery','solar','ev',
   'fan','ac','heatpump','hvac','thermostat','temperature','humidity','sun',
+  'cloud','rain','wind','storm','moon',
   'smoke','gas','co','fire','leak','water','valve','siren','security','armed','warning','doorbell','bell',
-  'camera','tv','speaker',
-  'wifi','router',
+  'camera','tv','speaker','media_player','remote','game','mic','music',
+  'wifi','router','printer','server','computer','storage','phone',
   'vehicle','package','mail',
-  'vacuum','lawn','fridge','laundry','pool','hottub',
-  'clock',
+  'vacuum','lawn','fridge','laundry','pool','hottub','grill','smoker','coffee','plant',
+  'clock','calendar','timer',
   'scene','script','button',
   'sensor',
 ];

--- a/services/api/src/ha.rs
+++ b/services/api/src/ha.rs
@@ -599,12 +599,14 @@ pub const CANONICAL_ICON_SLUGS: &[&str] = &[
     "motion",
     "occupancy",
     "person",
+    "home",
     "pet",
     "vibration",
     // lighting
     "lightbulb",
     "floodlight",
     "outdoor_light",
+    "landscape_light",
     // power & switches
     "switch",
     "power",
@@ -624,6 +626,12 @@ pub const CANONICAL_ICON_SLUGS: &[&str] = &[
     "temperature",
     "humidity",
     "sun",
+    // weather
+    "cloud",
+    "rain",
+    "wind",
+    "storm",
+    "moon",
     // safety & alarm (incl. smoke/gas/CO problem sensors)
     "smoke",
     "gas",
@@ -642,9 +650,19 @@ pub const CANONICAL_ICON_SLUGS: &[&str] = &[
     "camera",
     "tv",
     "speaker",
-    // network
+    "media_player",
+    "remote",
+    "game",
+    "mic",
+    "music",
+    // network & computing
     "wifi",
     "router",
+    "printer",
+    "server",
+    "computer",
+    "storage",
+    "phone",
     // vehicles & delivery
     "vehicle",
     "package",
@@ -656,8 +674,14 @@ pub const CANONICAL_ICON_SLUGS: &[&str] = &[
     "laundry",
     "pool",
     "hottub",
+    "grill",
+    "smoker",
+    "coffee",
+    "plant",
     // time
     "clock",
+    "calendar",
+    "timer",
     // automation
     "scene",
     "script",


### PR DESCRIPTION
## What

Expands the closed Home Assistant on-video badge **icon vocabulary** by **23 slugs**, headlined by the outdoor-cooking icons an operator asked for — `grill` and `smoker` — plus outdoor path/garden lighting (`landscape_light`), and a sensible batch of commonly-needed HA device icons:

- **weather**: `cloud`, `rain`, `wind`, `storm`, `moon`
- **media & compute**: `media_player`, `remote`, `game`, `mic`, `music`, `printer`, `server`, `computer`, `storage`, `phone`
- **appliances / outdoor**: `coffee`, `plant`
- **home & scheduling**: `home`, `calendar`, `timer`

Vocabulary grows 67 → **90 slugs**.

## Cross-surface sync (the #438 contract)

Every slug is added in lockstep across all five surfaces so it renders a real native glyph everywhere instead of degrading to the generic sensor dot:

| Surface | File |
|---|---|
| Server source of truth | `services/api/src/ha.rs` (`CANONICAL_ICON_SLUGS`) |
| Admin picker mirror | `services/api/src/admin.html` (`HA_ICON_SLUGS`) |
| Android (Material) | `apps/android/.../feature/live/HaVisual.kt` (`badgeIconSlugs`) |
| Desktop (Flutter) | `apps/desktop-flutter/lib/ui/ha_overlay/ha_icons.dart` (`kHaBadgeIconChoices`) |
| iOS (SF Symbols) | `apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift` (`HA.iconSlugToSymbol`) |

All five sets verified identical at 90 slugs. Every glyph was checked to exist on its platform's icon set at that platform's floor (Flutter classic Material Icons, Compose `material-icons-extended`, SF Symbols on the iOS 16 / macOS 13 floor). Where the iOS 16 floor has no dedicated glyph (outdoor cooking, kitchen appliances) the mapping leans on flame/smoke, consistent with the existing window-covering fallback pattern.

## Notes

Additive: new icons render only after clients are rebuilt/shipped — a natural fit for the next client release. No migration, no API shape change.