### PR TITLE
fix(desktop): keep the maximized pane's right-click menu available while a stream is connecting

### DIFF
--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -2934,22 +2934,37 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
                   // paint the wall tile's still-live video (if we got one) in
                   // its place — never a black pane while mpv waits for a
                   // keyframe. Errors still show the camera-off icon.
+                  //
+                  // The spinner/warm-frame branch keeps the right-click menu
+                  // reachable: after a stream-quality switch (e.g. Data
+                  // saver's on-demand transcode spinning up) the pane sits in
+                  // this branch for a few seconds, and without a gesture
+                  // handler the user couldn't open the menu to switch back.
+                  // Menu actions don't need a live controller.
                   child: _controller == null || !_firstFrame
-                      ? (_error != null
-                            ? Center(
-                                child: Icon(
-                                  Icons.videocam_off,
-                                  color: Colors.red.shade300,
-                                  size: 40,
+                      ? GestureDetector(
+                          behavior: HitTestBehavior.opaque,
+                          onDoubleTap: widget.onClose,
+                          onSecondaryTapDown: (d) =>
+                              _showMaximizedMenu(d.globalPosition),
+                          child: _error != null
+                              ? Center(
+                                  child: Icon(
+                                    Icons.videocam_off,
+                                    color: Colors.red.shade300,
+                                    size: 40,
+                                  ),
+                                )
+                              : widget.warmController != null
+                              ? Video(
+                                  controller: widget.warmController!,
+                                  controls: NoVideoControls,
+                                  fit: BoxFit.contain,
+                                )
+                              : const Center(
+                                  child: CircularProgressIndicator(),
                                 ),
-                              )
-                            : widget.warmController != null
-                            ? Video(
-                                controller: widget.warmController!,
-                                controls: NoVideoControls,
-                                fit: BoxFit.contain,
-                              )
-                            : const Center(child: CircularProgressIndicator()))
+                        )
                       : Listener(
                           onPointerDown: (e) {
                             // Mouse "back" button returns to the wall.


### PR DESCRIPTION
Found during v0.2.0 release testing: in **full view** (maximized pane), right-clicking after choosing **Data saver** did nothing until the stream came up — the menu was gone for the whole spin-up window.

**Root cause:** the maximized pane's entire gesture stack (including `onSecondaryTapDown -> _showMaximizedMenu`) only rendered on the first-frame branch (`_controller != null && _firstFrame`). A quality switch tears the player down, and Data saver's on-demand mobile transcode spins up lazily, so the pane sits in the spinner/warm-frame branch for a few seconds with **no gesture handler at all** — right-click was silently dead, and you couldn't switch back.

**Fix:** wrap the spinner/warm-frame branch in a `GestureDetector` carrying the same `onSecondaryTapDown` (and double-click-to-close). Menu actions don't need a live controller. The wall tile is unaffected (its GestureDetector wraps the whole Stack, so tile right-click already worked mid-reconnect).

`flutter analyze lib/ui/wall_screen.dart` on winbuild: **No issues found!**

Part of the v0.2.0 testing batch.