### PR TITLE
feat(admin): author per-state HA badge background (bg_color_on)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaVisual.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaVisual.kt
@@ -9,15 +9,21 @@ import androidx.compose.material.icons.filled.BatteryFull
 import androidx.compose.material.icons.filled.Blinds
 import androidx.compose.material.icons.filled.BlindsClosed
 import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.Campaign
 import androidx.compose.material.icons.filled.CleaningServices
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.Co2
+import androidx.compose.material.icons.filled.Coffee
+import androidx.compose.material.icons.filled.Computer
 import androidx.compose.material.icons.filled.Curtains
+import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.DeviceThermostat
 import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.DirectionsRun
+import androidx.compose.material.icons.filled.Dns
 import androidx.compose.material.icons.filled.Doorbell
+import androidx.compose.material.icons.filled.Eco
 import androidx.compose.material.icons.filled.ElectricMeter
 import androidx.compose.material.icons.filled.ElectricalServices
 import androidx.compose.material.icons.filled.EvStation
@@ -25,9 +31,11 @@ import androidx.compose.material.icons.filled.Fence
 import androidx.compose.material.icons.filled.Garage
 import androidx.compose.material.icons.filled.GasMeter
 import androidx.compose.material.icons.filled.GppGood
+import androidx.compose.material.icons.filled.Grain
 import androidx.compose.material.icons.filled.Grass
 import androidx.compose.material.icons.filled.HeatPump
 import androidx.compose.material.icons.filled.Highlight
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.HotTub
 import androidx.compose.material.icons.filled.Hvac
 import androidx.compose.material.icons.filled.Inventory2
@@ -39,9 +47,12 @@ import androidx.compose.material.icons.filled.LocalLaundryService
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.LockOpen
 import androidx.compose.material.icons.filled.Mail
+import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MovieFilter
+import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.NotificationsActive
 import androidx.compose.material.icons.filled.Opacity
+import androidx.compose.material.icons.filled.OutdoorGrill
 import androidx.compose.material.icons.filled.Outlet
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Pets
@@ -49,6 +60,7 @@ import androidx.compose.material.icons.filled.Plumbing
 import androidx.compose.material.icons.filled.Pool
 import androidx.compose.material.icons.filled.Power
 import androidx.compose.material.icons.filled.PowerOff
+import androidx.compose.material.icons.filled.Print
 import androidx.compose.material.icons.filled.RollerShades
 import androidx.compose.material.icons.filled.Router
 import androidx.compose.material.icons.filled.Schedule
@@ -56,12 +68,19 @@ import androidx.compose.material.icons.filled.SensorDoor
 import androidx.compose.material.icons.filled.SensorOccupied
 import androidx.compose.material.icons.filled.SensorWindow
 import androidx.compose.material.icons.filled.Sensors
+import androidx.compose.material.icons.filled.SettingsRemote
 import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material.icons.filled.SmartButton
+import androidx.compose.material.icons.filled.SmartDisplay
+import androidx.compose.material.icons.filled.Smartphone
 import androidx.compose.material.icons.filled.SolarPower
 import androidx.compose.material.icons.filled.Speaker
+import androidx.compose.material.icons.filled.SportsEsports
+import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.Terminal
 import androidx.compose.material.icons.filled.Thermostat
+import androidx.compose.material.icons.filled.Thunderstorm
+import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.ToggleOn
 import androidx.compose.material.icons.filled.Tv
 import androidx.compose.material.icons.filled.Vibration
@@ -70,8 +89,12 @@ import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.filled.WaterDamage
 import androidx.compose.material.icons.filled.WaterDrop
 import androidx.compose.material.icons.filled.WbIncandescent
+import androidx.compose.material.icons.filled.WbCloudy
 import androidx.compose.material.icons.filled.WbSunny
+import androidx.compose.material.icons.filled.WbTwilight
+import androidx.compose.material.icons.filled.Whatshot
 import androidx.compose.material.icons.filled.Wifi
+import androidx.compose.material.icons.filled.WindPower
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import video.crumb.app.data.HaLinkDto
@@ -178,12 +201,14 @@ private val badgeIconSlugs: Map<String, ImageVector> = mapOf(
     "motion" to Icons.Filled.DirectionsRun,
     "occupancy" to Icons.Filled.SensorOccupied,
     "person" to Icons.Filled.Person,
+    "home" to Icons.Filled.Home,
     "pet" to Icons.Filled.Pets,
     "vibration" to Icons.Filled.Vibration,
     // lighting
     "lightbulb" to Icons.Filled.Lightbulb,
     "floodlight" to Icons.Filled.Highlight,
     "outdoor_light" to Icons.Filled.WbIncandescent,
+    "landscape_light" to Icons.Filled.WbTwilight,
     // power & switches
     "switch" to Icons.Filled.ToggleOn,
     "power" to Icons.Filled.Power,
@@ -203,6 +228,12 @@ private val badgeIconSlugs: Map<String, ImageVector> = mapOf(
     "temperature" to Icons.Filled.DeviceThermostat,
     "humidity" to Icons.Filled.Opacity,
     "sun" to Icons.Filled.WbSunny,
+    // weather
+    "cloud" to Icons.Filled.WbCloudy,
+    "rain" to Icons.Filled.Grain,
+    "wind" to Icons.Filled.WindPower,
+    "storm" to Icons.Filled.Thunderstorm,
+    "moon" to Icons.Filled.DarkMode,
     // safety & alarm
     "smoke" to Icons.Filled.Cloud,
     "gas" to Icons.Filled.GasMeter,
@@ -221,9 +252,19 @@ private val badgeIconSlugs: Map<String, ImageVector> = mapOf(
     "camera" to Icons.Filled.Videocam,
     "tv" to Icons.Filled.Tv,
     "speaker" to Icons.Filled.Speaker,
-    // network
+    "media_player" to Icons.Filled.SmartDisplay,
+    "remote" to Icons.Filled.SettingsRemote,
+    "game" to Icons.Filled.SportsEsports,
+    "mic" to Icons.Filled.Mic,
+    "music" to Icons.Filled.MusicNote,
+    // network & computing
     "wifi" to Icons.Filled.Wifi,
     "router" to Icons.Filled.Router,
+    "printer" to Icons.Filled.Print,
+    "server" to Icons.Filled.Dns,
+    "computer" to Icons.Filled.Computer,
+    "storage" to Icons.Filled.Storage,
+    "phone" to Icons.Filled.Smartphone,
     // vehicles & delivery
     "vehicle" to Icons.Filled.DirectionsCar,
     "package" to Icons.Filled.Inventory2,
@@ -235,8 +276,14 @@ private val badgeIconSlugs: Map<String, ImageVector> = mapOf(
     "laundry" to Icons.Filled.LocalLaundryService,
     "pool" to Icons.Filled.Pool,
     "hottub" to Icons.Filled.HotTub,
+    "grill" to Icons.Filled.OutdoorGrill,
+    "smoker" to Icons.Filled.Whatshot,
+    "coffee" to Icons.Filled.Coffee,
+    "plant" to Icons.Filled.Eco,
     // time
     "clock" to Icons.Filled.Schedule,
+    "calendar" to Icons.Filled.CalendarToday,
+    "timer" to Icons.Filled.Timer,
     // automation
     "scene" to Icons.Filled.MovieFilter,
     "script" to Icons.Filled.Terminal,

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_icons.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_icons.dart
@@ -29,8 +29,12 @@
 // `water_drop`, `local_fire_department`, `thermostat`, `lock`, `lock_open`,
 // `videocam`, `pets`, `window`, `co2`, `water_damage`, and the #438 additions
 // `blinds_closed`, `outlet`, `device_thermostat`, `gas_meter`, `terminal`,
-// `smart_button`. `directions_run` and `sensors` ARE already used elsewhere
-// (confirmed safe).
+// `smart_button`, plus the vocabulary-expansion additions `wb_twilight`,
+// `wb_cloudy`, `grain`, `wind_power`, `thunderstorm`, `dark_mode`,
+// `smart_display`, `settings_remote`, `sports_esports`, `music_note`, `print`,
+// `dns`, `computer`, `storage`, `smartphone`, `outdoor_grill`, `whatshot`,
+// `coffee`, `eco`, `calendar_today`, `timer` (and `home`, `mic` already common).
+// `directions_run` and `sensors` ARE already used elsewhere (confirmed safe).
 
 import 'package:flutter/material.dart';
 
@@ -202,6 +206,30 @@ const Map<String, (IconData, String)> kHaBadgeIconChoices = {
   'gas': (Icons.gas_meter, 'Gas / CO'),
   'script': (Icons.terminal, 'Script'),
   'button': (Icons.smart_button, 'Button'),
+  // ── vocabulary expansion: outdoor cooking, weather, media/compute, etc. ─────
+  'home': (Icons.home, 'Home / zone'),
+  'landscape_light': (Icons.wb_twilight, 'Landscape light'),
+  'cloud': (Icons.wb_cloudy, 'Cloud / weather'),
+  'rain': (Icons.grain, 'Rain'),
+  'wind': (Icons.wind_power, 'Wind'),
+  'storm': (Icons.thunderstorm, 'Storm'),
+  'moon': (Icons.dark_mode, 'Moon / night'),
+  'media_player': (Icons.smart_display, 'Media player'),
+  'remote': (Icons.settings_remote, 'Remote'),
+  'game': (Icons.sports_esports, 'Game'),
+  'mic': (Icons.mic, 'Microphone'),
+  'music': (Icons.music_note, 'Music'),
+  'printer': (Icons.print, 'Printer'),
+  'server': (Icons.dns, 'Server'),
+  'computer': (Icons.computer, 'Computer'),
+  'storage': (Icons.storage, 'Storage / NAS'),
+  'phone': (Icons.smartphone, 'Phone'),
+  'grill': (Icons.outdoor_grill, 'Grill / BBQ'),
+  'smoker': (Icons.whatshot, 'Smoker'),
+  'coffee': (Icons.coffee, 'Coffee'),
+  'plant': (Icons.eco, 'Plant'),
+  'calendar': (Icons.calendar_today, 'Calendar'),
+  'timer': (Icons.timer, 'Timer'),
 };
 
 /// Parse a stored '#RRGGBB' badge color override into a [Color] (full

--- a/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
+++ b/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
@@ -219,7 +219,9 @@ enum HA {
     ///
     /// iOS has no dedicated window-covering symbol on our iOS 16 floor, so
     /// cover/blinds/curtains/shade all resolve to `window.vertical.closed`; that
-    /// is an honest, compilable choice, not a missing glyph.
+    /// is an honest, compilable choice, not a missing glyph. Likewise the iOS 16
+    /// floor has no grill/BBQ or kitchen-appliance symbols, so outdoor cooking
+    /// leans on flame/smoke (`grill`→`flame.fill`, `smoker`→`smoke.fill`).
     static let iconSlugToSymbol: [String: String] = [
         // contact & openings
         "door": "door.left.hand.closed", "window": "window.vertical.closed",
@@ -229,10 +231,10 @@ enum HA {
         "lock": "lock.fill", "key": "key.fill",
         // motion & presence
         "motion": "figure.run", "occupancy": "person.fill", "person": "person.fill",
-        "pet": "pawprint.fill", "vibration": "waveform",
+        "home": "house.fill", "pet": "pawprint.fill", "vibration": "waveform",
         // lighting
         "lightbulb": "lightbulb.fill", "floodlight": "flashlight.on.fill",
-        "outdoor_light": "lightbulb.fill",
+        "outdoor_light": "lightbulb.fill", "landscape_light": "light.beacon.max.fill",
         // power & switches
         "switch": "switch.2", "power": "power", "plug": "powerplug.fill",
         "outlet": "poweroutlet.type.b.fill", "energy": "bolt.fill", "meter": "gauge",
@@ -241,6 +243,9 @@ enum HA {
         "fan": "fanblades.fill", "ac": "snowflake", "heatpump": "thermometer.snowflake",
         "hvac": "wind", "thermostat": "thermometer", "temperature": "thermometer",
         "humidity": "humidity.fill", "sun": "sun.max.fill",
+        // weather
+        "cloud": "cloud.fill", "rain": "cloud.rain.fill", "wind": "wind",
+        "storm": "cloud.bolt.rain.fill", "moon": "moon.fill",
         // safety & alarm
         "smoke": "smoke.fill", "gas": "carbon.monoxide.cloud.fill",
         "co": "carbon.dioxide.cloud.fill", "fire": "flame.fill",
@@ -250,15 +255,21 @@ enum HA {
         "bell": "bell.fill",
         // camera & media
         "camera": "video.fill", "tv": "tv", "speaker": "hifispeaker.fill",
-        // network
+        "media_player": "play.tv.fill", "remote": "av.remote.fill",
+        "game": "gamecontroller.fill", "mic": "mic.fill", "music": "music.note",
+        // network & computing
         "wifi": "wifi", "router": "network",
+        "printer": "printer.fill", "server": "server.rack", "computer": "desktopcomputer",
+        "storage": "externaldrive.fill", "phone": "iphone",
         // vehicles & delivery
         "vehicle": "car.fill", "package": "shippingbox.fill", "mail": "envelope.fill",
         // appliances & outdoor
         "vacuum": "sparkles", "lawn": "leaf.fill", "fridge": "snowflake",
         "laundry": "tshirt.fill", "pool": "figure.pool.swim", "hottub": "water.waves",
+        "grill": "flame.fill", "smoker": "smoke.fill", "coffee": "cup.and.saucer.fill",
+        "plant": "leaf.circle.fill",
         // time
-        "clock": "clock.fill",
+        "clock": "clock.fill", "calendar": "calendar", "timer": "timer",
         // automation
         "scene": "film", "script": "curlybraces", "button": "hand.tap.fill",
         // generic fallback

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -5208,6 +5208,7 @@ let HA_PICKER_SEARCH = '';
 let HA_PICKER_SHOWALL = false;
 let HA_STYLE_OPEN = null;     // index of the HA_LINKS row whose icon/style editor is expanded
 let HA_CTRL_OPEN = null;      // index of the HA_LINKS row whose control-config editor is expanded
+let HA_STYLE_PREVIEW_ON = {}; // HA_LINKS index -> bool: which state (on/off) the style mockup is currently showing
 // device_classes worth linking to a camera; the rest hide under "Other sensors".
 const HA_SENSOR_CLASSES = ['motion','occupancy','presence','moving','door','window','opening','garage_door'];
 
@@ -5582,6 +5583,7 @@ function haMapLinkFromServer(l) {
     overlay_opacity: l.overlay_opacity ?? null,
     overlay_shape: l.overlay_shape ?? null,
     overlay_bg_color: l.overlay_bg_color ?? null,
+    overlay_bg_color_on: l.overlay_bg_color_on ?? null,
     overlay_outline: !!l.overlay_outline,
   };
 }
@@ -5599,6 +5601,7 @@ async function loadCameraHaLinks(camId) {
     HA_PICKER = null;
     HA_STYLE_OPEN = null;
     HA_CTRL_OPEN = null;
+    HA_STYLE_PREVIEW_ON = {};
     const configured = !!(cfg && cfg.enabled && cfg.base_url && cfg.has_token);
     renderHaLinks(configured);
   } catch (e) {
@@ -5675,11 +5678,14 @@ function haToggleCtrl(i) {
    in a live video canvas here (issue #439 — "a clean functional editor beats
    a fancy broken one"). Shows the icon SLUG as text: the console has no
    glyph atlas (that lives in the three native clients), so the slug itself
-   is the honest preview. */
-function haBadgePreviewHtml(l) {
+   is the honest preview. `onState` picks which of bg_color/bg_color_on the
+   mockup renders (see the On/Off chips in haStylePanel); base bg_color is
+   what actually shows while off/unknown, bg_color_on overrides it while on,
+   falling back to bg_color when unset ("Follows Off"). */
+function haBadgePreviewHtml(l, onState) {
   const shape = l.overlay_shape || 'dot';
   const color = l.overlay_color || '#3ddc84';
-  const bg = l.overlay_bg_color || '#1a1a1a';
+  const bg = onState ? (l.overlay_bg_color_on ?? l.overlay_bg_color ?? '#17171B') : (l.overlay_bg_color ?? '#17171B');
   const size = l.overlay_size != null ? l.overlay_size : 1;
   const opacity = l.overlay_opacity != null ? l.overlay_opacity : 1;
   const icon = l.overlay_icon || 'sensor';
@@ -5701,8 +5707,12 @@ function haStylePanel(i, l) {
   return `
     <div style="margin-top:8px;padding-top:8px;border-top:1px dashed var(--border);display:flex;gap:16px;flex-wrap:wrap;align-items:flex-start">
       <div style="display:flex;flex-direction:column;align-items:center;gap:4px">
-        <div id="ha-style-preview-${i}">${haBadgePreviewHtml(l)}</div>
+        <div id="ha-style-preview-${i}">${haBadgePreviewHtml(l, !!HA_STYLE_PREVIEW_ON[i])}</div>
         <span style="font-size:10px;color:var(--dim2)">Preview</span>
+        <div class="seg-toggle" role="group" aria-label="Preview state" style="margin-top:2px">
+          <button type="button" id="ha-preview-off-${i}" class="seg-btn ${!HA_STYLE_PREVIEW_ON[i] ? 'active' : ''}" style="padding:3px 8px;font-size:11px;min-height:auto" onclick="haSetPreviewState(${i}, false)">Off</button>
+          <button type="button" id="ha-preview-on-${i}" class="seg-btn ${HA_STYLE_PREVIEW_ON[i] ? 'active' : ''}" style="padding:3px 8px;font-size:11px;min-height:auto" onclick="haSetPreviewState(${i}, true)">On</button>
+        </div>
       </div>
       <div class="form-grid" style="min-width:170px">
         <label class="fg-label" style="margin-top:0">Icon</label>
@@ -5725,6 +5735,11 @@ function haStylePanel(i, l) {
         <div class="fg-ctl">
           <input type="color" value="${l.overlay_bg_color || '#1a1a1a'}" oninput="haStyleSet(${i}, 'overlay_bg_color', this.value)" style="width:44px;padding:0" />
           <button class="ghost sm" onclick="haStyleSet(${i}, 'overlay_bg_color', null)" title="Clear override, use the default dark background">Auto</button>
+        </div>
+        <label class="fg-label">Background (on)</label>
+        <div class="fg-ctl">
+          <input type="color" value="${l.overlay_bg_color_on || l.overlay_bg_color || '#1a1a1a'}" oninput="haStyleSet(${i}, 'overlay_bg_color_on', this.value)" style="width:44px;padding:0" />
+          <button class="ghost sm" onclick="haStyleSet(${i}, 'overlay_bg_color_on', null)" title="Clear override, follow the Background color while the entity is on">Auto (follows Off)</button>
         </div>
       </div>
       <div class="form-grid" style="min-width:170px">
@@ -5750,10 +5765,22 @@ function haStyleSet(i, field, value) {
   l[field] = value;
   if (field === 'overlay_size') { const e = $('ha-size-val-' + i); if (e) e.textContent = value.toFixed(2) + '×'; }
   if (field === 'overlay_opacity') { const e = $('ha-opacity-val-' + i); if (e) e.textContent = Math.round(value * 100) + '%'; }
-  const prev = $('ha-style-preview-' + i); if (prev) prev.innerHTML = haBadgePreviewHtml(l);
+  const prev = $('ha-style-preview-' + i); if (prev) prev.innerHTML = haBadgePreviewHtml(l, !!HA_STYLE_PREVIEW_ON[i]);
 }
 
-/* Persists icon/shape/color/bg_color/size/opacity via PUT .../placement.
+/* On/Off preview toggle in the style mockup (does not touch saved state): flips
+   which of bg_color / bg_color_on the swatch renders, so authoring bg_color_on
+   without a live entity to test against still shows the honest result. */
+function haSetPreviewState(i, on) {
+  const l = HA_LINKS[i]; if (!l) return;
+  HA_STYLE_PREVIEW_ON[i] = on;
+  const prev = $('ha-style-preview-' + i); if (prev) prev.innerHTML = haBadgePreviewHtml(l, on);
+  const offBtn = $('ha-preview-off-' + i), onBtn = $('ha-preview-on-' + i);
+  if (offBtn) offBtn.classList.toggle('active', !on);
+  if (onBtn) onBtn.classList.toggle('active', on);
+}
+
+/* Persists icon/shape/color/bg_color/bg_color_on/size/opacity via PUT .../placement.
    Only valid once the link has a server id (issue #439 — save links first).
    Preserves the link's existing x/y (or centers it if never placed) and its
    show_state/show_age/outline, and deliberately OMITS `label` from the body:
@@ -5775,6 +5802,7 @@ async function haSaveStyle(i) {
     opacity: l.overlay_opacity != null ? l.overlay_opacity : 1,
     shape: l.overlay_shape || null,
     bg_color: l.overlay_bg_color || null,
+    bg_color_on: l.overlay_bg_color_on || null,
     outline: !!l.overlay_outline,
   };
   try {
@@ -5926,7 +5954,7 @@ function haPick(entity_id) {
     id: null, entity_id, role, device_class: ent.device_class || null, label: ent.friendly_name || null, sort_order: HA_LINKS.length,
     require_confirm: false, allowed_actions: null,
     overlay_x: null, overlay_y: null, overlay_size: null, overlay_color: null, overlay_icon: null,
-    overlay_show_state: false, overlay_show_age: false, overlay_opacity: null, overlay_shape: null, overlay_bg_color: null, overlay_outline: false,
+    overlay_show_state: false, overlay_show_age: false, overlay_opacity: null, overlay_shape: null, overlay_bg_color: null, overlay_bg_color_on: null, overlay_outline: false,
   });
   renderHaLinks(true);
 }
@@ -5935,6 +5963,7 @@ function removeHaLink(i) {
   HA_LINKS.splice(i, 1);
   HA_STYLE_OPEN = null;
   HA_CTRL_OPEN = null;
+  HA_STYLE_PREVIEW_ON = {};
   renderHaLinks(true);
 }
 
@@ -5954,6 +5983,7 @@ async function saveHaLinks() {
     HA_PICKER = null;
     HA_STYLE_OPEN = null;
     HA_CTRL_OPEN = null;
+    HA_STYLE_PREVIEW_ON = {};
     toast('Home Assistant links saved.');
     renderHaLinks(true);
   } catch (e) {

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -5218,16 +5218,17 @@ const HA_SENSOR_CLASSES = ['motion','occupancy','presence','moving','door','wind
    not significant) or a save here will fail server-side validation. */
 const HA_ICON_SLUGS = [
   'door','window','gate','garage','cover','blinds','curtains','shade','lock','key',
-  'motion','occupancy','person','pet','vibration',
-  'lightbulb','floodlight','outdoor_light',
+  'motion','occupancy','person','home','pet','vibration',
+  'lightbulb','floodlight','outdoor_light','landscape_light',
   'switch','power','plug','outlet','energy','meter','battery','solar','ev',
   'fan','ac','heatpump','hvac','thermostat','temperature','humidity','sun',
+  'cloud','rain','wind','storm','moon',
   'smoke','gas','co','fire','leak','water','valve','siren','security','armed','warning','doorbell','bell',
-  'camera','tv','speaker',
-  'wifi','router',
+  'camera','tv','speaker','media_player','remote','game','mic','music',
+  'wifi','router','printer','server','computer','storage','phone',
   'vehicle','package','mail',
-  'vacuum','lawn','fridge','laundry','pool','hottub',
-  'clock',
+  'vacuum','lawn','fridge','laundry','pool','hottub','grill','smoker','coffee','plant',
+  'clock','calendar','timer',
   'scene','script','button',
   'sensor',
 ];

--- a/services/api/src/ha.rs
+++ b/services/api/src/ha.rs
@@ -599,12 +599,14 @@ pub const CANONICAL_ICON_SLUGS: &[&str] = &[
     "motion",
     "occupancy",
     "person",
+    "home",
     "pet",
     "vibration",
     // lighting
     "lightbulb",
     "floodlight",
     "outdoor_light",
+    "landscape_light",
     // power & switches
     "switch",
     "power",
@@ -624,6 +626,12 @@ pub const CANONICAL_ICON_SLUGS: &[&str] = &[
     "temperature",
     "humidity",
     "sun",
+    // weather
+    "cloud",
+    "rain",
+    "wind",
+    "storm",
+    "moon",
     // safety & alarm (incl. smoke/gas/CO problem sensors)
     "smoke",
     "gas",
@@ -642,9 +650,19 @@ pub const CANONICAL_ICON_SLUGS: &[&str] = &[
     "camera",
     "tv",
     "speaker",
-    // network
+    "media_player",
+    "remote",
+    "game",
+    "mic",
+    "music",
+    // network & computing
     "wifi",
     "router",
+    "printer",
+    "server",
+    "computer",
+    "storage",
+    "phone",
     // vehicles & delivery
     "vehicle",
     "package",
@@ -656,8 +674,14 @@ pub const CANONICAL_ICON_SLUGS: &[&str] = &[
     "laundry",
     "pool",
     "hottub",
+    "grill",
+    "smoker",
+    "coffee",
+    "plant",
     // time
     "clock",
+    "calendar",
+    "timer",
     // automation
     "scene",
     "script",


### PR DESCRIPTION
## Summary
- Admin-console-only change (`services/api/src/admin.html`) implementing the authoring UI for the frozen contract: placement save body gains nullable `bg_color_on`, link DTO exposes `overlay_bg_color_on`. Base `bg_color` renders off/unknown; `bg_color_on` overrides while on; null inherits from base ("Follows Off").
- `haStylePanel`: new "Background (on)" row under the existing Background color row, with its own color input and an "Auto (follows Off)" reset button that sends `null`.
- `haSaveStyle` body gains `bg_color_on`; `haMapLinkFromServer` and the unplaced-link defaults literal (in `haPick`) gain `overlay_bg_color_on` so a full links-resave round-trips it — this is the exact #439 clobber-bug pattern the task called out, and it's now covered.
- `haBadgePreviewHtml` takes an `onState` param and the style panel gets a small On/Off preview toggle (`seg-btn` chips, matching the existing watchlist segmented-toggle pattern) so the mockup shows the state being edited: On uses `bg_color_on ?? bg_color ?? default`, Off uses `bg_color ?? default`.
- Preview-only nit: aligned the mockup's default-bg literal from `#1a1a1a` to the clients' `#17171B` (the editor's own color-input fallback is untouched, still `#1a1a1a`).
- New `HA_STYLE_PREVIEW_ON` index-keyed state resets alongside `HA_STYLE_OPEN`/`HA_CTRL_OPEN` on camera switch, link removal, and links-resave, since it's indexed by `HA_LINKS` position and those operations can shift indices.

## Branch note
Stacked on `origin/feat/ha-icon-vocabulary-expansion` per the task's branch-base instruction (that branch rewrites parts of the HA style panel). This PR's base will need to retarget to `main` after the icon-vocabulary-expansion branch merges.

## Manual gate (GitHub Actions is in an outage)
Ran the equivalent checks manually since CI can't run right now:
- Extracted the inline `<script>` block from `admin.html` and ran `node --check` on it — passes clean.
- Grepped every `on*="fnName(...)"` handler reference (175 distinct names) against function/const declarations in the extracted script — all resolve except a benign `if` false-positive from pre-existing `onkeydown="if(event.key==='Enter')..."` patterns unrelated to this change.
- Manually traced the save round-trip: `haSaveStyle`'s placement body now sends `x,y,size,color,icon,show_state,show_age,opacity,shape,bg_color,bg_color_on,outline` (all pre-existing fields plus the new one); `haMapLinkFromServer` reads `overlay_bg_color_on` back from the server response; the unplaced-link defaults literal in `haPick` seeds it to `null` so a fresh link plus a full links-resave doesn't drop it.

Since this stacks on an unmerged branch and depends on server wave A (the `bg_color_on` field itself, added elsewhere), this should be re-verified once the base branch and server change are in and CI is healthy again.

## Test plan
- [ ] Rebuild the api image (`admin.html` is `include_str!`-embedded) and open a camera's HA links editor
- [ ] Expand a link's style editor, confirm the new "Background (on)" row renders under Background color
- [ ] Set a background-on color, click Save appearance, reload, confirm it persisted
- [ ] Click "Auto (follows Off)", Save, confirm it resets to null server-side
- [ ] Toggle the On/Off preview chips, confirm the mockup swatch updates to show `bg_color_on` vs `bg_color`
- [ ] Do a full "Save links" (not just style) with a bg_color_on set, confirm it survives the round-trip (the #439 clobber pattern)