### PR TITLE
fix(android): scale HA pill badges like desktop so labels stop overflowing

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -202,6 +202,16 @@ dependencies {
     // extractor test (Gate 3: proves +global_sidx makes a fragmented segment
     // seekable to ExoPlayer, and a no-sidx one is not).
     testImplementation(libs.junit)
+    // Compose UI tests run under Robolectric (no device/emulator needed): they
+    // drive REAL touch injection through Compose hit-testing, which is the only
+    // way to assert that a badge is actually tappable where it is drawn
+    // (HaBadgeTouchTargetTest). Both artifacts come from the Compose BOM above.
+    testImplementation(platform(libs.androidx.compose.bom))
+    testImplementation(libs.androidx.ui.test.junit4)
+    // Supplies the bare ComponentActivity the Compose test rule hosts its
+    // content in. Debug-only (unit tests run against the debug variant); the
+    // release APK never sees it.
+    debugImplementation(libs.androidx.ui.test.manifest)
     testImplementation("androidx.media3:media3-test-utils:1.4.1")
     testImplementation("org.robolectric:robolectric:4.11.1")
     testImplementation("androidx.test.ext:junit:1.1.5")

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaBadgeMetrics.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaBadgeMetrics.kt
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.feature.live
+
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Pure sizing math for the on-video Home Assistant badges.
+ *
+ * The desktop client is the source of truth for how a badge's `overlay_size`
+ * maps to glyph / container / text proportions
+ * (`apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_layer.dart`, `HaBadgeChip`
+ * plus its caption builder). Everything here is a straight port of that math so
+ * a badge authored on desktop reads the same on the phone.
+ *
+ * The rule the pill layout has to honor: **every part of the badge derives from
+ * the same height**, and the container derives from the icon + label, never the
+ * other way round. Android used to break that in three places, which is what
+ * made a small pill's label spill past its rounded background (v0.2.0 live
+ * testing):
+ *
+ *  1. the pill's box width came from a char-count heuristic evaluated against
+ *     the *nominal* font size, while the label actually rendered at the
+ *     *clamped* font size — below ~14dp of badge height the icon + padding +
+ *     label no longer fit the box at all;
+ *  2. the horizontal padding (6dp) and the icon/label gap (4dp) were fixed
+ *     constants instead of fractions of the height, and the icon had no minimum
+ *     while the label did — so at small sizes a floored label sat next to a
+ *     vanishing icon;
+ *  3. the label/caption `Text`s overrode only `fontSize`, inheriting the app
+ *     theme's `bodyLarge` **lineHeight of 22sp**, so the text's line box did not
+ *     shrink with the badge at all.
+ *
+ * All lengths are dp (the desktop's logical px); font sizes are dp too and the
+ * composable converts them with the current density, so the badge keeps the
+ * operator-authored geometry regardless of the phone's font-scale setting (the
+ * badge is a scale drawing of a scene, not body copy).
+ */
+internal object HaBadgeMetrics {
+    /** Reference badge height (dp) at scale 1.0 and pane-scale 1.0. */
+    const val BASE_REF_DP = 22f
+
+    /** Pane short side (dp) that maps to pane-scale 1.0. */
+    const val REF_SHORT_SIDE = 320f
+
+    /** Never render a badge smaller than this, at any scale. */
+    const val MIN_BADGE_DP = 8f
+
+    /** Labels longer than this ellipsize (matches the desktop width estimate). */
+    private const val MAX_LABEL_CHARS = 16
+
+    /**
+     * Mean glyph advance as a fraction of the font size, used only to size the
+     * pill so the label fits. Deliberately generous for a semibold sans; the
+     * label still ellipsizes if a particular string measures wider.
+     */
+    private const val GLYPH_ADVANCE_EM = 0.62f
+
+    /** Pane-scale for a `paneW` x `paneH` pane (dp) — desktop `overlay_geometry`. */
+    fun paneScale(paneW: Float, paneH: Float): Float =
+        (min(paneW, paneH) / REF_SHORT_SIDE).coerceIn(0.5f, 3.0f)
+
+    /**
+     * Badge height (dp) for a link's `overlay_size` at [paneScale]. The scale is
+     * clamped to the same 0.1..8.0 band the desktop controller clamps to, so a
+     * bogus value from the API cannot produce a badge the size of the pane.
+     */
+    fun badgeHeight(overlaySize: Float?, paneScale: Float): Float =
+        (BASE_REF_DP * (overlaySize ?: 1f).coerceIn(0.1f, 8.0f) * paneScale)
+            .coerceAtLeast(MIN_BADGE_DP)
+
+    // ── Pill parts — desktop `_pill(height)`. ────────────────────────────────
+
+    /**
+     * Icon side (dp). Desktop clamps to 10..40; the extra `coerceAtMost(height)`
+     * only bites when the badge itself is under 10dp, where the desktop floor
+     * would be taller than the chip it sits in.
+     */
+    fun pillIconSize(height: Float): Float =
+        (height * 0.56f).coerceIn(10f, 40f).coerceAtMost(height)
+
+    /** Label size (dp). */
+    fun pillFontSize(height: Float): Float = (height * 0.40f).coerceIn(8f, 26f)
+
+    /** Horizontal padding inside the pill (dp), each side. */
+    fun pillPadH(height: Float): Float = (height * 0.28f).coerceIn(5f, 16f)
+
+    /** Gap between the icon and the label (dp). */
+    fun pillGap(height: Float): Float = (height * 0.14f).coerceIn(3f, 8f)
+
+    /**
+     * The pill box the desktop authoring UI persists (`HaOverlayBadgeItem
+     * .baseSize()`): `(baseRef * 1.5 + chars * baseRef * 0.42) * scale`,
+     * rewritten in terms of the height (`height = baseRef * scale`).
+     */
+    fun nominalPillWidth(height: Float, label: String): Float =
+        height * (1.5f + 0.42f * labelChars(label))
+
+    /** Width (dp) the icon + gap + label + padding actually need. */
+    fun pillContentWidth(height: Float, label: String): Float =
+        2f * pillPadH(height) +
+            pillIconSize(height) +
+            pillGap(height) +
+            labelWidth(height, label)
+
+    /**
+     * The rendered pill width (dp): the desktop-authored footprint, widened when
+     * the (clamped) icon + label would not fit inside it. This is the fix for
+     * the overflow — the container is derived from the content, never assumed to
+     * be big enough for it.
+     */
+    fun pillWidth(height: Float, label: String): Float =
+        max(nominalPillWidth(height, label), pillContentWidth(height, label))
+
+    /** Estimated rendered label width (dp) at this badge height. */
+    fun labelWidth(height: Float, label: String): Float =
+        labelChars(label) * pillFontSize(height) * GLYPH_ADVANCE_EM
+
+    // ── Dot — desktop `_dot(side)`. ──────────────────────────────────────────
+
+    /** Icon side (dp) inside a dot badge of side [side]. */
+    fun dotIconSize(side: Float): Float =
+        (side * 0.58f).coerceIn(10f, 40f).coerceAtMost(side)
+
+    // ── Pinned caption below the badge — desktop `_captionFor`. ──────────────
+
+    fun captionFontSize(height: Float): Float = (height * 0.42f).coerceIn(8f, 13f)
+
+    fun captionPadH(height: Float): Float = (height * 0.16f).coerceIn(4f, 8f)
+
+    fun captionPadV(height: Float): Float = (height * 0.08f).coerceIn(2f, 4f)
+
+    /** Gap (dp) between the badge and its caption. */
+    fun captionGap(height: Float): Float = (height * 0.14f).coerceIn(2f, 6f)
+
+    // ── In-flight spinner — desktop `_withPendingOverlay`. ───────────────────
+
+    fun spinnerSize(width: Float, height: Float): Float =
+        (min(width, height) * 0.52f).coerceIn(10f, 22f)
+
+    private fun labelChars(label: String): Int =
+        label.length.coerceIn(1, MAX_LABEL_CHARS)
+}

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaBadgeOverlay.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaBadgeOverlay.kt
@@ -10,9 +10,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -40,7 +39,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import video.crumb.app.data.HaLinkDto
 import video.crumb.app.data.HaStatesResponse
 import java.time.Duration
@@ -63,8 +61,10 @@ import kotlin.math.min
 // entity sheet + more-info dialog so an entity reads identically wherever Android
 // draws it (#437).
 
-private const val BASE_REF_PX = 22f // reference badge size at pane-scale 1.0
-private const val REF_SHORT_SIDE = 320f
+// Every dp/font proportion (badge height, pill icon/label/padding/gap, caption
+// text + padding) comes from `HaBadgeMetrics`, the port of the desktop chip's
+// scaling contract. Nothing in this file may hardcode a size that should scale
+// with the badge — that is what made small pills spill their label.
 
 /** Compact "just now / 5s / 3m / 2h / 4d" from an RFC3339 timestamp. */
 private fun relativeAgo(iso: String?): String? {
@@ -84,7 +84,7 @@ private fun relativeAgo(iso: String?): String? {
 // ── Geometry (dp units) — port of desktop `overlay_geometry.dart`. ───────────
 
 private fun paneScale(paneW: Float, paneH: Float): Float =
-    (min(paneW, paneH) / REF_SHORT_SIDE).coerceIn(0.5f, 3.0f)
+    HaBadgeMetrics.paneScale(paneW, paneH)
 
 /**
  * The contain-fit (letterboxed) video rect within a `paneW`x`paneH` pane, in dp.
@@ -98,14 +98,22 @@ private fun fieldRect(paneW: Float, paneH: Float, videoW: Int, videoH: Int): Flo
     return floatArrayOf((paneW - fw) / 2f, (paneH - fh) / 2f, fw, fh)
 }
 
-/** Rendered badge box size (w, h) in dp for [link] at the given pane scale. */
+/**
+ * Rendered badge box size (w, h) in dp for [link] at the given pane scale.
+ *
+ * A pill's width is the desktop-authored footprint WIDENED to whatever the
+ * icon + label + padding actually need at this height ([HaBadgeMetrics
+ * .pillWidth]). The authored footprint alone is a char-count estimate taken
+ * against the un-clamped font size, so on a phone-sized pane (small pane =
+ * small pane-scale = a badge only a dozen dp tall) it came out NARROWER than
+ * the chip's own contents and the label spilled past the rounded background.
+ * Returning the true footprint here also keeps the edge clamp below, and the
+ * badge's touch target, honest about what is drawn.
+ */
 private fun badgeSize(link: HaLinkDto, ps: Float): FloatArray {
-    val size = (link.overlaySize ?: 1.0).toFloat()
-    val h = (BASE_REF_PX * size * ps).coerceAtLeast(8f)
+    val h = HaBadgeMetrics.badgeHeight(link.overlaySize?.toFloat(), ps)
     if (link.overlayShape != "pill") return floatArrayOf(h, h)
-    val chars = link.displayName.length.coerceIn(1, 16)
-    val w = ((BASE_REF_PX * 1.5f + chars * BASE_REF_PX * 0.42f) * size * ps).coerceAtLeast(8f)
-    return floatArrayOf(w, h)
+    return floatArrayOf(HaBadgeMetrics.pillWidth(h, link.displayName), h)
 }
 
 /**
@@ -196,9 +204,11 @@ private fun HaBadge(
             .alpha(opacity),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+        // The chip sizes ITSELF from `hDp` (a pill may end up a hair taller than
+        // the nominal box if the label's line box needs it), so this Box just
+        // wraps it — the touch target is exactly what is drawn.
         Box(
             modifier = Modifier
-                .size(width = wDp.dp, height = hDp.dp)
                 // Tap = primary gesture (fire/sheet/detail, decided by the caller);
                 // long-press = read-only inspect. Both consumed here so the touch
                 // does not fall through to the video/PTZ beneath. (#428)
@@ -213,21 +223,21 @@ private fun HaBadge(
                 pillLabel = link.displayName,
                 bgColor = bg,
                 outline = link.overlayOutline,
+                widthDp = wDp,
                 heightDp = hDp,
-                modifier = Modifier.fillMaxSize(),
             )
             // Brief in-flight spinner while an action posts — we never flip the
             // shown state locally; the `/ha/states` poll converges it. (#428)
             if (inFlight) {
                 Box(
                     modifier = Modifier
-                        .fillMaxSize()
+                        .matchParentSize()
                         .clip(if (isPill) RoundedCornerShape(percent = 50) else CircleShape)
                         .background(Color.Black.copy(alpha = 0.45f)),
                     contentAlignment = Alignment.Center,
                 ) {
                     CircularProgressIndicator(
-                        modifier = Modifier.fillMaxSize(0.6f),
+                        modifier = Modifier.size(HaBadgeMetrics.spinnerSize(wDp, hDp).dp),
                         color = Color.White,
                         strokeWidth = 2.dp,
                     )
@@ -245,17 +255,25 @@ private fun HaBadge(
             }
         }
         if (caption.isNotBlank()) {
+            // Caption text AND its chrome scale with the badge (desktop
+            // `_captionFor`): a fixed-padding, theme-line-height caption made a
+            // small dot look like a speck under an oversized label.
+            val captionFont = dpAsSp(HaBadgeMetrics.captionFontSize(hDp))
             Box(
                 modifier = Modifier
-                    .padding(top = 2.dp)
-                    .clip(RoundedCornerShape(4.dp))
+                    .padding(top = HaBadgeMetrics.captionGap(hDp).dp)
+                    .clip(RoundedCornerShape(5.dp))
                     .background(Color.Black.copy(alpha = 0.62f))
-                    .padding(horizontal = 5.dp, vertical = 2.dp),
+                    .padding(
+                        horizontal = HaBadgeMetrics.captionPadH(hDp).dp,
+                        vertical = HaBadgeMetrics.captionPadV(hDp).dp,
+                    ),
             ) {
                 Text(
                     text = caption,
                     color = visual.color,
-                    fontSize = (hDp * 0.42f).coerceIn(9f, 15f).sp,
+                    fontSize = captionFont,
+                    lineHeight = captionFont,
                     fontWeight = FontWeight.Medium,
                     maxLines = 1,
                     softWrap = false,
@@ -265,7 +283,15 @@ private fun HaBadge(
     }
 }
 
-/** A single badge chip — `dot` (icon only) or `pill` (icon + label). */
+/**
+ * A single badge chip — `dot` (icon only) or `pill` (icon + label).
+ *
+ * Sizes itself: a dot is a [heightDp] square, a pill is [widthDp] wide (already
+ * widened to fit its contents by [HaBadgeMetrics.pillWidth]) and at LEAST
+ * [heightDp] tall. Every inner length — icon, label, horizontal padding, the
+ * icon/label gap — is a fraction of [heightDp], the same fractions the desktop
+ * chip uses, so the whole badge scales as one piece at any size.
+ */
 @Composable
 private fun HaBadgeChip(
     visual: BadgeVisual,
@@ -273,11 +299,18 @@ private fun HaBadgeChip(
     pillLabel: String,
     bgColor: Color,
     outline: Boolean,
+    widthDp: Float,
     heightDp: Float,
-    modifier: Modifier = Modifier,
 ) {
     val shape = if (isPill) RoundedCornerShape(percent = 50) else CircleShape
-    val base = modifier
+    // The stadium/circle radius follows the box (percent corners are taken off
+    // the shorter side), so the corner scales with the badge for free.
+    val sizing = if (isPill) {
+        Modifier.width(widthDp.dp).heightIn(min = heightDp.dp)
+    } else {
+        Modifier.size(heightDp.dp)
+    }
+    val base = sizing
         .then(if (outline) Modifier.shadow(4.dp, shape) else Modifier)
         .clip(shape)
         .background(bgColor)
@@ -285,25 +318,36 @@ private fun HaBadgeChip(
 
     if (!isPill) {
         Box(base, contentAlignment = Alignment.Center) {
-            Icon(visual.icon, contentDescription = null, tint = visual.color, modifier = Modifier.fillMaxSize(0.58f))
+            Icon(
+                visual.icon,
+                contentDescription = null,
+                tint = visual.color,
+                modifier = Modifier.size(HaBadgeMetrics.dotIconSize(heightDp).dp),
+            )
         }
     } else {
         val labelColor = if (bgColor.luminance() > 0.5f) Color.Black else Color.White
+        // Font size AND line height come from the badge height. Without an
+        // explicit lineHeight the label inherits the app theme's body line box
+        // (22sp) whatever its font size, which is what made a small pill's text
+        // taller than the pill.
+        val labelFont = dpAsSp(HaBadgeMetrics.pillFontSize(heightDp))
         Row(
-            modifier = base.padding(horizontal = 6.dp),
+            modifier = base.padding(horizontal = HaBadgeMetrics.pillPadH(heightDp).dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Icon(
                 visual.icon,
                 contentDescription = null,
                 tint = visual.color,
-                modifier = Modifier.fillMaxHeight(0.56f).aspectRatio(1f),
+                modifier = Modifier.size(HaBadgeMetrics.pillIconSize(heightDp).dp),
             )
-            Spacer(Modifier.width(4.dp))
+            Spacer(Modifier.width(HaBadgeMetrics.pillGap(heightDp).dp))
             Text(
                 text = pillLabel,
                 color = labelColor,
-                fontSize = (heightDp * 0.40f).coerceIn(8f, 26f).sp,
+                fontSize = labelFont,
+                lineHeight = labelFont,
                 fontWeight = FontWeight.SemiBold,
                 maxLines = 1,
                 softWrap = false,
@@ -313,3 +357,15 @@ private fun HaBadgeChip(
         }
     }
 }
+
+/**
+ * A dp length as an sp font size at the current density.
+ *
+ * Badge text is part of a scale drawing pinned to the video, not body copy: the
+ * operator sizes it on the desktop editor and the container geometry is in dp,
+ * so the phone's font-scale setting must not stretch the label out of its pill.
+ * (Every other text surface in the app — sheets, dialogs, the entity list —
+ * still honors the system font scale.)
+ */
+@Composable
+private fun dpAsSp(valueDp: Float) = with(LocalDensity.current) { valueDp.dp.toSp() }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/HaBadgeOverlay.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/HaBadgeOverlay.kt
@@ -207,6 +207,13 @@ private fun HaBadge(
         // The chip sizes ITSELF from `hDp` (a pill may end up a hair taller than
         // the nominal box if the label's line box needs it), so this Box just
         // wraps it — the touch target is exactly what is drawn.
+        //
+        // CONTRACT: the gesture modifier belongs on the node that WRAPS the
+        // chip, and the chip must always measure to something. A chip that
+        // measured to nothing, or a gesture modifier moved onto a sibling,
+        // still draws a plausible badge while silently eating every touch —
+        // nothing about the rendering would look wrong. HaBadgeTouchTargetTest
+        // injects real touches through Compose hit-testing to hold that line.
         Box(
             modifier = Modifier
                 // Tap = primary gesture (fire/sheet/detail, decided by the caller);

--- a/apps/android/app/src/test/java/video/crumb/app/feature/live/HaBadgeMetricsTest.kt
+++ b/apps/android/app/src/test/java/video/crumb/app/feature/live/HaBadgeMetricsTest.kt
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.feature.live
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression tests for the HA badge scaling math — the Android sibling of the
+ * desktop `apps/desktop-flutter/test/ha_badge_scale_test.dart`.
+ *
+ * The bug these pin down (found on a Galaxy S24 during v0.2.0 live testing): a
+ * pill badge's label rendered LARGER than the pill it sat in, spilling past the
+ * rounded background, while the same badge at the same `overlay_size` was fine
+ * on desktop. The badge box came from a char-count estimate evaluated against
+ * the un-clamped font size, but the label rendered at the CLAMPED font size, so
+ * once the badge got small (a phone pane is small in dp, so its pane-scale and
+ * therefore its badges are small) the icon + padding + label no longer fit.
+ *
+ * Everything below is pure, headless, deterministic math — no Compose, no
+ * device. The sweep covers badge heights 8..40dp, the range a phone actually
+ * produces for the console's 0.5x..3x size slider.
+ */
+class HaBadgeMetricsTest {
+
+    private val heights: List<Float> = (8..40).map { it.toFloat() }
+
+    private val labels = listOf(
+        "A",
+        "Floodlight",
+        "patio door",
+        "Front Door Sensor",
+        "WWWWWWWWWWWWWWWWWWWW",
+    )
+
+    // ── The bug: the container must be derived from its contents. ────────────
+
+    @Test
+    fun `pill is always wide enough for its icon, gap, padding and label`() {
+        for (h in heights) {
+            for (label in labels) {
+                val w = HaBadgeMetrics.pillWidth(h, label)
+                val need = HaBadgeMetrics.pillContentWidth(h, label)
+                assertTrue(
+                    "pill h=$h label='$label' width=$w < content=$need",
+                    w >= need - 1e-4f,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `the old nominal-only width was too narrow for a small pill`() {
+        // Documents WHY pillWidth takes the max: at a phone-sized badge the
+        // desktop-authored footprint alone is narrower than the chip's own
+        // contents. If this ever stops being true the max() is harmless, but
+        // the assertion is what makes the fix legible.
+        val h = 12f
+        assertTrue(
+            HaBadgeMetrics.nominalPillWidth(h, "Floodlight") <
+                HaBadgeMetrics.pillContentWidth(h, "Floodlight"),
+        )
+        // ...and at a comfortable size the authored footprint still wins, so a
+        // badge that already looked right keeps its exact geometry.
+        val big = 30f
+        assertEquals(
+            HaBadgeMetrics.nominalPillWidth(big, "Floodlight"),
+            HaBadgeMetrics.pillWidth(big, "Floodlight"),
+            1e-4f,
+        )
+    }
+
+    @Test
+    fun `label never needs more room than the pill grants it`() {
+        for (h in heights) {
+            for (label in labels) {
+                val room = HaBadgeMetrics.pillWidth(h, label) -
+                    2f * HaBadgeMetrics.pillPadH(h) -
+                    HaBadgeMetrics.pillIconSize(h) -
+                    HaBadgeMetrics.pillGap(h)
+                assertTrue(
+                    "no label room at h=$h label='$label' (room=$room)",
+                    room >= HaBadgeMetrics.labelWidth(h, label) - 1e-4f,
+                )
+            }
+        }
+    }
+
+    // ── Nothing may overflow vertically either. ──────────────────────────────
+
+    @Test
+    fun `icons never exceed the badge box`() {
+        for (h in heights) {
+            assertTrue("pill icon > h at $h", HaBadgeMetrics.pillIconSize(h) <= h + 1e-4f)
+            assertTrue("dot icon > side at $h", HaBadgeMetrics.dotIconSize(h) <= h + 1e-4f)
+        }
+    }
+
+    @Test
+    fun `label line box fits the pill height`() {
+        // The label's line height is set to its font size (desktop `height: 1.0`),
+        // so this is the whole vertical story: font <= badge height at any size.
+        for (h in heights) {
+            assertTrue(
+                "font ${HaBadgeMetrics.pillFontSize(h)} > h=$h",
+                HaBadgeMetrics.pillFontSize(h) <= h + 1e-4f,
+            )
+        }
+    }
+
+    // ── Desktop parity: the exact fractions and clamps of `_pill(height)`. ───
+
+    @Test
+    fun `pill parts match the desktop fractions and clamps`() {
+        // desktop: icon .56 clamp 10..40, font .40 clamp 8..26,
+        //          padH .28 clamp 5..16, gap .14 clamp 3..8
+        assertEquals(11.2f, HaBadgeMetrics.pillIconSize(20f), 1e-4f)
+        assertEquals(8f, HaBadgeMetrics.pillFontSize(20f), 1e-4f) // at the floor
+        assertEquals(5.6f, HaBadgeMetrics.pillPadH(20f), 1e-4f)
+        assertEquals(3f, HaBadgeMetrics.pillGap(20f), 1e-4f) // clamped up
+
+        assertEquals(22.4f, HaBadgeMetrics.pillIconSize(40f), 1e-4f)
+        assertEquals(16f, HaBadgeMetrics.pillFontSize(40f), 1e-4f)
+        assertEquals(11.2f, HaBadgeMetrics.pillPadH(40f), 1e-4f)
+        assertEquals(5.6f, HaBadgeMetrics.pillGap(40f), 1e-4f)
+
+        // Upper clamps bite on a very large badge, exactly as on desktop.
+        assertEquals(40f, HaBadgeMetrics.pillIconSize(200f), 1e-4f)
+        assertEquals(26f, HaBadgeMetrics.pillFontSize(200f), 1e-4f)
+        assertEquals(16f, HaBadgeMetrics.pillPadH(200f), 1e-4f)
+        assertEquals(8f, HaBadgeMetrics.pillGap(200f), 1e-4f)
+    }
+
+    @Test
+    fun `dot icon matches the desktop fraction`() {
+        assertEquals(17.4f, HaBadgeMetrics.dotIconSize(30f), 1e-4f) // .58
+        assertEquals(40f, HaBadgeMetrics.dotIconSize(100f), 1e-4f) // clamped
+        assertEquals(10f, HaBadgeMetrics.dotIconSize(12f), 1e-4f) // floor
+    }
+
+    @Test
+    fun `caption text and chrome scale with the badge`() {
+        // desktop: state .42 clamp 8..13, padH .16 clamp 4..8, padV .08 clamp 2..4
+        assertEquals(12.6f, HaBadgeMetrics.captionFontSize(30f), 1e-4f)
+        assertEquals(13f, HaBadgeMetrics.captionFontSize(40f), 1e-4f)
+        assertEquals(8f, HaBadgeMetrics.captionFontSize(10f), 1e-4f)
+        assertEquals(4.8f, HaBadgeMetrics.captionPadH(30f), 1e-4f)
+        assertEquals(4f, HaBadgeMetrics.captionPadH(10f), 1e-4f)
+        assertEquals(2.4f, HaBadgeMetrics.captionPadV(30f), 1e-4f)
+        assertEquals(4f, HaBadgeMetrics.captionPadV(60f), 1e-4f)
+    }
+
+    @Test
+    fun `caption is not wildly out of proportion with a small dot`() {
+        // The reported "tiny icon under a huge caption": a caption fixed at 9sp
+        // with fixed padding beside an unclamped icon. Now both are bounded
+        // fractions of the same height, so the caption's text can never be more
+        // than ~1.6x the icon it labels.
+        for (h in heights) {
+            val ratio = HaBadgeMetrics.captionFontSize(h) / HaBadgeMetrics.dotIconSize(h)
+            assertTrue("caption/icon ratio $ratio at h=$h", ratio <= 1.6f)
+        }
+    }
+
+    // ── Scale -> height, and the shape-invariant. ────────────────────────────
+
+    @Test
+    fun `badge height is the scale times the reference, floored and clamped`() {
+        assertEquals(22f, HaBadgeMetrics.badgeHeight(1.0f, 1.0f), 1e-4f)
+        assertEquals(33f, HaBadgeMetrics.badgeHeight(1.5f, 1.0f), 1e-4f)
+        assertEquals(24.75f, HaBadgeMetrics.badgeHeight(1.5f, 0.75f), 1e-4f)
+        // A missing overlay_size is 1.0.
+        assertEquals(22f, HaBadgeMetrics.badgeHeight(null, 1.0f), 1e-4f)
+        // Floor: never smaller than MIN_BADGE_DP, whatever the scale.
+        assertEquals(
+            HaBadgeMetrics.MIN_BADGE_DP,
+            HaBadgeMetrics.badgeHeight(0.01f, 0.5f),
+            1e-4f,
+        )
+        // The desktop controller clamps overlay_size to 0.1..8.0; Android used
+        // to take it raw, so a bogus value made a pane-sized badge on the phone
+        // and a clamped one on the desktop.
+        assertEquals(
+            HaBadgeMetrics.badgeHeight(8f, 1f),
+            HaBadgeMetrics.badgeHeight(99f, 1f),
+            1e-4f,
+        )
+    }
+
+    @Test
+    fun `everything grows monotonically with the badge height`() {
+        for (h in heights) {
+            val next = h + 1f
+            assertTrue(HaBadgeMetrics.pillIconSize(next) >= HaBadgeMetrics.pillIconSize(h))
+            assertTrue(HaBadgeMetrics.pillFontSize(next) >= HaBadgeMetrics.pillFontSize(h))
+            assertTrue(HaBadgeMetrics.pillPadH(next) >= HaBadgeMetrics.pillPadH(h))
+            assertTrue(HaBadgeMetrics.pillGap(next) >= HaBadgeMetrics.pillGap(h))
+            assertTrue(HaBadgeMetrics.dotIconSize(next) >= HaBadgeMetrics.dotIconSize(h))
+            assertTrue(HaBadgeMetrics.captionFontSize(next) >= HaBadgeMetrics.captionFontSize(h))
+            assertTrue(
+                HaBadgeMetrics.pillWidth(next, "Floodlight") >=
+                    HaBadgeMetrics.pillWidth(h, "Floodlight"),
+            )
+        }
+    }
+
+    @Test
+    fun `a pill is wider than it is tall`() {
+        // Mirrors the desktop test's shape-invariant assertion.
+        val h = 22f
+        assertTrue(HaBadgeMetrics.pillWidth(h, "Front Door") > h)
+    }
+
+    @Test
+    fun `pane scale is the short side over the reference, clamped`() {
+        assertEquals(1f, HaBadgeMetrics.paneScale(640f, 320f), 1e-4f)
+        assertEquals(0.5f, HaBadgeMetrics.paneScale(100f, 100f), 1e-4f)
+        assertEquals(3f, HaBadgeMetrics.paneScale(4000f, 2000f), 1e-4f)
+    }
+
+    @Test
+    fun `spinner stays proportional on a wide pill`() {
+        // Keyed on the SHORT side (desktop `_withPendingOverlay`) so a long pill
+        // does not get a spinner the width of the badge.
+        assertEquals(10.4f, HaBadgeMetrics.spinnerSize(200f, 20f), 1e-4f)
+        assertEquals(22f, HaBadgeMetrics.spinnerSize(80f, 80f), 1e-4f)
+    }
+}

--- a/apps/android/app/src/test/java/video/crumb/app/feature/live/HaBadgeTouchTargetTest.kt
+++ b/apps/android/app/src/test/java/video/crumb/app/feature/live/HaBadgeTouchTargetTest.kt
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.feature.live
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import video.crumb.app.data.HaLinkDto
+import video.crumb.app.ui.player.ZoomableVideoSurface
+
+/**
+ * The badge TOUCH contract, exercised through real Compose hit-testing.
+ *
+ * [HaBadgeMetricsTest] proves the numbers; this proves the composable actually
+ * hands those numbers to a hit box. The two halves have to be checked together:
+ * the chip sizes ITSELF from [HaBadgeMetrics] and the tap/long-press
+ * `combinedClickable` sits on a wrap-content parent, so a chip that measured to
+ * nothing (or a gesture modifier that ended up on the wrong node) would still
+ * DRAW a plausible badge while silently swallowing every touch. That failure
+ * mode is invisible to a pure-geometry test and to a screenshot; it needs an
+ * injected touch, which is why this runs as a Compose UI test under Robolectric
+ * rather than as another plain unit test.
+ *
+ * What is asserted:
+ *  1. a placed badge contributes EXACTLY ONE clickable node (the drawn chip IS
+ *     the tappable node, not a sibling of it);
+ *  2. that node measures the footprint [HaBadgeMetrics.pillWidth] promises, and
+ *     is at least [HaBadgeMetrics.badgeHeight] tall, so the edge clamp and the
+ *     touch target agree with what is drawn;
+ *  3. tap and long-press both fire, including over the live video surface and
+ *     including a jittery press (a real finger drifts a few px between down and
+ *     up) - which is what would expose the zoom/pan detector underneath
+ *     stealing the gesture;
+ *  4. every geometry in the authored range stays tappable, at any placement.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], qualifiers = "w800dp-h480dp-land")
+class HaBadgeTouchTargetTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    private val base = HaLinkDto(
+        id = "l1",
+        entityId = "light.porch",
+        role = "actuator",
+        label = "Porch light",
+        overlayX = 0.4,
+        overlayY = 0.4,
+        overlaySize = 1.0,
+        overlayShape = "pill",
+        overlayShowState = true,
+        overlayShowAge = true,
+    )
+
+    private val link = mutableStateOf(base)
+    private val taps = mutableListOf<String>()
+    private val longPresses = mutableListOf<String>()
+
+    // Pane size in dp, read back from the composition: what `paneScale` sees.
+    private var paneW = 0f
+    private var paneH = 0f
+
+    /** The layer over a live video surface - the real fullscreen stacking order. */
+    private fun setContent(overVideo: Boolean = true) {
+        rule.setContent {
+            Box(Modifier.fillMaxSize().background(Color.Black)) {
+                if (overVideo) {
+                    ZoomableVideoSurface(modifier = Modifier.fillMaxSize(), onSwipeCamera = {}) {
+                        Box(Modifier.fillMaxSize().background(Color.DarkGray))
+                    }
+                }
+                HaBadgeOverlayLayer(
+                    links = listOf(link.value),
+                    states = null,
+                    videoWidth = 1920,
+                    videoHeight = 1080,
+                    onBadgeTap = { taps += it.id },
+                    onBadgeLongPress = { longPresses += it.id },
+                )
+            }
+        }
+        val root = rule.onRoot().fetchSemanticsNode().size
+        paneW = root.width / rule.density.density
+        paneH = root.height / rule.density.density
+    }
+
+    private fun badgeNode() = rule.onAllNodes(hasClickAction())[0]
+
+    private fun badgeNodes() = rule.onAllNodes(hasClickAction()).fetchSemanticsNodes()
+
+    @Test
+    fun aPlacedBadgeIsExactlyOneClickableNode() {
+        setContent()
+        assertEquals("a placed badge must be one clickable node", 1, badgeNodes().size)
+    }
+
+    /**
+     * The hit box is the drawn footprint. `badgeSize()` widens a pill to whatever
+     * its icon + label actually need, and the edge clamp and the touch target both
+     * have to use that widened width, not the narrower authored one.
+     */
+    @Test
+    fun theHitBoxIsTheDrawnFootprint() {
+        setContent()
+        val ps = HaBadgeMetrics.paneScale(paneW, paneH)
+        val h = HaBadgeMetrics.badgeHeight(base.overlaySize!!.toFloat(), ps)
+        val w = HaBadgeMetrics.pillWidth(h, base.displayName)
+        val b = badgeNodes()[0].boundsInRoot
+        val widthDp = b.width / rule.density.density
+        val heightDp = b.height / rule.density.density
+        assertEquals("hit-box width must be HaBadgeMetrics.pillWidth", w, widthDp, 1f)
+        assertTrue(
+            "hit box ($heightDp dp) must be at least the badge height ($h dp)",
+            heightDp >= h - 1f,
+        )
+    }
+
+    @Test
+    fun tapFires() {
+        setContent()
+        badgeNode().performClick()
+        rule.waitForIdle()
+        assertEquals(listOf("l1"), taps)
+    }
+
+    @Test
+    fun longPressFires() {
+        setContent()
+        badgeNode().performTouchInput { longClick() }
+        rule.waitForIdle()
+        assertEquals(listOf("l1"), longPresses)
+    }
+
+    @Test
+    fun dotBadgeTapFires() {
+        link.value = base.copy(overlayShape = "dot")
+        setContent()
+        badgeNode().performClick()
+        rule.waitForIdle()
+        assertEquals(listOf("l1"), taps)
+    }
+
+    /**
+     * A real finger drifts between down and up. The pan/zoom detector on the
+     * video surface underneath consumes position changes, so a badge that had
+     * lost its own hit box would hand the gesture to the surface and look inert.
+     */
+    @Test
+    fun aJitteryTapOverTheVideoSurfaceStillFires() {
+        setContent()
+        badgeNode().performTouchInput {
+            down(center)
+            moveBy(Offset(2f, 1f))
+            moveBy(Offset(1f, 2f))
+            up()
+        }
+        rule.waitForIdle()
+        assertEquals(listOf("l1"), taps)
+    }
+
+    @Test
+    fun aJitteryLongPressOverTheVideoSurfaceStillFires() {
+        setContent()
+        badgeNode().performTouchInput {
+            down(center)
+            moveBy(Offset(2f, 2f), delayMillis = 60)
+            advanceEventTime(700)
+            moveBy(Offset(1f, 0f))
+            up()
+        }
+        rule.waitForIdle()
+        assertEquals(listOf("l1"), longPresses)
+    }
+
+    /**
+     * Every authored geometry stays tappable: both shapes, the whole clamped
+     * `overlay_size` band and past both ends of it, label lengths either side of
+     * the ellipsize cap, and placements in the corners where the edge clamp bites.
+     */
+    @Test
+    fun everyGeometryInTheAuthoredRangeStaysTappable() {
+        setContent(overVideo = false)
+        val failures = mutableListOf<String>()
+        val sizes = listOf(0.05, 0.1, 0.4, 1.0, 2.5, 8.0, 20.0)
+        val labels = listOf("A", "Porch light", "Back yard flood lights XL")
+        val shapes = listOf("dot", "pill")
+        val spots = listOf(0.0 to 0.0, 0.5 to 0.5, 0.99 to 0.99)
+        for (s in sizes) for (lbl in labels) for (shape in shapes) for ((x, y) in spots) {
+            val what = "size=$s shape=$shape labelLen=${lbl.length} at ($x,$y)"
+            taps.clear()
+            link.value = base.copy(
+                overlaySize = s, overlayShape = shape, label = lbl, overlayX = x, overlayY = y,
+            )
+            rule.waitForIdle()
+            val nodes = badgeNodes()
+            if (nodes.size != 1) {
+                failures += "$what -> ${nodes.size} clickable nodes"
+                continue
+            }
+            val b = nodes[0].boundsInRoot
+            if (b.width <= 0f || b.height <= 0f) {
+                failures += "$what -> empty hit box $b"
+                continue
+            }
+            badgeNode().performClick()
+            rule.waitForIdle()
+            if (taps != listOf("l1")) failures += "$what -> not tappable (hit box $b)"
+        }
+        assertTrue(
+            "badges that swallowed their tap:\n" + failures.joinToString("\n"),
+            failures.isEmpty(),
+        )
+    }
+}

--- a/apps/android/gradle/libs.versions.toml
+++ b/apps/android/gradle/libs.versions.toml
@@ -26,6 +26,8 @@ androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", versi
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }


### PR DESCRIPTION
Fixes #498

Found on a phone during v0.2.0 live testing: a **pill** HA badge rendered its label bigger than the pill, spilling past the rounded background, and a dot badge's pinned caption was oversized next to a shrunken icon. The same badges, at the same `overlay_size`, render correctly on the desktop client, where they were authored.

## The inconsistency

Desktop's `HaBadgeChip` (`apps/desktop-flutter/lib/ui/ha_overlay/ha_overlay_layer.dart`) derives **every** part of a badge from one number, the badge height: icon `.56` clamp 10..40, label `.40` clamp 8..26, horizontal padding `.28` clamp 5..16, icon/label gap `.14` clamp 3..8, caption text `.42` clamp 8..13 with `.16`/`.08` padding, spinner `.52` clamp 10..22 off the short side.

Android applied `overlay_size` to the container and to the contents by different rules:

1. **The pill box was sized independently of what went in it.** Its width came from the desktop's char-count estimate, `(baseRef * 1.5 + chars * baseRef * 0.42) * scale`, which is calibrated against the *un-clamped* font size, but the label rendered at the *clamped* size. Below roughly 14dp of badge height the icon + padding + label no longer fit the box at all: e.g. at a 12dp badge, "Floodlight" needs ~73dp and the box gave 68dp. A phone pane is small in dp, so its pane-scale (short side / 320, clamped 0.5..3) and therefore its badges land right in that band; a desktop pane is big enough that the same `overlay_size` never gets there. That is the whole desktop-vs-Android divergence.
2. **Padding and gap did not scale, and the icon had no floor while the text did.** 6dp horizontal padding and a 4dp gap were fixed constants, and the icon was `fillMaxHeight(0.56)` with no minimum, so as the badge shrank the icon vanished while the label stayed at its 8sp floor.
3. **The label and caption inherited the theme's line height.** Both `Text`s overrode only `fontSize`, so they kept `bodyLarge`'s **22sp line height** at every badge size, and the phone's font-scale setting stretched them further against a dp-sized container. That is what made the text taller than the pill, and the caption box tall enough to dwarf a small dot.

## The fix

New `HaBadgeMetrics` (pure Kotlin, no Compose) ports the desktop contract verbatim, and the chip now:

- derives its width from icon + gap + label + padding, widening the authored footprint whenever the contents need more, so the container can never be smaller than what it holds (`badgeSize()` returns that true footprint, so the edge clamp and the touch target match what is drawn);
- scales the horizontal padding, the icon/label gap, the icon (with desktop's 10..40 clamp, additionally capped at the badge height so the floor cannot exceed a sub-10dp chip), the caption text, its padding and its gap;
- sets each text's `lineHeight` to its own font size (desktop's `height: 1.0`) and converts font sizes from dp at the current density, so an overlay pinned to video keeps its authored geometry regardless of the system font scale (every other text surface in the app still honors it);
- clamps `overlay_size` to 0.1..8.0 like the desktop controller does — Android took it raw;
- sizes the in-flight spinner off the short side instead of `fillMaxSize(0.6)`, which made a wide pill's spinner enormous.

The stadium corner already scaled (percent corners come off the shorter side); dot badges are unchanged apart from the icon floor.

## Tests

`HaBadgeMetricsTest` (14 tests, mirrors `apps/desktop-flutter/test/ha_badge_scale_test.dart`) sweeps badge heights 8..40dp across five labels and asserts: the pill is always wide enough for icon + gap + padding + label; the label always gets at least its estimated width; no icon exceeds its box; the label's line box fits the badge height; the desktop fractions and clamps hold exactly (including at the upper clamps); the caption/icon ratio stays sane; and everything grows monotonically with the height. One test documents the regression directly — at a 12dp badge the old nominal-only width is provably narrower than the chip's contents, while at 30dp the authored footprint still wins, so badges that already looked right keep their exact geometry.

## Gate (manual)

GitHub Actions is in an outage, so the Android gate was run by hand on a clean clone of this branch:

- `:app:testDebugUnitTest` — BUILD SUCCESSFUL, `HaBadgeMetricsTest` 14 tests / 0 failures
- `:app:assembleDebug` — BUILD SUCCESSFUL

## Scope / propagation

Android only. Checked against `docs/COMPONENT-MAP.md`'s Home Assistant overlay row: no surface added, no contract changed, this is client-side rendering parity with desktop, which stays the source of truth. iOS was read for the same drift and does **not** have it (its pill is a shrink-wrapping `HStack` with `side`-proportional padding/spacing); the only iOS gap is missing lower clamps on very small badges, not overflow, so nothing is changed there.

Merges cleanly with `feat/ha-overlay-bg-on-android` (#489), which touches the same file — verified with a trial merge — so this is based on `main` rather than stacked. Not for on-device verification yet; the combined APK build will cover that.