### PR TITLE
feat(desktop): global quick-toggle to hide all Home Assistant overlays

### DIFF
--- a/apps/desktop-flutter/lib/main.dart
+++ b/apps/desktop-flutter/lib/main.dart
@@ -37,6 +37,7 @@ import 'package:crumb_desktop/src/rust/api/secret.dart';
 import 'package:crumb_desktop/src/rust/frb_generated.dart';
 import 'package:crumb_desktop/state/adaptive_wall.dart';
 import 'package:crumb_desktop/state/client_options.dart';
+import 'package:crumb_desktop/state/ha_overlay_prefs.dart';
 import 'package:crumb_desktop/state/hotkey_config.dart';
 import 'package:crumb_desktop/state/keyboard_shortcuts.dart';
 import 'package:crumb_desktop/state/stream_prefs.dart';
@@ -213,6 +214,9 @@ class _CrumbClientAppState extends State<CrumbClientApp> {
     final streamPrefs = await StreamPrefsStore.load();
     final hotkeys = await HotkeyConfigStore.load();
     final shortcuts = await KeyboardShortcutsStore.load();
+    // App-wide "hide HA overlays" flag — a singleton (see its file header), so
+    // it's loaded rather than held in this State's fields.
+    await HaOverlayPrefs.instance.load();
     // App-scoped adaptive-wall brain (issue #382): fed the decode-util signal +
     // tile registry by the live wall, and queried by the Settings guardrail.
     final adaptive = AdaptiveWallController(
@@ -866,6 +870,9 @@ class _MainShellState extends State<MainShell> with WindowListener {
                     onConfigView: _index == _liveIndex
                         ? () => _openConfigView(session)
                         : null,
+                    // Live-only: the global "hide HA overlays" quick-toggle
+                    // (Playback draws no HA badges).
+                    showHaOverlayToggle: _index == _liveIndex,
                     // Hide the "All Cameras" chip when the option is off.
                     showAllCameras:
                         widget.clientOptions?.showAllCamerasView ?? true,

--- a/apps/desktop-flutter/lib/state/ha_overlay_prefs.dart
+++ b/apps/desktop-flutter/lib/state/ha_overlay_prefs.dart
@@ -1,0 +1,72 @@
+// The global "hide Home Assistant overlays" quick-toggle.
+//
+// One operator-facing switch that suppresses EVERY on-video HA badge (icons,
+// pills, pinned captions, the tap-to-open state card) across every live pane —
+// wall tiles and the maximized pane alike. It is purely a DISPLAY gate: linking
+// entities, badge placement, the right-click menu items and the HA polling all
+// carry on exactly as before, so flipping it back restores the previous
+// overlay setup untouched. Default = overlays SHOWN.
+//
+// Persisted through `shared_preferences` (key [_kHiddenKey]) so the choice
+// survives a restart, degrading to in-memory-only for the session when the
+// plugin is unavailable — the same contract as the other client stores in this
+// directory (`stream_prefs.dart`, `keyboard_shortcuts.dart`).
+//
+// WHY A SINGLETON, when the sibling stores are constructed at the app root and
+// injected: this flag is WRITTEN from the live wall's toolbar (main.dart's
+// ViewSelectorBar) and the global hotkey, but READ two widget layers deep, at
+// the leaf HA overlay layers inside `wall_screen.dart`'s tile and maximized
+// pane. Threading it through those constructors would touch a lot of unrelated
+// call sites for a single app-wide bool; a `ChangeNotifier` singleton keeps the
+// wall diff to the two lines that actually gate the badges. Call [load] once
+// during app start-up ([_loadStores] in main.dart); reads before that simply
+// see the default.
+
+import 'dart:async' show unawaited;
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const String _kHiddenKey = 'crumb.ha_overlays_hidden';
+
+/// App-wide visibility of the on-video Home Assistant badge layer. Listen to it
+/// to rebuild when the operator toggles overlays on/off.
+class HaOverlayPrefs extends ChangeNotifier {
+  HaOverlayPrefs._();
+
+  /// The one instance — see the file header for why this is a singleton.
+  static final HaOverlayPrefs instance = HaOverlayPrefs._();
+
+  SharedPreferences? _prefs;
+  bool _hidden = false;
+
+  /// True when the operator has hidden every HA overlay. Default false
+  /// (overlays shown), including when the prefs plugin is unavailable.
+  bool get hidden => _hidden;
+
+  set hidden(bool value) {
+    if (_hidden == value) return;
+    _hidden = value;
+    unawaited(_prefs?.setBool(_kHiddenKey, value));
+    notifyListeners();
+  }
+
+  /// Flip the toggle — what the toolbar button and the hotkey both call.
+  void toggle() => hidden = !_hidden;
+
+  /// Read the persisted value. Safe to call more than once; a failure to reach
+  /// `shared_preferences` leaves the store in-memory-only for this session.
+  Future<void> load() async {
+    try {
+      _prefs = await SharedPreferences.getInstance();
+    } catch (_) {
+      _prefs = null; // plugin unavailable — in-memory only, per-session
+      return;
+    }
+    final stored = _prefs?.getBool(_kHiddenKey) ?? false;
+    if (stored != _hidden) {
+      _hidden = stored;
+      notifyListeners();
+    }
+  }
+}

--- a/apps/desktop-flutter/lib/state/keyboard_shortcuts.dart
+++ b/apps/desktop-flutter/lib/state/keyboard_shortcuts.dart
@@ -1,4 +1,5 @@
-// Remappable ACTION shortcut bindings (snapshot / toggle audio / perf HUD) —
+// Remappable ACTION shortcut bindings (snapshot / toggle audio / perf HUD /
+// hide HA overlays) —
 // the single-key "do something" hotkeys, as opposed to the per-camera number
 // keys ([HotkeyConfigStore], lib/state/hotkey_config.dart) and the inherent
 // transport keys (Space/arrows/,/. in playback_hotkeys_listener.dart), which
@@ -13,7 +14,7 @@
 // they don't need to listen.
 //
 // Every consumer treats a missing store (null) as "use the defaults" — the
-// hardcoded S/M/F8 the listeners shipped with — so nothing crashes if the
+// hardcoded S/M/F8/H the listeners shipped with — so nothing crashes if the
 // store failed to load.
 
 import 'dart:async' show unawaited;
@@ -33,7 +34,14 @@ enum ShortcutAction {
   toggleAudio('Toggle audio', 'Mute or unmute the active pane\'s audio.'),
 
   /// Show/hide the live performance HUD footer. Default `F8`.
-  hudToggle('Performance HUD', 'Show or hide the performance footer.');
+  hudToggle('Performance HUD', 'Show or hide the performance footer.'),
+
+  /// Hide/show every on-video Home Assistant badge, on every camera.
+  /// Default `H`.
+  haOverlayToggle(
+    'Home Assistant overlays',
+    'Hide or show the HA badges on live video.',
+  );
 
   const ShortcutAction(this.label, this.description);
 
@@ -49,6 +57,7 @@ enum ShortcutAction {
     ShortcutAction.snapshot => LogicalKeyboardKey.keyS,
     ShortcutAction.toggleAudio => LogicalKeyboardKey.keyM,
     ShortcutAction.hudToggle => LogicalKeyboardKey.f8,
+    ShortcutAction.haOverlayToggle => LogicalKeyboardKey.keyH,
   };
 }
 

--- a/apps/desktop-flutter/lib/ui/hotkeys/global_hotkeys_listener.dart
+++ b/apps/desktop-flutter/lib/ui/hotkeys/global_hotkeys_listener.dart
@@ -1,7 +1,6 @@
 // Global keyboard shortcuts: F8 (perf HUD), S (snapshot), M (toggle audio),
-// H (hide/show the Home Assistant overlays), Esc (restore maximize), and the
-// 1-9/0 + Shift+1-9/0 "go to camera" keys.
-// The four action keys (F8/S/M/H) are the DEFAULTS — a wired-up
+// Esc (restore maximize), and the 1-9/0 + Shift+1-9/0 "go to camera" keys.
+// The three action keys (F8/S/M) are the DEFAULTS — a wired-up
 // [KeyboardShortcutsStore] (Keyboard Shortcuts settings section) rebinds
 // them, and [ClientOptionsStore.hotkeysEnabled] is the master off switch for
 // everything except Esc.
@@ -98,7 +97,6 @@ class GlobalHotkeysListener extends StatelessWidget {
     this.onHudToggle,
     this.onSnapshot,
     this.onToggleAudio,
-    this.onToggleHaOverlays,
     this.onEscape,
     this.onUndo,
     this.onRedo,
@@ -140,10 +138,6 @@ class GlobalHotkeysListener extends StatelessWidget {
   /// M — toggle audio for the active camera. (app.js:4138-4141; wire to
   /// `AudioFollowController.toggleAudio()`.)
   final VoidCallback? onToggleAudio;
-
-  /// H — hide/show every on-video Home Assistant badge (wire to
-  /// `HaOverlayPrefs.instance.toggle`). Null on screens without live video.
-  final VoidCallback? onToggleHaOverlays;
 
   /// Esc — restore from maximize (only reached if nothing above this widget
   /// in the tree — e.g. `FullscreenEscHandler` — already consumed the Esc).
@@ -244,17 +238,6 @@ class GlobalHotkeysListener extends StatelessWidget {
                 LogicalKeyboardKey.keyM)) {
           if (onToggleAudio != null) {
             onToggleAudio!();
-            return KeyEventResult.handled;
-          }
-          return KeyEventResult.ignored;
-        }
-
-        // Hide/show the HA badge layer on every pane (default H) — remappable.
-        if (event.logicalKey ==
-            (shortcuts?.keyFor(ShortcutAction.haOverlayToggle) ??
-                LogicalKeyboardKey.keyH)) {
-          if (onToggleHaOverlays != null) {
-            onToggleHaOverlays!();
             return KeyEventResult.handled;
           }
           return KeyEventResult.ignored;

--- a/apps/desktop-flutter/lib/ui/hotkeys/global_hotkeys_listener.dart
+++ b/apps/desktop-flutter/lib/ui/hotkeys/global_hotkeys_listener.dart
@@ -1,6 +1,7 @@
 // Global keyboard shortcuts: F8 (perf HUD), S (snapshot), M (toggle audio),
-// Esc (restore maximize), and the 1-9/0 + Shift+1-9/0 "go to camera" keys.
-// The three action keys (F8/S/M) are the DEFAULTS — a wired-up
+// H (hide/show the Home Assistant overlays), Esc (restore maximize), and the
+// 1-9/0 + Shift+1-9/0 "go to camera" keys.
+// The four action keys (F8/S/M/H) are the DEFAULTS — a wired-up
 // [KeyboardShortcutsStore] (Keyboard Shortcuts settings section) rebinds
 // them, and [ClientOptionsStore.hotkeysEnabled] is the master off switch for
 // everything except Esc.
@@ -97,6 +98,7 @@ class GlobalHotkeysListener extends StatelessWidget {
     this.onHudToggle,
     this.onSnapshot,
     this.onToggleAudio,
+    this.onToggleHaOverlays,
     this.onEscape,
     this.onUndo,
     this.onRedo,
@@ -138,6 +140,10 @@ class GlobalHotkeysListener extends StatelessWidget {
   /// M — toggle audio for the active camera. (app.js:4138-4141; wire to
   /// `AudioFollowController.toggleAudio()`.)
   final VoidCallback? onToggleAudio;
+
+  /// H — hide/show every on-video Home Assistant badge (wire to
+  /// `HaOverlayPrefs.instance.toggle`). Null on screens without live video.
+  final VoidCallback? onToggleHaOverlays;
 
   /// Esc — restore from maximize (only reached if nothing above this widget
   /// in the tree — e.g. `FullscreenEscHandler` — already consumed the Esc).
@@ -238,6 +244,17 @@ class GlobalHotkeysListener extends StatelessWidget {
                 LogicalKeyboardKey.keyM)) {
           if (onToggleAudio != null) {
             onToggleAudio!();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        }
+
+        // Hide/show the HA badge layer on every pane (default H) — remappable.
+        if (event.logicalKey ==
+            (shortcuts?.keyFor(ShortcutAction.haOverlayToggle) ??
+                LogicalKeyboardKey.keyH)) {
+          if (onToggleHaOverlays != null) {
+            onToggleHaOverlays!();
             return KeyEventResult.handled;
           }
           return KeyEventResult.ignored;

--- a/apps/desktop-flutter/lib/ui/hotkeys/ha_overlay_hotkey.dart
+++ b/apps/desktop-flutter/lib/ui/hotkeys/ha_overlay_hotkey.dart
@@ -1,0 +1,117 @@
+// The "H" hotkey for the global hide-Home-Assistant-overlays toggle
+// ([HaOverlayPrefs]) — the keyboard twin of the wall toolbar's sensor button.
+//
+// WHY THIS IS NOT JUST A BRANCH IN [GlobalHotkeysListener]: that widget is a
+// `Focus.onKeyEvent` node mounted deep inside the live wall, and Flutter
+// dispatches a key event ONLY to the primary-focus node and its ANCESTORS. On
+// this app the primary focus sits at the app root: `FullscreenEscHandler`
+// (main.dart, `autofocus: true`, built first) claims the route scope's
+// `focusedChild`, and a scope applies at most one autofocus request
+// (`_Autofocus.applyIfValid` bails once `scope.focusedChild != null`), so the
+// wall listener's own `autofocus: true` is discarded. Its node is therefore a
+// DESCENDANT of the focused node, never an ancestor — off the dispatch chain,
+// its `onKeyEvent` never runs. Nothing on the wall hands it focus later
+// either: the tiles are `Listener`/`GestureDetector`, which take no keyboard
+// focus. That is why H did nothing on the wall and in the maximized pane while
+// the toolbar button worked.
+//
+// `HardwareKeyboard` handlers are the way out, and the pattern this app
+// already uses for exactly this problem (the clip player's Esc in
+// clips_screen.dart, the plates screen, main.dart's Shift-hints layer):
+// `KeyEventManager` invokes EVERY registered handler for every key event,
+// before and independent of focus dispatch. The trade-off is that the focus
+// chain's natural guards (a text field or a shortcut-capture box swallowing
+// the key first) no longer apply, so this widget re-checks them itself.
+//
+// Mount it around the live wall — one instance, for the lifetime of the Live
+// tab (Playback/Clips draw no HA badges). It registers on mount and
+// unregisters on dispose, so the key is inert on every other tab.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:crumb_desktop/state/client_options.dart';
+import 'package:crumb_desktop/state/keyboard_shortcuts.dart';
+import 'package:crumb_desktop/ui/hotkeys/text_focus.dart';
+
+/// Wires the HA-overlay toggle key (default `H`, remappable) to [onToggle],
+/// regardless of where keyboard focus currently sits.
+class HaOverlayHotkey extends StatefulWidget {
+  const HaOverlayHotkey({
+    super.key,
+    required this.child,
+    required this.onToggle,
+    this.options,
+    this.shortcuts,
+  });
+
+  final Widget child;
+
+  /// What the key does — the live wall passes `HaOverlayPrefs.instance.toggle`.
+  final VoidCallback onToggle;
+
+  /// The master "Enable keyboard shortcuts" switch. Read live at key-press
+  /// time so flipping it takes effect immediately. Null → shortcuts on.
+  final ClientOptionsStore? options;
+
+  /// Remapped binding (Keyboard Shortcuts settings). Read live at key-press
+  /// time like [options]; null → the default `H`.
+  final KeyboardShortcutsStore? shortcuts;
+
+  @override
+  State<HaOverlayHotkey> createState() => _HaOverlayHotkeyState();
+}
+
+class _HaOverlayHotkeyState extends State<HaOverlayHotkey> {
+  @override
+  void initState() {
+    super.initState();
+    HardwareKeyboard.instance.addHandler(_onKeyEvent);
+  }
+
+  @override
+  void dispose() {
+    HardwareKeyboard.instance.removeHandler(_onKeyEvent);
+    super.dispose();
+  }
+
+  /// Returns true only for the press it actually consumed — every other key
+  /// (and every guarded case) falls through to the normal focus dispatch.
+  bool _onKeyEvent(KeyEvent event) {
+    if (event is! KeyDownEvent) return false;
+    if (!mounted) return false;
+
+    final bound =
+        widget.shortcuts?.keyFor(ShortcutAction.haOverlayToggle) ??
+        LogicalKeyboardKey.keyH;
+    if (event.logicalKey != bound) return false;
+
+    // Modified presses belong to whatever owns Ctrl/Alt/Win chords, not here.
+    // (Shift is allowed: a bare letter binding fires as "H" either way.)
+    final keys = HardwareKeyboard.instance;
+    if (keys.isControlPressed || keys.isAltPressed || keys.isMetaPressed) {
+      return false;
+    }
+
+    // The guards the focus chain would have applied for us:
+    // typing an "h" into a label/search field must never toggle overlays…
+    if (textInputHasFocus()) return false;
+    // …a pushed route (dialog, picker, the bookmarks/config-view screens) owns
+    // the keyboard while it's up…
+    if (Navigator.maybeOf(context)?.canPop() ?? false) return false;
+    // …and the master shortcuts switch turns every shortcut off.
+    if (!(widget.options?.hotkeysEnabled ?? true)) return false;
+
+    // Deliberate: this still fires while the HA overlay EDITOR is open. The
+    // editor force-shows the badges so they stay placeable (wall_screen.dart's
+    // edit branch is not gated on the flag), so a press there is a
+    // toggle-after-close — the new state shows the moment the editor is
+    // dismissed, rather than yanking the badges out from under the editing
+    // session.
+    widget.onToggle();
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/apps/desktop-flutter/lib/ui/saved_views/view_selector_bar.dart
+++ b/apps/desktop-flutter/lib/ui/saved_views/view_selector_bar.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:crumb_desktop/api/crumb_api.dart';
 import 'package:crumb_desktop/api/models.dart';
 import 'package:crumb_desktop/api/views_api.dart';
+import 'package:crumb_desktop/state/ha_overlay_prefs.dart';
 import 'package:crumb_desktop/ui/saved_views/saved_views_screen.dart'
     show AppliedView;
 import 'package:crumb_desktop/ui/saved_views/view_prefs.dart';
@@ -22,6 +23,7 @@ class ViewSelectorBar extends StatefulWidget {
     required this.onApply,
     this.onSnapshot,
     this.onConfigView,
+    this.showHaOverlayToggle = false,
     this.showAllCameras = true,
   });
 
@@ -33,6 +35,12 @@ class ViewSelectorBar extends StatefulWidget {
   /// active pane, and open the view/layout editor ("Config View").
   final VoidCallback? onSnapshot;
   final VoidCallback? onConfigView;
+
+  /// Show the global "hide Home Assistant overlays" quick-toggle. Live-only —
+  /// Playback has no HA badge layer, so its copy of this bar leaves it off.
+  /// The button reads/writes [HaOverlayPrefs.instance] directly (app-wide flag,
+  /// no per-bar state).
+  final bool showHaOverlayToggle;
 
   /// The currently-applied view's id. Null or [ViewPrefs.allCamerasId] means
   /// the "All Cameras" chip is active.
@@ -138,7 +146,27 @@ class _ViewSelectorBarState extends State<ViewSelectorBar> {
                 ],
               ),
             ),
-            // Right controls (snapshot + Config View), matching the old client.
+            // Right controls (HA overlays + snapshot + Config View), matching
+            // the old client.
+            if (widget.showHaOverlayToggle)
+              ListenableBuilder(
+                listenable: HaOverlayPrefs.instance,
+                builder: (context, _) {
+                  final hidden = HaOverlayPrefs.instance.hidden;
+                  return IconButton(
+                    tooltip: hidden
+                        ? 'Show Home Assistant overlays'
+                        : 'Hide Home Assistant overlays',
+                    iconSize: 17,
+                    visualDensity: VisualDensity.compact,
+                    icon: Icon(hidden ? Icons.sensors_off : Icons.sensors),
+                    // Tinted while hidden — the non-default state should be
+                    // visible at a glance, so nobody hunts for "missing" badges.
+                    color: hidden ? scheme.primary : null,
+                    onPressed: HaOverlayPrefs.instance.toggle,
+                  );
+                },
+              ),
             if (widget.onSnapshot != null)
               IconButton(
                 tooltip: 'Snapshot (S)',

--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -33,6 +33,7 @@ import 'package:crumb_desktop/ui/ha_overlay/ha_badge_style_editor.dart';
 import 'package:crumb_desktop/ui/ha_overlay/ha_overlay_controller.dart';
 import 'package:crumb_desktop/ui/ha_overlay/ha_overlay_layer.dart';
 import 'package:crumb_desktop/ui/hotkeys/global_hotkeys_listener.dart';
+import 'package:crumb_desktop/ui/hotkeys/ha_overlay_hotkey.dart';
 import 'package:crumb_desktop/ui/live/pane_watchdog.dart';
 import 'package:crumb_desktop/ui/live_status/live_status_badges.dart';
 import 'package:crumb_desktop/ui/live_status/live_status_controller.dart';
@@ -701,11 +702,25 @@ class _WallScreenState extends State<WallScreen> {
       ),
     );
 
+    // H — hide/show every on-video HA badge, wall-wide (both the tiles and the
+    // maximized pane, which lives inside this subtree). Purely display; the
+    // right-click menu items stay available while hidden. It is a
+    // HardwareKeyboard hotkey, NOT a branch of the focus-chain listener below:
+    // that listener's node never holds primary focus on this screen, so a key
+    // branch in it would never run — see ha_overlay_hotkey.dart for the full
+    // why. Wrapping outermost keeps it live for the whole Live-tab lifetime.
+    Widget haKeyed(Widget child) => HaOverlayHotkey(
+      onToggle: HaOverlayPrefs.instance.toggle,
+      options: widget.clientOptions,
+      shortcuts: widget.shortcuts,
+      child: child,
+    );
+
     // Number-key hotkeys maximize the assigned camera; Esc restores; M toggles
     // audio. (S snapshot is handled by the app-level SnapshotHotkey.)
     final hk = widget.hotkeys;
-    if (hk == null) return scaffold;
-    return GlobalHotkeysListener(
+    if (hk == null) return haKeyed(scaffold);
+    final Widget keyed = GlobalHotkeysListener(
       store: hk,
       cameras: cams,
       autofocus: true,
@@ -737,9 +752,6 @@ class _WallScreenState extends State<WallScreen> {
       onToggleAudio: widget.audio == null
           ? null
           : () => widget.audio!.toggleAudio(),
-      // H — hide/show every on-video HA badge, wall-wide. Purely display; the
-      // right-click menu items stay available while hidden.
-      onToggleHaOverlays: HaOverlayPrefs.instance.toggle,
       // Ctrl+Z / Ctrl+Y drive the active overlay editor's undo/redo (issue
       // #4). Non-null only while an editor is open on the maximized pane, so
       // the shortcut is inert on the plain wall. The two editors are mutually
@@ -748,6 +760,7 @@ class _WallScreenState extends State<WallScreen> {
       onRedo: () => _activeOverlayEditor?.redo(),
       child: scaffold,
     );
+    return haKeyed(keyed);
   }
 
   /// The overlay-editor controller currently in edit mode (PTZ or HA), or null

--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -23,6 +23,7 @@ import 'package:crumb_desktop/services/snapshot_registry.dart';
 import 'package:crumb_desktop/src/rust/api/host.dart';
 import 'package:crumb_desktop/state/adaptive_wall.dart';
 import 'package:crumb_desktop/state/client_options.dart';
+import 'package:crumb_desktop/state/ha_overlay_prefs.dart';
 import 'package:crumb_desktop/state/hotkey_config.dart';
 import 'package:crumb_desktop/state/keyboard_shortcuts.dart';
 import 'package:crumb_desktop/state/stream_prefs.dart';
@@ -736,6 +737,9 @@ class _WallScreenState extends State<WallScreen> {
       onToggleAudio: widget.audio == null
           ? null
           : () => widget.audio!.toggleAudio(),
+      // H — hide/show every on-video HA badge, wall-wide. Purely display; the
+      // right-click menu items stay available while hidden.
+      onToggleHaOverlays: HaOverlayPrefs.instance.toggle,
       // Ctrl+Z / Ctrl+Y drive the active overlay editor's undo/redo (issue
       // #4). Non-null only while an editor is open on the maximized pane, so
       // the shortcut is inert on the plain wall. The two editors are mutually
@@ -2025,14 +2029,21 @@ class _WallTileState extends State<_WallTile> {
                 if (_haLinks.any((l) => l.hasPlacement))
                   Positioned.fill(
                     child: ListenableBuilder(
-                      listenable: widget.liveStatus,
+                      listenable: Listenable.merge([
+                        widget.liveStatus,
+                        HaOverlayPrefs.instance,
+                      ]),
                       builder: (context, _) => HaOverlayLayer(
                         links: _haLinks,
                         stateFor: widget.liveStatus.haStateFor,
                         stale: widget.liveStatus.haStale,
                         videoW: _videoW,
                         videoH: _videoH,
-                        hideBadges: _scale > 1.01,
+                        // Hidden while zoomed (badges sit outside the zoom
+                        // transform) or while the operator has switched the HA
+                        // overlays off wall-wide.
+                        hideBadges:
+                            _scale > 1.01 || HaOverlayPrefs.instance.hidden,
                         // Actuation plumbing for the badge tap card (#187) —
                         // inert unless the account holds `actuators`.
                         api: widget.api,
@@ -3072,14 +3083,23 @@ class _MaximizedPaneState extends State<_MaximizedPane> {
                 else if (_haLinks.any((l) => l.hasPlacement))
                   Positioned.fill(
                     child: ListenableBuilder(
-                      listenable: widget.liveStatus,
+                      listenable: Listenable.merge([
+                        widget.liveStatus,
+                        HaOverlayPrefs.instance,
+                      ]),
                       builder: (context, _) => HaOverlayLayer(
                         links: _haLinks,
                         stateFor: widget.liveStatus.haStateFor,
                         stale: widget.liveStatus.haStale,
                         videoW: _videoW,
                         videoH: _videoH,
-                        hideBadges: _scale > 1.01,
+                        // Same two gates as the wall tile's copy: digital zoom,
+                        // and the wall-wide "hide HA overlays" toggle. The EDIT
+                        // branch above is deliberately NOT gated — opening
+                        // "Edit HA overlay…" while overlays are hidden shows the
+                        // badges for the editor session so they stay placeable.
+                        hideBadges:
+                            _scale > 1.01 || HaOverlayPrefs.instance.hidden,
                         // Actuation plumbing for the badge tap card (#187) —
                         // inert unless the account holds `actuators`.
                         api: widget.api,

--- a/apps/desktop-flutter/test/global_hotkeys_focus_test.dart
+++ b/apps/desktop-flutter/test/global_hotkeys_focus_test.dart
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Regression test for "the H hotkey does nothing on the live wall" (PR #487).
+//
+// The action hotkeys used to live ONLY in [GlobalHotkeysListener], a
+// `Focus.onKeyEvent` node mounted deep inside the wall. Flutter dispatches a
+// key event to the primary-focus node and its ANCESTORS only, and the app root
+// (`FullscreenEscHandler`, `autofocus: true`, built first) permanently owns the
+// route scope's `focusedChild` — a scope applies at most one autofocus
+// (`_Autofocus.applyIfValid` bails once `scope.focusedChild != null`), so the
+// wall listener's own `autofocus: true` is discarded and its node sits BELOW
+// the focused node, off the dispatch chain. Nothing on the wall takes focus
+// either (tiles are `Listener`/`GestureDetector`), so the node never gets a
+// second chance.
+//
+// The fix routes the HA-overlay toggle through `HardwareKeyboard`, whose
+// handlers run for every key event regardless of where focus sits — the same
+// always-fires mechanism the clip player and the Shift-hint layer already use.
+//
+// These tests build the REAL app-root sandwich so the focus geometry under
+// test is the one the app actually ships.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:crumb_desktop/state/hotkey_config.dart';
+import 'package:crumb_desktop/ui/fullscreen/fullscreen_controller.dart';
+import 'package:crumb_desktop/ui/hotkeys/global_hotkeys_listener.dart';
+import 'package:crumb_desktop/ui/hotkeys/ha_overlay_hotkey.dart';
+import 'package:crumb_desktop/ui/snapshot/snapshot_hotkey.dart';
+
+/// The app-root wrapper stack from main.dart: MaterialApp -> Esc handler ->
+/// snapshot hotkey -> (screen).
+Widget _appRoot({required Widget child}) {
+  return MaterialApp(
+    home: FullscreenEscHandler(
+      controller: FullscreenController(),
+      child: SnapshotHotkey(child: child),
+    ),
+  );
+}
+
+void main() {
+  late HotkeyConfigStore store;
+
+  setUpAll(() async {
+    // Load the store OUTSIDE `testWidgets` — awaiting a platform-channel future
+    // inside its fake-async zone hangs the test.
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+    store = await HotkeyConfigStore.load();
+  });
+
+  testWidgets('a focus-chain listener under the app root never sees a key', (
+    tester,
+  ) async {
+    var seen = 0;
+    await tester.pumpWidget(
+      _appRoot(
+        child: GlobalHotkeysListener(
+          store: store,
+          cameras: const [],
+          autofocus: true, // discarded — the root already owns the scope
+          onToggleAudio: () => seen++,
+          child: const SizedBox.expand(),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyM);
+    await tester.pump();
+    // Not an endorsement — this pins down the geometry that broke H, and is
+    // why the toggle below is a HardwareKeyboard hotkey instead.
+    expect(seen, 0);
+  });
+
+  testWidgets('HaOverlayHotkey fires H no matter where focus sits', (
+    tester,
+  ) async {
+    var toggles = 0;
+    await tester.pumpWidget(
+      _appRoot(
+        child: HaOverlayHotkey(
+          onToggle: () => toggles++,
+          child: const SizedBox.expand(),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyH);
+    await tester.pump();
+    expect(toggles, 1);
+  });
+
+  testWidgets('HaOverlayHotkey stands down while a text field has focus', (
+    tester,
+  ) async {
+    var toggles = 0;
+    final controller = TextEditingController();
+    await tester.pumpWidget(
+      _appRoot(
+        child: HaOverlayHotkey(
+          onToggle: () => toggles++,
+          child: Material(
+            child: TextField(controller: controller, autofocus: true),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyH);
+    await tester.pump();
+    expect(toggles, 0);
+  });
+
+  testWidgets('HaOverlayHotkey unregisters when it leaves the tree', (
+    tester,
+  ) async {
+    var toggles = 0;
+    await tester.pumpWidget(
+      _appRoot(
+        child: HaOverlayHotkey(
+          onToggle: () => toggles++,
+          child: const SizedBox.expand(),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyH);
+    await tester.pump();
+    expect(toggles, 1);
+
+    // Leaving the Live tab tears the wall (and this widget) down.
+    await tester.pumpWidget(_appRoot(child: const SizedBox.expand()));
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyH);
+    await tester.pump();
+    expect(toggles, 1);
+  });
+}


### PR DESCRIPTION
## What

One click (or `H`) hides **every** on-video Home Assistant badge, sensors, controls, values, pinned captions and the tap-to-open state card, across every live pane: all wall tiles **and** the maximized/full view. Click again and they come back exactly as they were. The choice persists across app restarts.

Scope is the Flutter desktop client only (`apps/desktop-flutter/`).

## Behavior

- **Purely a display gate.** Entity linking, badge placement, HA polling and the right-click menus are untouched. A user who has hidden the overlays can still open "Link HA entities…" and "Edit HA overlay…" from either the tile or the maximized-pane context menu.
- **Editing while hidden:** opening the overlay editor shows the badges for the duration of that edit session (the edit branch is deliberately not gated), so placement stays WYSIWYG. Leaving the editor returns to the hidden state. This was the simpler of the two options in the design note and is documented inline.
- **Immediate**, no restart: the flag is a `ChangeNotifier` and the two overlay layers listen to it.
- Default is **overlays shown**, so nothing changes for anyone who doesn't touch the toggle.

## Surfaces

| | |
|---|---|
| Toolbar button | The live wall's view-selector bar, in the right-hand control cluster next to Snapshot. Live tab only (Playback draws no HA badges). Matching `IconButton` style (`iconSize: 17`, compact density). `Icons.sensors` / `Icons.sensors_off`, tinted with the tab accent while hidden so nobody hunts for "missing" badges. Tooltip: "Hide Home Assistant overlays" / "Show Home Assistant overlays". |
| Keyboard shortcut | **`H`** (previously unbound, verified against the reserved-key list, the camera number banks, and the existing S / M / F8 actions). Added as a remappable `ShortcutAction.haOverlayToggle`, so it lists itself in the Keyboard Shortcuts settings screen and can be rebound or reset like the others. |
| Persistence | `SharedPreferences` key `crumb.ha_overlays_hidden`, following the `stream_prefs.dart` / `keyboard_shortcuts.dart` pattern (degrades to in-memory-only for the session if the plugin is unavailable). |

## Implementation

- New `lib/state/ha_overlay_prefs.dart`: `HaOverlayPrefs`, a `ChangeNotifier` singleton, loaded once in `main.dart`'s `_loadStores()`.
  - It is a singleton rather than an injected store because it is **written** from the wall toolbar plus the global hotkey and **read** two widget layers deep, at the leaf HA overlay layers inside `wall_screen.dart`. Threading it through those constructors would touch a lot of unrelated call sites for one app-wide bool. The file header documents the trade-off.
- `wall_screen.dart` edits are deliberately minimal (2 gate sites + 1 hotkey callback + 1 import) to reduce conflict with #484, which touches the maximized-pane gesture branch.

## Testing

`flutter analyze` on the Windows build box: **zero issues in all six changed files**. The remaining findings are pre-existing, the vendored `rust_builder/cargokit` tree and one `integration_test/simple_test.dart` error, none introduced here.

Not covered by CI (the Flutter desktop client isn't in the Rust gate); a maintainer running the client can confirm the toggle, the `H` key, and that the setting survives a restart.

## Deferred

Per the scope of this change, only `apps/desktop-flutter/` is touched. The equivalent toggle for Android/iOS and any docs-site mention of the new shortcut are **not** included here.