### PR TITLE
fix(db,recorder): make ADD CONSTRAINT migrations re-appliable; default MOTION_HWACCEL to cpu in code

### DIFF
--- a/db/migrations/0058_ha_overlay_placement.sql
+++ b/db/migrations/0058_ha_overlay_placement.sql
@@ -17,6 +17,14 @@ ALTER TABLE camera_ha_links
 -- x and y are set together or not at all (a half-placed badge is meaningless),
 -- and both live in [0,1] (fractions of the video frame). size is left
 -- unconstrained beyond NULL-vs-set; the API clamps it to a sane range.
+--
+-- Idempotent (DROP IF EXISTS + re-ADD, the 0071 pattern): ADD CONSTRAINT has no
+-- IF NOT EXISTS form, and the runner records schema_migrations in a SEPARATE
+-- statement from the apply, so an interrupted boot must be able to re-run this
+-- file instead of erroring with SQLSTATE 42710.
+ALTER TABLE camera_ha_links
+    DROP CONSTRAINT IF EXISTS camera_ha_links_overlay_xy_paired,
+    DROP CONSTRAINT IF EXISTS camera_ha_links_overlay_range;
 ALTER TABLE camera_ha_links
     ADD CONSTRAINT camera_ha_links_overlay_xy_paired
         CHECK ((overlay_x IS NULL) = (overlay_y IS NULL)),

--- a/db/migrations/0059_ha_overlay_badge_style.sql
+++ b/db/migrations/0059_ha_overlay_badge_style.sql
@@ -16,6 +16,13 @@ ALTER TABLE camera_ha_links
     ADD COLUMN IF NOT EXISTS overlay_show_state boolean NOT NULL DEFAULT false,
     ADD COLUMN IF NOT EXISTS overlay_show_age   boolean NOT NULL DEFAULT false;
 
+-- Idempotent (DROP IF EXISTS + re-ADD, the 0071 pattern): ADD CONSTRAINT has no
+-- IF NOT EXISTS form, and the runner records schema_migrations in a SEPARATE
+-- statement from the apply, so an interrupted boot must be able to re-run this
+-- file instead of erroring with SQLSTATE 42710.
+ALTER TABLE camera_ha_links
+    DROP CONSTRAINT IF EXISTS camera_ha_links_overlay_color_hex,
+    DROP CONSTRAINT IF EXISTS camera_ha_links_overlay_icon_len;
 ALTER TABLE camera_ha_links
     ADD CONSTRAINT camera_ha_links_overlay_color_hex
         CHECK (overlay_color IS NULL OR overlay_color ~ '^#[0-9a-fA-F]{6}$'),

--- a/db/migrations/0060_ha_overlay_opacity.sql
+++ b/db/migrations/0060_ha_overlay_opacity.sql
@@ -10,6 +10,12 @@
 ALTER TABLE camera_ha_links
     ADD COLUMN IF NOT EXISTS overlay_opacity real;
 
+-- Idempotent (DROP IF EXISTS + re-ADD, the 0071 pattern): ADD CONSTRAINT has no
+-- IF NOT EXISTS form, and the runner records schema_migrations in a SEPARATE
+-- statement from the apply, so an interrupted boot must be able to re-run this
+-- file instead of erroring with SQLSTATE 42710.
+ALTER TABLE camera_ha_links
+    DROP CONSTRAINT IF EXISTS camera_ha_links_overlay_opacity_range;
 ALTER TABLE camera_ha_links
     ADD CONSTRAINT camera_ha_links_overlay_opacity_range
         CHECK (overlay_opacity IS NULL

--- a/db/migrations/0062_ha_overlay_shape_bg.sql
+++ b/db/migrations/0062_ha_overlay_shape_bg.sql
@@ -21,6 +21,13 @@ ALTER TABLE camera_ha_links
     ADD COLUMN IF NOT EXISTS overlay_bg_color text,
     ADD COLUMN IF NOT EXISTS overlay_outline  boolean NOT NULL DEFAULT false;
 
+-- Idempotent (DROP IF EXISTS + re-ADD, the 0071 pattern): ADD CONSTRAINT has no
+-- IF NOT EXISTS form, and the runner records schema_migrations in a SEPARATE
+-- statement from the apply, so an interrupted boot must be able to re-run this
+-- file instead of erroring with SQLSTATE 42710.
+ALTER TABLE camera_ha_links
+    DROP CONSTRAINT IF EXISTS camera_ha_links_overlay_shape_vocab,
+    DROP CONSTRAINT IF EXISTS camera_ha_links_overlay_bg_color_hex;
 ALTER TABLE camera_ha_links
     ADD CONSTRAINT camera_ha_links_overlay_shape_vocab
         CHECK (overlay_shape IS NULL OR overlay_shape IN ('dot', 'pill')),

--- a/db/migrations/0076_ha_overlay_bg_on.sql
+++ b/db/migrations/0076_ha_overlay_bg_on.sql
@@ -27,6 +27,13 @@
 ALTER TABLE camera_ha_links
     ADD COLUMN IF NOT EXISTS overlay_bg_color_on text;
 
+-- Idempotent (DROP IF EXISTS + re-ADD, the 0071 pattern): ALTER TABLE ... ADD
+-- CONSTRAINT has no IF NOT EXISTS form, and the runner records
+-- schema_migrations in a SEPARATE statement from the apply — so an interrupted
+-- boot must be able to re-run this file harmlessly instead of erroring with
+-- SQLSTATE 42710 and refusing to start the api and the recorder.
+ALTER TABLE camera_ha_links
+    DROP CONSTRAINT IF EXISTS camera_ha_links_overlay_bg_color_on_hex;
 ALTER TABLE camera_ha_links
     ADD CONSTRAINT camera_ha_links_overlay_bg_color_on_hex
         CHECK (overlay_bg_color_on IS NULL OR overlay_bg_color_on ~ '^#[0-9a-fA-F]{6}$');

--- a/services/common/src/config.rs
+++ b/services/common/src/config.rs
@@ -382,9 +382,16 @@ impl Config {
             "SEGMENT_SECONDS must be in [2, 6], got {segment_seconds}"
         );
 
-        // Default is "auto" so a fresh install works on both GPU and CPU hosts
-        // without any env configuration.  "cuda" and "cpu" are explicit overrides.
-        let hwaccel_str = optional_env("MOTION_HWACCEL", "auto");
+        // Default is "cpu": software motion decode works on ANY host, and is fast
+        // enough for Crumb's fps-capped motion. This must match the shipped
+        // docker-compose.yml / .env.example default (#478) — an install that does
+        // not go through compose, or an upgrade whose existing .env predates that
+        // change, reaches this default instead, and "auto" on a GPU-less host is
+        // the broken path (motion dies, the recorder falls back to continuous
+        // recording, retention pressure follows). "cuda"/"vaapi" enable a GPU
+        // explicitly (see the compose overlays); "auto" probes for NVDEC and stays
+        // opt-in until its probe is made robust (#479).
+        let hwaccel_str = optional_env("MOTION_HWACCEL", "cpu");
         let motion_hwaccel = HwAccel::from_str(&hwaccel_str).with_context(|| {
             format!("MOTION_HWACCEL must be 'cuda', 'vaapi', 'cpu', or 'auto', got '{hwaccel_str}'")
         })?;

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -12743,6 +12743,168 @@ mod tests {
         assert!(check_migration_parsing_invariants(conc, true).is_ok());
     }
 
+    /// Find every `ADD CONSTRAINT` in one migration that the runner could NOT
+    /// safely re-apply, returning the offending constraint names.
+    ///
+    /// `ALTER TABLE ... ADD CONSTRAINT` has no `IF NOT EXISTS` form in Postgres,
+    /// and [`run_migrations_locked`] applies a migration's SQL and records it in
+    /// `schema_migrations` as two SEPARATE statements. A process killed between
+    /// the two leaves the DDL committed but unrecorded, so the next boot
+    /// re-applies the file — and a bare `ADD CONSTRAINT` then fails with
+    /// SQLSTATE 42710 (`constraint ... already exists`). `run_migrations` returns
+    /// `Err`, and since the api AND the recorder both embed this migration set
+    /// and run it at startup, NEITHER boots: recording stops until someone
+    /// hand-edits the database.
+    ///
+    /// An `ADD CONSTRAINT` is considered guarded when either:
+    ///
+    /// * a matching `DROP CONSTRAINT IF EXISTS <same name>` appears EARLIER in
+    ///   the same file (the 0058/0059/0060/0062/0071/0076 pattern), or
+    /// * it sits inside a `$$ ... $$` body, i.e. a `DO` block that does its own
+    ///   catalog existence check (the 0014/0018/0054/0069 pattern).
+    fn unguarded_add_constraints(sql: &str) -> Vec<String> {
+        // Strip `--` comments exactly as the runner does, so prose that merely
+        // mentions `ADD CONSTRAINT` (several files discuss this very hazard)
+        // cannot false-trigger. Then collapse each run of whitespace to a single
+        // space so `ADD\n    CONSTRAINT` and `DROP CONSTRAINT  IF EXISTS` match
+        // as written; all offsets below are into this normalized string.
+        let stripped: String = sql
+            .lines()
+            .map(|l| l.find("--").map_or(l, |pos| &l[..pos]))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let norm: String = {
+            let mut out = String::with_capacity(stripped.len());
+            let mut prev_ws = false;
+            for ch in stripped.chars() {
+                if ch.is_ascii_whitespace() {
+                    if !prev_ws {
+                        out.push(' ');
+                    }
+                    prev_ws = true;
+                } else {
+                    out.push(ch);
+                    prev_ws = false;
+                }
+            }
+            out
+        };
+        // `to_ascii_uppercase` rewrites only ASCII a-z, so byte offsets into
+        // `upper` line up with `norm` exactly even if the SQL has non-ASCII.
+        let upper = norm.to_ascii_uppercase();
+
+        // Byte ranges spanned by a `$$ ... $$` body. The existing
+        // `migrations_satisfy_runner_parsing_invariants` tripwire already proves
+        // dollar-quoting in these files is well formed, so pairing the marks in
+        // order is sound.
+        let mut bodies: Vec<(usize, usize)> = Vec::new();
+        let mut marks = upper.match_indices("$$").map(|(i, _)| i);
+        while let (Some(open), Some(close)) = (marks.next(), marks.next()) {
+            bodies.push((open, close));
+        }
+
+        let mut offenders = Vec::new();
+        for (pos, _) in upper.match_indices("ADD CONSTRAINT") {
+            if bodies.iter().any(|(o, c)| pos > *o && pos < *c) {
+                continue; // inside a DO block's own existence guard
+            }
+            let name: String = norm[pos + "ADD CONSTRAINT".len()..]
+                .trim_start()
+                .chars()
+                .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+                .collect();
+            if name.is_empty() {
+                continue; // e.g. a `format('... ADD CONSTRAINT %I')` template
+            }
+            let guard = format!("DROP CONSTRAINT IF EXISTS {}", name.to_ascii_uppercase());
+            let guarded = upper.match_indices(&guard).any(|(g, _)| {
+                // Earlier in the file, and a whole-identifier match (not a
+                // prefix of some longer constraint name).
+                g < pos
+                    && !upper[g + guard.len()..]
+                        .starts_with(|c: char| c.is_ascii_alphanumeric() || c == '_')
+            });
+            if !guarded {
+                offenders.push(name);
+            }
+        }
+        offenders
+    }
+
+    /// Every registered migration must be safely RE-APPLIABLE, because the
+    /// runner records `schema_migrations` in a separate statement from the apply
+    /// — see [`unguarded_add_constraints`]. This is the CI tripwire for a FUTURE
+    /// migration that would otherwise only fail after an interrupted prod boot,
+    /// by refusing to start the api and the recorder.
+    #[test]
+    fn migrations_guard_add_constraint_for_reapply() {
+        for (filename, sql) in MIGRATIONS {
+            let offenders = unguarded_add_constraints(sql);
+            assert!(
+                offenders.is_empty(),
+                "{filename}: unguarded ADD CONSTRAINT {offenders:?} — Postgres has \
+                 no ADD CONSTRAINT IF NOT EXISTS, and the migration runner may \
+                 re-apply this file after an interrupted boot, which would fail \
+                 with SQLSTATE 42710 and stop BOTH the api and the recorder from \
+                 starting. Precede each ADD with `ALTER TABLE <t> DROP CONSTRAINT \
+                 IF EXISTS <name>;` (the 0071 pattern), or wrap it in a DO $$ \
+                 block that checks the catalog first (the 0069 pattern)."
+            );
+        }
+    }
+
+    /// The scanner itself must actually catch the flaw — otherwise the tripwire
+    /// above is a no-op.
+    #[test]
+    fn add_constraint_scanner_detects_unguarded() {
+        // Bare ADD CONSTRAINT: the bug this exists to prevent.
+        let bare = "ALTER TABLE t ADD CONSTRAINT t_chk CHECK (c > 0);";
+        assert_eq!(unguarded_add_constraints(bare), vec!["t_chk".to_string()]);
+
+        // A DROP that comes AFTER the ADD does not save the re-apply.
+        let after = "ALTER TABLE t ADD CONSTRAINT t_chk CHECK (c > 0);\n\
+                     ALTER TABLE t DROP CONSTRAINT IF EXISTS t_chk;";
+        assert_eq!(unguarded_add_constraints(after), vec!["t_chk".to_string()]);
+
+        // A DROP of a DIFFERENT constraint does not guard this one.
+        let other = "ALTER TABLE t DROP CONSTRAINT IF EXISTS t_other;\n\
+                     ALTER TABLE t ADD CONSTRAINT t_chk CHECK (c > 0);";
+        assert_eq!(unguarded_add_constraints(other), vec!["t_chk".to_string()]);
+
+        // A DROP of a LONGER name that merely starts with this one is not a
+        // match either (`t_chk` vs `t_chk_extra`).
+        let prefix = "ALTER TABLE t DROP CONSTRAINT IF EXISTS t_chk_extra;\n\
+                      ALTER TABLE t ADD CONSTRAINT t_chk CHECK (c > 0);";
+        assert_eq!(unguarded_add_constraints(prefix), vec!["t_chk".to_string()]);
+
+        // Only the unguarded one of a pair is reported.
+        let mixed = "ALTER TABLE t DROP CONSTRAINT IF EXISTS a_chk;\n\
+                     ALTER TABLE t ADD CONSTRAINT a_chk CHECK (c > 0),\n\
+                     ADD CONSTRAINT b_chk CHECK (d > 0);";
+        assert_eq!(unguarded_add_constraints(mixed), vec!["b_chk".to_string()]);
+
+        // Guarded forms pass. The 0071 pattern (DROP IF EXISTS, then ADD)...
+        let guarded = "ALTER TABLE t DROP CONSTRAINT IF EXISTS t_chk;\n\
+                       ALTER TABLE t ADD CONSTRAINT t_chk CHECK (c > 0);";
+        assert!(unguarded_add_constraints(guarded).is_empty());
+        // ...including the multi-clause 0058/0062 shape, and across a line break.
+        let multi = "ALTER TABLE t\n    DROP CONSTRAINT IF EXISTS a_chk,\n\
+                     \x20   DROP CONSTRAINT IF EXISTS b_chk;\nALTER TABLE t\n\
+                     \x20   ADD\n    CONSTRAINT a_chk CHECK (c > 0),\n\
+                     \x20   ADD CONSTRAINT b_chk CHECK (d > 0);";
+        assert!(unguarded_add_constraints(multi).is_empty());
+        // ...and the 0069 pattern (a DO block that checks the catalog itself).
+        let do_block = "DO $$ BEGIN\n IF NOT EXISTS (SELECT 1 FROM pg_constraint \
+                        WHERE conname = 't_chk') THEN\n  ALTER TABLE t ADD \
+                        CONSTRAINT t_chk CHECK (c > 0);\n END IF;\nEND $$;";
+        assert!(unguarded_add_constraints(do_block).is_empty());
+
+        // Prose mentioning the keywords is stripped before the scan.
+        let comment = "-- never write a bare ADD CONSTRAINT foo_chk here\n\
+                       ALTER TABLE t ADD COLUMN IF NOT EXISTS c int;";
+        assert!(unguarded_add_constraints(comment).is_empty());
+    }
+
     // ── reap_invalid_indexes — throwaway-DB integration test ─────────────────
     //
     // Opt-in: skips (passes) unless `TEST_DATABASE_URL` points at a reachable

--- a/services/recorder/Dockerfile
+++ b/services/recorder/Dockerfile
@@ -15,7 +15,7 @@
 #   runtime — minimal bookworm-slim image with jellyfin-ffmpeg + the binary.
 #
 # GPU is OPT-IN: the base docker-compose.yml boots this image GPU-free
-# (MOTION_HWACCEL=auto → CPU when no GPU). NVDEC is enabled by the GPU overlay
+# (MOTION_HWACCEL=cpu, software motion decode). NVDEC is enabled by the GPU overlay
 # docker-compose.gpu.example.yml, which re-adds the nvidia device reservation +
 # 'video' capability + NVIDIA_DRIVER_CAPABILITIES=video,compute,utility.
 
@@ -122,13 +122,15 @@ RUN groupadd --gid 1001 crumb \
 USER crumb
 
 # Default environment (overridden by docker-compose.yml / .env).
-# MOTION_HWACCEL defaults to 'auto': the recorder probes for NVDEC and falls back
-# to CPU when no GPU is present, so this image boots GPU-free. Force NVDEC with the
-# GPU overlay (docker-compose.gpu.example.yml) or MOTION_HWACCEL=cuda.
+# MOTION_HWACCEL defaults to 'cpu': software motion decode works on any host, so
+# this image boots GPU-free and motion always runs. Matches the shipped
+# docker-compose.yml / .env.example default (#478). Enable a GPU explicitly with
+# the overlays (docker-compose.gpu.example.yml / .vaapi.example.yml) or
+# MOTION_HWACCEL=cuda / vaapi; 'auto' probes for NVDEC and stays opt-in (#479).
 ENV LOG_FORMAT=json \
     RUST_LOG=info \
     SEGMENT_SECONDS=4 \
-    MOTION_HWACCEL=auto \
+    MOTION_HWACCEL=cpu \
     MAX_GPU_DECODE_SESSIONS=4 \
     CONFIG_POLL_SECONDS=30 \
     MEDIA_ROOT=/data \


### PR DESCRIPTION
Two confirmed backend defects from the v0.2.0 release audit. Both are one-line-shaped fixes with an outsized blast radius, so they ride together.

Fixes #502

## B2 (blocker) — an interrupted migration bricked both services at boot

`run_migrations_locked` applies a migration's SQL and records the row in `schema_migrations` as **two separate statements**. Its own comment states the contract that makes that safe:

> if the process dies between apply and record, every migration is idempotent (IF NOT EXISTS / ON CONFLICT) so it simply re-applies harmlessly on the next startup.

`0076_ha_overlay_bg_on.sql` broke it. The `ADD COLUMN` was guarded with `IF NOT EXISTS`, but Postgres has no `IF NOT EXISTS` form of `ALTER TABLE ... ADD CONSTRAINT`. Kill the process between the commit and the record (OOM, container restart, power loss) and the next boot re-applies the file straight into SQLSTATE 42710. `run_migrations` returns `Err` — and since **the api and the recorder both embed this migration set and run it at startup, neither boots**. Recording stops until someone hand-edits the database.

Rewrote the constraint in `0076` to the `DROP CONSTRAINT IF EXISTS` + `ADD` form the repo already uses in `0071`, and swept the same flaw in `0058`, `0059`, `0060`, `0062` (pre-existing; each verified to actually have it before touching).

**Editing already-shipped migration files is safe here.** A database that already recorded these files skips them entirely, and on any other the guarded form drops and immediately re-adds an identical constraint definition inside the runner's implicit transaction. The proof below confirms the resulting constraint set is byte-identical to before.

### Double-apply proof (real Postgres 16, scratch DBs)

Each of the five files applied twice against a fresh database, pre-fix vs post-fix:

```
=============== BEFORE (origin/main, pre-fix) — apply each file TWICE ===============
  pass2 0058_ha_overlay_placement:  FAILED -> ERROR: constraint "camera_ha_links_overlay_xy_paired" ... already exists
  pass2 0059_ha_overlay_badge_style: FAILED -> ERROR: constraint "camera_ha_links_overlay_color_hex" ... already exists
  pass2 0060_ha_overlay_opacity:    FAILED -> ERROR: constraint "camera_ha_links_overlay_opacity_range" ... already exists
  pass2 0062_ha_overlay_shape_bg:   FAILED -> ERROR: constraint "camera_ha_links_overlay_shape_vocab" ... already exists
  pass2 0076_ha_overlay_bg_on:      FAILED -> ERROR: constraint "camera_ha_links_overlay_bg_color_on_hex" ... already exists
  constraints after two passes: 8 total

=============== AFTER (this branch) — apply each file TWICE ===============
  pass2 0058_ha_overlay_placement:  OK
  pass2 0059_ha_overlay_badge_style: OK
  pass2 0060_ha_overlay_opacity:    OK
  pass2 0062_ha_overlay_shape_bg:   OK
  pass2 0076_ha_overlay_bg_on:      OK
  constraints after two passes: 8 total (same names, same definitions)
```

### Tripwire

`unguarded_add_constraints` scans every registered migration for an `ADD CONSTRAINT` that is neither preceded in the same file by a matching `DROP CONSTRAINT IF EXISTS` nor wrapped in a `DO $$` catalog check (the `0014`/`0018`/`0054`/`0069` pattern). `migrations_guard_add_constraint_for_reapply` fails the build on one, so a future migration cannot reintroduce a defect that would otherwise only surface after an interrupted production boot. It strips `--` comments the same way the runner does, so prose discussing the hazard cannot false-trigger.

`add_constraint_scanner_detects_unguarded` asserts the scanner catches each shape of the flaw (bare add, drop-after-add, drop of a different name, drop of a longer name that merely shares a prefix, and the mixed guarded/unguarded pair) so the tripwire cannot silently rot into a no-op. This sits next to the existing `migrations_satisfy_runner_parsing_invariants` tripwire.

## H6 (high) — `MOTION_HWACCEL` code default was still `auto`

#478 flipped `docker-compose.yml`, `.env.example` and the docs to `cpu`, but the two code-level defaults were missed:

- `services/common/src/config.rs` — `optional_env("MOTION_HWACCEL", "auto")`
- `services/recorder/Dockerfile` — `ENV MOTION_HWACCEL=auto`

Those are exactly the paths a fresh compose install does *not* take. A non-compose install, and an upgrade whose existing `.env` predates #478 and so has no `MOTION_HWACCEL` key, both fall through to the code default. On a GPU-less host `auto` probes ffmpeg's built-in support rather than a usable runtime device, picks cuda, and motion decode dies — the recorder falls back to continuous recording and retention pressure follows.

Both flipped to `cpu`, with the adjacent comments corrected (they still described `auto` as the safe GPU-free default). `docs-site/.../environment-reference.md` already documented `cpu`, so this removes drift rather than creating it. Making `auto` itself robust stays #479.

## Gate

Run on the dev/CI box against a throwaway Postgres 16:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean, exit 0. Nobody had run clippy on this tree this round; there were **no** pre-existing failures to report.
- `cargo test --workspace` — green, exit 0, including the two new tests:

```
test db::tests::migrations_guard_add_constraint_for_reapply ... ok
test db::tests::add_constraint_scanner_detects_unguarded ... ok
```

Negative control — the tripwire was re-run with `0076` reverted to its pre-fix content, and it fails exactly as intended, so it is catching the real defect and not merely passing vacuously:

```
test db::tests::migrations_guard_add_constraint_for_reapply ... FAILED
0076_ha_overlay_bg_on.sql: unguarded ADD CONSTRAINT ["camera_ha_links_overlay_bg_color_on_hex"]
  — Postgres has no ADD CONSTRAINT IF NOT EXISTS, and the migration runner may
  re-apply this file after an interrupted boot, which would fail with SQLSTATE
  42710 and stop BOTH the api and the recorder from starting. ...
```
