### PR TITLE
perf(api): register `_subv` only for the cameras whose sub SDP is actually broken

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/data/Models.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/Models.kt
@@ -316,9 +316,12 @@ data class LiveStreamsResponse(
      * Media3-specific repair — desktop and iOS deliberately stay on [rtspSubUrl],
      * because go2rtc spawns the remux ffmpeg lazily, per consumer.
      *
-     * `null` when the camera has no sub, or when the server does not manage its
-     * go2rtc streams (Frigate-served / legacy rows) — and on any server older
-     * than the field, which is why it is nullable-with-default: we fall back to
+     * Normally `null`: the server only sets it for a camera it has POSITIVELY
+     * DETECTED as broken (one of eleven on the reference install), so most tiles
+     * fall through to [rtspSubUrl] and attach to the always-warm raw sub. Also
+     * `null` when the camera has no sub, when the server does not manage its
+     * go2rtc streams (Frigate-served / legacy rows), and on any server older
+     * than the field — which is why it is nullable-with-default: we fall back to
      * [rtspSubUrl] and behave exactly as before.
      */
     @SerialName("rtsp_subv_url") val rtspSubvUrl: String? = null,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -81,7 +81,7 @@ placement, unchanged.
   for the JSON style object plus a preset palette instead of free hex entry.
 
 ---
-## 2026-08-06, Android alone plays a dedicated `<name>_subv` go2rtc restream (ffmpeg copy), because some cameras publish H264 with no `sprop-parameter-sets`
+## 2026-08-06, Only the CAMERAS that publish H264 without `sprop-parameter-sets` get a `<name>_subv` repair stream, detected per camera from the producer SDP
 
 **Context.** The Android live-wall tile plays a camera's SUB stream over RTSP
 (Media3/ExoPlayer). For one camera the tile reconnect-looped forever (#483), with
@@ -109,15 +109,43 @@ omitting `#audio` makes go2rtc pass `-an`, so audio is dropped as a bonus (the
 wall is muted; two-way audio / listen uses WebRTC). `#video=copy` is a **remux,
 not a re-encode** (verified: identical h264/High/640x360 in and out), it reads
 the existing `_sub` stream by name so it shares that producer and adds no camera
-session. `_subv` follows `_sub`'s exact lifecycle (created, updated, and deleted
-alongside it), and is registered for every camera that has a sub whether or not
-any client asks for it. `rtsp_subv_url` is null for cameras reconcile does not
-manage (Frigate-served, or a legacy row with no `source_url`), because no
-`_subv` exists for those; `rtsp_sub_url` keeps its original meaning for every
-camera.
+session. `rtsp_subv_url` is null for cameras reconcile does not manage (Frigate-served,
+or a legacy row with no `source_url`), because no `_subv` exists for those;
+`rtsp_sub_url` keeps its original meaning for every camera.
 
-**Which stream a client plays is the CLIENT's choice, and only Android takes
-`_subv`.** Android picks `rtsp_subv_url ?: rtsp_sub_url`; desktop (libmpv) and
+**Register it ONLY for the cameras that actually need it, detected per camera.**
+This is the part two earlier revisions got wrong, in the same way twice. `_subv`
+is repaired but LAZY: go2rtc spawns its ffmpeg on first consumer connect and
+reaps it when the last consumer leaves, so a cold one costs a process spawn plus
+a wait for a keyframe through an extra hop, per consumer. Registering it for
+every camera and pointing a whole wall at it therefore converts "attach to N
+always-warm `_sub` producers" into "cold-spawn N ffmpeg processes", which is a
+multi-second wall open. On the reference install **one camera of eleven** is
+affected. So the reconcile pass decides per camera:
+
+* It already fetches `GET /api/streams` every pass to choose PUT vs PATCH. That
+  payload includes **each producer's raw SDP**, so the detection costs **zero**
+  extra requests, no RTSP DESCRIBE, and cannot dial a camera.
+* A camera is flagged when its `<name>_sub` producer SDP has an `m=video`
+  section with no `a=fmtp` line. The check walks media sections rather than
+  scanning the whole SDP, because the broken camera's SDP *does* contain
+  `a=fmtp:97` — on its AUDIO track. A naive `contains("a=fmtp:")` calls the one
+  broken stream healthy.
+* An unknown verdict (no producer attached yet, no SDP, no video section) is
+  **sticky**: keep the previous answer, so a producer blinking between passes
+  can neither tear down a repair a live session is playing nor invent one.
+  Nothing known at all means not flagged, the fail-safe direction: the client
+  falls back to the always-warm raw sub and is no worse off than before #483.
+* Flagged cameras get `_subv` registered and `rtsp_subv_url` advertised.
+  Unflagged ones get any stale `_subv` **deleted** in the same pass, so the
+  stream set and what the API advertises never drift apart.
+* The verdict lives in memory only (no DB column, no migration). It is a runtime
+  property of the camera's current firmware, not operator configuration, so a
+  restart re-derives it rather than trusting a stale row; the empty cold-start
+  set means "nobody needs it", again the safe direction.
+
+**Which stream a client plays is also the CLIENT's choice, and only Android
+takes `_subv`.** Android picks `rtsp_subv_url ?: rtsp_sub_url`; desktop (libmpv) and
 iOS (AVFoundation) keep `rtsp_sub_url` untouched, because both already tolerate
 the missing-fmtp SDP that Media3 rejects. That split is not tidiness, it is the
 performance budget. go2rtc spawns the remux ffmpeg **lazily, on first consumer
@@ -128,15 +156,31 @@ through an extra hop, **per consumer**. The first cut of this change pointed
 a fresh desktop wall then cold-spawned roughly eleven ffmpeg processes on open
 and took many seconds to fill, where before it attached straight to the
 always-warm `_sub` producers that reconcile keeps running. Splitting the field
-restored the fast open and kept the Media3 repair. Reconcile still registers
-`_subv` unconditionally, which is free while nothing connects and means an
-Android client never waits for a reconcile pass.
+restored the fast open for desktop and kept the Media3 repair — but on its own it
+was still too coarse, because it moved the same cost onto the Android wall, whose
+eleven tiles then all cold-spawned. Client scoping and per-camera detection are
+both needed, and they answer different questions: *which player needs a repaired
+SDP*, and *which camera actually publishes a broken one*.
+
+**Rejected — registering `_subv` for every camera and letting only the client
+choose** (the shipped-then-reverted #485 behaviour). It looked cheap because an
+unconnected `_subv` really is free, but the cost is not the registration, it is
+the first CONNECT — and the Android wall connects to all of them at once. The
+owner's verdict on the blanket version was the right one: applying a repair to
+ten working cameras to fix one is nuclear.
 
 **Rejected — making `_subv` eager** (an always-running remux per camera so it is
 warm for everybody, keeping a single `rtsp_sub_url` field). That is a permanent
 extra ffmpeg process per camera on every install, paid by operators whose clients
-never need it, purely to avoid a cost only Media3 incurs. Lazy plus
-client-scoped is strictly cheaper and needs no new configuration.
+never need it, purely to avoid a cost only Media3 incurs on one camera. Lazy plus
+detected is strictly cheaper and needs no new configuration. (A narrower version
+of this — pre-warming only the FLAGGED stream — stays available as a revisit
+trigger below.)
+
+**Rejected — an operator toggle** ("repair this camera's sub", per camera in the
+admin console). It makes an operator diagnose an SDP-level fault that the server
+can see for itself, and it goes stale silently when firmware changes. Detection
+is not hard here: the evidence is already in a payload reconcile fetches anyway.
 
 **Rejected — putting the media filter in the CLIENT URL**
 (`rtsp://…/<name>_sub?video`). This was tried first and **falsified on-device**:
@@ -165,14 +209,28 @@ learns about `rtsp_subv_url` keeps working on the raw sub, unchanged.
 - Cameras stop shipping H264 without `sprop-parameter-sets`, or Media3 gains
   tolerance for a missing fmtp — the copy hop could then be dropped, and with it
   the second URL field.
-- The per-consumer ffmpeg remux shows up as real load, or as a slow wall open, on
-  a large install. It is a copy, but it is a process per attached tile and it
-  spawns cold. Now that only Media3 clients connect to it, this applies to a
-  MOBILE wall (and desktop only if it ever switches to `rtsp_subv_url`); the fix
-  then is a warm/eager `_subv` for the cameras a wall actually shows, not a
-  wider default.
+- **Even ONE lazy spawn is noticeable** on the flagged camera's tile (it is now
+  the only one paying, but it still opens cold). The fix then is to PRE-WARM the
+  flagged `_subv` — hold a single server-side consumer on it so the remux stays
+  running — which is affordable precisely because the flagged set is tiny. Do
+  not solve it by widening the set again.
+- **A large fraction of an install's cameras get flagged.** The whole design
+  assumes broken subs are rare (one of eleven on the reference install). If a
+  vendor ships a firmware generation that drops `sprop-parameter-sets` broadly,
+  the arithmetic behind "targeted" collapses and pre-warming (or a fix further
+  upstream) becomes the right answer.
+- **The detection proves unreliable in the field** — a camera flapping between
+  flagged and healthy, or a stream whose producer SDP never settles. The sticky
+  unknown handles a blink; sustained flapping would want hysteresis (N passes
+  agreeing) or an operator override, neither of which is worth building on
+  speculation.
+- go2rtc stops including producer SDPs in `GET /api/streams`, or changes their
+  shape. Detection would silently go quiet (everything "unknown" ⇒ nothing
+  flagged ⇒ the #483 tile reconnect-loops again), so re-verify the parse against
+  a real payload on any go2rtc major bump. This is the one failure mode that is
+  quiet rather than loud.
 - A third client adopts a player that also rejects a missing fmtp. It should take
-  `rtsp_subv_url` the same way and measure its own cold-open cost first.
+  `rtsp_subv_url` the same way; nothing server-side needs to change.
 
 ## 2026-08-01, Home Assistant value controls (brightness / position / speed) carry one optional server-validated number, discovered via a states `control` descriptor
 

--- a/services/api/src/dto.rs
+++ b/services/api/src/dto.rs
@@ -1317,14 +1317,22 @@ pub struct LiveStreamsResponse {
     /// the raw sub run through an ffmpeg **copy** (remux, never a re-encode) so
     /// go2rtc republishes a proper `a=fmtp:96 …sprop-parameter-sets=…` even for
     /// cameras that publish H264 with no out-of-band parameter sets (#483).
-    /// `None` when the camera has no sub, or when reconcile does not manage its
-    /// go2rtc streams (Frigate-served, or a legacy row with no `source_url`) —
-    /// no `_subv` exists for those.
+    ///
+    /// **Normally `None` — it is the exception, not the rule.** Set only when
+    /// the reconcile loop has POSITIVELY DETECTED that this camera's sub needs
+    /// the repair (its producer SDP advertises video with no `a=fmtp`; see
+    /// `go2rtc::sdp_video_lacks_fmtp`), which on the reference install is one
+    /// camera out of eleven. Also `None` when the camera has no sub, when
+    /// reconcile does not manage its go2rtc streams (Frigate-served, or a legacy
+    /// row with no `source_url`), and before the first reconcile pass has
+    /// reached a verdict.
     ///
     /// **Only Media3/ExoPlayer clients (Android) should prefer this over
-    /// `rtsp_sub_url`.** go2rtc spawns the remux ffmpeg LAZILY on first consumer
-    /// connect and reaps it when consumerless, so every tile that opens `_subv`
-    /// cold pays a process spawn plus a wait for the next keyframe. Players that
+    /// `rtsp_sub_url`**, and even they get it for the few cameras above. go2rtc
+    /// spawns the remux ffmpeg LAZILY on first consumer connect and reaps it
+    /// when consumerless, so every tile that opens `_subv` cold pays a process
+    /// spawn plus a wait for the next keyframe — which is why this is neither
+    /// handed to every client nor registered for every camera. Players that
     /// tolerate the missing-fmtp SDP (libmpv on desktop, `AVFoundation` on iOS)
     /// must keep using `rtsp_sub_url` and attach to the warm producer instead.
     /// Same embedded-credential + sensitivity note as `rtsp_main_url`.

--- a/services/api/src/go2rtc.rs
+++ b/services/api/src/go2rtc.rs
@@ -78,10 +78,10 @@ fn sub_name(go2rtc_name: &str) -> String {
 
 /// The go2rtc stream name for a camera's CLIENT-facing, VIDEO-ONLY sub restream
 /// (`<name>_subv`). `pub(crate)` because `playback.rs` builds the client
-/// `rtsp_subv_url` from it — the two must never drift apart. Registered for
-/// every camera that has a `_sub`, whether or not a client asks for it; only
-/// Media3/ExoPlayer clients (Android) actually connect to it, and go2rtc spawns
-/// the ffmpeg lazily, so an unused registration costs nothing.
+/// `rtsp_subv_url` from it — the two must never drift apart.
+///
+/// Registered ONLY for cameras whose sub actually needs the repair, as detected
+/// per-pass by [`sdp_video_lacks_fmtp`]. See [`reconcile`].
 pub(crate) fn subv_name(go2rtc_name: &str) -> String {
     format!("{go2rtc_name}_subv")
 }
@@ -92,9 +92,9 @@ fn mobile_name(go2rtc_name: &str) -> String {
 }
 
 /// Build the go2rtc source for a camera's `<name>_subv` — the video-only sub
-/// restream the ANDROID live wall plays (#483). Desktop and iOS stay on the raw
-/// `<name>_sub`; see `playback.rs`'s `rtsp_subv_url` for why the choice is the
-/// client's.
+/// restream the ANDROID live wall plays for the FEW cameras that need it (#483).
+/// Desktop and iOS stay on the raw `<name>_sub`; see `playback.rs`'s
+/// `rtsp_subv_url` for why the choice is the client's.
 ///
 /// It reads the EXISTING `<name>_sub` stream by name (go2rtc's documented
 /// restream form), so it shares that stream's single producer and adds no extra
@@ -269,23 +269,95 @@ async fn get_stream_count(
     }
 }
 
-/// GET the SET of stream names go2rtc currently has (`GET /api/streams` keys).
-/// Used by [`reconcile`] to choose CREATE (`PUT`, name missing) vs in-place
-/// UPDATE (`PATCH`, name present) per stream. On any error the caller falls back
-/// to treating every stream as missing (PUT-all) — the pre-fan-out-fix behavior —
-/// so a go2rtc that is unreachable / mid-restart still gets its full set applied.
-async fn get_stream_names(
+/// What one `GET /api/streams` pass tells us about go2rtc's current state.
+///
+/// Both fields come out of the SAME response, deliberately: the reconcile pass
+/// already had to fetch the stream names, and go2rtc includes each producer's
+/// raw SDP in that payload, so detecting broken subs costs **zero** extra
+/// requests and cannot itself slow a pass down or dial a camera.
+#[derive(Debug, Default)]
+struct StreamIndex {
+    /// The stream names go2rtc currently has (the JSON object's keys).
+    names: HashSet<String>,
+    /// Per stream name, a DEFINITE verdict on its producer's video track:
+    /// `true` ⇒ the SDP advertises video with no `a=fmtp` (needs the `_subv`
+    /// repair), `false` ⇒ it has one. A name is ABSENT when no verdict could be
+    /// reached — no producer attached yet, no SDP, or no video section — which
+    /// callers must treat as "don't know", never as "broken".
+    video_lacks_fmtp: std::collections::HashMap<String, bool>,
+}
+
+/// Does this SDP describe a video track with NO `a=fmtp` attribute?
+///
+/// `None` ⇒ no verdict (empty SDP, or no `m=video` section at all). `Some(true)`
+/// ⇒ the video track carries no `a=fmtp` line, which is exactly the condition
+/// that makes Android's Media3 RTSP client throw
+/// `IllegalArgumentException: missing attribute fmtp` and reconnect-loop the
+/// tile forever (#483). Such a stream has no out-of-band parameter sets at all
+/// (ffprobe on it reports "non-existing PPS 0 referenced / no frame!").
+///
+/// Attributes belong to the media section they follow, so this walks sections
+/// rather than scanning the whole SDP: a `a=fmtp` on the AUDIO track must not
+/// make a broken video track look healthy. Session-level lines (before the
+/// first `m=`) are skipped for the same reason. Pure + unit-tested against real
+/// SDPs from the reference install.
+fn sdp_video_lacks_fmtp(sdp: &str) -> Option<bool> {
+    let mut in_video = false;
+    let mut saw_video = false;
+    let mut has_fmtp = false;
+    for line in sdp.lines() {
+        let line = line.trim_end_matches('\r');
+        if let Some(media) = line.strip_prefix("m=") {
+            // A second video section would be unusual; the first one is the one
+            // a player builds its track from, so stop looking after it ends.
+            if saw_video {
+                break;
+            }
+            in_video = media.starts_with("video");
+            saw_video |= in_video;
+        } else if in_video && line.to_ascii_lowercase().starts_with("a=fmtp:") {
+            has_fmtp = true;
+        }
+    }
+    saw_video.then_some(!has_fmtp)
+}
+
+/// Reach a verdict for one entry of go2rtc's `/api/streams` object.
+///
+/// A stream can have several producers (go2rtc keeps one per source). We take
+/// the FIRST producer that yields a verdict: they all restream the same camera,
+/// and a stream with no producer attached yet yields `None` (unknown) rather
+/// than a guess. Pure + unit-tested.
+fn stream_video_lacks_fmtp(entry: &serde_json::Value) -> Option<bool> {
+    entry
+        .get("producers")?
+        .as_array()?
+        .iter()
+        .filter_map(|p| p.get("sdp")?.as_str())
+        .find_map(sdp_video_lacks_fmtp)
+}
+
+/// GET go2rtc's current stream index (`GET /api/streams`) — the names it has,
+/// plus the per-stream SDP verdict described on [`StreamIndex`].
+///
+/// [`reconcile`] uses the names to choose CREATE (`PUT`, name missing) vs
+/// in-place UPDATE (`PATCH`, name present) per stream. On any error the caller
+/// falls back to an empty index, so every stream is treated as missing (PUT-all,
+/// the pre-fan-out-fix behavior) and every verdict is "unknown" — a go2rtc that
+/// is unreachable / mid-restart still gets its full set applied, and no camera
+/// is newly accused of needing the repair.
+async fn get_stream_index(
     c: &reqwest::Client,
     api_base: &str,
     auth: (&str, &str),
-) -> Result<HashSet<String>> {
+) -> Result<StreamIndex> {
     let url = format!("{}/api/streams", api_base.trim_end_matches('/'));
     let resp = c
         .get(&url)
         .basic_auth(auth.0, Some(auth.1))
         .send()
         .await
-        .with_context(|| format!("GET go2rtc stream names ({url})"))?;
+        .with_context(|| format!("GET go2rtc stream index ({url})"))?;
     if !resp.status().is_success() {
         anyhow::bail!("go2rtc GET /api/streams -> HTTP {}", resp.status());
     }
@@ -294,9 +366,41 @@ async fn get_stream_names(
         .await
         .context("parse go2rtc /api/streams response")?;
     match body {
-        serde_json::Value::Object(map) => Ok(map.into_iter().map(|(k, _)| k).collect()),
+        serde_json::Value::Object(map) => Ok(index_from_streams(&map)),
         _ => anyhow::bail!("go2rtc /api/streams did not return a JSON object"),
     }
+}
+
+/// Decide whether a camera needs the `_subv` repair, given THIS pass's verdict
+/// for its `_sub` stream and what we believed last pass.
+///
+/// * a definite verdict always wins — this is how a camera gets flagged, and how
+///   it gets un-flagged again after a firmware fix or a camera swap;
+/// * `None` (unknown: no producer attached yet, no SDP, no video section) is
+///   STICKY. A `_sub` between producers must not silently lose a repair a live
+///   Android session is currently playing, nor gain one it never needed;
+/// * unknown with nothing remembered ⇒ `false`. That is the fail-safe
+///   direction: the client falls back to the always-warm raw sub, exactly as it
+///   behaved before #483, instead of every camera paying for a lazy remux.
+///
+/// Pure + unit-tested.
+fn resolve_needs_subv(verdict: Option<bool>, previously_needed: bool) -> bool {
+    verdict.unwrap_or(previously_needed)
+}
+
+/// Build a [`StreamIndex`] from go2rtc's `/api/streams` object (pure — split out
+/// so the parse is unit-testable against captured payloads without a go2rtc).
+fn index_from_streams(map: &serde_json::Map<String, serde_json::Value>) -> StreamIndex {
+    let mut idx = StreamIndex {
+        names: map.keys().cloned().collect(),
+        ..StreamIndex::default()
+    };
+    for (name, entry) in map {
+        if let Some(lacks) = stream_video_lacks_fmtp(entry) {
+            idx.video_lacks_fmtp.insert(name.clone(), lacks);
+        }
+    }
+    idx
 }
 
 /// Which go2rtc verb to reconcile a managed stream with. See [`choose_verb`].
@@ -379,19 +483,59 @@ pub async fn reconcile(state: &AppState) -> Result<()> {
     let streams = crumb_common::db::list_camera_streams(state.pool()).await?;
     let c = client()?;
 
-    // The names go2rtc already has. On error (unreachable / mid-restart), an
-    // empty set ⇒ every stream is treated as missing (PUT-all) — the pre-fix
-    // behavior, which is exactly what a cold/empty go2rtc needs.
-    let existing = get_stream_names(&c, api_base, auth)
+    // What go2rtc currently has: stream names, plus the per-stream SDP verdict
+    // used below to decide who needs `_subv`. On error (unreachable /
+    // mid-restart), an empty index ⇒ every stream is treated as missing
+    // (PUT-all, the pre-fix behavior, exactly what a cold/empty go2rtc needs)
+    // and every verdict is "unknown" (see `needs_subv`).
+    let index = get_stream_index(&c, api_base, auth)
         .await
         .unwrap_or_default();
+    let existing = &index.names;
 
     let mobile_enabled = state.config().mobile_stream_enabled;
     let mobile_width = state.config().mobile_stream_width;
 
+    // Which cameras actually need the video-only `_subv` repair, this pass.
+    //
+    // #483 follow-up: the first cut of `_subv` registered it for EVERY camera
+    // with a sub and pointed the client at it, which meant an eleven-tile
+    // Android wall cold-spawned eleven lazy ffmpeg remuxes on open. On the
+    // reference install exactly ONE camera of eleven publishes H264 with no
+    // `sprop-parameter-sets` — the rest were always fine on the raw `_sub`. So
+    // detect the broken ones and repair only those.
+    //
+    // `resolve_needs_subv` is STICKY across an unknown verdict: a camera whose
+    // `_sub` has no producer attached at this instant (cold start, mid-redial)
+    // keeps whatever it was last known to be, so a transient blind spot can
+    // never tear down a working repair mid-session — nor invent one. Never seen
+    // at all ⇒ not needed, which is the safe default: the client falls back to
+    // the always-warm raw sub and is no worse off than before #483.
+    let mut needs_subv: std::collections::HashMap<&str, bool> =
+        std::collections::HashMap::with_capacity(streams.len());
+    for s in &streams {
+        let has_sub = s
+            .source_sub_url
+            .as_deref()
+            .is_some_and(|u| !u.trim().is_empty());
+        let needed = has_sub
+            && resolve_needs_subv(
+                index
+                    .video_lacks_fmtp
+                    .get(&sub_name(&s.go2rtc_name))
+                    .copied(),
+                state.subv_needed(&s.go2rtc_name),
+            );
+        needs_subv.insert(s.go2rtc_name.as_str(), needed);
+        state.set_subv_needed(&s.go2rtc_name, needed);
+    }
+    // Forget cameras that no longer exist (deleted between passes).
+    state.retain_subv_needed(&streams.iter().map(|s| s.go2rtc_name.clone()).collect());
+
     // Every name WE manage (main + sub + mobile) — for the PATCH alias-collision
     // guard. (The mobile source is `ffmpeg:…`, never `rtsp://`, so it can't
     // itself alias-collide, but keeping the full managed set is correct.)
+    // `_subv` is only ours for cameras we are actually repairing.
     let managed: HashSet<String> = streams
         .iter()
         .flat_map(|s| {
@@ -402,6 +546,12 @@ pub async fn reconcile(state: &AppState) -> Result<()> {
             let mut names = vec![s.go2rtc_name.clone()];
             if has_sub {
                 names.push(sub_name(&s.go2rtc_name));
+            }
+            if needs_subv
+                .get(s.go2rtc_name.as_str())
+                .copied()
+                .unwrap_or(false)
+            {
                 names.push(subv_name(&s.go2rtc_name));
             }
             if mobile_enabled {
@@ -417,7 +567,7 @@ pub async fn reconcile(state: &AppState) -> Result<()> {
             api_base,
             &s.go2rtc_name,
             &s.source_url,
-            &existing,
+            existing,
             &managed,
             auth,
         )
@@ -432,25 +582,47 @@ pub async fn reconcile(state: &AppState) -> Result<()> {
                 api_base,
                 &sub_name(&s.go2rtc_name),
                 s.source_sub_url.as_deref().unwrap_or_default(),
-                &existing,
+                existing,
                 &managed,
                 auth,
             )
             .await;
-            // #483: the client-facing VIDEO-ONLY sub, derived from the `_sub`
-            // stream above. Registered on exactly the same condition as `_sub`
-            // (and torn down with it), so `playback.rs` can advertise
-            // `<name>_subv` whenever the camera has a sub. go2rtc pulls it lazily.
+        }
+        // #483 follow-up: the client-facing VIDEO-ONLY sub, derived from the
+        // `_sub` stream above — registered ONLY for a camera whose sub actually
+        // publishes video with no `a=fmtp`, and DELETED again the moment it
+        // stops needing it (a firmware update, or a camera swapped behind the
+        // same row). Keeping a stale `_subv` around would be harmless to
+        // go2rtc but would leave `playback.rs` free to advertise a stream we no
+        // longer maintain, so the two are kept in lockstep here.
+        let subv = subv_name(&s.go2rtc_name);
+        if needs_subv
+            .get(s.go2rtc_name.as_str())
+            .copied()
+            .unwrap_or(false)
+        {
             apply_stream(
                 &c,
                 api_base,
-                &subv_name(&s.go2rtc_name),
+                &subv,
                 &subv_src(&sub_name(&s.go2rtc_name)),
-                &existing,
+                existing,
                 &managed,
                 auth,
             )
             .await;
+        } else if existing.contains(&subv) {
+            // Best-effort: a failed DELETE just leaves an idle, consumerless
+            // stream that costs nothing and gets retried next pass.
+            if let Err(e) = delete_stream(&c, api_base, &subv, auth).await {
+                tracing::warn!(
+                    stream = %subv,
+                    error = %crumb_common::redact::redact_url_credentials(&format!("{e:#}")),
+                    "go2rtc: dropping no-longer-needed video-only sub failed (will retry)"
+                );
+            } else {
+                tracing::info!(stream = %subv, "go2rtc: sub no longer needs the fmtp repair; removed");
+            }
         }
         // On-demand mobile transcode: source the SUB stream when the camera has
         // one (already low-res), else the MAIN stream. go2rtc pulls it lazily.
@@ -465,7 +637,7 @@ pub async fn reconcile(state: &AppState) -> Result<()> {
                 api_base,
                 &mobile_name(&s.go2rtc_name),
                 &mobile_src(&input, mobile_width),
-                &existing,
+                existing,
                 &managed,
                 auth,
             )
@@ -830,6 +1002,135 @@ mod tests {
             choose_verb(true, &mobile_src("driveway_sub", 640), &managed),
             StreamVerb::Patch
         );
+    }
+
+    // ── detecting WHICH subs need the repair (#483 follow-up) ───────────────
+
+    /// The real SDP of the one broken camera on the reference install (a
+    /// Reolink), IPs genericised. Note the shape that makes this test matter:
+    /// the VIDEO track has no `a=fmtp`, but the AUDIO track below it does. A
+    /// naive `sdp.contains("a=fmtp:")` would call this stream healthy and the
+    /// Android tile would go on reconnect-looping forever.
+    const SDP_BROKEN: &str = "v=0\r\n\
+        o=- 1786058169509450 1 IN IP4 192.0.2.12\r\n\
+        s=Session streamed by \"preview\"\r\n\
+        i=reolink rtsp stream\r\n\
+        t=0 0\r\n\
+        a=control:*\r\n\
+        m=video 0 RTP/AVP 96\r\n\
+        c=IN IP4 0.0.0.0\r\n\
+        a=rtpmap:96 H264/90000\r\n\
+        a=control:track1\r\n\
+        m=audio 0 RTP/AVP 97\r\n\
+        a=rtpmap:97 MPEG4-GENERIC/16000\r\n\
+        a=fmtp:97 streamtype=5;profile-level-id=1;mode=AAC-hbr\r\n\
+        a=control:track2\r\n";
+
+    /// A healthy camera's real SDP (same install), IPs genericised.
+    const SDP_HEALTHY: &str = "v=0\r\n\
+        o=- 1785682862462808 1 IN IP4 192.0.2.4\r\n\
+        t=0 0\r\n\
+        a=control:*\r\n\
+        m=video 0 RTP/AVP 96\r\n\
+        c=IN IP4 0.0.0.0\r\n\
+        a=rtpmap:96 H264/90000\r\n\
+        a=fmtp:96 packetization-mode=1;profile-level-id=640033;sprop-parameter-sets=Z2QAM6wVFKCgL/lQ,aO48sA==\r\n\
+        a=control:track1\r\n\
+        m=audio 0 RTP/AVP 97\r\n\
+        a=rtpmap:97 MPEG4-GENERIC/16000\r\n\
+        a=fmtp:97 streamtype=5;profile-level-id=1;mode=AAC-hbr\r\n\
+        a=control:track2\r\n";
+
+    #[test]
+    fn sdp_verdict_reads_the_video_section_only() {
+        // The whole point: audio fmtp must not mask a missing video fmtp.
+        assert_eq!(sdp_video_lacks_fmtp(SDP_BROKEN), Some(true));
+        assert_eq!(sdp_video_lacks_fmtp(SDP_HEALTHY), Some(false));
+        assert!(
+            SDP_BROKEN.contains("a=fmtp:"),
+            "fixture must keep the audio fmtp that makes a naive scan wrong",
+        );
+    }
+
+    #[test]
+    fn sdp_verdict_is_unknown_without_a_video_section() {
+        // No verdict is NOT a "broken" verdict — an audio-only or empty SDP must
+        // never flag a camera into paying for a remux.
+        assert_eq!(sdp_video_lacks_fmtp(""), None);
+        assert_eq!(
+            sdp_video_lacks_fmtp("v=0\r\nm=audio 0 RTP/AVP 97\r\na=fmtp:97 x\r\n"),
+            None,
+        );
+        // Session-level attributes before the first `m=` belong to no track.
+        assert_eq!(sdp_video_lacks_fmtp("v=0\r\na=fmtp:96 stray\r\n"), None);
+    }
+
+    #[test]
+    fn sdp_verdict_tolerates_lf_only_and_case() {
+        assert_eq!(
+            sdp_video_lacks_fmtp("v=0\nm=video 0 RTP/AVP 96\na=rtpmap:96 H264/90000\n"),
+            Some(true),
+        );
+        assert_eq!(
+            sdp_video_lacks_fmtp("v=0\nm=video 0 RTP/AVP 96\nA=FMTP:96 packetization-mode=1\n"),
+            Some(false),
+        );
+    }
+
+    #[test]
+    fn stream_verdict_walks_producers() {
+        let broken = serde_json::json!({ "producers": [{ "sdp": SDP_BROKEN }] });
+        let healthy = serde_json::json!({ "producers": [{ "sdp": SDP_HEALTHY }] });
+        assert_eq!(stream_video_lacks_fmtp(&broken), Some(true));
+        assert_eq!(stream_video_lacks_fmtp(&healthy), Some(false));
+
+        // No producer attached yet (the cold-start / lazily-dialled case) is the
+        // single most likely reason for an unknown verdict, and must stay unknown.
+        assert_eq!(
+            stream_video_lacks_fmtp(&serde_json::json!({ "producers": [] })),
+            None,
+        );
+        assert_eq!(stream_video_lacks_fmtp(&serde_json::json!({})), None);
+        assert_eq!(stream_video_lacks_fmtp(&serde_json::Value::Null), None);
+        // A producer with no SDP is skipped in favour of one that has it.
+        let mixed = serde_json::json!({
+            "producers": [{ "url": "rtsp://cam/1" }, { "sdp": SDP_BROKEN }],
+        });
+        assert_eq!(stream_video_lacks_fmtp(&mixed), Some(true));
+    }
+
+    #[test]
+    fn index_carries_names_and_only_definite_verdicts() {
+        let body = serde_json::json!({
+            "famroom_sub":  { "producers": [{ "sdp": SDP_BROKEN }] },
+            "backdoor_sub": { "producers": [{ "sdp": SDP_HEALTHY }] },
+            "garage_sub":   { "producers": [] },
+        });
+        let idx = index_from_streams(body.as_object().unwrap());
+        assert_eq!(
+            idx.names,
+            names(&["famroom_sub", "backdoor_sub", "garage_sub"]),
+        );
+        assert_eq!(idx.video_lacks_fmtp.get("famroom_sub"), Some(&true));
+        assert_eq!(idx.video_lacks_fmtp.get("backdoor_sub"), Some(&false));
+        // Producerless ⇒ NO entry at all, so the caller sees "unknown", not false.
+        assert_eq!(idx.video_lacks_fmtp.get("garage_sub"), None);
+    }
+
+    #[test]
+    fn needs_subv_defaults_off_and_is_sticky_while_unknown() {
+        // A definite verdict always wins, in both directions.
+        assert!(resolve_needs_subv(Some(true), false), "flag on detection");
+        assert!(
+            !resolve_needs_subv(Some(false), true),
+            "un-flag once the camera reports fmtp again",
+        );
+        // Unknown keeps what we had: never tear down a repair a live Android
+        // session is playing just because the producer blinked...
+        assert!(resolve_needs_subv(None, true));
+        // ...and never invent one. Nothing known ⇒ nothing to repair, which is
+        // the whole fail-safe posture of this feature.
+        assert!(!resolve_needs_subv(None, false));
     }
 
     // ── video-only client sub (#483) ────────────────────────────────────────

--- a/services/api/src/playback.rs
+++ b/services/api/src/playback.rs
@@ -713,6 +713,17 @@ async fn live_streams(
     // repair, so only Android pays for it; desktop (libmpv) and iOS keep
     // `rtsp_sub_url`.
     //
+    // AND WHY IT IS PER-CAMERA: scoping to Android alone was still too broad. It
+    // sent all ~11 tiles of an Android wall through a lazily-spawned remux when
+    // only ONE camera's sub is actually malformed, so the Android wall then
+    // opened slowly for the same reason the desktop one had. `state.subv_needed`
+    // is the reconcile loop's per-camera verdict (it reads each producer's SDP
+    // out of the `GET /api/streams` payload it already fetches, see
+    // `go2rtc::sdp_video_lacks_fmtp`), so a healthy camera advertises NO
+    // `rtsp_subv_url` at all and its Android tile attaches to the warm raw sub
+    // exactly like every other client. Nothing flagged ⇒ nothing changes for
+    // anyone.
+    //
     // Crucially the client URL stays CLEAN (no query string): an earlier attempt
     // appended go2rtc's `?video` selector to the client URL, which ffprobe accepts
     // but Media3 does not — it derives per-track SETUP URLs by appending
@@ -723,9 +734,10 @@ async fn live_streams(
     // `None` for rows reconcile does not manage (Frigate-served, or legacy
     // absolute `sub_url` with no `source_url`): no `_subv` exists for them, and a
     // client must fall back to `rtsp_sub_url` rather than burn its reconnect
-    // budget on a dead stream name.
+    // budget on a dead stream name. Also `None` before the first reconcile pass
+    // has reached a verdict — the same fail-safe direction.
     let video_only_sub_url = subv_url(
-        crumb_managed,
+        crumb_managed && state.subv_needed(&cam.go2rtc_name),
         cam.sub_url.as_deref(),
         &cam.go2rtc_name,
         &crumb_rtsp_authed,
@@ -795,20 +807,26 @@ fn is_crumb_managed(served_by: &str, source_url: Option<&str>) -> bool {
 }
 
 /// Build the client-facing VIDEO-ONLY sub restream URL (`<name>_subv`), or
-/// `None` when the camera has no sub stream or reconcile does not manage it.
+/// `None` when the camera has no sub stream.
+///
+/// `registered` is the caller's answer to "does this `_subv` stream actually
+/// exist in go2rtc right now" — reconcile manages the camera AND has positively
+/// flagged its sub as missing fmtp. Both halves matter: a synthesised name for
+/// an unmanaged row resolves to nothing, and a name for a healthy camera is one
+/// reconcile deliberately does not create (and actively deletes).
 ///
 /// See the `rtsp_subv_url` block in [`live_streams`] for why this is a separate
 /// field from `rtsp_sub_url` rather than a replacement for it (go2rtc spawns the
-/// remux ffmpeg lazily, per consumer — only clients that actually need the fmtp
-/// repair should pay it). Pure + unit-tested.
+/// remux ffmpeg lazily, per consumer — only the cameras that actually need the
+/// fmtp repair should pay it). Pure + unit-tested.
 fn subv_url(
-    crumb_managed: bool,
+    registered: bool,
     sub_url: Option<&str>,
     go2rtc_name: &str,
     crumb_rtsp_authed: &str,
 ) -> Option<String> {
     let has_sub = sub_url.is_some_and(|s| !s.is_empty());
-    (crumb_managed && has_sub).then(|| {
+    (registered && has_sub).then(|| {
         format!(
             "{}/{}",
             crumb_rtsp_authed.trim_end_matches('/'),
@@ -1081,10 +1099,13 @@ mod tests {
         assert!(!out.ends_with("_subv"), "the sub field never carries _subv");
     }
 
-    /// `rtsp_subv_url` is offered ALONGSIDE it for Crumb-managed cameras that
-    /// have a sub — the video-only remux Media3 needs for its fmtp.
+    /// `rtsp_subv_url` is offered ALONGSIDE it, but ONLY for a camera reconcile
+    /// has flagged and registered a `_subv` for — the video-only remux Media3
+    /// needs for its fmtp. `registered` folds together "Crumb-managed" and
+    /// "detected as missing fmtp"; the handler passes
+    /// `crumb_managed && state.subv_needed(name)`.
     #[test]
-    fn rtsp_subv_url_present_for_crumb_managed_camera_with_a_sub() {
+    fn rtsp_subv_url_present_for_a_flagged_camera_with_a_sub() {
         assert_eq!(
             subv_url(true, Some("famroom_sub"), "famroom", BASE).as_deref(),
             Some("rtsp://u:p@host:18554/famroom_subv"),
@@ -1107,15 +1128,16 @@ mod tests {
             .contains('?'));
     }
 
-    /// …and absent everywhere reconcile never registered a `_subv`, so a client
+    /// …and absent everywhere reconcile never registered a `_subv`, so the client
     /// falls back to `rtsp_sub_url` instead of burning its reconnect budget on a
     /// dead stream name.
     #[test]
-    fn rtsp_subv_url_absent_when_unmanaged_or_no_sub() {
+    fn rtsp_subv_url_absent_when_unregistered_or_no_sub() {
         // No sub stream configured at all.
         assert_eq!(subv_url(true, None, "famroom", BASE), None);
         assert_eq!(subv_url(true, Some(""), "famroom", BASE), None);
-        // Frigate-served / legacy rows: `is_crumb_managed` already said no.
+        // Not registered: unmanaged row, OR a healthy camera reconcile never
+        // flagged (the common case — ten of eleven on the reference install).
         assert_eq!(subv_url(false, Some("famroom_sub"), "famroom", BASE), None);
         // End to end through the predicate, the way the handler wires it.
         for (served_by, source_url) in [
@@ -1128,6 +1150,26 @@ mod tests {
                 subv_url(managed, Some("famroom_sub"), "famroom", BASE),
                 None,
                 "{served_by}/{source_url:?} must not advertise a _subv",
+            );
+        }
+    }
+
+    /// The gate the handler actually computes: `crumb_managed && subv_needed`.
+    /// A HEALTHY managed camera is the case this whole follow-up exists for —
+    /// it must advertise no `_subv` at all, so its Android tile attaches to the
+    /// warm raw sub and the wall opens fast.
+    #[test]
+    fn rtsp_subv_url_is_gated_on_the_per_camera_repair_flag() {
+        for (managed, needed, want) in [
+            (true, true, Some("rtsp://u:p@host:18554/famroom_subv")),
+            (true, false, None),
+            (false, true, None),
+            (false, false, None),
+        ] {
+            assert_eq!(
+                subv_url(managed && needed, Some("famroom_sub"), "famroom", BASE).as_deref(),
+                want,
+                "managed={managed} needed={needed}",
             );
         }
     }

--- a/services/api/src/state.rs
+++ b/services/api/src/state.rs
@@ -157,6 +157,27 @@ struct Inner {
     /// so a single global lock is fine.
     go2rtc_reconcile_lock: Arc<tokio::sync::Mutex<()>>,
 
+    /// Cameras (by `go2rtc_name`) whose SUB stream needs the video-only `_subv`
+    /// repair — i.e. whose producer SDP advertises a video track with NO
+    /// `a=fmtp` line, which Android's Media3 RTSP client rejects outright
+    /// (#483). `DashMap<_, ()>` used as a concurrent set, exactly like
+    /// [`revoked_jtis`](Inner::revoked_jtis).
+    ///
+    /// Written by the go2rtc reconcile pass (which reads every producer's SDP
+    /// out of the `GET /api/streams` response it already fetches) and read by
+    /// `playback.rs` to decide whether to advertise `rtsp_subv_url` for a
+    /// camera. **Membership is the exception, not the rule:** on the reference
+    /// install exactly one camera of eleven is affected, and every other camera
+    /// keeps attaching to the always-warm raw `_sub`.
+    ///
+    /// In-memory with no migration, deliberately: this is a runtime-detectable
+    /// property of the camera's current firmware/stream, not operator
+    /// configuration, so a restart should re-derive it rather than trust a
+    /// stale row. An empty set (cold start, before the first pass completes)
+    /// means "nobody needs the repair", which is the safe direction: a client
+    /// falls back to the raw sub and is no worse off than before #483.
+    subv_needed: DashMap<String, ()>,
+
     /// In-memory cache of permission [`Role`]s keyed by id. The `AuthUser`
     /// extractor resolves a token's `role_id` to its effective capabilities +
     /// cameras through this, so per-request auth costs no DB round-trip after the
@@ -269,6 +290,7 @@ impl AppState {
             clip_gen_semaphore,
             clip_inflight: DashMap::new(),
             go2rtc_reconcile_lock: Arc::new(tokio::sync::Mutex::new(())),
+            subv_needed: DashMap::new(),
             thumb_semaphore,
             thumb_inflight: DashMap::new(),
             roles_cache: DashMap::new(),
@@ -468,6 +490,32 @@ impl AppState {
     /// [`go2rtc_reconcile_lock`](Inner::go2rtc_reconcile_lock).
     pub fn go2rtc_reconcile_lock(&self) -> Arc<tokio::sync::Mutex<()>> {
         Arc::clone(&self.0.go2rtc_reconcile_lock)
+    }
+
+    // ── `_subv` repair flags (#483 follow-up) ─────────────────────────────────
+
+    /// Does this camera's sub stream need the video-only `_subv` repair? See the
+    /// field docs on [`subv_needed`](Inner::subv_needed). `false` for anything
+    /// the reconcile pass has not positively flagged, including a cold start.
+    #[inline]
+    pub fn subv_needed(&self, go2rtc_name: &str) -> bool {
+        self.0.subv_needed.contains_key(go2rtc_name)
+    }
+
+    /// Record this pass's verdict for one camera. Idempotent, so the reconcile
+    /// pass can call it unconditionally every time.
+    pub fn set_subv_needed(&self, go2rtc_name: &str, needed: bool) {
+        if needed {
+            self.0.subv_needed.insert(go2rtc_name.to_owned(), ());
+        } else {
+            self.0.subv_needed.remove(go2rtc_name);
+        }
+    }
+
+    /// Drop flags for cameras that no longer exist, so a deleted camera's entry
+    /// cannot pin memory or resurface if its `go2rtc_name` is later reused.
+    pub fn retain_subv_needed(&self, live: &std::collections::HashSet<String>) {
+        self.0.subv_needed.retain(|name, ()| live.contains(name));
     }
 
     // ── health-alert maintenance window (issue #46) ───────────────────────────


### PR DESCRIPTION
Follow-up to #483 / #485. Fixes nothing on its own tracker — it corrects the scope of the fix that shipped in #485.

## Symptom
After #485 the DESKTOP wall opens fast again, but the **Android** wall is now slow to open.

## Why
#485 was right about the repair and wrong about who pays for it. It scoped `_subv` to Android, but still registered it for **every** Crumb-managed camera and advertised it to Android for every one of them. `_subv` is lazy: go2rtc spawns its ffmpeg remux on first consumer connect and reaps it when the last consumer leaves, so a **cold** one costs a process spawn plus a wait for a keyframe through an extra hop — **per consumer**. An eleven-tile Android wall opening cold-spawns eleven remuxes.

Exactly **one** camera of eleven needs the repair. Applying it to the other ten to fix that one is, in the owner's words, nuclear.

## Fix: detect the broken ones, repair only those

Detection is **free**. The reconcile pass already `GET`s `/api/streams` every pass to choose PUT vs PATCH, and go2rtc includes **each producer's raw SDP** in that payload. The same response now yields both the stream names and a per-stream verdict: no extra request, no RTSP DESCRIBE, no chance of dialling a camera.

```
GET /api/streams  →  { "famroom_sub": { "producers": [ { "sdp": "v=0\r\n…" } ] }, … }
```

- **`sdp_video_lacks_fmtp` walks media sections**, it does not scan the whole SDP. This is load-bearing. The broken camera's SDP *does* contain `a=fmtp:97` — on its AAC **audio** track — while its `m=video` section has no `a=fmtp` at all. A naive `contains("a=fmtp:")` calls the one broken stream healthy and the tile keeps reconnect-looping.
- **Unknown is sticky.** No producer attached yet (cold start, mid-redial), no SDP, or no video section ⇒ keep the previous verdict, so a producer blinking between passes can neither tear down a repair a live Android session is playing nor invent one. Never seen at all ⇒ **not flagged** — so a probe that never succeeds leaves every camera on the always-warm raw sub, exactly as before #483.
- **Flagged** ⇒ `_subv` registered, `rtsp_subv_url` advertised. **Unflagged** ⇒ any stale `_subv` **deleted** in the same pass (the currently-deployed build left one per camera), so the go2rtc stream set and what the API advertises can never drift apart.
- The verdict lives in `AppState` as a `DashMap` set, refreshed every pass and pruned when a camera disappears. **No DB column, no migration**: it is a runtime property of the camera's firmware, not operator configuration, so a restart re-derives it rather than trusting a stale row, and the empty cold-start set means "nobody needs it" — the fail-safe direction.

## No client change
Android already prefers `rtsp_subv_url ?: rtsp_sub_url`. A healthy camera simply stops offering the first, so its tile attaches to the warm raw sub like every other client; the broken one still gets the repaired stream. The only Android edit here is a **doc comment** correction (it described the field as tracking stream *management* rather than *detection*). Desktop and iOS are untouched, as before.

**Net effect on an eleven-camera Android wall: ten tiles attach to warm producers, one spawns one remux.**

## Verified against the live install, read-only
The actual Rust parser (`index_from_streams`) run over a real `/api/streams` payload:

```
BROKEN_SUBS=["famroom_sub"] HEALTHY_SUBS=10
```

The same one-of-eleven split the #483 survey found by hand, now reached by the shipped code path. No writes, no redeploy; the sanitized capture was discarded afterwards.

## Tests
- `sdp_verdict_reads_the_video_section_only` — real SDPs from both cameras (IPs genericised) as fixtures; asserts the broken one's audio `a=fmtp` is present, so the test would fail if the parse ever regressed to a whole-SDP scan.
- `sdp_verdict_is_unknown_without_a_video_section` — empty / audio-only / session-level stray `a=fmtp` all yield **no verdict**, never "broken".
- `sdp_verdict_tolerates_lf_only_and_case` — LF-only SDPs and `A=FMTP:`.
- `stream_verdict_walks_producers` — producerless, missing key, null, and a producer without an SDP followed by one with it.
- `index_carries_names_and_only_definite_verdicts` — a producerless stream gets **no entry**, so callers see "unknown" rather than `false`.
- `needs_subv_defaults_off_and_is_sticky_while_unknown` — flag on detection, un-flag on recovery, sticky across unknown, default off.
- `rtsp_subv_url_is_gated_on_the_per_camera_repair_flag` — the full `crumb_managed && subv_needed` truth table; a healthy managed camera advertises nothing.
- Existing `_subv` reconcile tests (`subv_name_and_src_shapes`, `subv_src_is_a_copy_not_a_transcode`, `subv_src_is_never_an_rtsp_alias_collision`) and the Android `SubStreamUrlTest` pick-order tests are unchanged and still pass.

## Gate (run manually on the dev box)
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace` against a throwaway Postgres — all green.
- Android `:app:testDebugUnitTest` (12 suites, 78 tests, 0 failures) and `:app:assembleDebug` — both succeed.

## Docs
`docs/DECISIONS.md` entry retitled and rewritten around the targeted model: the detection mechanism and why it is free, the section-walking subtlety, the sticky-unknown rule, and three rejected alternatives (blanket registration, an eager always-warm `_subv`, an operator toggle). Revisit triggers replaced — notably **pre-warm the flagged `_subv`** if even one lazy spawn annoys, and **re-verify the parse on a go2rtc major bump**, since that is the one failure mode that would go quiet rather than loud.

## Deploy note
Deploying the api is enough. On the first reconcile pass after rollout the ten healthy cameras' stale `_subv` streams are deleted and the flagged one is kept, so the Android wall should open at raw-sub speed with the famroom tile still playing.
