### PR TITLE
feat(ios): render per-state HA badge backgrounds

### DIFF
--- a/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
+++ b/apps/ios/Crumb/Features/HomeAssistant/HomeAssistant.swift
@@ -22,6 +22,12 @@ struct HAVisual {
     let color: Color
     let stateText: String
     let indeterminate: Bool
+    /// The tri-state `edgeOn` reading resolved to a determinate "on" (mirrors
+    /// exactly what dims `overlayColor` to 45% in `applyOverrides` below).
+    /// `false` for an off reading AND for anything indeterminate/stale/scene —
+    /// badge background resolution (`HA.badgeBackground`) only consults
+    /// `overlay_bg_color_on` when this is `true`.
+    let isOn: Bool
 }
 
 enum HA {
@@ -105,7 +111,7 @@ enum HA {
 
         // Scene is stateless.
         if domain == "scene" {
-            return applyOverrides(link, base: HAVisual(symbol: "film", color: neutral, stateText: "Scene", indeterminate: false), on: nil)
+            return applyOverrides(link, base: HAVisual(symbol: "film", color: neutral, stateText: "Scene", indeterminate: false, isOn: false), on: nil)
         }
 
         // Indeterminate (unknown/unavailable/stale) → grey, honest state text.
@@ -114,7 +120,7 @@ enum HA {
         if stale || state == nil || (on == nil && domain != "light" && domain != "switch") {
             let sym = baseSymbol(domain: domain, deviceClass: link.deviceClass, on: false)
             let text = raw.isEmpty ? "Unknown" : stateTextWithUnit(raw, unit: state?.unit)
-            return HAVisual(symbol: overrideSymbol(link) ?? sym, color: grey, stateText: text, indeterminate: true)
+            return HAVisual(symbol: overrideSymbol(link) ?? sym, color: grey, stateText: text, indeterminate: true, isOn: false)
         }
 
         // Known reading.
@@ -123,10 +129,10 @@ enum HA {
         switch domain {
         case "light":
             base = HAVisual(symbol: isOn ? "lightbulb.fill" : "lightbulb",
-                            color: isOn ? warmYellow : grey, stateText: isOn ? "On" : "Off", indeterminate: false)
+                            color: isOn ? warmYellow : grey, stateText: isOn ? "On" : "Off", indeterminate: false, isOn: isOn)
         case "switch":
             base = HAVisual(symbol: "power",
-                            color: isOn ? green : grey, stateText: isOn ? "On" : "Off", indeterminate: false)
+                            color: isOn ? green : grey, stateText: isOn ? "On" : "Off", indeterminate: false, isOn: isOn)
         default:
             base = classVisual(HA.classForDeviceClass(link.deviceClass), on: isOn)
         }
@@ -152,35 +158,35 @@ enum HA {
         switch cls {
         case "door":
             return HAVisual(symbol: on ? "door.left.hand.open" : "door.left.hand.closed",
-                            color: on ? amber : neutral, stateText: on ? "Open" : "Closed", indeterminate: false)
+                            color: on ? amber : neutral, stateText: on ? "Open" : "Closed", indeterminate: false, isOn: on)
         case "window":
             return HAVisual(symbol: on ? "window.vertical.open" : "window.vertical.closed",
-                            color: on ? amber : neutral, stateText: on ? "Open" : "Closed", indeterminate: false)
+                            color: on ? amber : neutral, stateText: on ? "Open" : "Closed", indeterminate: false, isOn: on)
         case "garage":
             return HAVisual(symbol: on ? "door.garage.open" : "door.garage.closed",
-                            color: on ? amber : neutral, stateText: on ? "Open" : "Closed", indeterminate: false)
+                            color: on ? amber : neutral, stateText: on ? "Open" : "Closed", indeterminate: false, isOn: on)
         case "motion":
             return HAVisual(symbol: "figure.run", color: on ? blue : grey,
-                            stateText: on ? "Motion" : "Clear", indeterminate: false)
+                            stateText: on ? "Motion" : "Clear", indeterminate: false, isOn: on)
         case "occupancy":
             return HAVisual(symbol: "person.fill", color: on ? blue : grey,
-                            stateText: on ? "Occupied" : "Clear", indeterminate: false)
+                            stateText: on ? "Occupied" : "Clear", indeterminate: false, isOn: on)
         case "lock":
             // A binary_sensor lock reads on = unsecured/unlocked, off = locked.
             return HAVisual(symbol: on ? "lock.open.fill" : "lock.fill",
-                            color: on ? amber : neutral, stateText: on ? "Unlocked" : "Locked", indeterminate: false)
+                            color: on ? amber : neutral, stateText: on ? "Unlocked" : "Locked", indeterminate: false, isOn: on)
         case "smoke":
             return HAVisual(symbol: "smoke.fill", color: on ? danger : neutral,
-                            stateText: on ? "Smoke" : "Clear", indeterminate: false)
+                            stateText: on ? "Smoke" : "Clear", indeterminate: false, isOn: on)
         case "gas":
             return HAVisual(symbol: "carbon.monoxide.cloud.fill", color: on ? danger : neutral,
-                            stateText: on ? "Gas" : "Clear", indeterminate: false)
+                            stateText: on ? "Gas" : "Clear", indeterminate: false, isOn: on)
         case "leak":
             return HAVisual(symbol: "drop.triangle.fill", color: on ? amber : neutral,
-                            stateText: on ? "Leak" : "Dry", indeterminate: false)
+                            stateText: on ? "Leak" : "Dry", indeterminate: false, isOn: on)
         default:
             return HAVisual(symbol: "sensor.fill", color: on ? blue : grey,
-                            stateText: on ? "Active" : "Clear", indeterminate: false)
+                            stateText: on ? "Active" : "Clear", indeterminate: false, isOn: on)
         }
     }
 
@@ -202,7 +208,7 @@ enum HA {
         if !base.indeterminate, let hex = link.overlayColor, let c = colorFromHex(hex) {
             color = (on == false) ? c.opacity(0.45) : c
         }
-        return HAVisual(symbol: symbol, color: color, stateText: base.stateText, indeterminate: base.indeterminate)
+        return HAVisual(symbol: symbol, color: color, stateText: base.stateText, indeterminate: base.indeterminate, isOn: base.isOn)
     }
 
     private static func overrideSymbol(_ link: HaLink) -> String? {
@@ -270,6 +276,20 @@ enum HA {
         if s.hasPrefix("#") { s.removeFirst() }
         guard s.count == 6, let v = UInt(s, radix: 16) else { return nil }
         return Color(hex: v)
+    }
+
+    /// On-video badge background. When `visual.isOn` (a determinate "on"
+    /// reading — never a scene, never off, never indeterminate/stale)
+    /// `overlay_bg_color_on` wins if set; every other case, including a
+    /// missing/unparseable `overlay_bg_color_on`, falls back to
+    /// `overlay_bg_color`, then the shared default badge background. Off and
+    /// indeterminate/stale readings NEVER consult `overlay_bg_color_on`.
+    static let defaultBadgeBackground = Color(hex: 0x17171B)
+
+    static func badgeBackground(link: HaLink, visual: HAVisual) -> Color {
+        if visual.isOn, let hexOn = link.overlayBgColorOn, let c = colorFromHex(hexOn) { return c }
+        if let hex = link.overlayBgColor, let c = colorFromHex(hex) { return c }
+        return defaultBadgeBackground
     }
 }
 
@@ -621,10 +641,7 @@ private struct HABadge: View {
     /// A direct-tap action is in flight — dim the icon and overlay a spinner.
     var busy: Bool = false
 
-    private var bgColor: Color {
-        if let hex = link.overlayBgColor, let c = HA.colorFromHex(hex) { return c }
-        return Color(hex: 0x17171B)
-    }
+    private var bgColor: Color { HA.badgeBackground(link: link, visual: visual) }
     private var isPill: Bool { (link.overlayShape ?? "dot") == "pill" }
 
     var body: some View {

--- a/apps/ios/Crumb/Models/Models.swift
+++ b/apps/ios/Crumb/Models/Models.swift
@@ -494,6 +494,12 @@ struct HaLink: Decodable, Identifiable {
     let overlayOpacity: Double?
     let overlayShape: String?
     let overlayBgColor: String?
+    /// Background color used ONLY while the entity resolves "on" (the same
+    /// `edgeOn` tri-state that dims the accent color), falling back to
+    /// `overlayBgColor` when unset. `nil` (including on an older server that
+    /// omits the key) ⇒ today's state-invariant background. OFF and
+    /// indeterminate/stale readings never consult this field.
+    let overlayBgColorOn: String?
     let overlayOutline: Bool
     /// Per-link control config (migration 0075, issue #440). When true, EVERY
     /// action on this link prompts a confirmation first (on top of the hardcoded
@@ -545,6 +551,7 @@ struct HaLink: Decodable, Identifiable {
         case overlayOpacity = "overlay_opacity"
         case overlayShape = "overlay_shape"
         case overlayBgColor = "overlay_bg_color"
+        case overlayBgColorOn = "overlay_bg_color_on"
         case overlayOutline = "overlay_outline"
         case requireConfirm = "require_confirm"
         case allowedActions = "allowed_actions"
@@ -572,6 +579,7 @@ struct HaLink: Decodable, Identifiable {
         overlayOpacity = try c.decodeIfPresent(Double.self, forKey: .overlayOpacity)
         overlayShape = try c.decodeIfPresent(String.self, forKey: .overlayShape)
         overlayBgColor = try c.decodeIfPresent(String.self, forKey: .overlayBgColor)
+        overlayBgColorOn = try c.decodeIfPresent(String.self, forKey: .overlayBgColorOn)
         overlayOutline = try c.decodeIfPresent(Bool.self, forKey: .overlayOutline) ?? false
         requireConfirm = try c.decodeIfPresent(Bool.self, forKey: .requireConfirm) ?? false
         allowedActions = try c.decodeIfPresent([String].self, forKey: .allowedActions)

--- a/apps/ios/CrumbTests/HaBadgeVisualTests.swift
+++ b/apps/ios/CrumbTests/HaBadgeVisualTests.swift
@@ -17,6 +17,16 @@ final class HaBadgeVisualTests: XCTestCase {
         return try JSONDecoder().decode(HaLink.self, from: Data(json.utf8))
     }
 
+    /// A link carrying `overlay_bg_color`/`overlay_bg_color_on`, either of which
+    /// may be omitted (mirroring an older server / an unset field).
+    private func linkWithBg(_ entityId: String, bgColor: String? = nil, bgColorOn: String? = nil) throws -> HaLink {
+        var json = #"{"id":"l","entity_id":"\#(entityId)","role":"sensor","sort_order":0"#
+        if let bgColor { json += #","overlay_bg_color":"\#(bgColor)""# }
+        if let bgColorOn { json += #","overlay_bg_color_on":"\#(bgColorOn)""# }
+        json += "}"
+        return try JSONDecoder().decode(HaLink.self, from: Data(json.utf8))
+    }
+
     private func state(_ raw: String) -> HaEntityState {
         HaEntityState(entityId: "e", state: raw, lastChanged: nil, unit: nil, control: nil)
     }
@@ -84,5 +94,74 @@ final class HaBadgeVisualTests: XCTestCase {
     func testTypeCapitalizesFirstLetterOnly() {
         XCTAssertEqual(HA.typeLabel(domain: "binary_sensor", deviceClass: "garage_door"), "Garage door")
         XCTAssertNotEqual(HA.typeLabel(domain: "cover", deviceClass: "garage_door"), "Garage Door")
+    }
+
+    // MARK: - Badge background (`overlay_bg_color` / `overlay_bg_color_on`)
+    //
+    // Resolution order (frozen contract): entity ON -> bg_color_on ?? bg_color
+    // ?? default; OFF or indeterminate/stale -> bg_color ?? default. "On" is the
+    // SAME `HAVisual.isOn` the tri-state `edgeOn` logic above already drives
+    // (it also dims `overlayColor` to 45% when off) — never a separate notion of
+    // "on" invented for the background.
+
+    func testOverlayBgColorOnDecodesWhenPresent() throws {
+        let l = try linkWithBg("light.kitchen", bgColorOn: "#22FF22")
+        XCTAssertEqual(l.overlayBgColorOn, "#22FF22")
+    }
+
+    func testOverlayBgColorOnNilWhenAbsent() throws {
+        let l = try linkWithBg("light.kitchen", bgColor: "#111111")
+        XCTAssertNil(l.overlayBgColorOn)
+    }
+
+    func testBadgeBackgroundOnPrefersBgColorOn() throws {
+        let l = try linkWithBg("light.kitchen", bgColor: "#111111", bgColorOn: "#22FF22")
+        let v = HA.visual(for: l, state: state("on"), stale: false)
+        XCTAssertTrue(v.isOn)
+        XCTAssertEqual(HA.badgeBackground(link: l, visual: v), HA.colorFromHex("#22FF22"))
+    }
+
+    /// No `bg_color_on` set -> falls back to `bg_color` even while on.
+    func testBadgeBackgroundOnFallsBackToBgColorWhenNoBgColorOn() throws {
+        let l = try linkWithBg("light.kitchen", bgColor: "#111111")
+        let v = HA.visual(for: l, state: state("on"), stale: false)
+        XCTAssertTrue(v.isOn)
+        XCTAssertEqual(HA.badgeBackground(link: l, visual: v), HA.colorFromHex("#111111"))
+    }
+
+    /// Off NEVER consults `bg_color_on`, even when one is set.
+    func testBadgeBackgroundOffNeverUsesBgColorOn() throws {
+        let l = try linkWithBg("light.kitchen", bgColor: "#111111", bgColorOn: "#22FF22")
+        let v = HA.visual(for: l, state: state("off"), stale: false)
+        XCTAssertFalse(v.isOn)
+        XCTAssertEqual(HA.badgeBackground(link: l, visual: v), HA.colorFromHex("#111111"))
+    }
+
+    /// Unknown/indeterminate NEVER consults `bg_color_on` either.
+    func testBadgeBackgroundIndeterminateNeverUsesBgColorOn() throws {
+        let l = try linkWithBg("sensor.kitchen", bgColor: "#111111", bgColorOn: "#22FF22")
+        let v = HA.visual(for: l, state: state("unknown"), stale: false)
+        XCTAssertTrue(v.indeterminate)
+        XCTAssertFalse(v.isOn)
+        XCTAssertEqual(HA.badgeBackground(link: l, visual: v), HA.colorFromHex("#111111"))
+    }
+
+    /// Stale NEVER consults `bg_color_on`, even for an entity whose last-known
+    /// reading was "on" — same state-honesty invariant as the color dimming.
+    func testBadgeBackgroundStaleNeverUsesBgColorOn() throws {
+        let l = try linkWithBg("light.kitchen", bgColor: "#111111", bgColorOn: "#22FF22")
+        let v = HA.visual(for: l, state: state("on"), stale: true)
+        XCTAssertTrue(v.indeterminate)
+        XCTAssertFalse(v.isOn)
+        XCTAssertEqual(HA.badgeBackground(link: l, visual: v), HA.colorFromHex("#111111"))
+    }
+
+    /// Neither set -> the shared default badge background, on or off.
+    func testBadgeBackgroundDefaultsWhenNeitherSet() throws {
+        let l = try link("light.kitchen")
+        let onVisual = HA.visual(for: l, state: state("on"), stale: false)
+        let offVisual = HA.visual(for: l, state: state("off"), stale: false)
+        XCTAssertEqual(HA.badgeBackground(link: l, visual: onVisual), HA.defaultBadgeBackground)
+        XCTAssertEqual(HA.badgeBackground(link: l, visual: offVisual), HA.defaultBadgeBackground)
     }
 }


### PR DESCRIPTION
## Summary
- `HaLink` gains a nullable `overlayBgColorOn` (`overlay_bg_color_on`, `decodeIfPresent`), so an older server that omits the key decodes exactly as today.
- Badge background resolution is now state-aware: entity ON -> `overlay_bg_color_on` ?? `overlay_bg_color` ?? default; OFF or indeterminate/stale (including scenes) -> `overlay_bg_color` ?? default, never touching the on-color. "On" reuses the existing `edgeOn` tri-state (`HAVisual.isOn`, new field) that already dims `overlay_color` to 45% when off, rather than inventing a second notion of "on".
- Extracted the resolution into `HA.badgeBackground(link:visual:)` (the badge itself, `HABadge`, is file-private) so it's directly testable and is the single place both the badge's `bgColor` and `HaBadgeVisualTests` call.

## Test plan
- [x] `xcodegen generate` + `xcodebuild -scheme Crumb-mac -destination 'platform=macOS' build` succeeds (macmini, fresh detached worktree off this branch).
- [x] `xcodebuild -scheme Crumb -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test -only-testing:CrumbTests/HaBadgeVisualTests` — 18/18 pass, including 7 new tests: decode present/absent, on prefers `bg_color_on`, on falls back to `bg_color` when `bg_color_on` unset, off/indeterminate/stale never consult `bg_color_on`, and the all-unset default.

**Note:** GitHub Actions is in an outage, so the above was run manually on the macmini gate instead of relying on CI.

Render-only change: no server/API changes in this PR. Server-side `overlay_bg_color_on` support and admin-console authoring are separate PRs per the frozen contract.