### PR TITLE
feat(ios): global quick-toggle to hide Home Assistant overlays on live video

### DIFF
--- a/apps/ios/Crumb/App/AppSettings.swift
+++ b/apps/ios/Crumb/App/AppSettings.swift
@@ -50,6 +50,13 @@ final class AppSettings: ObservableObject {
     /// defaulting it off avoids surprising an existing user with a new gate
     /// they never asked for.
     @Published var biometricLockEnabled: Bool { didSet { defaults.set(biometricLockEnabled, forKey: Keys.biometricLockEnabled) } }
+    /// Global quick-toggle for the on-video Home Assistant badges. `false` hides
+    /// every HA overlay on every live surface (wall and single-camera) at once —
+    /// purely a display switch: links, placement and config are untouched, and
+    /// the entity sheet / detail card reached from other entry points still
+    /// works. On by default, so an operator who linked entities keeps seeing
+    /// them until they deliberately clear the video.
+    @Published var showHaOverlays: Bool { didSet { defaults.set(showHaOverlays, forKey: Keys.showHaOverlays) } }
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
@@ -65,6 +72,7 @@ final class AppSettings: ObservableObject {
         showAllCamerasView = defaults.object(forKey: Keys.showAllCamerasView) as? Bool ?? true
         activeViewId = defaults.string(forKey: Keys.activeViewId)
         biometricLockEnabled = defaults.object(forKey: Keys.biometricLockEnabled) as? Bool ?? false
+        showHaOverlays = defaults.object(forKey: Keys.showHaOverlays) as? Bool ?? true
     }
 
     // MARK: - Per-camera audio preference
@@ -98,5 +106,6 @@ final class AppSettings: ObservableObject {
         static let showAllCamerasView = "show_all_cameras_view"
         static let activeViewId = "active_view_id"
         static let biometricLockEnabled = "biometric_lock_enabled"
+        static let showHaOverlays = "show_ha_overlays"
     }
 }

--- a/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
+++ b/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
@@ -517,6 +517,11 @@ final class HAController: ObservableObject {
 /// nothing is drawn (prevents misplaced badges).
 struct HAOverlayLayer: View {
     @ObservedObject var controller: HAController
+    /// The global "show HA overlays" quick-toggle. Observed *here*, inside the
+    /// overlay itself, rather than at each call site, so every live surface that
+    /// composites badges — the single-camera/fullscreen view today, anything
+    /// added later — is governed by the one flag and can't drift out of sync.
+    @ObservedObject var settings: AppSettings
     let videoSize: CGSize?
 
     /// Presents the detail card (read-only links + cover/lock on tap; any link on
@@ -528,6 +533,16 @@ struct HAOverlayLayer: View {
     @State private var actionError: String?
 
     var body: some View {
+        // Hidden = render nothing at all: no badges, and with them no tap /
+        // long-press targets, so the video underneath is completely clear.
+        // Display-only — the controller keeps polling, so flipping the toggle
+        // back shows live states immediately with no reload.
+        if settings.showHaOverlays {
+            overlayBody
+        }
+    }
+
+    private var overlayBody: some View {
         GeometryReader { geo in
             if let vs = videoSize, vs.width > 0, vs.height > 0, !controller.placedLinks.isEmpty {
                 let field = fieldRect(pane: geo.size, video: vs)

--- a/apps/ios/Crumb/Features/Live/LiveFullscreenView.swift
+++ b/apps/ios/Crumb/Features/Live/LiveFullscreenView.swift
@@ -41,6 +41,12 @@ struct LiveFullscreenView: View {
     /// when the link flips metered mid-session.
     @ObservedObject private var connectivity: ConnectivityMonitor
 
+    /// Observed (not just read through `vm.container`) so the HA-overlay
+    /// quick-toggle in the control bar re-renders its own icon the moment it's
+    /// tapped — `AppSettings` is a plain `let` on the container, so nothing else
+    /// here would publish the change. Same pattern `LiveWallView`/`RootView` use.
+    @ObservedObject private var settings: AppSettings
+
     /// Home Assistant entity links + live states for on-video badges + sheet.
     @StateObject private var ha: HAController
     @State private var haVideoSize: CGSize?
@@ -71,6 +77,7 @@ struct LiveFullscreenView: View {
         self.onSwipeCamera = onSwipeCamera
         self.onOpenPlayback = onOpenPlayback
         _connectivity = ObservedObject(wrappedValue: vm.container.connectivity)
+        _settings = ObservedObject(wrappedValue: vm.container.settings)
         _ha = StateObject(wrappedValue: HAController(container: vm.container))
     }
 
@@ -99,7 +106,7 @@ struct LiveFullscreenView: View {
                 // Hidden while digitally zoomed — the overlay lives outside the
                 // zoom transform and would otherwise sit on the wrong pixels.
                 if videoZoom <= 1.01 {
-                    HAOverlayLayer(controller: ha, settings: vm.container.settings, videoSize: haVideoSize)
+                    HAOverlayLayer(controller: ha, settings: settings, videoSize: haVideoSize)
                         .ignoresSafeArea()
                 }
 
@@ -370,6 +377,25 @@ struct LiveFullscreenView: View {
                             .foregroundColor(.white)
                     }
                     .accessibilityLabel("Home Assistant entities")
+
+                    // The same global show/hide-overlays quick-toggle the Live
+                    // wall carries, repeated here so it's reachable from where
+                    // the badges actually render — no backing out to the wall to
+                    // clear the video. Drives the identical persisted setting,
+                    // so the two buttons are always in agreement. Like the PiP
+                    // button, the icon alone carries the state (white on video).
+                    // Gated on `hasLinks` for the same reason as the sheet
+                    // button: nothing to hide on a camera with no linked
+                    // entities. Links keep loading while overlays are hidden, so
+                    // this button never strands the operator with no way back.
+                    Button { settings.showHaOverlays.toggle() } label: {
+                        Image(systemName: settings.showHaOverlays ? "house" : "house.slash")
+                            .font(.title3)
+                            .foregroundColor(.white)
+                    }
+                    .accessibilityLabel(settings.showHaOverlays
+                                        ? "Hide Home Assistant overlays"
+                                        : "Show Home Assistant overlays")
                 }
 
                 // Secondary actions in a menu — keeps the bar uncluttered

--- a/apps/ios/Crumb/Features/Live/LiveFullscreenView.swift
+++ b/apps/ios/Crumb/Features/Live/LiveFullscreenView.swift
@@ -99,7 +99,7 @@ struct LiveFullscreenView: View {
                 // Hidden while digitally zoomed — the overlay lives outside the
                 // zoom transform and would otherwise sit on the wrong pixels.
                 if videoZoom <= 1.01 {
-                    HAOverlayLayer(controller: ha, videoSize: haVideoSize)
+                    HAOverlayLayer(controller: ha, settings: vm.container.settings, videoSize: haVideoSize)
                         .ignoresSafeArea()
                 }
 

--- a/apps/ios/Crumb/Features/Live/LiveWallView.swift
+++ b/apps/ios/Crumb/Features/Live/LiveWallView.swift
@@ -556,6 +556,19 @@ struct LiveWallView: View {
             Spacer()
 
             if showLiveActions {
+                // Global HA-overlay quick-toggle (see `haOverlayButton`), with
+                // the desktop bar's plain style + hover help.
+                Button {
+                    settings.showHaOverlays.toggle()
+                } label: {
+                    Image(systemName: settings.showHaOverlays ? "house" : "house.slash")
+                        .foregroundColor(settings.showHaOverlays ? CrumbColors.teal : CrumbColors.textTertiary)
+                }
+                .buttonStyle(.plain)
+                .help(settings.showHaOverlays
+                      ? "Hide Home Assistant overlays"
+                      : "Show Home Assistant overlays")
+
                 if settings.bookmarksButtonEnabled && (container.isAdmin || container.capabilities.canBookmark) {
                     Button {
                         showBookmarks = true
@@ -647,6 +660,21 @@ struct LiveWallView: View {
         }
     }
 
+    /// Global quick-toggle: hide (or restore) every Home Assistant overlay badge
+    /// on live video, across every camera and both the wall and the
+    /// single-camera view. Purely a display switch — entity links, placement and
+    /// config are untouched, and the read-only entity sheet reached from the
+    /// fullscreen toolbar still opens. The choice persists (`show_ha_overlays`).
+    private var haOverlayButton: some View {
+        Button { settings.showHaOverlays.toggle() } label: {
+            Image(systemName: settings.showHaOverlays ? "house" : "house.slash")
+                .foregroundColor(settings.showHaOverlays ? CrumbColors.teal : CrumbColors.textTertiary)
+        }
+        .accessibilityLabel(settings.showHaOverlays
+                            ? "Hide Home Assistant overlays"
+                            : "Show Home Assistant overlays")
+    }
+
     private var settingsButton: some View {
         Button { showSettings = true } label: {
             Image(systemName: "gearshape.fill")
@@ -670,6 +698,7 @@ struct LiveWallView: View {
                     modeTabs
                     Spacer()
                     tileSizeButton
+                    haOverlayButton
                     bookmarksButton
                     settingsButton
                 }
@@ -686,6 +715,7 @@ struct LiveWallView: View {
                     Spacer()
 
                     tileSizeButton
+                    haOverlayButton
                     bookmarksButton
                     settingsButton
                 }


### PR DESCRIPTION
## What

Adds a global quick-toggle to the iOS/macOS client that hides **all** Home Assistant overlay badges on live video in one tap, and brings them back with another.

- **iOS wall**: new `house` / `house.slash` toolbar button on the Live wall, between the tile-size and bookmarks buttons (present in both the portrait toolbar row and the landscape inline row).
- **macOS wall**: the same affordance in the Live secondary bar (plain style + hover help), shown with the other Live-only actions.
- **Fullscreen / single-camera live view**: the same toggle again in the control bar, next to the existing `house.fill` entity-sheet button — this is where the badges actually render, so the video can be cleared without backing out to the wall. Gated on `ha.hasLinks` for the same reason as the sheet button (nothing to hide on a camera with no linked entities); links keep loading while overlays are hidden, so it never strands you with no way back.

All three drive the identical persisted setting, so they are always in agreement.

## Behavior

Purely a display switch:

- Entity links, overlay placement and HA config are untouched.
- The `HAController` keeps polling, so restoring the overlays shows live state immediately with no reload.
- The read-only entity sheet / detail card reached from the fullscreen toolbar's `house.fill` button still opens and works normally.
- Hiding removes the badge views entirely, so their tap and long-press targets go with them and the video underneath is completely clear.

## Where the gate lives

Inside `HAOverlayLayer` itself rather than at each call site, so every live surface that composites badges (the fullscreen view today, anything added later) is governed by the one flag and can't drift out of sync.

`LiveFullscreenView` observes `AppSettings` directly rather than reading it through `vm.container` — it's a plain `let` on the container, so nothing in that view would have published the flip and the control-bar icon would have gone stale. Same pattern `LiveWallView` and `RootView` already use.

## Persistence

`AppSettings.showHaOverlays`, UserDefaults key `show_ha_overlays`, **defaulting to `true` (overlays shown)** so an existing operator sees no change until they ask for one. Matches how every other display preference in `AppSettings` persists.

## Keyboard shortcut

Checked, and skipped: the app has no keyboard-shortcut convention. The only `.keyboardShortcut` in the target is a `.cancelAction` role on a Cancel button, and Esc is handled via `.onExitCommand`. Nothing to match, so none was invented.

## Verification

Run from a fresh detached worktree off this branch on macOS (Xcode 26.6), after `xcodegen generate`:

- `xcodebuild -scheme Crumb-mac -destination 'platform=macOS' build` → **BUILD SUCCEEDED**
- `xcodebuild test -scheme Crumb -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` → **TEST SUCCEEDED**, 59 tests, 0 failures
- `house.slash` confirmed present in the SF Symbols catalog on the build host (not a silently-blank glyph)

Client-only display change: no backend, migration, install-guide or RBAC surface touched.