### PR TITLE
fix(api,android): video-only `_subv` sub restream repairs H264 fmtp for Media3, scoped to Android

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/data/Models.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/Models.kt
@@ -306,12 +306,44 @@ data class LiveStreamsResponse(
     @SerialName("rtsp_main_url") val rtspMainUrl: String,
     @SerialName("rtsp_sub_url") val rtspSubUrl: String? = null,
     /**
+     * Video-only sub restream (`<name>_subv`): the raw sub run through an ffmpeg
+     * copy so go2rtc republishes a proper `a=fmtp:…sprop-parameter-sets=…`.
+     *
+     * Media3's RTSP client REQUIRES an `fmtp` attribute on every track it builds
+     * and throws `IllegalArgumentException: missing attribute fmtp` without one,
+     * so a camera that publishes H264 with no out-of-band parameter sets (seen on
+     * Reolink) reconnect-loops forever on the plain sub (#483). This is the
+     * Media3-specific repair — desktop and iOS deliberately stay on [rtspSubUrl],
+     * because go2rtc spawns the remux ffmpeg lazily, per consumer.
+     *
+     * `null` when the camera has no sub, or when the server does not manage its
+     * go2rtc streams (Frigate-served / legacy rows) — and on any server older
+     * than the field, which is why it is nullable-with-default: we fall back to
+     * [rtspSubUrl] and behave exactly as before.
+     */
+    @SerialName("rtsp_subv_url") val rtspSubvUrl: String? = null,
+    /**
      * On-demand low-res H.264 transcode for cellular "Data saver" fullscreen live.
      * `null` when the server has the feature disabled or the camera is
      * Frigate-served. Nullable-with-default so older servers deserialize cleanly.
      */
     @SerialName("rtsp_mobile_url") val rtspMobileUrl: String? = null,
 )
+
+/**
+ * The low-res (sub) stream this client should play, or `null` when the camera
+ * exposes no sub at all.
+ *
+ * Prefer the video-only [LiveStreamsResponse.rtspSubvUrl] because Media3 needs
+ * its repaired `fmtp`; fall back to the raw [LiveStreamsResponse.rtspSubUrl]
+ * when the server published none — an unmanaged (Frigate-served / legacy)
+ * camera, or a server predating the field. Never invents a URL, so a caller's
+ * own main-stream fallback still applies when both are `null`.
+ *
+ * Single source of truth for the pick order: the live wall tile and fullscreen
+ * live must not drift apart.
+ */
+fun LiveStreamsResponse.subStreamUrl(): String? = rtspSubvUrl ?: rtspSubUrl
 
 // ─── export ──────────────────────────────────────────────────────────────────
 

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveCameraTile.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveCameraTile.kt
@@ -63,6 +63,7 @@ import video.crumb.app.data.CameraDto
 import video.crumb.app.data.DetectionIcons
 import video.crumb.app.data.LiveStreamsResponse
 import video.crumb.app.data.MediaUrls
+import video.crumb.app.data.subStreamUrl
 import video.crumb.app.ui.player.MediaFactory
 import video.crumb.app.ui.player.PlayerSurface
 import video.crumb.app.ui.theme.DangerRed
@@ -75,8 +76,9 @@ import kotlinx.coroutines.launch
  * A single camera tile for the live wall grid.
  *
  * Playback notes:
- * - Uses rtspSubUrl when available (low-res, conserves bandwidth in grid view),
- *   otherwise falls back to rtspMainUrl.
+ * - Uses the sub stream when available (low-res, conserves bandwidth in grid
+ *   view), otherwise falls back to rtspMainUrl. Which sub is [subStreamUrl]'s
+ *   call: the video-only `_subv` when the server offers one, else the raw sub.
  * - The [LiveStreamsResponse] is pre-resolved by [LiveViewModel] so this
  *   composable never performs network I/O.
  * - The ExoPlayer is built once in [remember], starts playing immediately, and
@@ -330,9 +332,12 @@ private fun LiveRtspContent(
     // we show a subtle "Reconnecting…" badge instead of the hard error.
     var isReconnecting by remember { mutableStateOf(false) }
 
-    // Choose sub stream for grid; fall back to main.
+    // Choose sub stream for grid; fall back to main. `subStreamUrl()` prefers the
+    // video-only `_subv` restream, which repairs the missing-fmtp SDP that makes
+    // Media3 reconnect-loop on some cameras (#483), and falls back to the raw sub
+    // when the server has no `_subv` for this camera (unmanaged / older server).
     val rtspUrl: String? = remember(streams) {
-        streams?.rtspSubUrl ?: streams?.rtspMainUrl
+        streams?.subStreamUrl() ?: streams?.rtspMainUrl
     }
 
     // Device connectivity (#3). While offline, reconnect attempts PAUSE instead of

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
@@ -62,6 +62,7 @@ import video.crumb.app.data.HaStatesResponse
 import video.crumb.app.data.PtzPresetDto
 import video.crumb.app.data.controlActions
 import video.crumb.app.data.haPrimaryAction
+import video.crumb.app.data.subStreamUrl
 import video.crumb.app.data.toUserMessage
 import video.crumb.app.di.appContainer
 import video.crumb.app.ui.player.MediaFactory
@@ -369,13 +370,19 @@ fun LiveFullscreenScreen(
             repo.liveStreams(currentCameraId).fold(
                 onSuccess = { streams ->
                     mainUrl = streams.rtspMainUrl
-                    subUrl = streams.rtspSubUrl
+                    // `subStreamUrl()` prefers the video-only `_subv` restream
+                    // (repaired fmtp — without it Media3 rejects the DESCRIBE on
+                    // some cameras, #483) and falls back to the raw sub when the
+                    // server offers no `_subv`. Both the H265-main fallback below
+                    // and the metered start-low path use this one value.
+                    val lowRes = streams.subStreamUrl()
+                    subUrl = lowRes
                     // On a metered link, start on a data-saver stream: the camera's
                     // sub when it has one, else the server's on-demand mobile
                     // transcode. Off metered (Wi-Fi/LAN), start on the main (HD)
                     // stream. Either way the codec-failure fallback + "tap for HD"
                     // badge below still apply.
-                    val lowFirst = if (isMetered) (streams.rtspSubUrl ?: streams.rtspMobileUrl) else null
+                    val lowFirst = if (isMetered) (lowRes ?: streams.rtspMobileUrl) else null
                     if (lowFirst != null) {
                         usingSub = true
                         hdUnavailable = true

--- a/apps/android/app/src/test/java/video/crumb/app/data/SubStreamUrlTest.kt
+++ b/apps/android/app/src/test/java/video/crumb/app/data/SubStreamUrlTest.kt
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.data
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pick order for the low-res (sub) live stream — [subStreamUrl].
+ *
+ * Android is the ONLY client that prefers the server's video-only `_subv`
+ * restream. Media3's RTSP client requires an `fmtp` attribute on every track it
+ * builds and throws `IllegalArgumentException: missing attribute fmtp` without
+ * one, so cameras that publish H264 with no out-of-band parameter sets
+ * reconnect-loop forever on the plain sub (#483); `_subv` is that stream run
+ * through an ffmpeg copy, which restores the fmtp.
+ *
+ * The fallback matters just as much as the preference: go2rtc spawns the `_subv`
+ * remux ffmpeg lazily per consumer, so the server publishes it as a SEPARATE
+ * field and leaves `rtsp_sub_url` pointing at the always-warm raw sub for
+ * desktop/iOS. A server that predates the field, or a camera whose go2rtc
+ * streams the server does not manage (Frigate-served / legacy rows), simply has
+ * no `_subv` — and this client must behave exactly as it did before.
+ */
+class SubStreamUrlTest {
+
+    /** Mirrors `Network.json` — the decoder Retrofit actually uses. */
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun streams(sub: String?, subv: String?) = LiveStreamsResponse(
+        cameraId = "8f14e45f-ceea-467a-9f3a-8f14e45fceea",
+        rtspMainUrl = "rtsp://u:p@host:18554/famroom",
+        rtspSubUrl = sub,
+        rtspSubvUrl = subv,
+    )
+
+    @Test
+    fun `prefers subv when the server offers one`() {
+        val s = streams(
+            sub = "rtsp://u:p@host:18554/famroom_sub",
+            subv = "rtsp://u:p@host:18554/famroom_subv",
+        )
+        assertEquals("rtsp://u:p@host:18554/famroom_subv", s.subStreamUrl())
+    }
+
+    @Test
+    fun `falls back to the raw sub when there is no subv`() {
+        // Unmanaged camera (Frigate-served / legacy row): the server publishes a
+        // sub but no `_subv`, because reconcile never registered one.
+        val s = streams(sub = "rtsp://frigate:8554/famroom_sub", subv = null)
+        assertEquals("rtsp://frigate:8554/famroom_sub", s.subStreamUrl())
+    }
+
+    @Test
+    fun `null when the camera has no sub stream at all`() {
+        // Caller falls back to the main stream itself; this must not invent a URL.
+        assertNull(streams(sub = null, subv = null).subStreamUrl())
+    }
+
+    @Test
+    fun `subv alone is still used`() {
+        // Defensive: the two fields are independent on the wire.
+        val s = streams(sub = null, subv = "rtsp://u:p@host:18554/famroom_subv")
+        assertEquals("rtsp://u:p@host:18554/famroom_subv", s.subStreamUrl())
+    }
+
+    @Test
+    fun `an older server without the field decodes and behaves exactly as before`() {
+        // Wire payload from a server predating `rtsp_subv_url`. The field is
+        // nullable-with-default, so decoding must succeed and the pick order must
+        // land on the raw sub — no behaviour change against an old server.
+        val body = """
+            {
+              "camera_id": "8f14e45f-ceea-467a-9f3a-8f14e45fceea",
+              "rtsp_main_url": "rtsp://u:p@host:18554/famroom",
+              "rtsp_sub_url": "rtsp://u:p@host:18554/famroom_sub"
+            }
+        """.trimIndent()
+        val decoded = json.decodeFromString(LiveStreamsResponse.serializer(), body)
+        assertNull(decoded.rtspSubvUrl)
+        assertEquals("rtsp://u:p@host:18554/famroom_sub", decoded.subStreamUrl())
+    }
+
+    @Test
+    fun `decodes the new field when the server sends it`() {
+        val body = """
+            {
+              "camera_id": "8f14e45f-ceea-467a-9f3a-8f14e45fceea",
+              "rtsp_main_url": "rtsp://u:p@host:18554/famroom",
+              "rtsp_sub_url": "rtsp://u:p@host:18554/famroom_sub",
+              "rtsp_subv_url": "rtsp://u:p@host:18554/famroom_subv"
+            }
+        """.trimIndent()
+        val decoded = json.decodeFromString(LiveStreamsResponse.serializer(), body)
+        assertEquals("rtsp://u:p@host:18554/famroom_subv", decoded.subStreamUrl())
+        // The raw sub is still there for anything that wants the warm producer.
+        assertEquals("rtsp://u:p@host:18554/famroom_sub", decoded.rtspSubUrl)
+    }
+}

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,66 @@ revisit.
 
 ---
 
+## 2026-08-06, The client-facing sub is a dedicated `<name>_subv` go2rtc restream (ffmpeg copy), because some cameras publish H264 with no `sprop-parameter-sets`
+
+**Context.** The Android live-wall tile plays a camera's SUB stream over RTSP
+(Media3/ExoPlayer). For one camera the tile reconnect-looped forever (#483), with
+`IllegalArgumentException: missing attribute fmtp` from Media3's RTSP client,
+which requires an `fmtp` attribute on the media tracks it builds. Fullscreen was
+unaffected (WebRTC/main path).
+
+The initial diagnosis blamed the camera's **audio** tracks (a
+`audio, sendonly, PCMU/8000` two-way-audio backchannel). Surveying every sub
+restream on a live install disproved that: cameras with PCMA and AAC audio all
+work, and go2rtc already drops the sendonly backchannel from its restream. The
+real discriminator is the **video** track. The failing camera is a Reolink whose
+own SDP advertises `m=video … H264/90000` with **no `a=fmtp` / no
+`sprop-parameter-sets`**, and go2rtc's plain restream passes that gap straight
+through — it was the only stream of eleven whose video track had no fmtp. Such a
+stream has no out-of-band parameter sets at all: `ffprobe` on it reports
+"non-existing PPS 0 referenced / decode_slice_header error / no frame!".
+
+**Decision — register a dedicated video-only sub restream `<name>_subv`** in the
+API's go2rtc reconcile loop, sourced `ffmpeg:<name>_sub#video=copy`, and point the
+client `rtsp_sub_url` at it. Passing the bitstream through ffmpeg recovers the
+in-band SPS/PPS, so go2rtc republishes a proper
+`a=fmtp:96 …sprop-parameter-sets=…`; omitting `#audio` makes go2rtc pass `-an`, so
+audio is dropped as a bonus (the wall is muted; two-way audio / listen uses
+WebRTC). `#video=copy` is a **remux, not a re-encode** (verified: identical
+h264/High/640x360 in and out), it reads the existing `_sub` stream by name so it
+shares that producer and adds no camera session, and go2rtc spawns the process
+lazily so an idle `_subv` costs nothing. `_subv` follows `_sub`'s exact lifecycle
+(created, updated, and deleted alongside it). Cameras that reconcile does not
+manage (Frigate-served, or legacy absolute `sub_url`) keep the previous
+resolution.
+
+**Rejected — putting the media filter in the CLIENT URL**
+(`rtsp://…/<name>_sub?video`). This was tried first and **falsified on-device**:
+it broke playback of *every* camera. `ffprobe` accepts a query-string RTSP URL,
+but Media3 derives per-track SETUP URLs by appending `/trackID=N` to the base URI,
+so `…?video` produces malformed SETUP URLs. It also would not have fixed the
+reported camera anyway — the filtered SDP still had no fmtp on the video track —
+and its single-segment rtsp path collides with a managed stream name, forcing
+reconcile onto the `PUT` path (object replacement) every pass. Lesson recorded:
+**prove a client-facing streaming fix with the client's own stack, not just
+ffprobe.**
+
+**Rejected — a per-client fix** (each client selecting only the video track, or
+tolerating a missing fmtp). It needs parallel changes in three clients on their
+own release cadences, Media3 offers no clean "skip an unparseable track" hook, and
+it leaves every future client re-hitting the trap. The server fix is one place and
+needs no client rebuild.
+
+**Revisit triggers (any one):**
+- The live wall needs audio on the RTSP sub (then request `#audio=` explicitly and
+  re-verify the SDP, keeping the fmtp repair).
+- go2rtc changes `ffmpeg:` source semantics, drops `#video=copy`, or stops
+  emitting `-an` when no `#audio` is given — re-verify the `_subv` SDP.
+- Cameras stop shipping H264 without `sprop-parameter-sets`, or Media3 gains
+  tolerance for a missing fmtp — the copy hop could then be dropped.
+- The per-consumer ffmpeg remux ever shows up as real load on a large install
+  (it is a copy, but it is a process per attached wall tile).
+
 ## 2026-08-01, Home Assistant value controls (brightness / position / speed) carry one optional server-validated number, discovered via a states `control` descriptor
 
 **Context.** The action model above shipped on/off/toggle/press control. The

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,7 +8,7 @@ revisit.
 
 ---
 
-## 2026-08-06, The client-facing sub is a dedicated `<name>_subv` go2rtc restream (ffmpeg copy), because some cameras publish H264 with no `sprop-parameter-sets`
+## 2026-08-06, Android alone plays a dedicated `<name>_subv` go2rtc restream (ffmpeg copy), because some cameras publish H264 with no `sprop-parameter-sets`
 
 **Context.** The Android live-wall tile plays a camera's SUB stream over RTSP
 (Media3/ExoPlayer). For one camera the tile reconnect-looped forever (#483), with
@@ -28,18 +28,42 @@ stream has no out-of-band parameter sets at all: `ffprobe` on it reports
 "non-existing PPS 0 referenced / decode_slice_header error / no frame!".
 
 **Decision — register a dedicated video-only sub restream `<name>_subv`** in the
-API's go2rtc reconcile loop, sourced `ffmpeg:<name>_sub#video=copy`, and point the
-client `rtsp_sub_url` at it. Passing the bitstream through ffmpeg recovers the
-in-band SPS/PPS, so go2rtc republishes a proper
-`a=fmtp:96 …sprop-parameter-sets=…`; omitting `#audio` makes go2rtc pass `-an`, so
-audio is dropped as a bonus (the wall is muted; two-way audio / listen uses
-WebRTC). `#video=copy` is a **remux, not a re-encode** (verified: identical
-h264/High/640x360 in and out), it reads the existing `_sub` stream by name so it
-shares that producer and adds no camera session, and go2rtc spawns the process
-lazily so an idle `_subv` costs nothing. `_subv` follows `_sub`'s exact lifecycle
-(created, updated, and deleted alongside it). Cameras that reconcile does not
-manage (Frigate-served, or legacy absolute `sub_url`) keep the previous
-resolution.
+API's go2rtc reconcile loop, sourced `ffmpeg:<name>_sub#video=copy`, and hand it
+to clients as its own `rtsp_subv_url` field **alongside** the raw
+`rtsp_sub_url`. Passing the bitstream through ffmpeg recovers the in-band
+SPS/PPS, so go2rtc republishes a proper `a=fmtp:96 …sprop-parameter-sets=…`;
+omitting `#audio` makes go2rtc pass `-an`, so audio is dropped as a bonus (the
+wall is muted; two-way audio / listen uses WebRTC). `#video=copy` is a **remux,
+not a re-encode** (verified: identical h264/High/640x360 in and out), it reads
+the existing `_sub` stream by name so it shares that producer and adds no camera
+session. `_subv` follows `_sub`'s exact lifecycle (created, updated, and deleted
+alongside it), and is registered for every camera that has a sub whether or not
+any client asks for it. `rtsp_subv_url` is null for cameras reconcile does not
+manage (Frigate-served, or a legacy row with no `source_url`), because no
+`_subv` exists for those; `rtsp_sub_url` keeps its original meaning for every
+camera.
+
+**Which stream a client plays is the CLIENT's choice, and only Android takes
+`_subv`.** Android picks `rtsp_subv_url ?: rtsp_sub_url`; desktop (libmpv) and
+iOS (AVFoundation) keep `rtsp_sub_url` untouched, because both already tolerate
+the missing-fmtp SDP that Media3 rejects. That split is not tidiness, it is the
+performance budget. go2rtc spawns the remux ffmpeg **lazily, on first consumer
+connect**, and reaps it when the last consumer leaves: an idle `_subv` costs
+nothing, but a **cold** one costs a process spawn plus a wait for a keyframe
+through an extra hop, **per consumer**. The first cut of this change pointed
+`rtsp_sub_url` itself at `_subv`, so every client got it. On the owner's install
+a fresh desktop wall then cold-spawned roughly eleven ffmpeg processes on open
+and took many seconds to fill, where before it attached straight to the
+always-warm `_sub` producers that reconcile keeps running. Splitting the field
+restored the fast open and kept the Media3 repair. Reconcile still registers
+`_subv` unconditionally, which is free while nothing connects and means an
+Android client never waits for a reconcile pass.
+
+**Rejected — making `_subv` eager** (an always-running remux per camera so it is
+warm for everybody, keeping a single `rtsp_sub_url` field). That is a permanent
+extra ffmpeg process per camera on every install, paid by operators whose clients
+never need it, purely to avoid a cost only Media3 incurs. Lazy plus
+client-scoped is strictly cheaper and needs no new configuration.
 
 **Rejected — putting the media filter in the CLIENT URL**
 (`rtsp://…/<name>_sub?video`). This was tried first and **falsified on-device**:
@@ -52,11 +76,13 @@ reconcile onto the `PUT` path (object replacement) every pass. Lesson recorded:
 **prove a client-facing streaming fix with the client's own stack, not just
 ffprobe.**
 
-**Rejected — a per-client fix** (each client selecting only the video track, or
-tolerating a missing fmtp). It needs parallel changes in three clients on their
-own release cadences, Media3 offers no clean "skip an unparseable track" hook, and
-it leaves every future client re-hitting the trap. The server fix is one place and
-needs no client rebuild.
+**Rejected — fixing it inside the client** (each client selecting only the video
+track itself, or tolerating a missing fmtp). Media3 offers no clean "skip an
+unparseable track" hook, and every future client would re-hit the trap. The
+**repair** therefore stays server-side and is built once; what is per-client is
+only the one-line choice of which of two published URLs to open, which is exactly
+where the knowledge of "my player needs fmtp" lives. An old client that never
+learns about `rtsp_subv_url` keeps working on the raw sub, unchanged.
 
 **Revisit triggers (any one):**
 - The live wall needs audio on the RTSP sub (then request `#audio=` explicitly and
@@ -64,9 +90,16 @@ needs no client rebuild.
 - go2rtc changes `ffmpeg:` source semantics, drops `#video=copy`, or stops
   emitting `-an` when no `#audio` is given — re-verify the `_subv` SDP.
 - Cameras stop shipping H264 without `sprop-parameter-sets`, or Media3 gains
-  tolerance for a missing fmtp — the copy hop could then be dropped.
-- The per-consumer ffmpeg remux ever shows up as real load on a large install
-  (it is a copy, but it is a process per attached wall tile).
+  tolerance for a missing fmtp — the copy hop could then be dropped, and with it
+  the second URL field.
+- The per-consumer ffmpeg remux shows up as real load, or as a slow wall open, on
+  a large install. It is a copy, but it is a process per attached tile and it
+  spawns cold. Now that only Media3 clients connect to it, this applies to a
+  MOBILE wall (and desktop only if it ever switches to `rtsp_subv_url`); the fix
+  then is a warm/eager `_subv` for the cameras a wall actually shows, not a
+  wider default.
+- A third client adopts a player that also rejects a missing fmtp. It should take
+  `rtsp_subv_url` the same way and measure its own cold-open cost first.
 
 ## 2026-08-01, Home Assistant value controls (brightness / position / speed) carry one optional server-validated number, discovered via a states `control` descriptor
 

--- a/services/api/src/dto.rs
+++ b/services/api/src/dto.rs
@@ -1308,8 +1308,27 @@ pub struct LiveStreamsResponse {
     /// camera on this server; treat this response like any other
     /// authenticated, per-user payload (JWT/RBAC-gated, not further exposed).
     pub rtsp_main_url: String,
-    /// RTSP URL for the sub stream (same credential note as `rtsp_main_url`).
+    /// RTSP URL for the RAW sub stream `<name>_sub` (same credential note as
+    /// `rtsp_main_url`). This is the always-warm restream: reconcile keeps one
+    /// producer per camera running, so a consumer attaches to it immediately.
+    /// Desktop (libmpv) and iOS use this.
     pub rtsp_sub_url: Option<String>,
+    /// RTSP URL for the client-facing VIDEO-ONLY sub restream `<name>_subv` —
+    /// the raw sub run through an ffmpeg **copy** (remux, never a re-encode) so
+    /// go2rtc republishes a proper `a=fmtp:96 …sprop-parameter-sets=…` even for
+    /// cameras that publish H264 with no out-of-band parameter sets (#483).
+    /// `None` when the camera has no sub, or when reconcile does not manage its
+    /// go2rtc streams (Frigate-served, or a legacy row with no `source_url`) —
+    /// no `_subv` exists for those.
+    ///
+    /// **Only Media3/ExoPlayer clients (Android) should prefer this over
+    /// `rtsp_sub_url`.** go2rtc spawns the remux ffmpeg LAZILY on first consumer
+    /// connect and reaps it when consumerless, so every tile that opens `_subv`
+    /// cold pays a process spawn plus a wait for the next keyframe. Players that
+    /// tolerate the missing-fmtp SDP (libmpv on desktop, `AVFoundation` on iOS)
+    /// must keep using `rtsp_sub_url` and attach to the warm producer instead.
+    /// Same embedded-credential + sensitivity note as `rtsp_main_url`.
+    pub rtsp_subv_url: Option<String>,
     /// RTSP URL for the on-demand mobile transcode (`<name>_mobile`) — a low-res
     /// H.264 variant produced by go2rtc only while a consumer is connected, for a
     /// cellular "Data saver" fullscreen-live mode. `None` when the feature is

--- a/services/api/src/go2rtc.rs
+++ b/services/api/src/go2rtc.rs
@@ -78,7 +78,10 @@ fn sub_name(go2rtc_name: &str) -> String {
 
 /// The go2rtc stream name for a camera's CLIENT-facing, VIDEO-ONLY sub restream
 /// (`<name>_subv`). `pub(crate)` because `playback.rs` builds the client
-/// `rtsp_sub_url` from it — the two must never drift apart.
+/// `rtsp_subv_url` from it — the two must never drift apart. Registered for
+/// every camera that has a `_sub`, whether or not a client asks for it; only
+/// Media3/ExoPlayer clients (Android) actually connect to it, and go2rtc spawns
+/// the ffmpeg lazily, so an unused registration costs nothing.
 pub(crate) fn subv_name(go2rtc_name: &str) -> String {
     format!("{go2rtc_name}_subv")
 }
@@ -89,7 +92,9 @@ fn mobile_name(go2rtc_name: &str) -> String {
 }
 
 /// Build the go2rtc source for a camera's `<name>_subv` — the video-only sub
-/// restream the live wall / desktop sub-fallback actually plays (#483).
+/// restream the ANDROID live wall plays (#483). Desktop and iOS stay on the raw
+/// `<name>_sub`; see `playback.rs`'s `rtsp_subv_url` for why the choice is the
+/// client's.
 ///
 /// It reads the EXISTING `<name>_sub` stream by name (go2rtc's documented
 /// restream form), so it shares that stream's single producer and adds no extra

--- a/services/api/src/go2rtc.rs
+++ b/services/api/src/go2rtc.rs
@@ -76,9 +76,50 @@ fn sub_name(go2rtc_name: &str) -> String {
     format!("{go2rtc_name}_sub")
 }
 
+/// The go2rtc stream name for a camera's CLIENT-facing, VIDEO-ONLY sub restream
+/// (`<name>_subv`). `pub(crate)` because `playback.rs` builds the client
+/// `rtsp_sub_url` from it — the two must never drift apart.
+pub(crate) fn subv_name(go2rtc_name: &str) -> String {
+    format!("{go2rtc_name}_subv")
+}
+
 /// The go2rtc stream name for a camera's on-demand MOBILE transcode.
 fn mobile_name(go2rtc_name: &str) -> String {
     format!("{go2rtc_name}_mobile")
+}
+
+/// Build the go2rtc source for a camera's `<name>_subv` — the video-only sub
+/// restream the live wall / desktop sub-fallback actually plays (#483).
+///
+/// It reads the EXISTING `<name>_sub` stream by name (go2rtc's documented
+/// restream form), so it shares that stream's single producer and adds no extra
+/// camera session; go2rtc only spawns the ffmpeg process while a consumer is
+/// attached, so an idle `_subv` costs nothing.
+///
+/// `#video=copy` is a **remux, never a re-encode** (verified against a live
+/// camera: identical h264/High/640x360 in and out). Two things come out of it,
+/// both required:
+///
+/// * **Audio is dropped** — go2rtc passes `-an` when no `#audio` is requested.
+///   The wall is muted, and two-way audio / listen uses the WebRTC path.
+/// * **The H264 parameter sets are recovered.** Some cameras (verified: Reolink)
+///   advertise an H264 track with NO `sprop-parameter-sets`, and go2rtc's plain
+///   restream passes that gap straight through — so `<name>_sub` publishes a
+///   video track with no `a=fmtp` line at all (ffprobe on such a stream reports
+///   "non-existing PPS 0 referenced / no frame!"). Android Media3 requires fmtp
+///   and throws `IllegalArgumentException: missing attribute fmtp`, so the tile
+///   reconnect-loops forever. Passing the bitstream through ffmpeg recovers the
+///   in-band SPS/PPS, and go2rtc then republishes a proper
+///   `a=fmtp:96 …sprop-parameter-sets=…`.
+///
+/// Deliberately NOT an `rtsp://…/<name>_sub?video` source: that form also yields
+/// a video-only SDP, but it leaves the video track's fmtp missing (so Media3
+/// still fails), and its single-segment path collides with a managed stream name,
+/// which would force reconcile down the `PUT` path forever (see
+/// [`is_patch_alias_collision`]). An `ffmpeg:` source can never alias-collide, so
+/// `_subv` `PATCH`es in place exactly like `_mobile`. Pure + unit-tested.
+fn subv_src(sub_stream: &str) -> String {
+    format!("ffmpeg:{sub_stream}#video=copy")
 }
 
 /// Build the go2rtc source for a camera's `<name>_mobile` transcode. It reads
@@ -356,6 +397,7 @@ pub async fn reconcile(state: &AppState) -> Result<()> {
             let mut names = vec![s.go2rtc_name.clone()];
             if has_sub {
                 names.push(sub_name(&s.go2rtc_name));
+                names.push(subv_name(&s.go2rtc_name));
             }
             if mobile_enabled {
                 names.push(mobile_name(&s.go2rtc_name));
@@ -385,6 +427,20 @@ pub async fn reconcile(state: &AppState) -> Result<()> {
                 api_base,
                 &sub_name(&s.go2rtc_name),
                 s.source_sub_url.as_deref().unwrap_or_default(),
+                &existing,
+                &managed,
+                auth,
+            )
+            .await;
+            // #483: the client-facing VIDEO-ONLY sub, derived from the `_sub`
+            // stream above. Registered on exactly the same condition as `_sub`
+            // (and torn down with it), so `playback.rs` can advertise
+            // `<name>_subv` whenever the camera has a sub. go2rtc pulls it lazily.
+            apply_stream(
+                &c,
+                api_base,
+                &subv_name(&s.go2rtc_name),
+                &subv_src(&sub_name(&s.go2rtc_name)),
                 &existing,
                 &managed,
                 auth,
@@ -462,6 +518,9 @@ pub async fn remove(state: &AppState, go2rtc_name: &str) -> Result<()> {
     let c = client()?;
     delete_stream(&c, api_base, go2rtc_name, auth).await?;
     delete_stream(&c, api_base, &sub_name(go2rtc_name), auth).await?;
+    // Best-effort: drop the video-only client sub too (a no-op if the camera
+    // never had a sub — go2rtc DELETE tolerates a missing name).
+    let _ = delete_stream(&c, api_base, &subv_name(go2rtc_name), auth).await;
     // Best-effort: drop the mobile transcode too (a no-op if it was never
     // registered — go2rtc DELETE tolerates a missing name).
     let _ = delete_stream(&c, api_base, &mobile_name(go2rtc_name), auth).await;
@@ -497,6 +556,11 @@ pub async fn reconnect(state: &AppState, go2rtc_name: &str) -> Result<()> {
     }
     if let Err(e) = delete_stream(&c, api_base, &sub_name(go2rtc_name), auth).await {
         tracing::warn!(go2rtc_name, error = %format!("{e:#}"), "reconnect: DELETE sub stream failed (ignoring)");
+    }
+    // The video-only client sub is derived from `_sub`, so it must be re-dialled
+    // with it (its ffmpeg reader is bound to the old `_sub` object otherwise).
+    if let Err(e) = delete_stream(&c, api_base, &subv_name(go2rtc_name), auth).await {
+        tracing::warn!(go2rtc_name, error = %format!("{e:#}"), "reconnect: DELETE video-only sub stream failed (ignoring)");
     }
     // Drop the mobile transcode too, so a source-URL change re-derives it fresh
     // (its input stream name is unchanged, but symmetry with reconcile's PUT-all
@@ -761,6 +825,52 @@ mod tests {
             choose_verb(true, &mobile_src("driveway_sub", 640), &managed),
             StreamVerb::Patch
         );
+    }
+
+    // ── video-only client sub (#483) ────────────────────────────────────────
+
+    #[test]
+    fn subv_name_and_src_shapes() {
+        assert_eq!(subv_name("famroom"), "famroom_subv");
+        // Sources the EXISTING `_sub` stream by name (shares its producer) and
+        // COPIES video. No `#audio` ⇒ go2rtc passes `-an` ⇒ audio dropped.
+        assert_eq!(
+            subv_src(&sub_name("famroom")),
+            "ffmpeg:famroom_sub#video=copy"
+        );
+    }
+
+    #[test]
+    fn subv_src_is_a_copy_not_a_transcode() {
+        // Guard against someone "helpfully" turning this into a re-encode: the
+        // whole point is a remux that recovers SPS/PPS at zero decode cost.
+        let src = subv_src(&sub_name("driveway"));
+        assert!(src.contains("#video=copy"), "must copy, got: {src}");
+        assert!(!src.contains("#video=h264"), "must not re-encode: {src}");
+        assert!(!src.contains("#audio"), "must not request audio: {src}");
+    }
+
+    #[test]
+    fn subv_src_is_never_an_rtsp_alias_collision() {
+        // The reason `_subv` uses an `ffmpeg:` source rather than
+        // `rtsp://…/<name>_sub?video`: an rtsp source whose single-segment path
+        // equals a managed stream name trips the alias guard, which would force
+        // PUT (object replacement) on EVERY reconcile pass. An `ffmpeg:` source
+        // can't alias-collide, so `_subv` PATCHes in place like `_mobile`.
+        let managed = names(&["famroom", "famroom_sub", "famroom_subv"]);
+        assert!(!is_patch_alias_collision(
+            &subv_src(&sub_name("famroom")),
+            &managed
+        ));
+        assert_eq!(
+            choose_verb(true, &subv_src(&sub_name("famroom")), &managed),
+            StreamVerb::Patch
+        );
+        // ...whereas the rejected rtsp form WOULD collide (documents the trap).
+        assert!(is_patch_alias_collision(
+            "rtsp://127.0.0.1:8554/famroom_sub?video",
+            &managed
+        ));
     }
 
     // ── choose_verb (create-vs-patch fan-out fix) ───────────────────────────

--- a/services/api/src/playback.rs
+++ b/services/api/src/playback.rs
@@ -655,21 +655,70 @@ async fn live_streams(
         &b.frigate_rtsp,
     );
 
+    // Does reconcile actually manage this camera's go2rtc streams? This is the
+    // exact predicate `db::list_camera_streams` filters on, so it decides whether
+    // Crumb-synthesised stream names (`_subv`, `_mobile`) really exist. A legacy
+    // `served_by='crumb'` row with an absolute `main_url` but empty `source_url`
+    // is NOT managed, so we must not advertise a synthesised name for it.
+    let has_source = cam
+        .source_url
+        .as_deref()
+        .is_some_and(|s| !s.trim().is_empty());
+    let crumb_managed = cam.served_by != "frigate" && has_source;
+
     // Only expose a sub RTSP URL if the camera actually has a sub stream
-    // configured.  Resolve from cam.sub_url (which may be absolute or relative)
-    // rather than synthesising a `_sub` name — synthesised names can differ from
-    // the actual go2rtc stream name for legacy cameras.
+    // configured.
+    //
+    // #483: for Crumb-managed cameras the client gets the dedicated VIDEO-ONLY
+    // sub restream `<name>_subv` (registered by the reconcile loop — see
+    // `go2rtc::subv_src`), NOT the raw `<name>_sub`.
+    //
+    // The live wall plays the sub over RTSP (Android Media3/ExoPlayer, and the
+    // desktop sub-fallback). Media3's RTSP client requires an `fmtp` attribute on
+    // the media tracks it builds and throws
+    // `IllegalArgumentException: missing attribute fmtp` without one, rejecting
+    // the whole DESCRIBE before video decodes → the tile "reconnects" forever.
+    // Some cameras (verified: Reolink) publish an H264 track with NO
+    // `sprop-parameter-sets`, and go2rtc's plain restream passes that gap through,
+    // so `<name>_sub` advertises a video track with no fmtp at all — such a stream
+    // is undecodable out-of-band (ffprobe on it reports "non-existing PPS 0
+    // referenced / no frame!"). `<name>_subv` runs the sub through an ffmpeg
+    // **copy** (no re-encode), which recovers the in-band SPS/PPS so go2rtc
+    // republishes a proper `a=fmtp:96 …sprop-parameter-sets=…`, and drops audio
+    // (go2rtc passes `-an` when no `#audio` is requested) — the wall is muted and
+    // two-way audio / listen uses the WebRTC path anyway.
+    //
+    // Crucially the client URL stays CLEAN (no query string): an earlier attempt
+    // appended go2rtc's `?video` selector to the client URL, which ffprobe accepts
+    // but Media3 does not — it derives per-track SETUP URLs by appending
+    // `/trackID=N` to the base URI, so `…/name?video` produced malformed SETUP
+    // URLs and broke EVERY camera. The media filtering is therefore done
+    // server-side, inside go2rtc's own source.
+    //
+    // Unmanaged rows (Frigate-served, or legacy absolute `sub_url`) keep the
+    // previous behaviour: resolve `cam.sub_url` as-is, since no `_subv` exists for
+    // them and a synthesised name can differ from their real go2rtc stream name.
+    // The `<name>_sub` stream, the recorder's own internal sub consumption
+    // (motion, over loopback), `webrtc_sub_url`, main and mobile are untouched.
     let rtsp_sub_url = cam
         .sub_url
         .as_deref()
         .filter(|s| !s.is_empty())
         .map(|sub_stream| {
-            crumb_common::db::resolve_stream_url(
-                &cam.served_by,
-                sub_stream,
-                &crumb_rtsp_authed,
-                &b.frigate_rtsp,
-            )
+            if crumb_managed {
+                format!(
+                    "{}/{}",
+                    crumb_rtsp_authed.trim_end_matches('/'),
+                    crate::go2rtc::subv_name(&cam.go2rtc_name)
+                )
+            } else {
+                crumb_common::db::resolve_stream_url(
+                    &cam.served_by,
+                    sub_stream,
+                    &crumb_rtsp_authed,
+                    &b.frigate_rtsp,
+                )
+            }
         });
 
     // WebRTC signaling now goes through the AUTHENTICATED API proxy
@@ -695,21 +744,16 @@ async fn live_streams(
     // an absolute `main_url` but empty `source_url` gets no `_mobile` stream, so we
     // must not advertise a URL that resolves to nothing (else fullscreen live would
     // burn its reconnect budget on a dead stream). go2rtc spawns the transcode
-    // ffmpeg lazily on first consumer connect (idle cost zero).
-    let has_source = cam
-        .source_url
-        .as_deref()
-        .is_some_and(|s| !s.trim().is_empty());
-    let rtsp_mobile_url = (state.config().mobile_stream_enabled
-        && cam.served_by != "frigate"
-        && has_source)
-        .then(|| {
-            format!(
-                "{}/{}_mobile",
-                crumb_rtsp_authed.trim_end_matches('/'),
-                cam.go2rtc_name
-            )
-        });
+    // ffmpeg lazily on first consumer connect (idle cost zero). `crumb_managed`
+    // is that same "Crumb-owned AND has a source_url" predicate, hoisted above
+    // because the `_subv` sub URL needs it too.
+    let rtsp_mobile_url = (state.config().mobile_stream_enabled && crumb_managed).then(|| {
+        format!(
+            "{}/{}_mobile",
+            crumb_rtsp_authed.trim_end_matches('/'),
+            cam.go2rtc_name
+        )
+    });
 
     Ok(Json(LiveStreamsResponse {
         camera_id,

--- a/services/api/src/playback.rs
+++ b/services/api/src/playback.rs
@@ -660,33 +660,58 @@ async fn live_streams(
     // Crumb-synthesised stream names (`_subv`, `_mobile`) really exist. A legacy
     // `served_by='crumb'` row with an absolute `main_url` but empty `source_url`
     // is NOT managed, so we must not advertise a synthesised name for it.
-    let has_source = cam
-        .source_url
-        .as_deref()
-        .is_some_and(|s| !s.trim().is_empty());
-    let crumb_managed = cam.served_by != "frigate" && has_source;
+    let crumb_managed = is_crumb_managed(&cam.served_by, cam.source_url.as_deref());
 
     // Only expose a sub RTSP URL if the camera actually has a sub stream
-    // configured.
+    // configured.  Resolve from cam.sub_url (which may be absolute or relative)
+    // rather than synthesising a `_sub` name — synthesised names can differ from
+    // the actual go2rtc stream name for legacy cameras.
     //
-    // #483: for Crumb-managed cameras the client gets the dedicated VIDEO-ONLY
-    // sub restream `<name>_subv` (registered by the reconcile loop — see
-    // `go2rtc::subv_src`), NOT the raw `<name>_sub`.
+    // This is the RAW sub, `<name>_sub`, and it stays that way for every client
+    // that can play it. Reconcile keeps exactly one `_sub` producer per camera
+    // running at all times, so a consumer attaches to a warm stream and gets a
+    // keyframe on the next GOP — which is why the desktop wall can bring eleven
+    // tiles up quickly. See `rtsp_subv_url` below for the client that needs more.
+    let rtsp_sub_url = cam
+        .sub_url
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .map(|sub_stream| {
+            crumb_common::db::resolve_stream_url(
+                &cam.served_by,
+                sub_stream,
+                &crumb_rtsp_authed,
+                &b.frigate_rtsp,
+            )
+        });
+
+    // #483: the dedicated VIDEO-ONLY sub restream `<name>_subv`, registered by
+    // the reconcile loop (see `go2rtc::subv_src`), offered ALONGSIDE the raw sub
+    // rather than in place of it.
     //
-    // The live wall plays the sub over RTSP (Android Media3/ExoPlayer, and the
-    // desktop sub-fallback). Media3's RTSP client requires an `fmtp` attribute on
-    // the media tracks it builds and throws
-    // `IllegalArgumentException: missing attribute fmtp` without one, rejecting
-    // the whole DESCRIBE before video decodes → the tile "reconnects" forever.
-    // Some cameras (verified: Reolink) publish an H264 track with NO
-    // `sprop-parameter-sets`, and go2rtc's plain restream passes that gap through,
-    // so `<name>_sub` advertises a video track with no fmtp at all — such a stream
-    // is undecodable out-of-band (ffprobe on it reports "non-existing PPS 0
-    // referenced / no frame!"). `<name>_subv` runs the sub through an ffmpeg
-    // **copy** (no re-encode), which recovers the in-band SPS/PPS so go2rtc
-    // republishes a proper `a=fmtp:96 …sprop-parameter-sets=…`, and drops audio
-    // (go2rtc passes `-an` when no `#audio` is requested) — the wall is muted and
-    // two-way audio / listen uses the WebRTC path anyway.
+    // Media3's RTSP client (Android) requires an `fmtp` attribute on the media
+    // tracks it builds and throws `IllegalArgumentException: missing attribute
+    // fmtp` without one, rejecting the whole DESCRIBE before video decodes → the
+    // tile "reconnects" forever. Some cameras (verified: Reolink) publish an H264
+    // track with NO `sprop-parameter-sets`, and go2rtc's plain restream passes
+    // that gap through, so `<name>_sub` advertises a video track with no fmtp at
+    // all — such a stream is undecodable out-of-band (ffprobe on it reports
+    // "non-existing PPS 0 referenced / no frame!"). `<name>_subv` runs the sub
+    // through an ffmpeg **copy** (no re-encode), which recovers the in-band
+    // SPS/PPS so go2rtc republishes a proper
+    // `a=fmtp:96 …sprop-parameter-sets=…`, and drops audio (go2rtc passes `-an`
+    // when no `#audio` is requested) — the wall is muted and two-way audio /
+    // listen uses the WebRTC path anyway.
+    //
+    // WHY IT IS A SEPARATE FIELD and not just the value of `rtsp_sub_url`: go2rtc
+    // spawns the remux ffmpeg LAZILY on first consumer connect and reaps it when
+    // the last consumer leaves. An idle `_subv` costs nothing, but a COLD one
+    // costs a process spawn plus a wait for the next keyframe through an extra
+    // hop — per tile. Pointing every client at it made a fresh desktop wall open
+    // cold-spawn one ffmpeg per tile and take many seconds to fill, where before
+    // it attached straight to the warm `_sub` producers. Only Media3 needs the
+    // repair, so only Android pays for it; desktop (libmpv) and iOS keep
+    // `rtsp_sub_url`.
     //
     // Crucially the client URL stays CLEAN (no query string): an earlier attempt
     // appended go2rtc's `?video` selector to the client URL, which ffprobe accepts
@@ -695,31 +720,16 @@ async fn live_streams(
     // URLs and broke EVERY camera. The media filtering is therefore done
     // server-side, inside go2rtc's own source.
     //
-    // Unmanaged rows (Frigate-served, or legacy absolute `sub_url`) keep the
-    // previous behaviour: resolve `cam.sub_url` as-is, since no `_subv` exists for
-    // them and a synthesised name can differ from their real go2rtc stream name.
-    // The `<name>_sub` stream, the recorder's own internal sub consumption
-    // (motion, over loopback), `webrtc_sub_url`, main and mobile are untouched.
-    let rtsp_sub_url = cam
-        .sub_url
-        .as_deref()
-        .filter(|s| !s.is_empty())
-        .map(|sub_stream| {
-            if crumb_managed {
-                format!(
-                    "{}/{}",
-                    crumb_rtsp_authed.trim_end_matches('/'),
-                    crate::go2rtc::subv_name(&cam.go2rtc_name)
-                )
-            } else {
-                crumb_common::db::resolve_stream_url(
-                    &cam.served_by,
-                    sub_stream,
-                    &crumb_rtsp_authed,
-                    &b.frigate_rtsp,
-                )
-            }
-        });
+    // `None` for rows reconcile does not manage (Frigate-served, or legacy
+    // absolute `sub_url` with no `source_url`): no `_subv` exists for them, and a
+    // client must fall back to `rtsp_sub_url` rather than burn its reconnect
+    // budget on a dead stream name.
+    let video_only_sub_url = subv_url(
+        crumb_managed,
+        cam.sub_url.as_deref(),
+        &cam.go2rtc_name,
+        &crumb_rtsp_authed,
+    );
 
     // WebRTC signaling now goes through the AUTHENTICATED API proxy
     // (`POST /live/{camera_id}/webrtc?stream=main|sub`), NOT directly at
@@ -744,9 +754,10 @@ async fn live_streams(
     // an absolute `main_url` but empty `source_url` gets no `_mobile` stream, so we
     // must not advertise a URL that resolves to nothing (else fullscreen live would
     // burn its reconnect budget on a dead stream). go2rtc spawns the transcode
-    // ffmpeg lazily on first consumer connect (idle cost zero). `crumb_managed`
+    // ffmpeg lazily on first consumer connect (idle cost zero — and only ONE
+    // fullscreen consumer ever attaches, unlike a wall of tiles). `crumb_managed`
     // is that same "Crumb-owned AND has a source_url" predicate, hoisted above
-    // because the `_subv` sub URL needs it too.
+    // because the `_subv` URL needs it too.
     let rtsp_mobile_url = (state.config().mobile_stream_enabled && crumb_managed).then(|| {
         format!(
             "{}/{}_mobile",
@@ -761,11 +772,50 @@ async fn live_streams(
         webrtc_sub_url,
         rtsp_main_url,
         rtsp_sub_url,
+        rtsp_subv_url: video_only_sub_url,
         rtsp_mobile_url,
     }))
 }
 
 // ─── private helpers ──────────────────────────────────────────────────────────
+
+/// Does the API's go2rtc reconcile loop actually manage this camera's streams?
+///
+/// This is the exact predicate `db::list_camera_streams` filters on, so it is
+/// also the predicate for "do Crumb-synthesised stream names (`<name>_subv`,
+/// `<name>_mobile`) really exist for this camera". Frigate-served cameras live on
+/// a separate BYO go2rtc Crumb does not touch, and a legacy `served_by='crumb'`
+/// row with an absolute `main_url` but empty `source_url` is never reconciled —
+/// advertising a synthesised name for either would hand the client a URL that
+/// resolves to nothing.
+///
+/// Pure + unit-tested; kept next to the two call sites that must agree.
+fn is_crumb_managed(served_by: &str, source_url: Option<&str>) -> bool {
+    served_by != "frigate" && source_url.is_some_and(|s| !s.trim().is_empty())
+}
+
+/// Build the client-facing VIDEO-ONLY sub restream URL (`<name>_subv`), or
+/// `None` when the camera has no sub stream or reconcile does not manage it.
+///
+/// See the `rtsp_subv_url` block in [`live_streams`] for why this is a separate
+/// field from `rtsp_sub_url` rather than a replacement for it (go2rtc spawns the
+/// remux ffmpeg lazily, per consumer — only clients that actually need the fmtp
+/// repair should pay it). Pure + unit-tested.
+fn subv_url(
+    crumb_managed: bool,
+    sub_url: Option<&str>,
+    go2rtc_name: &str,
+    crumb_rtsp_authed: &str,
+) -> Option<String> {
+    let has_sub = sub_url.is_some_and(|s| !s.is_empty());
+    (crumb_managed && has_sub).then(|| {
+        format!(
+            "{}/{}",
+            crumb_rtsp_authed.trim_end_matches('/'),
+            crate::go2rtc::subv_name(go2rtc_name)
+        )
+    })
+}
 
 /// Convert a [`crumb_common::Segment`] to the [`ResolvedSegment`] DTO.
 ///
@@ -997,6 +1047,89 @@ mod tests {
         assert_eq!(out, "rtsp://host:18554", "no user:pass@ when auth is off");
         assert!(!out.contains('@'), "auth-off URL must carry no userinfo");
         assert_eq!(format!("{out}/driveway"), "rtsp://host:18554/driveway");
+    }
+
+    // ── sub vs subv stream selection (#483 / the desktop cold-open regression) ─
+
+    const BASE: &str = "rtsp://u:p@host:18554";
+    const FRIGATE: &str = "rtsp://frigate:8554";
+
+    /// The two "reconcile really registers this camera's synthesised streams"
+    /// cases. A Crumb row with a `source_url` is managed; nothing else is.
+    #[test]
+    fn crumb_managed_predicate() {
+        assert!(is_crumb_managed("crumb", Some("rtsp://cam/live")));
+        // Frigate-served: a separate BYO go2rtc Crumb does not manage.
+        assert!(!is_crumb_managed("frigate", Some("rtsp://cam/live")));
+        // Legacy Crumb row: absolute main_url, no source_url → never reconciled.
+        assert!(!is_crumb_managed("crumb", None));
+        assert!(!is_crumb_managed("crumb", Some("")));
+        assert!(
+            !is_crumb_managed("crumb", Some("   ")),
+            "whitespace is empty"
+        );
+    }
+
+    /// `rtsp_sub_url` is the RAW `<name>_sub`, always — that is the always-warm
+    /// producer every client can attach to instantly. It must NOT be the `_subv`
+    /// remux: pointing every client at the lazily-spawned `_subv` made a fresh
+    /// desktop wall cold-spawn one ffmpeg per tile.
+    #[test]
+    fn rtsp_sub_url_is_the_raw_sub_for_a_crumb_managed_camera() {
+        let out = crumb_common::db::resolve_stream_url("crumb", "famroom_sub", BASE, FRIGATE);
+        assert_eq!(out, "rtsp://u:p@host:18554/famroom_sub");
+        assert!(!out.ends_with("_subv"), "the sub field never carries _subv");
+    }
+
+    /// `rtsp_subv_url` is offered ALONGSIDE it for Crumb-managed cameras that
+    /// have a sub — the video-only remux Media3 needs for its fmtp.
+    #[test]
+    fn rtsp_subv_url_present_for_crumb_managed_camera_with_a_sub() {
+        assert_eq!(
+            subv_url(true, Some("famroom_sub"), "famroom", BASE).as_deref(),
+            Some("rtsp://u:p@host:18554/famroom_subv"),
+        );
+        // A trailing slash on the base must not double up.
+        assert_eq!(
+            subv_url(
+                true,
+                Some("famroom_sub"),
+                "famroom",
+                "rtsp://u:p@host:18554/"
+            )
+            .as_deref(),
+            Some("rtsp://u:p@host:18554/famroom_subv"),
+        );
+        // Clean URL: no go2rtc `?video` query string (Media3 appends
+        // `/trackID=N` to the base URI and would build malformed SETUP URLs).
+        assert!(!subv_url(true, Some("famroom_sub"), "famroom", BASE)
+            .unwrap()
+            .contains('?'));
+    }
+
+    /// …and absent everywhere reconcile never registered a `_subv`, so a client
+    /// falls back to `rtsp_sub_url` instead of burning its reconnect budget on a
+    /// dead stream name.
+    #[test]
+    fn rtsp_subv_url_absent_when_unmanaged_or_no_sub() {
+        // No sub stream configured at all.
+        assert_eq!(subv_url(true, None, "famroom", BASE), None);
+        assert_eq!(subv_url(true, Some(""), "famroom", BASE), None);
+        // Frigate-served / legacy rows: `is_crumb_managed` already said no.
+        assert_eq!(subv_url(false, Some("famroom_sub"), "famroom", BASE), None);
+        // End to end through the predicate, the way the handler wires it.
+        for (served_by, source_url) in [
+            ("frigate", Some("rtsp://cam/live")),
+            ("crumb", None),
+            ("crumb", Some("")),
+        ] {
+            let managed = is_crumb_managed(served_by, source_url);
+            assert_eq!(
+                subv_url(managed, Some("famroom_sub"), "famroom", BASE),
+                None,
+                "{served_by}/{source_url:?} must not advertise a _subv",
+            );
+        }
     }
 
     // ── guard_path_traversal ──────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #483

> **v3 — v1 was falsified on-device; v2 fixed Android but regressed the DESKTOP wall's open time, and v3 scopes the repair to the client that needs it.** See "What changed since v2" and "What changed since v1" at the bottom.

## Symptom
On the Android live wall, one camera's tile is stuck perpetually "reconnecting". Fullscreen for the same camera works.

## Root cause (corrected)
Media3's RTSP client requires an `fmtp` attribute on the media tracks it builds and throws `IllegalArgumentException: missing attribute fmtp` without one, rejecting the DESCRIBE before any video decodes.

**The audio backchannel was a red herring.** Surveying every sub restream on a live install:

| stream | video has fmtp | audio |
|---|---|---|
| backdoor, frontdoor, frontroom, frontyard, sideyard | YES | AAC |
| backyard, driveway, sidegate | YES | PCMA |
| garage, lpr | YES | none |
| **famroom (the failing one)** | **NO** | AAC |

Cameras with PCMA and AAC audio all work, and go2rtc already drops the `sendonly` PCMU backchannel from its restream. The discriminator is the **video** track.

The failing camera is a **Reolink** whose own SDP advertises the H264 track with **no `sprop-parameter-sets` and no `a=fmtp`**:

```
m=video 0 RTP/AVP 96
a=rtpmap:96 H264/90000        <- no a=fmtp, no sprop-parameter-sets
```

A Dahua on the same install does carry `a=fmtp:96 packetization-mode=1;profile-level-id=4D6034;sprop-parameter-sets=...` and works. go2rtc's plain restream passes the gap through, so `famroom_sub` publishes a video track with no fmtp at all — it has no out-of-band parameter sets, and even ffprobe on it fails:

```
[h264] non-existing PPS 0 referenced
[h264] decode_slice_header error
[h264] no frame!
```

## Fix
Register a dedicated **video-only sub restream `<name>_subv`** in the API's go2rtc reconcile loop, sourced `ffmpeg:<name>_sub#video=copy`, and publish it to clients as its own **`rtsp_subv_url`** field, *alongside* the unchanged raw `rtsp_sub_url`. **Android prefers `rtsp_subv_url ?? rtsp_sub_url`; desktop and iOS keep the raw sub.**

- Running the bitstream through ffmpeg **recovers the in-band SPS/PPS**, so go2rtc republishes a proper `a=fmtp:96 ...sprop-parameter-sets=...` — this is the actual repair.
- Omitting `#audio` makes go2rtc pass `-an`, so **audio is dropped** as a bonus (the wall is muted; two-way audio / listen use the WebRTC path).
- `#video=copy` is a **remux, never a re-encode** — verified identical h264/High/640x360 in and out. It reads the existing `_sub` stream **by name**, so it shares that producer and adds **no extra camera session**, and go2rtc spawns the process lazily, so an idle `_subv` costs nothing.
- The **client URL stays clean** (no query string).

**Lifecycle** — `_subv` follows `_sub` exactly: registered whenever `_sub` is, included in the managed set, `PATCH`ed in place on later passes (an `ffmpeg:` source can never trip `is_patch_alias_collision`, so it does not regress to PUT-all), and deleted alongside `_sub` in both `remove()` and `reconnect()`.

**Untouched:** the `<name>_sub` stream itself and the value of `rtsp_sub_url`, the recorder's own internal sub consumption (motion, over loopback), `webrtc_sub_url`, main, and mobile. `rtsp_subv_url` is `null` for cameras reconcile does not manage (Frigate-served, or a legacy row with no `source_url`), because no `_subv` exists for them.

### Client scoping (v3) — why `_subv` is a separate field, not the value of `rtsp_sub_url`

go2rtc spawns the `_subv` remux ffmpeg **lazily, on first consumer connect**, and reaps it when the last consumer leaves. An idle `_subv` costs nothing, but a **cold** one costs a process spawn plus a wait for a keyframe through an extra hop, **per consumer**.

Reconcile keeps exactly one always-warm `_sub` producer per camera running. Before v2 the desktop wall attached straight to those, which is why it filled quickly. v2 sent every client to `_subv`, so a fresh desktop open cold-spawned roughly one ffmpeg **per tile** (~11 on the owner's install) and took many seconds to fill. That is the regression this revision fixes.

Only Media3 ever needed the repair: libmpv (desktop) and AVFoundation (iOS) already play the missing-fmtp SDP that Media3 rejects. So only Android pays the lazy-spawn cost.

- **Server** — `rtsp_sub_url` resolves the raw sub via `resolve_stream_url`, exactly as before #483. New nullable `rtsp_subv_url` carries `<name>_subv` under the same predicate v2 used (Crumb-managed **and** the camera has a sub). The reconcile registration is **unchanged**: `_subv` is still created, PATCHed and deleted alongside `_sub` for every camera with a sub, so an Android client never waits for a reconcile pass and an unconnected `_subv` still costs nothing.
- **Android** — `rtsp_subv_url` on the DTO, plus one `subStreamUrl()` helper (`rtspSubvUrl ?: rtspSubUrl`) used by the wall tile *and* by fullscreen's sub / H265-main-fallback / metered start-low paths, so the two cannot drift. Nullable-with-default: against a server without the field the pick falls to `rtspSubUrl` and behaves exactly as today. **An APK rebuild is needed for the Media3 fix; an un-rebuilt APK is no worse than before #483.**
- **Desktop and iOS** — no change, and none made. Both read `rtsp_sub_url`, which is raw again, and neither references `_subv` anywhere.

## End-to-end proof (go2rtc 1.9.14, authenticated external client URL, no query string)
`rtsp://<user>:<pass>@<host>:18554/famroom_subv`

```
v=0
m=video 0 RTP/AVP 96
a=rtpmap:96 H264/90000
a=fmtp:96 packetization-mode=1; sprop-parameter-sets=Z2QAM6wTEqCgL/lhAAAE9gAAYzgEAA==,aO48sAA=; profile-level-id=640033
a=control:trackID=0
```

Single video track, **fmtp present**, no audio track, clean URL. Packets actually flow: `h264,640,360,32` (32 packets read) — versus the raw `_sub`, which cannot even be decoded. The temporary stream used for this proof was removed afterwards; no server was redeployed.

## Tests / gate
- **Reconcile (unchanged from v2):** `subv_name_and_src_shapes`, `subv_src_is_a_copy_not_a_transcode` (guards against someone turning the copy into a re-encode), `subv_src_is_never_an_rtsp_alias_collision` (also asserts the rejected rtsp form *would* collide, documenting the trap).
- **URL selection (new in v3):** `is_crumb_managed` and `subv_url` extracted as pure helpers and covered by `crumb_managed_predicate`, `rtsp_sub_url_is_the_raw_sub_for_a_crumb_managed_camera` (pins that the sub field never carries `_subv`), `rtsp_subv_url_present_for_crumb_managed_camera_with_a_sub` (plus no query string, no double slash), `rtsp_subv_url_absent_when_unmanaged_or_no_sub` (frigate / legacy / no-sub).
- **Android pick order (new in v3):** `SubStreamUrlTest` — prefers `_subv`, falls back to the raw sub, `null` when the camera has no sub, and decodes a payload from a server that predates the field (must behave exactly as before).
- **Gate run manually on the dev/CI box** (CI may still be draining post-outage): `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --workspace` against a throwaway Postgres all pass. Android `:app:testDebugUnitTest` (10 suites, 50 tests, 0 failures) and `:app:assembleDebug` both succeed.

## What changed since v2 (the desktop regression)
v2 was correct about the root cause and the repair, and it is kept whole. Its one mistake was **scope**: it swapped the value of the shared `rtsp_sub_url` field instead of adding a field, so a fix only Media3 needed was billed to every client. Because go2rtc spawns `_subv` lazily and per consumer, that turned a desktop wall open from "attach to N warm producers" into "cold-spawn N ffmpeg processes and wait for a keyframe each", which the owner saw as many seconds to load a view. v3 changes nothing about `_subv` itself; it only lets each client pick.

## What changed since v1 (the falsified approach)
v1 appended go2rtc's `?video` media selector to the **client** URL. Deployed and tested on-device, it **broke playback of every camera**: ffprobe accepts a query-string RTSP URL, but Media3 derives per-track SETUP URLs by appending `/trackID=N` to the base URI, so `.../name?video` produced malformed SETUP URLs. It also would not have fixed the reported camera — the `?video` SDP still had **no fmtp on the video track**. And its single-segment rtsp path collides with a managed stream name, which would have forced reconcile onto the `PUT` path (object replacement) every pass.

Lesson, recorded in `docs/DECISIONS.md`: **prove a client-facing streaming fix against the client's own stack, not just ffprobe.**

## Docs
`docs/DECISIONS.md` entry rewritten again for v3: the corrected root cause, the `_subv` decision **and its client scoping** (with the measured desktop regression that forced it), the rejected alternatives (client-URL filter with its falsification; an eager always-warm `_subv`; fixing it inside each client), and revisit triggers. The per-consumer-ffmpeg trigger that v2 already flagged is now narrowed: it applies to a **mobile** wall, since desktop no longer connects to `_subv`, and its remedy would be a warm `_subv` for the cameras a wall actually shows rather than a wider default.
