### PR TITLE
feat(install): preflight storage so an install cannot silently record nothing

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -26,8 +26,13 @@ tags = ["homelab", "network"]
 
 [[rules]]
 id = "homelab-mount-path"
-description = "Internal NAS / array mount path (Synology / Unraid conventions)"
-regex = '''(/volume1|/mnt/user)(/|\b)'''
+description = "Internal NAS mount path (Synology convention)"
+# `/mnt/user` was dropped: it is Unraid's universal default share path, so any
+# platform-compatibility doc must be able to say it — it identifies nothing.
+# If a Synology doc ever legitimately needs `/volume1` examples, retire this
+# rule too and move the maintainer's specific subtree to the private denylist
+# (HOMELAB_DENYLIST_B64), which is where non-generic paths belong anyway.
+regex = '''/volume1(/|\b)'''
 tags = ["homelab", "path"]
 
 [[rules]]

--- a/README.md
+++ b/README.md
@@ -285,7 +285,13 @@ one-person project.
 ## Install
 
 **What you need:** one machine on your home network with **Docker** installed and some free
-disk for recordings. Linux is ideal. Windows and macOS work via Docker Desktop. New to Docker?
+disk for recordings. Linux on **x86-64** is ideal, and is what this is actually tested on. The
+server images are amd64 only, so a **Raspberry Pi or other ARM board will not run the server
+yet**. Windows and macOS work via Docker Desktop for trying it out, though bind-mount
+permissions and speed make them a poor choice for a recorder that runs for months (and Apple
+Silicon runs the images emulated). NAS appliances, Unraid, and unprivileged Proxmox LXC all
+work differently enough around storage ownership to be worth reading first, see
+[Platform notes](https://docs.crumbvms.com/getting-started/platform-notes). New to Docker?
 Install [Docker Engine](https://docs.docker.com/engine/install/) (Linux) or
 [Docker Desktop](https://www.docker.com/products/docker-desktop/) (Windows/macOS) first, then
 come back here.
@@ -299,6 +305,9 @@ git clone https://github.com/badbread/crumbvms.git
 cd crumbvms
 
 # 2. Generate a .env file with strong random secrets
+#    Recording onto a mounted disk or NAS share? Name it here, so the script
+#    prepares and permission-checks the real target:
+#      MEDIA_HOST_PATH=/mnt/tank/crumb ./scripts/setup-env.sh
 ./scripts/setup-env.sh
 
 # 3. Download the images and start the stack (recorder + api + postgres + caddy)
@@ -308,6 +317,14 @@ docker compose up -d
 # 4. Confirm every service came up healthy
 docker compose ps
 ```
+
+**If step 2 stops with a storage error, do not skip past it.** The recorder writes as user ID
+1001, and `setup-env.sh` checks that it actually can before you start anything. When that check
+fails, an install looks completely healthy and records nothing: live view works, the wizard
+shows green, and no footage is ever saved. The script prints the exact fix, usually
+`sudo chown -R 1001:1001 <your media path>` on a local disk, or a server-side permission change
+on a NAS share. Details per platform:
+[Platform notes](https://docs.crumbvms.com/getting-started/platform-notes).
 
 **Then open `http://<your-server-ip>:8080/admin` in a browser** and sign in with username
 `admin` and the memorable password `setup-env.sh` printed (it is also stored in `.env` as
@@ -327,9 +344,12 @@ That is the whole install. A few options if you want them:
 - **Build from source** instead of pulling images (you are developing Crumb, running
   air-gapped, or on a fork that has not published images):
   `docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build`
-- **Running on Proxmox?** Same stack in a Debian/Ubuntu VM or LXC, though nobody has verified
-  that path yet. See [Running on Proxmox](docs/AI-INSTALL.md#running-on-proxmox-vm-or-lxc)
-  for the VM-vs-LXC tradeoff, GPU passthrough, and where to put recordings.
+- **Running on Proxmox, a NAS, or Unraid?** Read
+  [Platform notes](https://docs.crumbvms.com/getting-started/platform-notes) first. It is an
+  honest table of what is tested, what should work but is unverified, and what is not supported
+  yet, plus the storage gotcha specific to each. For Proxmox in particular, see
+  [Running on Proxmox](docs/AI-INSTALL.md#running-on-proxmox-vm-or-lxc) for the VM-vs-LXC
+  tradeoff, GPU passthrough, and where to put recordings
   ([docs/IMAGES.md](docs/IMAGES.md)).
 
 > Headless/CI: the admin is already seeded from `SEED_ADMIN_PASSWORD`; accept the terms and

--- a/docs-site/docs/getting-started/platform-notes.md
+++ b/docs-site/docs/getting-started/platform-notes.md
@@ -1,0 +1,205 @@
+---
+title: Platform notes
+sidebar_label: Platform notes
+slug: /getting-started/platform-notes
+---
+
+# Platform notes
+
+Crumb is a Docker Compose stack, so in principle it runs anywhere Docker runs.
+In practice one thing decides whether an install works or quietly does nothing:
+**can the recorder write to your storage?**
+
+The recorder runs as user ID **1001** inside its container. It writes every
+frame of footage to the directory you point `MEDIA_HOST_PATH` at. If uid 1001
+cannot write there, the failure is nasty because it does not look like a
+failure:
+
+- live view still works, because live video never touches the disk
+- the setup wizard still shows green, because the API mounts storage read only
+  and cannot test writing
+- and nothing, ever, is recorded
+
+`scripts/setup-env.sh` now tests this for you before you start the stack. It
+detects the filesystem type, tries to write to the media directory as uid 1001,
+and refuses to finish if the answer is definitely no. The rest of this page is
+what that test cannot tell you: which platforms people actually install on, and
+where each one trips.
+
+## Status at a glance
+
+| Platform | Status | Why |
+|---|---|---|
+| Debian or Ubuntu, bare metal or VM | **Tested** | What CI builds and what the developer runs daily. |
+| Proxmox, Debian or Ubuntu VM guest | **Tested** | A VM guest is just a Linux host. No Proxmox specific requirements. |
+| Proxmox, unprivileged LXC | Should work, not verified | Docker in LXC is routine but needs nesting turned on, and the container's user ID shift changes what `chown 1001` means. |
+| Synology or QNAP, Container Manager | Untested | Storage is usually a shared folder with its own user mapping. `chown` often does not stick. |
+| Unraid | Untested | User shares (`/mnt/user`) are a FUSE layer that synthesises ownership from settings, not from the disk. |
+| Windows or macOS, Docker Desktop / WSL2 | Untested | Bind mounts cross a filesystem translation layer and do not carry Linux ownership. Apple Silicon also emulates. |
+| Raspberry Pi or any ARM board | **Not supported yet** | Published images are amd64 only. |
+
+"Tested" means the project is actually run this way. "Untested" means nobody has
+reported success or failure, not that it is known to be broken. If you get one
+of the untested rows working, or find where it breaks, please open an issue: it
+is how these rows change.
+
+## The one check that matters
+
+Whatever platform you are on, this is the test. Run it against your media
+directory before you add cameras:
+
+```bash
+sudo -u '#1001' touch /path/to/your/media/.crumb-write-test
+sudo rm /path/to/your/media/.crumb-write-test
+```
+
+If the `touch` succeeds, recording will work. If it fails, fix that first.
+Nothing else on this page matters until it passes.
+
+## Debian or Ubuntu, bare metal or VM
+
+The reference platform. Follow
+[Install with Docker Compose](/getting-started/install-docker-compose) and
+`setup-env.sh` handles the media directory ownership for you if you run it with
+`sudo`, or tells you the exact command to run if you do not.
+
+**What to check:** that `MEDIA_HOST_PATH` is on a real data disk and not the
+root filesystem. Footage fills disks. A full root disk takes the whole machine
+down, not just recording.
+
+## Proxmox
+
+Both guest types work. Pick based on how you want to handle the GPU, and put
+footage on a dedicated dataset or disk either way.
+
+**VM guest.** Nothing special. It is an ordinary Linux host. If you want
+hardware motion decode, pass the GPU through with PCIe passthrough, which
+dedicates the card to that one guest.
+
+**Unprivileged LXC.** More efficient, and the GPU stays shareable because you
+bind the render node in rather than passing the whole card. Two things to set
+up:
+
+- Docker needs nesting: `pct set <id> --features nesting=1`, or tick "Nesting"
+  in the GUI. Some setups also need `keyctl=1`.
+- **User IDs are shifted.** An unprivileged container maps its uid 0 to a high
+  uid on the Proxmox host, commonly 100000. So container uid 1001 is host uid
+  101001. If you attach storage as a mount point from the host, set ownership
+  using the host side number:
+
+  ```bash
+  # on the Proxmox HOST, for the default 100000 offset
+  chown -R 101001:101001 /tank/crumb-media
+  ```
+
+  Getting this wrong is the single most likely reason a Proxmox LXC install
+  records nothing.
+
+**What to check:** run the write test above from inside the container. If
+Docker in LXC fights you, particularly with NVIDIA, fall back to a VM. That
+tradeoff is covered in
+[Install with an AI agent](/getting-started/install-with-ai-agent).
+
+## Synology and QNAP
+
+Container Manager (Synology) and Container Station (QNAP) both run standard
+Docker, so the stack itself is not the problem. Storage is.
+
+**Known sharp edges:**
+
+- Media usually lives in a shared folder. The NAS decides ownership through its
+  own user and permission model, and a `chown 1001:1001` from inside a terminal
+  session may be reverted, ignored, or blocked outright.
+- If you mount the share over SMB rather than using a local volume, ownership
+  comes from the mount options, not from the disk. Every file appears owned by
+  whatever uid the mount was told to use.
+- Some models place shares on a filesystem where the container user cannot be
+  granted access at all without creating a matching NAS user.
+
+**What to check:**
+
+1. Prefer a **local volume path** on the NAS over an SMB or network mount. A
+   local path behaves like normal Linux storage.
+2. Create a user with uid 1001 on the NAS, or give your media folder permissions
+   that allow uid 1001 to write.
+3. Run the write test. Do not skip it. This is the platform where "it looked
+   fine" most often means "it recorded nothing".
+
+## Unraid
+
+Unraid installs are common and the stack should run, but the default storage
+path is the thing to think about.
+
+**Known sharp edges:**
+
+- `/mnt/user/...` is a **FUSE user share**. Ownership is presented by the share
+  layer based on your share settings, not stored on the underlying disk, so
+  `chown` may appear to succeed and change nothing that the container sees.
+- The user share layer also adds overhead on write heavy workloads, and
+  continuous recording is exactly that.
+- Docker on Unraid commonly remaps to the `nobody:users` pair (uid 99, gid 100),
+  which is not uid 1001.
+
+**What to check:**
+
+1. Consider pointing `MEDIA_HOST_PATH` at a **specific disk or a cache pool**
+   (`/mnt/disk1/...` or `/mnt/cache/...`) rather than `/mnt/user/...`. You give
+   up share spanning and get predictable ownership and faster writes.
+2. Set the share's Access Mode and ownership so uid 1001 can write, or adjust
+   the container's user mapping to match what your share grants.
+3. Run the write test.
+
+## Windows and macOS, Docker Desktop or WSL2
+
+Fine for trying Crumb out. Not what you want for a recorder that runs for
+months.
+
+**Known sharp edges:**
+
+- A bind mount from a Windows drive or a macOS folder crosses a translation
+  layer (9p or virtiofs). Linux file ownership is synthesised, so `chown 1001`
+  is meaningless and permissions come from the mount configuration.
+- Writing continuous video across that layer is much slower than writing to a
+  native Linux filesystem.
+- Docker Desktop's virtual machine has its own disk size limit, which footage
+  will reach.
+- **Apple Silicon Macs run the server images under emulation**, because they are
+  amd64 only. Expect it to be slow.
+
+**What to check:**
+
+1. On WSL2, keep `MEDIA_HOST_PATH` inside the **WSL filesystem**
+   (`/home/you/crumb-data`), not on `/mnt/c/...`. This avoids the translation
+   layer entirely and is much faster.
+2. On macOS, use a Docker named volume or a path inside the VM rather than a
+   bind mount from your home folder.
+3. Run the write test.
+
+## Raspberry Pi and other ARM boards
+
+**The Crumb server does not run on ARM today.** The published `api` and
+`recorder` images are built for `linux/amd64` only. This is a deliberate choice,
+not an oversight: the ARM build was an emulated compile that added roughly an
+hour to every deploy, for no known ARM operator.
+
+Your options right now:
+
+- Run the server on any amd64 machine. A small mini PC is inexpensive and will
+  outperform a Pi at continuous recording anyway.
+- Build the images yourself on the ARM host. Nothing in the code is amd64
+  specific, so this is expected to work, but it is not tested and you are on
+  your own for it.
+
+**The clients are unaffected.** The Android app ships its own build, and the
+desktop app is built separately. Only the server side is amd64 only.
+
+This is demand gated. If you want to self host the Crumb server on ARM, open an
+issue and say so. A real operator asking is exactly the trigger for adding ARM
+images back.
+
+## Still not recording?
+
+Work through
+[Troubleshooting](/troubleshooting/), and check the recorder's own alert: it
+raises a loud `storage_unwritable` warning in the admin console when it cannot
+write, which is the definitive answer for a stack that is already running.

--- a/docs-site/sidebars.js
+++ b/docs-site/sidebars.js
@@ -11,6 +11,7 @@ const sidebars = {
         'getting-started/quickstart',
         'getting-started/what-is-crumb',
         'getting-started/requirements',
+        'getting-started/platform-notes',
         'getting-started/install-docker-compose',
         'getting-started/install-with-ai-agent',
         'getting-started/first-run-wizard',

--- a/docs/AI-INSTALL.md
+++ b/docs/AI-INSTALL.md
@@ -101,7 +101,11 @@ dataset:
 
 - **LXC:** a mount point to a ZFS dataset, e.g.
   `pct set <id> --mp0 /tank/crumb-media,mp=/data/media`, then set
-  `MEDIA_HOST_PATH=/data/media` in `.env`.
+  `MEDIA_HOST_PATH=/data/media` in `.env`. **Unprivileged LXC shifts user IDs**:
+  container uid 1001 is host uid **101001** with the usual 100000 offset, so the
+  ownership fix runs on the Proxmox *host*
+  (`chown -R 101001:101001 /tank/crumb-media`). Getting this wrong is the most
+  likely reason an LXC install records nothing; Step 3's preflight catches it.
 - **VM:** a separate virtio disk on the pool, mounted in the guest, then point
   `MEDIA_HOST_PATH` at that mount.
 
@@ -161,9 +165,47 @@ Set the media path in `.env` to the target disk:
 - `MEDIA_HOST_PATH`: host directory bind-mounted into the containers.
 - (Storage buckets live under it; the default live/archive paths are fine for most.)
 
-Ensure the directory exists and is writable by the container user.
+**Prefer setting it BEFORE Step 2**, so `setup-env.sh` prepares and preflights
+the real target instead of the `./_data` default:
 
-**Verify:** the path exists, is on the intended disk, and is writable.
+```sh
+MEDIA_HOST_PATH=/mnt/tank/crumb scripts/setup-env.sh
+```
+
+If you already ran Step 2, edit `MEDIA_HOST_PATH` in `.env` and re-run
+`MEDIA_HOST_PATH=<path> scripts/setup-env.sh --force` (this rotates the
+generated secrets, so capture the new admin password), or do the ownership and
+write check by hand as below.
+
+**The recorder writes as uid 1001, and this is the failure that hurts.** If uid
+1001 cannot write to `MEDIA_HOST_PATH`, live view still works, the wizard still
+shows green (the api mounts `/data` read-only and cannot test writing), and
+**nothing is ever recorded**. `setup-env.sh` now preflights it:
+
+- It reports the media directory's **filesystem type**, and prints a prominent
+  block for NFS / SMB-CIFS / FUSE mounts, where `chown 1001:1001` on this host
+  may do nothing because the server or the mount options decide ownership.
+- It **probes an actual uid-1001 write** (impersonating uid 1001 when run as
+  root, otherwise a container as `--user 1001`, otherwise reading the
+  directory's own mode) and **exits non-zero** when the answer is definitely no.
+  The admin password is still printed before it exits.
+- It **warns** (does not fail) when free space is under 10 GiB.
+
+**Verify:** the path exists, is on the intended disk, and `setup-env.sh` exited
+0 with `storage preflight: uid 1001 CAN write to <path>`. If you set the path up
+by hand, confirm it yourself:
+
+```sh
+sudo -u '#1001' touch <MEDIA_HOST_PATH>/.crumb-write-test && sudo rm <MEDIA_HOST_PATH>/.crumb-write-test
+```
+
+**Not a plain Debian/Ubuntu host?** NAS appliances (Synology, QNAP), Unraid user
+shares, unprivileged Proxmox LXC (uid shift), and Docker Desktop / WSL2 each
+break the ownership assumption differently, and the Crumb server images are
+**amd64 only** so Raspberry Pi and other ARM boards are not supported yet. The
+per-platform caveats and what to check are in
+`docs-site/docs/getting-started/platform-notes.md`
+(published at `/getting-started/platform-notes`).
 
 **About the recording modes (read before adding cameras).** Continuous
 records every camera to disk 24/7, the safe, well-understood default.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,57 @@ revisit.
 
 ---
 
+## 2026-08-06, setup-env.sh fails the install when uid 1001 cannot write to the media dir (tiered probe, deferred exit)
+
+**Context.** A media directory the recorder (uid 1001) cannot write is the worst
+failure mode Crumb has, because it does not present as a failure: live view runs
+off go2rtc and never touches disk, the first-run wizard shows green (the api
+mounts `/data` read-only and so cannot test writing), and footage is silently
+never saved. `setup-env.sh` only did a best-effort `chown 1001:1001`, which on a
+large share of real hosts reports success while changing nothing the container
+sees: NFS `root_squash`, SMB uid mapping, FUSE user shares (Unraid `/mnt/user`),
+and the 100000 uid shift of an unprivileged Proxmox LXC.
+
+**Decision.** Preflight the media directory and **exit non-zero** on a definite
+negative, rather than warn. Recording nothing is not a degraded install, it is a
+non-install, and the operator finds out days later when they go looking for
+footage. Three supporting choices:
+
+- **Tiered probe, most faithful method that can answer honestly.** Impersonate
+  uid 1001 (root, `sudo -u '#1001'` or `setpriv`), else a container run as
+  `--user 1001`, else read the directory's own owner/group/mode. An inconclusive
+  tier never produces a verdict, it falls through; if no tier can answer, the
+  script prints the manual one-liner and exits 0. A false hard failure on a
+  working install would be worse than the warning it replaces.
+- **The docker tier never pulls.** It runs only against an image already on the
+  host, and discriminates `touch`'s exit 1 (a real EACCES verdict) from docker's
+  own 125/126/127 (an exec problem, not a verdict). setup-env runs before any
+  `docker compose pull`, and making secret generation depend on registry
+  reachability would break air-gapped installs.
+- **The exit is deferred to the end of the run**, after the one-time admin
+  password is printed. `.env` is complete and correct when storage is broken;
+  what failed is the host. Dying mid-script would cost the operator their
+  credential to save them a scroll.
+
+**Rejected:** warn-only (the status quo that produced the bug, and the reason
+nobody noticed); probing from the recorder at boot *instead of* here (it already
+raises `storage_unwritable`, but by then the operator has walked away believing
+the install succeeded, so this is additive, not a replacement); requiring root
+for setup-env (would break the documented non-root install path).
+
+**Trade-off accepted:** a plain non-root `git clone && ./scripts/setup-env.sh`
+on a host where the media dir is not yet uid-1001-writable now exits 1 where it
+previously printed a NOTE and exited 0. That is intended, it is exactly the
+broken install this catches, and the error names the fix. Any automation that
+treated setup-env's exit code as "secrets generated" needs to read it as
+"secrets generated AND storage verified".
+
+**Revisit when:** the probe produces a false negative on a real operator's host
+(then narrow the tier that got it wrong, do not weaken the exit), or the wizard
+grows a genuine server-side write test that makes the pre-boot check redundant.
+
+---
+
 ## 2026-08-06, Per-state HA badge backgrounds: one extra nullable column that inherits from the base (not paired per-state columns)
 
 **Context.** Migration 0062 gave a placed HA badge a single solid background

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -164,6 +164,21 @@ else
   log "NOTE: could not detect a host LAN IP — leaving WEBRTC_CANDIDATE blank. Set it to <server-LAN-ip>:8556 in .env for iOS/WebRTC live view (docs/IOS-LIVE-VIDEO.md)."
 fi
 
+# ── Where footage will be written ────────────────────────────────────────────
+# Defaults to ./_data (relative to the repo root), which is what a plain
+# `git clone && setup-env.sh` wants. Real installs usually record onto a
+# mounted disk or a NAS share instead, so accept it up front rather than making
+# the operator hand-edit .env and re-do the ownership work by hand:
+#
+#   MEDIA_HOST_PATH=/mnt/tank/crumb scripts/setup-env.sh
+#
+# Whatever it points at gets the same prep + storage preflight below.
+MEDIA_HOST_PATH_VALUE="${MEDIA_HOST_PATH:-./_data}"
+case "${MEDIA_HOST_PATH_VALUE}" in
+  /*) MEDIA_DIR_HOST="${MEDIA_HOST_PATH_VALUE}" ;;
+  *)  MEDIA_DIR_HOST="${REPO_ROOT}/${MEDIA_HOST_PATH_VALUE#./}" ;;
+esac
+
 # Write atomically: build in a temp file, then move into place.
 TMP="$(mktemp "${ENV_FILE}.XXXXXX")"
 trap 'rm -f "${TMP}"' EXIT
@@ -247,7 +262,7 @@ MOTION_RECORDING_SHADOW=0
 # --- Storage ---
 # ONE broad media root, bind-mounted into both containers. Add a disk by mounting
 # it under MEDIA_HOST_PATH and adding the storage path '/data/<subdir>' in the UI.
-MEDIA_HOST_PATH=./_data
+MEDIA_HOST_PATH=${MEDIA_HOST_PATH_VALUE}
 MEDIA_ROOT=/data
 LIVE_STORAGE_PATH=/data/live
 ARCHIVE_STORAGE_PATH=/data/archive
@@ -355,7 +370,7 @@ trap - EXIT
 # probe writability). Prep it here with the right ownership so a stock install
 # actually records. Best-effort: a non-root run without sudo prints exactly what
 # to fix, and the recorder now also raises a loud `storage_unwritable` alert.
-MEDIA_DIR_HOST="${REPO_ROOT}/_data"
+# (MEDIA_DIR_HOST was resolved from MEDIA_HOST_PATH above.)
 mkdir -p "${MEDIA_DIR_HOST}" 2>/dev/null || true
 if [[ -d "${MEDIA_DIR_HOST}" ]]; then
   if chown 1001:1001 "${MEDIA_DIR_HOST}" 2>/dev/null; then
@@ -367,6 +382,169 @@ if [[ -d "${MEDIA_DIR_HOST}" ]]; then
   fi
 else
   log "NOTE: could not create ${MEDIA_DIR_HOST} — create it and chown 1001:1001 before 'docker compose up', or the recorder records nothing."
+fi
+
+# ── Storage preflight ────────────────────────────────────────────────────────
+# The chown above is best-effort AND, on a lot of real hosts, meaningless: it
+# reports success while the recorder still cannot write a byte. The three that
+# actually bite people:
+#
+#   * Network mounts (NFS / SMB-CIFS). chown either fails or is ignored, because
+#     the SERVER owns the permissions. NFS root_squash maps root to nobody; SMB
+#     applies whatever uid the mount options say, for the whole mount.
+#   * FUSE user shares (Unraid /mnt/user, rclone, sshfs, MergerFS). Ownership is
+#     synthesised by the fuse driver from mount options, not stored on disk.
+#   * A root-owned directory and a non-root run with no sudo. chown fails, the
+#     script says so, and the operator does not notice.
+#
+# In every one of those the failure mode is identical and silent: live view
+# works, the wizard shows green, and NOTHING is recorded. So probe for real
+# instead of assuming, and fail the run when the answer is definitely no.
+# Platform-by-platform notes: docs-site/docs/getting-started/platform-notes.md.
+STORAGE_PREFLIGHT_FAILED=0
+FREE_SPACE_FLOOR_KIB=10485760   # 10 GiB
+
+# Filesystem type of the mount holding $1. Empty = could not determine (that is
+# a "skip the check", never a failure). GNU stat first, then df -T, then mount.
+fs_type_of() {
+  local dir="$1" t=""
+  t="$(stat -f -c %T "${dir}" 2>/dev/null || true)"
+  [[ -n "${t}" ]] && { printf '%s' "${t}"; return 0; }
+  t="$(df -T "${dir}" 2>/dev/null | awk 'NR==2 {print $2}' || true)"
+  [[ -n "${t}" ]] && { printf '%s' "${t}"; return 0; }
+  t="$(mount 2>/dev/null | awk -v d="${dir}" '$3 == d {print $5}' | head -n1 || true)"
+  printf '%s' "${t}"
+}
+
+# True for filesystems where uid/gid are decided somewhere other than this
+# host's inode bits, so `chown 1001:1001` is not the fix (or not the whole fix).
+fs_is_remapping() {
+  case "$1" in
+    nfs*|cifs|smb*|fuse|fuse.*|fuseblk|9p|drvfs|afs|sshfs|gluster*|ceph*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Can uid 1001 create a file in $1? Prints exactly one of: pass | fail | unknown.
+# Tiers, most faithful first; each tier only answers when it can answer honestly.
+probe_uid1001_write() {
+  local dir="$1" marker="$1/.crumb-write-test" rc=0 img mode owner group u g o
+
+  # Tier 1 — actually become uid 1001. Needs root, and is the real answer.
+  if [[ "$(id -u)" -eq 0 ]]; then
+    if command -v sudo >/dev/null 2>&1; then
+      if sudo -n -u '#1001' touch "${marker}" 2>/dev/null; then
+        rm -f "${marker}" 2>/dev/null || true; printf 'pass'; return 0
+      fi
+      # Distinguish "uid 1001 was refused" from "sudo itself is unusable here".
+      if sudo -n -u '#1001' true 2>/dev/null; then printf 'fail'; return 0; fi
+    elif command -v setpriv >/dev/null 2>&1; then
+      if setpriv --reuid=1001 --regid=1001 --clear-groups touch "${marker}" 2>/dev/null; then
+        rm -f "${marker}" 2>/dev/null || true; printf 'pass'; return 0
+      fi
+      if setpriv --reuid=1001 --regid=1001 --clear-groups true 2>/dev/null; then
+        printf 'fail'; return 0
+      fi
+    fi
+  fi
+
+  # Tier 2 — the actual runtime: a container as uid 1001 with the dir bind-mounted.
+  # Only ever with an image ALREADY on this host; setup-env must not pull anything.
+  # The marker is created AND removed inside the same container, because it lands
+  # owned by uid 1001: a non-root run of this script often cannot unlink it
+  # afterwards, and leaving litter in the footage root is not acceptable.
+  # Exit 1 is the verdict (touch hit EACCES); docker's own 125/126/127 are not.
+  if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    for img in alpine:latest busybox:latest debian:stable-slim ubuntu:latest; do
+      docker image inspect "${img}" >/dev/null 2>&1 || continue
+      if docker run --rm --user 1001:1001 --entrypoint sh \
+           -v "${dir}:/probe" "${img}" \
+           -c 'touch /probe/.crumb-write-test && rm -f /probe/.crumb-write-test' \
+           >/dev/null 2>&1; then
+        printf 'pass'; return 0
+      else
+        rc=$?
+      fi
+      [[ "${rc}" -eq 1 ]] && { printf 'fail'; return 0; }
+      break   # 125/126/127: docker/exec problem, not a verdict about permissions
+    done
+  fi
+
+  # Tier 3 — no way to impersonate (non-root, no usable docker). Read the
+  # directory's own owner/group/mode. Creating a file needs BOTH w and x, so the
+  # relevant octal digits are 3 (-wx) and 7 (rwx).
+  owner="$(stat -c %u "${dir}" 2>/dev/null || true)"
+  group="$(stat -c %g "${dir}" 2>/dev/null || true)"
+  mode="$(stat -c %a "${dir}" 2>/dev/null || true)"
+  [[ -n "${owner}" && -n "${mode}" ]] || { printf 'unknown'; return 0; }
+  while [[ "${#mode}" -lt 4 ]]; do mode="0${mode}"; done
+  u="${mode:1:1}"; g="${mode:2:1}"; o="${mode:3:1}"
+  if [[ "${owner}" == "1001" ]] && [[ "${u}" == "3" || "${u}" == "7" ]]; then printf 'pass'; return 0; fi
+  if [[ "${group}" == "1001" ]] && [[ "${g}" == "3" || "${g}" == "7" ]]; then printf 'pass'; return 0; fi
+  if [[ "${o}" == "3" || "${o}" == "7" ]]; then printf 'pass'; return 0; fi
+  printf 'fail'
+}
+
+if [[ -d "${MEDIA_DIR_HOST}" ]]; then
+  MEDIA_FS="$(fs_type_of "${MEDIA_DIR_HOST}")"
+  if [[ -n "${MEDIA_FS}" ]]; then log "media filesystem: ${MEDIA_FS} (${MEDIA_DIR_HOST})"; fi
+
+  # 1. Network / remapping filesystem: say plainly that this is a SERVER-side fix.
+  MEDIA_FS_REMAPS=0
+  if [[ -n "${MEDIA_FS}" ]] && fs_is_remapping "${MEDIA_FS}"; then
+    MEDIA_FS_REMAPS=1
+    log ""
+    log "  ┌─ NETWORK / REMAPPING FILESYSTEM (${MEDIA_FS}) ───────────────────────"
+    log "  │ ${MEDIA_DIR_HOST} is not a plain local disk, so 'chown 1001:1001'"
+    log "  │ here may do nothing at all — the export's server decides ownership."
+    log "  │ Grant uid 1001 write access on the SERVER side instead:"
+    log "  │"
+    log "  │   NFS  : export with no_root_squash, or chown the directory to"
+    log "  │          uid 1001 ON THE NFS SERVER (root_squash maps root->nobody)."
+    log "  │   SMB  : mount with uid=1001,gid=1001 (and file_mode/dir_mode=0775),"
+    log "  │          or map the share's user to uid 1001 on the NAS."
+    log "  │   FUSE : ownership comes from the mount options, not the disk"
+    log "  │          (Unraid /mnt/user, rclone, sshfs, MergerFS)."
+    log "  │"
+    log "  │ Confirm it yourself, from this host, before adding cameras:"
+    log "  │   sudo -u '#1001' touch ${MEDIA_DIR_HOST}/.crumb-write-test"
+    log "  └──────────────────────────────────────────────────────────────────────"
+    log ""
+  fi
+
+  # 2. The probe that decides whether this install can record at all.
+  MEDIA_WRITE="$(probe_uid1001_write "${MEDIA_DIR_HOST}")"
+  case "${MEDIA_WRITE}" in
+    pass)
+      log "storage preflight: uid 1001 CAN write to ${MEDIA_DIR_HOST}" ;;
+    fail)
+      STORAGE_PREFLIGHT_FAILED=1
+      log "storage preflight: uid 1001 CANNOT write to ${MEDIA_DIR_HOST} — see the failure at the end." ;;
+    *)
+      log "storage preflight: could not determine whether uid 1001 can write to ${MEDIA_DIR_HOST}."
+      log "      Check it by hand before adding cameras:"
+      log "        sudo -u '#1001' touch ${MEDIA_DIR_HOST}/.crumb-write-test && sudo rm ${MEDIA_DIR_HOST}/.crumb-write-test" ;;
+  esac
+
+  # A remapping filesystem plus a negative probe is still worth failing on, but
+  # the fix is the server-side one printed above, not a local chown — so say so.
+  if [[ "${STORAGE_PREFLIGHT_FAILED}" -eq 1 && "${MEDIA_FS_REMAPS}" -eq 1 ]]; then
+    log "      (on ${MEDIA_FS} the fix is server-side, per the block above — a local chown will not help.)"
+  fi
+
+  # 3. Free space. A warning, never a failure: a small disk is a legitimate
+  #    choice, an unnoticed one is not.
+  MEDIA_FREE_KIB="$(df -Pk "${MEDIA_DIR_HOST}" 2>/dev/null | awk 'NR==2 {print $4}' || true)"
+  if [[ -n "${MEDIA_FREE_KIB}" ]]; then
+    if [[ "${MEDIA_FREE_KIB}" -lt "${FREE_SPACE_FLOOR_KIB}" ]]; then
+      log "NOTE: only $(( MEDIA_FREE_KIB / 1024 )) MiB free at ${MEDIA_DIR_HOST}."
+      log "      Cameras eat terabytes. Point MEDIA_HOST_PATH at a real disk, or set"
+      log "      retention low enough that this fills predictably rather than by surprise:"
+      log "        MEDIA_HOST_PATH=/mnt/<disk>/crumb scripts/setup-env.sh --force"
+    else
+      log "storage preflight: $(( MEDIA_FREE_KIB / 1048576 )) GiB free at ${MEDIA_DIR_HOST}"
+    fi
+  fi
 fi
 
 # ── DB-backup directory prep ─────────────────────────────────────────────────
@@ -428,4 +606,30 @@ log "    username: ${SEED_ADMIN_USERNAME}"
 log "    password: ${SEED_ADMIN_PASSWORD}"
 log ""
 log "  (also stored as SEED_ADMIN_PASSWORD in ${ENV_FILE}; change it in the console after first login)"
+
+# The storage preflight verdict is reported LAST and, on a definite failure,
+# exits nonzero. It runs earlier (right after the media dir is prepped) but the
+# exit is deferred to here on purpose: the admin password above is printed once,
+# and dying before it would cost the operator their credential to save them a
+# scroll. .env itself is complete and correct either way — what is broken is the
+# host's storage, not the config.
+if [[ "${STORAGE_PREFLIGHT_FAILED}" -eq 1 ]]; then
+  log ""
+  printf '[setup-env] ERROR: %s\n' "the recorder (uid 1001) cannot write to ${MEDIA_DIR_HOST}." >&2
+  printf '[setup-env]        %s\n' "Starting the stack like this looks fine and records NOTHING: live" >&2
+  printf '[setup-env]        %s\n' "view works, the wizard shows green, and no footage is ever saved." >&2
+  printf '[setup-env]        %s\n' "" >&2
+  printf '[setup-env]        %s\n' "Local disk, fix and re-run:" >&2
+  printf '[setup-env]        %s\n' "  sudo chown -R 1001:1001 ${MEDIA_DIR_HOST}" >&2
+  printf '[setup-env]        %s\n' "" >&2
+  printf '[setup-env]        %s\n' "NFS / SMB / FUSE share, grant uid 1001 write access on the SERVER" >&2
+  printf '[setup-env]        %s\n' "or in the mount options (see the block printed above)." >&2
+  printf '[setup-env]        %s\n' "" >&2
+  printf '[setup-env]        %s\n' "Then confirm, and only then 'docker compose up -d':" >&2
+  printf '[setup-env]        %s\n' "  sudo -u '#1001' touch ${MEDIA_DIR_HOST}/.crumb-write-test" >&2
+  printf '[setup-env]        %s\n' "" >&2
+  printf '[setup-env]        %s\n' "Platform-by-platform notes: docs-site/docs/getting-started/platform-notes.md" >&2
+  exit 1
+fi
+
 log "NEXT: 'docker compose up -d', then open http://<host>:8080/admin and sign in with the above."


### PR DESCRIPTION
## Why

A media directory the recorder (uid 1001) cannot write is the worst failure this project has, and it does not present as a failure:

- live view works (go2rtc restream, never touches disk)
- the first-run wizard shows green (the api mounts `/data` read-only, so it cannot test writing)
- and no footage is ever saved

`setup-env.sh` only did a best-effort `chown 1001:1001`. On a large share of hosts strangers actually install on, that reports success while changing nothing the container sees: NFS `root_squash`, SMB uid mapping, FUSE user shares (Unraid `/mnt/user`), and the 100000 uid shift of an unprivileged Proxmox LXC.

## What changed

**`scripts/setup-env.sh` preflights the media directory.**

1. **Filesystem type detection** (`stat -f -c %T`, then `df -T`, then `mount`). For `nfs*` / `cifs` / `smb*` / `fuse*` / `9p` / `drvfs` / sshfs / gluster / ceph it prints a prominent block saying the fix is server side, with the per-protocol change (NFS `no_root_squash` or chown on the server, SMB `uid=1001,gid=1001`, FUSE mount options) and the confirm one-liner.
2. **A real uid-1001 write probe**, most faithful method that can answer honestly first:
   - **Tier 1** impersonate uid 1001 (`sudo -u '#1001'`, else `setpriv`), root only
   - **Tier 2** a container run as `--user 1001` with the dir bind-mounted, using only an image **already on the host** (never pulls), discriminating `touch`'s exit 1 (real EACCES) from docker's own 125/126/127 (exec problem, not a verdict). Marker is created and removed inside the same container, since a non-root run often cannot unlink a uid-1001 file afterwards.
   - **Tier 3** read the directory's own owner/group/mode
   - A definite "no" **exits non-zero**. An inconclusive answer never fails, it prints the manual check.
3. **Free-space warning** under 10 GiB. A warning, never a failure.

**The hard exit is deferred** to after the one-time admin password is printed. `.env` is complete and correct when storage is broken; what failed is the host. Dying mid-script would cost the operator their credential to save them a scroll.

**`MEDIA_HOST_PATH` is now honoured as an input**, so the directory that gets prepped and preflighted is the real target instead of always `./_data`:

```sh
MEDIA_HOST_PATH=/mnt/tank/crumb scripts/setup-env.sh
```

**New docs page: `getting-started/platform-notes`.** An honest table (tested / should work but unverified / not supported) for Debian-Ubuntu bare and VM, Proxmox VM and unprivileged LXC (including the 100000 uid shift), Synology and QNAP, Unraid user shares, Docker Desktop and WSL2, and Raspberry Pi / ARM. ARM is stated plainly as **not supported**: the server images are `linux/amd64` only per `docs/DECISIONS.md` 2026-07-16, and it is demand gated.

## Behaviour matrix

Verified on dev2 (Debian 13, Docker 29.6.1), all six cases:

| Filesystem | Run as | Tier that answered | Outcome |
|---|---|---|---|
| local (tmpfs/zfs) | root | 1, impersonation | pass, exit 0 |
| local (zfs), dir not uid-1001-writable | non-root, no docker | 3, static mode | **fail, exit 1** |
| `nfs4` | root, chown succeeded | 1 | warning block + pass, exit 0 |
| `nfs4`, not writable | non-root | 3 | warning block + "fix is server-side" + **exit 1** |
| local, dir not uid-1001-writable | non-root in docker group | 2, container | **fail, exit 1** |
| local, dir chowned 1001 | non-root in docker group | 2, container | pass, exit 0, no leftover marker |
| no docker, no `stat -c` | non-root | none | **unknown, exit 0** + manual one-liner (no false failure) |
| 8 MiB tmpfs target | root | 1 | pass + free-space NOTE, exit 0 |

Credential ordering confirmed: the admin password is printed before the failure block in every failing case.

## Gate

- `bash -n scripts/setup-env.sh` clean.
- `sh -n` fails at line 60 on **`origin/main` too** (`local adjectives=(...)`, a pre-existing bash array in `gen_password`). This file is `#!/usr/bin/env bash` and already uses arrays and `[[ ]]`; the added code introduces no new dash incompatibility. Converting the whole script to POSIX sh is out of scope for this PR.
- Docs site green on dev2: `sync-arch-docs.mjs` + `gen-camera-compat.mjs` + `npm ci` + `npm run build` all succeed, new page builds at `/getting-started/platform-notes` and appears in the Getting Started sidebar.
- No Rust touched, so the cargo gate is unaffected.

## Golden rules

- **5 (install guide honest):** `docs/AI-INSTALL.md` step 3 rewritten (preflight behaviour, the `MEDIA_HOST_PATH=` invocation, the manual write test) plus the Proxmox LXC storage bullet (uid shift), and the README manual path (what-you-need paragraph now states amd64-only and the Docker Desktop caveats, step 2 comment, a "do not skip the storage error" note, and the Proxmox bullet now points at platform notes).
- **7 (decision log):** entry added for the hard-fail choice, the tiered probe, the never-pull docker tier, and the deferred exit, each with what was rejected and a revisit trigger.
- No chown lines were modified, to stay clear of the separate fail-loud-on-chown fix.

## Note for the reviewer

This changes an exit code that automation may depend on: a non-root `git clone && ./scripts/setup-env.sh` on a host whose media dir is not yet uid-1001-writable now exits 1 where it previously exited 0 with a NOTE. That is the intended catch, and it is called out in the decision entry.
