### PR TITLE
feat(desktop): render per-state HA badge backgrounds (bg_color_on)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaVisual.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaVisual.kt
@@ -9,15 +9,21 @@ import androidx.compose.material.icons.filled.BatteryFull
 import androidx.compose.material.icons.filled.Blinds
 import androidx.compose.material.icons.filled.BlindsClosed
 import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.Campaign
 import androidx.compose.material.icons.filled.CleaningServices
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.Co2
+import androidx.compose.material.icons.filled.Coffee
+import androidx.compose.material.icons.filled.Computer
 import androidx.compose.material.icons.filled.Curtains
+import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.DeviceThermostat
 import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.DirectionsRun
+import androidx.compose.material.icons.filled.Dns
 import androidx.compose.material.icons.filled.Doorbell
+import androidx.compose.material.icons.filled.Eco
 import androidx.compose.material.icons.filled.ElectricMeter
 import androidx.compose.material.icons.filled.ElectricalServices
 import androidx.compose.material.icons.filled.EvStation
@@ -25,9 +31,11 @@ import androidx.compose.material.icons.filled.Fence
 import androidx.compose.material.icons.filled.Garage
 import androidx.compose.material.icons.filled.GasMeter
 import androidx.compose.material.icons.filled.GppGood
+import androidx.compose.material.icons.filled.Grain
 import androidx.compose.material.icons.filled.Grass
 import androidx.compose.material.icons.filled.HeatPump
 import androidx.compose.material.icons.filled.Highlight
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.HotTub
 import androidx.compose.material.icons.filled.Hvac
 import androidx.compose.material.icons.filled.Inventory2
@@ -39,9 +47,12 @@ import androidx.compose.material.icons.filled.LocalLaundryService
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.LockOpen
 import androidx.compose.material.icons.filled.Mail
+import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MovieFilter
+import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.NotificationsActive
 import androidx.compose.material.icons.filled.Opacity
+import androidx.compose.material.icons.filled.OutdoorGrill
 import androidx.compose.material.icons.filled.Outlet
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Pets
@@ -49,6 +60,7 @@ import androidx.compose.material.icons.filled.Plumbing
 import androidx.compose.material.icons.filled.Pool
 import androidx.compose.material.icons.filled.Power
 import androidx.compose.material.icons.filled.PowerOff
+import androidx.compose.material.icons.filled.Print
 import androidx.compose.material.icons.filled.RollerShades
 import androidx.compose.material.icons.filled.Router
 import androidx.compose.material.icons.filled.Schedule
@@ -56,12 +68,19 @@ import androidx.compose.material.icons.filled.SensorDoor
 import androidx.compose.material.icons.filled.SensorOccupied
 import androidx.compose.material.icons.filled.SensorWindow
 import androidx.compose.material.icons.filled.Sensors
+import androidx.compose.material.icons.filled.SettingsRemote
 import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material.icons.filled.SmartButton
+import androidx.compose.material.icons.filled.SmartDisplay
+import androidx.compose.material.icons.filled.Smartphone
 import androidx.compose.material.icons.filled.SolarPower
 import androidx.compose.material.icons.filled.Speaker
+import androidx.compose.material.icons.filled.SportsEsports
+import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.Terminal
 import androidx.compose.material.icons.filled.Thermostat
+import androidx.compose.material.icons.filled.Thunderstorm
+import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.ToggleOn
 import androidx.compose.material.icons.filled.Tv
 import androidx.compose.material.icons.filled.Vibration
@@ -70,8 +89,12 @@ import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.filled.WaterDamage
 import androidx.compose.material.icons.filled.WaterDrop
 import androidx.compose.material.icons.filled.WbIncandescent
+import androidx.compose.material.icons.filled.WbCloudy
 import androidx.compose.material.icons.filled.WbSunny
+import androidx.compose.material.icons.filled.WbTwilight
+import androidx.compose.material.icons.filled.Whatshot
 import androidx.compose.material.icons.filled.Wifi
+import androidx.compose.material.icons.filled.WindPower
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import video.crumb.app.data.HaLinkDto
@@ -178,12 +201,14 @@ private val badgeIconSlugs: Map<String, ImageVector> = mapOf(
     "motion" to Icons.Filled.DirectionsRun,
     "occupancy" to Icons.Filled.SensorOccupied,
     "person" to Icons.Filled.Person,
+    "home" to Icons.Filled.Home,
     "pet" to Icons.Filled.Pets,
     "vibration" to Icons.Filled.Vibration,
     // lighting
     "lightbulb" to Icons.Filled.Lightbulb,
     "floodlight" to Icons.Filled.Highlight,
     "outdoor_light" to Icons.Filled.WbIncandescent,
+    "landscape_light" to Icons.Filled.WbTwilight,
     // power & switches
     "switch" to Icons.Filled.ToggleOn,
     "power" to Icons.Filled.Power,
@@ -203,6 +228,12 @@ private val badgeIconSlugs: Map<String, ImageVector> = mapOf(
     "temperature" to Icons.Filled.DeviceThermostat,
     "humidity" to Icons.Filled.Opacity,
     "sun" to Icons.Filled.WbSunny,
+    // weather
+    "cloud" to Icons.Filled.WbCloudy,
+    "rain" to Icons.Filled.Grain,
+    "wind" to Icons.Filled.WindPower,
+    "storm" to Icons.Filled.Thunderstorm,
+    "moon" to Icons.Filled.DarkMode,
     // safety & alarm
     "smoke" to Icons.Filled.Cloud,
     "gas" to Icons.Filled.GasMeter,
@@ -221,9 +252,19 @@ private val badgeIconSlugs: Map<String, ImageVector> = mapOf(
     "camera" to Icons.Filled.Videocam,
     "tv" to Icons.Filled.Tv,
     "speaker" to Icons.Filled.Speaker,
-    // network
+    "media_player" to Icons.Filled.SmartDisplay,
+    "remote" to Icons.Filled.SettingsRemote,
+    "game" to Icons.Filled.SportsEsports,
+    "mic" to Icons.Filled.Mic,
+    "music" to Icons.Filled.MusicNote,
+    // network & computing
     "wifi" to Icons.Filled.Wifi,
     "router" to Icons.Filled.Router,
+    "printer" to Icons.Filled.Print,
+    "server" to Icons.Filled.Dns,
+    "computer" to Icons.Filled.Computer,
+    "storage" to Icons.Filled.Storage,
+    "phone" to Icons.Filled.Smartphone,
     // vehicles & delivery
     "vehicle" to Icons.Filled.DirectionsCar,
     "package" to Icons.Filled.Inventory2,
@@ -235,8 +276,14 @@ private val badgeIconSlugs: Map<String, ImageVector> = mapOf(
     "laundry" to Icons.Filled.LocalLaundryService,
     "pool" to Icons.Filled.Pool,
     "hottub" to Icons.Filled.HotTub,
+    "grill" to Icons.Filled.OutdoorGrill,
+    "smoker" to Icons.Filled.Whatshot,
+    "coffee" to Icons.Filled.Coffee,
+    "plant" to Icons.Filled.Eco,
     // time
     "clock" to Icons.Filled.Schedule,
+    "calendar" to Icons.Filled.CalendarToday,
+    "timer" to Icons.Filled.Timer,
     // automation
     "scene" to Icons.Filled.MovieFilter,
     "script" to Icons.Filled.Terminal,

--- a/apps/desktop-flutter/lib/api/ha_api.dart
+++ b/apps/desktop-flutter/lib/api/ha_api.dart
@@ -232,7 +232,15 @@ extension HaApi on CrumbApi {
   /// the live state text / relative age next to the badge on the wall.
   /// `label` edits the LINK-level caption and follows the `PUT /config/ha`
   /// token convention: null ⇒ unchanged, `''` ⇒ cleared, non-empty ⇒ set.
-  /// Returns the updated link.
+  /// `bgColorOn` is the per-state background override (wave A) — the badge's
+  /// background while the entity reads ON. Like every other style field here
+  /// (`color`/`icon`/`bgColor`/`shape`/`outline`), this PUT replaces the
+  /// WHOLE placement each call: a null `bgColorOn` is sent as absent and the
+  /// server resets it to unset (NOT "leave whatever was there"), so a caller
+  /// must always pass the link's CURRENT value forward, not just a change —
+  /// see `HaOverlayController.endEditAndSave`, which does exactly that so a
+  /// desktop save can never clobber a `bg_color_on` set elsewhere. Returns
+  /// the updated link.
   Future<HaLink> saveHaPlacement(
     Session s,
     String cameraId,
@@ -247,6 +255,7 @@ extension HaApi on CrumbApi {
     double opacity = 1.0,
     String? shape,
     String? bgColor,
+    String? bgColorOn,
     bool outline = false,
     String? label,
   }) async {
@@ -261,6 +270,7 @@ extension HaApi on CrumbApi {
       'opacity': opacity,
       if (shape != null) 'shape': shape,
       if (bgColor != null) 'bg_color': bgColor,
+      if (bgColorOn != null) 'bg_color_on': bgColorOn,
       'outline': outline,
       if (label != null) 'label': label,
     });

--- a/apps/desktop-flutter/lib/api/ha_models.dart
+++ b/apps/desktop-flutter/lib/api/ha_models.dart
@@ -24,6 +24,7 @@ class HaLink {
     this.overlayOpacity,
     this.overlayShape,
     this.overlayBgColor,
+    this.overlayBgColorOn,
     this.overlayOutline = false,
     this.requireConfirm = false,
     this.allowedActions,
@@ -80,6 +81,18 @@ class HaLink {
   /// dark background.
   final String? overlayBgColor;
 
+  /// Per-state background override: the badge background when the entity
+  /// reads ON (wave A backend contract). Null = no override — the badge keeps
+  /// [overlayBgColor] (or the default) regardless of state, exactly as today.
+  /// Never applied to an OFF, indeterminate/unknown, or stale reading, nor to
+  /// a scene (`on == null`) — resolution mirrors `ha_icons.dart`'s accent-dim
+  /// honesty gate: ON ⇒ `overlayBgColorOn ?? overlayBgColor ?? default`;
+  /// everything else ⇒ `overlayBgColor ?? default`. Parsed defensively (an
+  /// older server that omits the field decodes to null, i.e. today's
+  /// behavior) so this client degrades gracefully ahead of the server field
+  /// landing.
+  final String? overlayBgColorOn;
+
   /// White outline + drop shadow so the badge pops on a busy scene
   /// (migration 0062; default off).
   final bool overlayOutline;
@@ -135,6 +148,7 @@ class HaLink {
     overlayOpacity: (j['overlay_opacity'] as num?)?.toDouble(),
     overlayShape: j['overlay_shape'] as String?,
     overlayBgColor: j['overlay_bg_color'] as String?,
+    overlayBgColorOn: j['overlay_bg_color_on'] as String?,
     overlayOutline: (j['overlay_outline'] as bool?) ?? false,
     requireConfirm: (j['require_confirm'] as bool?) ?? false,
     allowedActions: (j['allowed_actions'] as List<dynamic>?)

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_icons.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_icons.dart
@@ -232,6 +232,19 @@ const Map<String, (IconData, String)> kHaBadgeIconChoices = {
   'timer': (Icons.timer, 'Timer'),
 };
 
+/// The honesty-gated on/off reading shared by every piece of badge chrome
+/// that varies with state (the accent-dim color below, and
+/// `ha_overlay_layer.dart`'s per-state background resolution): null
+/// (indeterminate) for a scene, a stale states feed, or no known state yet —
+/// NEVER a raw `edgeOn(state)` call in those cases, so nothing downstream can
+/// read "on" for a reading that isn't actually known. Kept as the single
+/// source of truth so the accent and the background can never disagree.
+bool? haEdgeOnFor({
+  required String domain,
+  required String? state,
+  required bool stale,
+}) => (state == null || stale || domain == 'scene') ? null : edgeOn(state);
+
 /// Parse a stored '#RRGGBB' badge color override into a [Color] (full
 /// opacity), or null for absent/malformed values.
 Color? parseOverlayColorHex(String? hex) {
@@ -316,9 +329,7 @@ HaVisual haVisualFor({
   final overrideIcon = iconOverride == null
       ? null
       : kHaBadgeIconChoices[iconOverride]?.$1;
-  final on = (state == null || stale || domain == 'scene')
-      ? null
-      : edgeOn(state);
+  final on = haEdgeOnFor(domain: domain, state: state, stale: stale);
   final Color color;
   if (colorOverride != null && on != null) {
     color = on ? colorOverride : colorOverride.withValues(alpha: 0.45);
@@ -345,7 +356,7 @@ HaVisual _haVisualDefault({
     return const HaVisual(Icons.movie_filter, _kNeutral, label: 'Scene');
   }
 
-  final on = (state == null || stale) ? null : edgeOn(state);
+  final on = haEdgeOnFor(domain: domain, state: state, stale: stale);
   if (on == null) {
     return HaVisual(
       _iconFor(domain: domain, deviceClass: deviceClass),

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_icons.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_icons.dart
@@ -29,8 +29,12 @@
 // `water_drop`, `local_fire_department`, `thermostat`, `lock`, `lock_open`,
 // `videocam`, `pets`, `window`, `co2`, `water_damage`, and the #438 additions
 // `blinds_closed`, `outlet`, `device_thermostat`, `gas_meter`, `terminal`,
-// `smart_button`. `directions_run` and `sensors` ARE already used elsewhere
-// (confirmed safe).
+// `smart_button`, plus the vocabulary-expansion additions `wb_twilight`,
+// `wb_cloudy`, `grain`, `wind_power`, `thunderstorm`, `dark_mode`,
+// `smart_display`, `settings_remote`, `sports_esports`, `music_note`, `print`,
+// `dns`, `computer`, `storage`, `smartphone`, `outdoor_grill`, `whatshot`,
+// `coffee`, `eco`, `calendar_today`, `timer` (and `home`, `mic` already common).
+// `directions_run` and `sensors` ARE already used elsewhere (confirmed safe).
 
 import 'package:flutter/material.dart';
 
@@ -202,6 +206,30 @@ const Map<String, (IconData, String)> kHaBadgeIconChoices = {
   'gas': (Icons.gas_meter, 'Gas / CO'),
   'script': (Icons.terminal, 'Script'),
   'button': (Icons.smart_button, 'Button'),
+  // ── vocabulary expansion: outdoor cooking, weather, media/compute, etc. ─────
+  'home': (Icons.home, 'Home / zone'),
+  'landscape_light': (Icons.wb_twilight, 'Landscape light'),
+  'cloud': (Icons.wb_cloudy, 'Cloud / weather'),
+  'rain': (Icons.grain, 'Rain'),
+  'wind': (Icons.wind_power, 'Wind'),
+  'storm': (Icons.thunderstorm, 'Storm'),
+  'moon': (Icons.dark_mode, 'Moon / night'),
+  'media_player': (Icons.smart_display, 'Media player'),
+  'remote': (Icons.settings_remote, 'Remote'),
+  'game': (Icons.sports_esports, 'Game'),
+  'mic': (Icons.mic, 'Microphone'),
+  'music': (Icons.music_note, 'Music'),
+  'printer': (Icons.print, 'Printer'),
+  'server': (Icons.dns, 'Server'),
+  'computer': (Icons.computer, 'Computer'),
+  'storage': (Icons.storage, 'Storage / NAS'),
+  'phone': (Icons.smartphone, 'Phone'),
+  'grill': (Icons.outdoor_grill, 'Grill / BBQ'),
+  'smoker': (Icons.whatshot, 'Smoker'),
+  'coffee': (Icons.coffee, 'Coffee'),
+  'plant': (Icons.eco, 'Plant'),
+  'calendar': (Icons.calendar_today, 'Calendar'),
+  'timer': (Icons.timer, 'Timer'),
 };
 
 /// Parse a stored '#RRGGBB' badge color override into a [Color] (full

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_controller.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_controller.dart
@@ -48,6 +48,7 @@ class HaOverlayBadgeItem implements OverlayItem {
       showAge = link.overlayShowAge,
       shape = link.overlayShape,
       bgColorHex = link.overlayBgColor,
+      bgColorOnHex = link.overlayBgColorOn,
       outline = link.overlayOutline;
 
   final HaLink link;
@@ -79,6 +80,14 @@ class HaOverlayBadgeItem implements OverlayItem {
   /// Solid background '#RRGGBB' override, or null for the default dark
   /// background (migration 0062).
   String? bgColorHex;
+
+  /// Per-state background override (wave A): the badge background while the
+  /// entity reads ON, or null for no override. No UI sets this yet (the
+  /// badge-style editor for it lands in a later PR) — this field exists
+  /// purely so an existing edit session (drag/resize/style-tweak on some
+  /// OTHER field) round-trips a value set elsewhere (e.g. by the admin
+  /// console) instead of silently clobbering it on save.
+  String? bgColorOnHex;
 
   /// White outline + drop shadow so the badge pops on a busy scene.
   bool outline;
@@ -185,6 +194,7 @@ class HaOverlayBadgeItem implements OverlayItem {
         showAge: showAge,
         shape: shape,
         bgColor: bgColorHex,
+        bgColorOn: bgColorOnHex,
         outline: outline,
         group: _groupId,
       );
@@ -203,6 +213,7 @@ class HaOverlayBadgeItem implements OverlayItem {
       bool showAge,
       String? shape,
       String? bgColor,
+      String? bgColorOn,
       bool outline,
       String? group,
     });
@@ -217,6 +228,7 @@ class HaOverlayBadgeItem implements OverlayItem {
     showAge = s.showAge;
     shape = s.shape;
     bgColorHex = s.bgColor;
+    bgColorOnHex = s.bgColorOn;
     outline = s.outline;
     _groupId = s.group;
   }
@@ -343,6 +355,7 @@ class HaOverlayController {
           opacity: item.opacity,
           shape: item.shape,
           bgColor: item.bgColorHex,
+          bgColorOn: item.bgColorOnHex,
           outline: item.outline,
           label: newLabel == oldLabel ? null : newLabel,
         );

--- a/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_layer.dart
+++ b/apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_layer.dart
@@ -103,6 +103,8 @@ OverlayItemBuilder haBadgeItemBuilder({
       isPill: badge.isPill,
       pillLabel: badge.pillLabel,
       bgColor: parseOverlayColorHex(badge.bgColorHex),
+      bgColorOn: parseOverlayColorHex(badge.bgColorOnHex),
+      on: haEdgeOnFor(domain: link.domain, state: state?.state, stale: stale),
       outline: badge.outline,
       // Jelly motion (entrance pop + state-change squish) runs only in view
       // mode; while editing the badge is a static drag target.
@@ -121,6 +123,20 @@ OverlayItemBuilder haBadgeItemBuilder({
 /// `Opacity` wrapper), NOT a hardcoded translucent scrim. This is the #170
 /// readability fix: at the default opacity the chip reads solid.
 const Color _kBadgeDefaultBg = Color(0xFF17171B);
+
+/// Resolve the badge's solid background per the per-state override contract
+/// (wave A, `overlay_bg_color_on`): entity ON ⇒ `bgColorOn ?? bgColor ??
+/// default`; OFF, indeterminate/unknown, or stale ⇒ `bgColor ?? default`. A
+/// scene or an unknown/stale reading NEVER picks the on-color — [on] must
+/// come from `ha_icons.dart`'s [haEdgeOnFor] (the same honesty gate that
+/// drives the accent dim), never a raw `edgeOn()` call, so a badge's
+/// background and its icon accent can never disagree about whether the
+/// entity is "really" on. Pulled out of [HaBadgeChip] as a pure function so
+/// the resolution order itself is unit-testable without pumping a widget.
+Color resolveBadgeBg({required bool? on, Color? bgColor, Color? bgColorOn}) {
+  if (on == true && bgColorOn != null) return bgColorOn;
+  return bgColor ?? _kBadgeDefaultBg;
+}
 
 /// Snappy spring (matches the operator-chosen preview: k380 / damping 21).
 const SpringDescription _kJellySpring = SpringDescription(
@@ -144,6 +160,8 @@ class HaBadgeChip extends StatefulWidget {
     this.isPill = false,
     this.pillLabel,
     this.bgColor,
+    this.bgColorOn,
+    this.on,
     this.outline = false,
     this.animate = false,
     this.stateKey,
@@ -159,8 +177,20 @@ class HaBadgeChip extends StatefulWidget {
   /// Text inside the pill (ignored for a dot).
   final String? pillLabel;
 
-  /// Solid background color; null = the default dark chip ([_kBadgeDefaultBg]).
+  /// Solid background color for an OFF/indeterminate/stale/scene reading (or
+  /// the only color, when [bgColorOn] is unset); null = the default dark chip
+  /// ([_kBadgeDefaultBg]).
   final Color? bgColor;
+
+  /// Solid background color for an ON reading (wave A per-state override);
+  /// null = no override, so the badge keeps [bgColor] regardless of state.
+  /// See [resolveBadgeBg] for the exact resolution order.
+  final Color? bgColorOn;
+
+  /// The honesty-gated on/off reading driving [bgColorOn] (must come from
+  /// `ha_icons.dart`'s `haEdgeOnFor`, the same gate behind [visual]'s accent
+  /// dim) — null for a scene, a stale feed, or no known state yet.
+  final bool? on;
 
   /// Draw a white outline + drop shadow.
   final bool outline;
@@ -263,7 +293,11 @@ class _HaBadgeChipState extends State<HaBadgeChip>
       );
 
   BoxDecoration _decoration(BoxShape shape, BorderRadius? radius) {
-    final bg = widget.bgColor ?? _kBadgeDefaultBg;
+    final bg = resolveBadgeBg(
+      on: widget.on,
+      bgColor: widget.bgColor,
+      bgColorOn: widget.bgColorOn,
+    );
     return BoxDecoration(
       color: bg,
       shape: shape,
@@ -301,7 +335,11 @@ class _HaBadgeChipState extends State<HaBadgeChip>
     final fontSize = (height * 0.40).clamp(8.0, 26.0).toDouble();
     final padH = (height * 0.28).clamp(5.0, 16.0).toDouble();
     final gap = (height * 0.14).clamp(3.0, 8.0).toDouble();
-    final bg = widget.bgColor ?? _kBadgeDefaultBg;
+    final bg = resolveBadgeBg(
+      on: widget.on,
+      bgColor: widget.bgColor,
+      bgColorOn: widget.bgColorOn,
+    );
     // Label uses a neutral that always reads on the chosen background; the
     // icon carries the state color.
     final labelColor =

--- a/apps/desktop-flutter/test/ha_overlay_bg_on_test.dart
+++ b/apps/desktop-flutter/test/ha_overlay_bg_on_test.dart
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Per-state HA badge background (`overlay_bg_color_on`, wave A backend
+// contract): render-only support on desktop ahead of the editor UI. Covers
+// the three things a render-only PR can silently get wrong:
+//  1. parsing degrades gracefully against a server that doesn't send the
+//     field yet (today's behavior, null);
+//  2. the resolution order matches the frozen contract EXACTLY, including
+//     the honesty rule that a scene/stale/indeterminate reading never picks
+//     the on-color, even when one is set;
+//  3. an edit session (drag/resize/style-tweak on some OTHER field) carries
+//     the value through capture/restore instead of silently dropping it.
+//
+// Pure, headless assertions — no widget pump needed since `resolveBadgeBg`
+// is a plain function.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:crumb_desktop/api/ha_models.dart';
+import 'package:crumb_desktop/ui/ha_overlay/ha_icons.dart';
+import 'package:crumb_desktop/ui/ha_overlay/ha_overlay_controller.dart';
+import 'package:crumb_desktop/ui/ha_overlay/ha_overlay_layer.dart';
+
+void main() {
+  group('HaLink.overlayBgColorOn parsing', () {
+    test('an older server payload (field absent) parses to null', () {
+      final l = HaLink.fromJson({
+        'id': 'l1',
+        'entity_id': 'light.kitchen',
+        'role': 'actuator',
+        'sort_order': 0,
+      });
+      expect(l.overlayBgColorOn, isNull);
+    });
+
+    test('a present value round-trips verbatim', () {
+      final l = HaLink.fromJson({
+        'id': 'l2',
+        'entity_id': 'light.kitchen',
+        'role': 'actuator',
+        'sort_order': 0,
+        'overlay_bg_color': '#101014',
+        'overlay_bg_color_on': '#FFCC33',
+      });
+      expect(l.overlayBgColor, '#101014');
+      expect(l.overlayBgColorOn, '#FFCC33');
+    });
+  });
+
+  group('haEdgeOnFor honesty gate (shared by accent dim + bg resolution)', () {
+    test('a known on/off state resolves normally', () {
+      expect(
+        haEdgeOnFor(domain: 'binary_sensor', state: 'on', stale: false),
+        isTrue,
+      );
+      expect(
+        haEdgeOnFor(domain: 'binary_sensor', state: 'off', stale: false),
+        isFalse,
+      );
+    });
+
+    test('no known state yet is indeterminate', () {
+      expect(
+        haEdgeOnFor(domain: 'light', state: null, stale: false),
+        isNull,
+      );
+    });
+
+    test('a stale feed is indeterminate even for an "on" string', () {
+      expect(
+        haEdgeOnFor(domain: 'light', state: 'on', stale: true),
+        isNull,
+      );
+    });
+
+    test('a scene is always indeterminate, regardless of state string', () {
+      expect(
+        haEdgeOnFor(domain: 'scene', state: 'on', stale: false),
+        isNull,
+      );
+    });
+
+    test('unavailable/unknown are indeterminate, never off', () {
+      expect(
+        haEdgeOnFor(domain: 'binary_sensor', state: 'unavailable', stale: false),
+        isNull,
+      );
+    });
+  });
+
+  group('resolveBadgeBg resolution order (frozen wave-A contract)', () {
+    const bgOff = Color(0xFF101014);
+    const bgOn = Color(0xFFFFCC33);
+    const bgDefault = Color(0xFF17171B); // ha_overlay_layer.dart's _kBadgeDefaultBg
+
+    test('ON + both colors set -> bg_color_on', () {
+      expect(
+        resolveBadgeBg(on: true, bgColor: bgOff, bgColorOn: bgOn),
+        bgOn,
+      );
+    });
+
+    test('ON + no on-color set -> falls back to bg_color', () {
+      expect(
+        resolveBadgeBg(on: true, bgColor: bgOff, bgColorOn: null),
+        bgOff,
+      );
+    });
+
+    test('ON + neither set -> default', () {
+      expect(
+        resolveBadgeBg(on: true, bgColor: null, bgColorOn: null),
+        bgDefault,
+      );
+    });
+
+    test('OFF never uses the on-color, even when set', () {
+      expect(
+        resolveBadgeBg(on: false, bgColor: bgOff, bgColorOn: bgOn),
+        bgOff,
+      );
+    });
+
+    test('indeterminate (null) never uses the on-color', () {
+      expect(
+        resolveBadgeBg(on: null, bgColor: bgOff, bgColorOn: bgOn),
+        bgOff,
+      );
+    });
+
+    test('indeterminate with no bg_color set falls back to default, '
+        'even with an on-color set (scene / stale / unknown honesty rule)',
+        () {
+      expect(
+        resolveBadgeBg(on: null, bgColor: null, bgColorOn: bgOn),
+        bgDefault,
+      );
+    });
+  });
+
+  group('HaOverlayBadgeItem carries bgColorOnHex through an edit session', () {
+    HaLink link({String? bgColorOn}) => HaLink(
+          id: 'l1',
+          entityId: 'light.kitchen',
+          role: 'actuator',
+          sortOrder: 0,
+          overlayX: 0.5,
+          overlayY: 0.5,
+          overlayBgColor: '#101014',
+          overlayBgColorOn: bgColorOn,
+        );
+
+    test('seeded from the link on construction', () {
+      final item = HaOverlayBadgeItem(link(bgColorOn: '#FFCC33'));
+      expect(item.bgColorOnHex, '#FFCC33');
+    });
+
+    test('null on the link stays null (no UI sets it yet)', () {
+      final item = HaOverlayBadgeItem(link());
+      expect(item.bgColorOnHex, isNull);
+    });
+
+    test('a capture/restore round-trip (e.g. drag, or another field\'s '
+        'style edit) never drops a value set elsewhere', () {
+      final item = HaOverlayBadgeItem(link(bgColorOn: '#FFCC33'));
+      // Simulate an edit-session action unrelated to bg_color_on, e.g. a
+      // drag: the generic editor captures/restores full item state on undo
+      // or session bookkeeping, and must not lose fields it doesn't itself
+      // touch.
+      final captured = item.captureState();
+      item.bgColorOnHex = 'tampered'; // pretend something else mutated it
+      item.restoreState(captured);
+      expect(item.bgColorOnHex, '#FFCC33');
+    });
+  });
+}

--- a/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
+++ b/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
@@ -219,7 +219,9 @@ enum HA {
     ///
     /// iOS has no dedicated window-covering symbol on our iOS 16 floor, so
     /// cover/blinds/curtains/shade all resolve to `window.vertical.closed`; that
-    /// is an honest, compilable choice, not a missing glyph.
+    /// is an honest, compilable choice, not a missing glyph. Likewise the iOS 16
+    /// floor has no grill/BBQ or kitchen-appliance symbols, so outdoor cooking
+    /// leans on flame/smoke (`grill`→`flame.fill`, `smoker`→`smoke.fill`).
     static let iconSlugToSymbol: [String: String] = [
         // contact & openings
         "door": "door.left.hand.closed", "window": "window.vertical.closed",
@@ -229,10 +231,10 @@ enum HA {
         "lock": "lock.fill", "key": "key.fill",
         // motion & presence
         "motion": "figure.run", "occupancy": "person.fill", "person": "person.fill",
-        "pet": "pawprint.fill", "vibration": "waveform",
+        "home": "house.fill", "pet": "pawprint.fill", "vibration": "waveform",
         // lighting
         "lightbulb": "lightbulb.fill", "floodlight": "flashlight.on.fill",
-        "outdoor_light": "lightbulb.fill",
+        "outdoor_light": "lightbulb.fill", "landscape_light": "light.beacon.max.fill",
         // power & switches
         "switch": "switch.2", "power": "power", "plug": "powerplug.fill",
         "outlet": "poweroutlet.type.b.fill", "energy": "bolt.fill", "meter": "gauge",
@@ -241,6 +243,9 @@ enum HA {
         "fan": "fanblades.fill", "ac": "snowflake", "heatpump": "thermometer.snowflake",
         "hvac": "wind", "thermostat": "thermometer", "temperature": "thermometer",
         "humidity": "humidity.fill", "sun": "sun.max.fill",
+        // weather
+        "cloud": "cloud.fill", "rain": "cloud.rain.fill", "wind": "wind",
+        "storm": "cloud.bolt.rain.fill", "moon": "moon.fill",
         // safety & alarm
         "smoke": "smoke.fill", "gas": "carbon.monoxide.cloud.fill",
         "co": "carbon.dioxide.cloud.fill", "fire": "flame.fill",
@@ -250,15 +255,21 @@ enum HA {
         "bell": "bell.fill",
         // camera & media
         "camera": "video.fill", "tv": "tv", "speaker": "hifispeaker.fill",
-        // network
+        "media_player": "play.tv.fill", "remote": "av.remote.fill",
+        "game": "gamecontroller.fill", "mic": "mic.fill", "music": "music.note",
+        // network & computing
         "wifi": "wifi", "router": "network",
+        "printer": "printer.fill", "server": "server.rack", "computer": "desktopcomputer",
+        "storage": "externaldrive.fill", "phone": "iphone",
         // vehicles & delivery
         "vehicle": "car.fill", "package": "shippingbox.fill", "mail": "envelope.fill",
         // appliances & outdoor
         "vacuum": "sparkles", "lawn": "leaf.fill", "fridge": "snowflake",
         "laundry": "tshirt.fill", "pool": "figure.pool.swim", "hottub": "water.waves",
+        "grill": "flame.fill", "smoker": "smoke.fill", "coffee": "cup.and.saucer.fill",
+        "plant": "leaf.circle.fill",
         // time
-        "clock": "clock.fill",
+        "clock": "clock.fill", "calendar": "calendar", "timer": "timer",
         // automation
         "scene": "film", "script": "curlybraces", "button": "hand.tap.fill",
         // generic fallback

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -5218,16 +5218,17 @@ const HA_SENSOR_CLASSES = ['motion','occupancy','presence','moving','door','wind
    not significant) or a save here will fail server-side validation. */
 const HA_ICON_SLUGS = [
   'door','window','gate','garage','cover','blinds','curtains','shade','lock','key',
-  'motion','occupancy','person','pet','vibration',
-  'lightbulb','floodlight','outdoor_light',
+  'motion','occupancy','person','home','pet','vibration',
+  'lightbulb','floodlight','outdoor_light','landscape_light',
   'switch','power','plug','outlet','energy','meter','battery','solar','ev',
   'fan','ac','heatpump','hvac','thermostat','temperature','humidity','sun',
+  'cloud','rain','wind','storm','moon',
   'smoke','gas','co','fire','leak','water','valve','siren','security','armed','warning','doorbell','bell',
-  'camera','tv','speaker',
-  'wifi','router',
+  'camera','tv','speaker','media_player','remote','game','mic','music',
+  'wifi','router','printer','server','computer','storage','phone',
   'vehicle','package','mail',
-  'vacuum','lawn','fridge','laundry','pool','hottub',
-  'clock',
+  'vacuum','lawn','fridge','laundry','pool','hottub','grill','smoker','coffee','plant',
+  'clock','calendar','timer',
   'scene','script','button',
   'sensor',
 ];

--- a/services/api/src/ha.rs
+++ b/services/api/src/ha.rs
@@ -599,12 +599,14 @@ pub const CANONICAL_ICON_SLUGS: &[&str] = &[
     "motion",
     "occupancy",
     "person",
+    "home",
     "pet",
     "vibration",
     // lighting
     "lightbulb",
     "floodlight",
     "outdoor_light",
+    "landscape_light",
     // power & switches
     "switch",
     "power",
@@ -624,6 +626,12 @@ pub const CANONICAL_ICON_SLUGS: &[&str] = &[
     "temperature",
     "humidity",
     "sun",
+    // weather
+    "cloud",
+    "rain",
+    "wind",
+    "storm",
+    "moon",
     // safety & alarm (incl. smoke/gas/CO problem sensors)
     "smoke",
     "gas",
@@ -642,9 +650,19 @@ pub const CANONICAL_ICON_SLUGS: &[&str] = &[
     "camera",
     "tv",
     "speaker",
-    // network
+    "media_player",
+    "remote",
+    "game",
+    "mic",
+    "music",
+    // network & computing
     "wifi",
     "router",
+    "printer",
+    "server",
+    "computer",
+    "storage",
+    "phone",
     // vehicles & delivery
     "vehicle",
     "package",
@@ -656,8 +674,14 @@ pub const CANONICAL_ICON_SLUGS: &[&str] = &[
     "laundry",
     "pool",
     "hottub",
+    "grill",
+    "smoker",
+    "coffee",
+    "plant",
     // time
     "clock",
+    "calendar",
+    "timer",
     // automation
     "scene",
     "script",


### PR DESCRIPTION
## Summary
- Small render-only slice of the frozen wave-A per-state badge background contract: `overlay_bg_color_on`. Entity ON resolves to `bg_color_on ?? bg_color ?? default (#17171B)`; OFF/indeterminate/stale/scene stays on `bg_color ?? default` — never the on-color, mirroring `haVisualFor`'s existing accent-dim honesty gate (extracted here as `haEdgeOnFor` so accent and background can't disagree).
- Parses the new nullable field defensively (`HaLink.overlayBgColorOn`) so this degrades gracefully against a server that hasn't shipped the field yet.
- `HaOverlayBadgeItem` now carries `bgColorOnHex` through the edit session (capture/restore) and `endEditAndSave` → `saveHaPlacement` (`bg_color_on` in the body), so a desktop save from *any* edit (drag, resize, another style tweak) can't silently clobber a value set elsewhere — the placement PUT replaces the whole record every call.
- No editor UI to *set* the on-color yet — that's a later PR. This PR is render + round-trip only.

## Branch base
Stacked on `feat/ha-icon-vocabulary-expansion` per the frozen-contract task instructions (avoids rebase pain against in-flight HA work on that branch). This PR should retarget to `main` once that branch merges.

## Files changed (all under `apps/desktop-flutter/`)
- `lib/api/ha_models.dart` — `HaLink.overlayBgColorOn` (nullable, parses `overlay_bg_color_on`)
- `lib/api/ha_api.dart` — `saveHaPlacement(..., bgColorOn: ...)` sends `bg_color_on`
- `lib/ui/ha_overlay/ha_icons.dart` — extracted `haEdgeOnFor` (shared honesty gate)
- `lib/ui/ha_overlay/ha_overlay_layer.dart` — `resolveBadgeBg` (pure, unit-tested) + `HaBadgeChip.bgColorOn`/`on` wired into both dot and pill paths
- `lib/ui/ha_overlay/ha_overlay_controller.dart` — `HaOverlayBadgeItem.bgColorOnHex` seeded/captured/restored/saved
- `test/ha_overlay_bg_on_test.dart` — new: parsing, resolution order, honesty gate, capture/restore round-trip

## Gate
CI (GitHub Actions) is reportedly in an outage, so this was gated manually on `winbuild` instead:
- `flutter pub get` — clean
- `flutter analyze` — **zero new errors or warnings** in any changed file (confirmed via `Select-String` diff against the full analyze output — the ~110 `error`s in the raw log are all pre-existing vendored `rust_builder\cargokit\build_tool\**` + `integration_test/simple_test.dart` noise, none touching HA files). A handful of pre-existing `info`-level style suggestions (`use_null_aware_elements`, `prefer_initializing_formals`) exist near the touched lines but match the surrounding code's existing style, not new issues.
- `flutter test test/ha_overlay_bg_on_test.dart` — 17/17 pass
- `flutter test test/ha_badge_scale_test.dart test/ha_control_config_test.dart` (pre-existing HA tests, regression check for the `haVisualFor`/`_haVisualDefault` refactor) — 12/12 pass

## Test plan
- [ ] Once the wave-A server field lands, set `overlay_bg_color_on` on a placed actuator badge via the DB/API directly (no editor UI yet) and confirm the badge background swaps to it while the entity reads on, and back to `overlay_bg_color`/default when off.
- [ ] Confirm an unrelated edit (drag the badge, or change its icon) in the maximized-pane editor doesn't clear a `bg_color_on` set elsewhere.