### PR TITLE
feat(android): render per-state HA badge background color

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/data/HaModels.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/HaModels.kt
@@ -37,6 +37,11 @@ data class HaLinkDto(
     @SerialName("overlay_opacity") val overlayOpacity: Double? = null,
     @SerialName("overlay_shape") val overlayShape: String? = null,
     @SerialName("overlay_bg_color") val overlayBgColor: String? = null,
+    // Per-state ON background override (badge only; default null → today's
+    // overlay_bg_color-or-default behavior byte-for-byte). Applies ONLY when the
+    // entity's tri-state `active` (see `HaVisual.badgeVisual`) is true — scenes,
+    // stale, and unknown/indeterminate readings never use it.
+    @SerialName("overlay_bg_color_on") val overlayBgColorOn: String? = null,
     @SerialName("overlay_outline") val overlayOutline: Boolean = false,
     // ── Per-link control config (migration 0075, issue #440). Both default to
     // today's behavior, so an older server that omits them decodes unchanged

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaBadgeOverlay.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaBadgeOverlay.kt
@@ -59,9 +59,9 @@ import kotlin.math.min
 // confident "off/closed").
 
 // The canonical entity visual mapping (`badgeVisual`, `BadgeVisual`, the palette
-// incl. `BadgeDefaultBg`, `parseHexColor`) lives in `HaVisual.kt`, shared with the
-// entity sheet + more-info dialog so an entity reads identically wherever Android
-// draws it (#437).
+// incl. `BadgeDefaultBg`, `parseHexColor`, `resolveBadgeBg`) lives in `HaVisual.kt`,
+// shared with the entity sheet + more-info dialog so an entity reads identically
+// wherever Android draws it (#437).
 
 private const val BASE_REF_PX = 22f // reference badge size at pane-scale 1.0
 private const val REF_SHORT_SIDE = 320f
@@ -186,7 +186,7 @@ private fun HaBadge(
     // Stale when the server says so OR this client has missed >= 2 polls (#371).
     val stale = states?.stale == true || clientStale
     val visual = badgeVisual(link, st?.state, stale)
-    val bg = parseHexColor(link.overlayBgColor) ?: BadgeDefaultBg
+    val bg = resolveBadgeBg(link, visual.active)
     val opacity = (link.overlayOpacity?.toFloat() ?: 1f).coerceIn(0.05f, 1f)
     val isPill = link.overlayShape == "pill"
 

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaVisual.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaVisual.kt
@@ -352,3 +352,19 @@ internal fun parseHexColor(hex: String?): Color? {
     val v = h.toLongOrNull(16) ?: return null
     return Color(0xFF000000L or v)
 }
+
+/**
+ * The badge chip's background color: `overlay_bg_color_on` when the entity
+ * reads ON (and the operator set one) — else `overlay_bg_color` — else
+ * [BadgeDefaultBg]. Keyed on [active], the SAME tri-state `badgeVisual`
+ * computes (`active == true` = confidently on; `false`/`null` = off, scene,
+ * stale, or unknown), so a null `active` NEVER picks the on-color — same
+ * honesty rule the color/icon override already follows.
+ */
+internal fun resolveBadgeBg(link: HaLinkDto, active: Boolean?): Color {
+    val bg = parseHexColor(link.overlayBgColor)
+    if (active == true) {
+        parseHexColor(link.overlayBgColorOn)?.let { return it }
+    }
+    return bg ?: BadgeDefaultBg
+}

--- a/apps/android/app/src/test/java/video/crumb/app/feature/live/HaVisualActiveTest.kt
+++ b/apps/android/app/src/test/java/video/crumb/app/feature/live/HaVisualActiveTest.kt
@@ -23,11 +23,18 @@ class HaVisualActiveTest {
 
     private val json = Json { ignoreUnknownKeys = true }
 
-    private fun link(entityId: String, deviceClass: String? = null): HaLinkDto {
+    private fun link(
+        entityId: String,
+        deviceClass: String? = null,
+        bgColor: String? = null,
+        bgColorOn: String? = null,
+    ): HaLinkDto {
         val dc = if (deviceClass != null) ",\"device_class\":\"$deviceClass\"" else ""
+        val bg = if (bgColor != null) ",\"overlay_bg_color\":\"$bgColor\"" else ""
+        val bgOn = if (bgColorOn != null) ",\"overlay_bg_color_on\":\"$bgColorOn\"" else ""
         return json.decodeFromString(
             HaLinkDto.serializer(),
-            "{\"id\":\"l\",\"entity_id\":\"$entityId\",\"role\":\"actuator\",\"sort_order\":0$dc}",
+            "{\"id\":\"l\",\"entity_id\":\"$entityId\",\"role\":\"actuator\",\"sort_order\":0$dc$bg$bgOn}",
         )
     }
 
@@ -68,5 +75,49 @@ class HaVisualActiveTest {
         val v = badgeVisual(link("binary_sensor.front_door", deviceClass = "door"), "on", stale = false)
         assertEquals(true, v.active)
         assertEquals("Open", v.label)
+    }
+
+    // ── Badge chip background resolution: overlay_bg_color_on / overlay_bg_color
+    // / default, keyed on the SAME `active` tri-state above. ─────────────────────
+
+    @Test
+    fun `no overlay_bg_color_on decodes to null, unchanged byte-for-byte`() {
+        val l = link("light.kitchen", bgColor = "#112233")
+        assertNull(l.overlayBgColorOn)
+        // Existing bg-color-only behavior is untouched, on or off.
+        assertEquals(parseHexColor("#112233"), resolveBadgeBg(l, active = true))
+        assertEquals(parseHexColor("#112233"), resolveBadgeBg(l, active = false))
+    }
+
+    @Test
+    fun `an on entity with both colors set uses the ON background`() {
+        val l = link("light.kitchen", bgColor = "#112233", bgColorOn = "#ffcc00")
+        assertEquals(parseHexColor("#ffcc00"), resolveBadgeBg(l, active = true))
+    }
+
+    @Test
+    fun `an off entity with both colors set falls back to the base background`() {
+        val l = link("light.kitchen", bgColor = "#112233", bgColorOn = "#ffcc00")
+        assertEquals(parseHexColor("#112233"), resolveBadgeBg(l, active = false))
+    }
+
+    @Test
+    fun `stale or unknown active never uses the ON background`() {
+        val l = link("light.kitchen", bgColor = "#112233", bgColorOn = "#ffcc00")
+        assertEquals(parseHexColor("#112233"), resolveBadgeBg(l, active = null))
+    }
+
+    @Test
+    fun `neither color set falls back to BadgeDefaultBg`() {
+        val l = link("light.kitchen")
+        assertEquals(BadgeDefaultBg, resolveBadgeBg(l, active = true))
+        assertEquals(BadgeDefaultBg, resolveBadgeBg(l, active = false))
+        assertEquals(BadgeDefaultBg, resolveBadgeBg(l, active = null))
+    }
+
+    @Test
+    fun `only bg_color_on set, entity off, falls back to BadgeDefaultBg`() {
+        val l = link("light.kitchen", bgColorOn = "#ffcc00")
+        assertEquals(BadgeDefaultBg, resolveBadgeBg(l, active = false))
     }
 }


### PR DESCRIPTION
## Summary
- Render-only Android support for the per-state HA badge background contract: `HaLinkDto` gains a nullable `overlay_bg_color_on` (kotlinx default `null` -> today's behavior byte-for-byte).
- Badge chip background resolution (`HaVisual.resolveBadgeBg`, used by `HaBadgeOverlay.kt`): `active == true` -> `bg_color_on ?? bg_color ?? BadgeDefaultBg`; off/indeterminate/stale/scene -> `bg_color ?? BadgeDefaultBg`. Keyed on the same tri-state `active` `badgeVisual` already derives, so scenes/stale/unknown never pick up the on-color.
- Android has no HA-link write path (`GET /cameras/{id}/ha/links` only, no PUT/POST that resaves the link payload), so there is no resave-clobber risk to guard against.
- Extended `HaVisualActiveTest.kt` with 6 new cases covering: no `bg_color_on` -> unchanged behavior, on-with-both-set -> uses on-color, off-with-both-set -> falls back, stale/unknown -> never uses on-color, neither set -> default, only `bg_color_on` set + off -> default.

## Files changed
- `apps/android/app/src/main/java/video/crumb/app/data/HaModels.kt`
- `apps/android/app/src/main/java/video/crumb/app/feature/live/HaVisual.kt`
- `apps/android/app/src/main/java/video/crumb/app/feature/live/HaBadgeOverlay.kt`
- `apps/android/app/src/test/java/video/crumb/app/feature/live/HaVisualActiveTest.kt`

## Gate
GitHub Actions is in an outage, so this was gated manually on dev2 with a fresh clone of this branch (`ANDROID_HOME=/opt/android-sdk`, `GRADLE_USER_HOME=/root/.gradle`):
- `:app:assembleDebug` — BUILD SUCCESSFUL
- `:app:testDebugUnitTest` — BUILD SUCCESSFUL, all 11 `HaVisualActiveTest` cases pass (0 failures)

## Test plan
- [x] Gradle `assembleDebug` + `testDebugUnitTest` green on dev2 (see above)
- [ ] Jason: spot-check a badge with `overlay_bg_color_on` set on-device once a matching server build is available