### PR TITLE
fix(admin): warn on the Motion tab when a camera has no sub-stream

### DIFF
--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -6156,6 +6156,12 @@ function renderCamMotionTab(c) {
   const gridOpts = CM_GRID_OPTS.map(([v,l]) => `<option value="${v}" ${gridKey===v?'selected':''}>${l}</option>`).join('');
   // Manual-floor SLIDER seed: the effective threshold as a % of frame (0.05–5).
   const thPct = p.motion_threshold != null ? +(p.motion_threshold * 100).toFixed(2) : 0.5;
+  // Pixel analysis runs on the SUB stream only (recorder: `sub_rtsp_url_opt()`),
+  // so a main-only camera can never produce a motion event — it just fails open
+  // and records continuously. That was invisible here while the box stayed
+  // ticked, so warn on the tab that owns the setting (#522). Same emptiness test
+  // the recorder uses; `sub_url` is derived from the Connection tab's sub URL.
+  const hasSub = !!(c.sub_url && String(c.sub_url).trim());
   // LIVE-TUNER-FIRST layout (UX principle): the tuner window is pinned at the TOP,
   // settings sit UNDER it in two columns, so changing a setting and seeing the live
   // meter result needs no scrolling.
@@ -6199,6 +6205,7 @@ function renderCamMotionTab(c) {
             <label class="chk"><input type="checkbox" id="ce-motion-ha" ${(c.motion_ha_enabled ?? (c.motion_source==='ha'))?'checked':''} onchange="ceMotionSourceChanged()"/> Home Assistant sensors</label>
           </div>
         </div>
+        ${hasSub ? '' : `<div id="ce-motion-nosub-warn" class="warn-note hidden"><b>This camera has no sub-stream, so pixel analysis can't run.</b> Crumb's pixel detector reads the sub-stream only, so this camera produces no motion events, no timeline motion track and no motion clips — a Motion-mode policy falls back to recording continuously. Add a <b>sub-stream URL</b> on the <b>Connection</b> tab, or use Frigate detections / Home Assistant sensors as the motion source instead.</div>`}
         <div id="ce-motion-algo-wrap" style="margin-top:8px">
           <div class="form-grid narrow">
             <label class="fg-label" for="ce-motion-algorithm">Algorithm ${infoHint(MOTION_ALGO_HINT_ALL)}</label>
@@ -7813,6 +7820,11 @@ function ceMotionSourceChanged() {
   const wrap = $('ce-motion-algo-wrap');
   const help = $('ce-motion-algo-help');
   if (wrap) wrap.classList.toggle('hidden', !pixel);
+  // #522: the no-sub warning only exists when the camera HAS no sub-stream; show
+  // it exactly while pixel analysis is the (silently no-op) selected source, so
+  // ticking the box surfaces the problem before the operator ever hits Save.
+  const noSub = $('ce-motion-nosub-warn');
+  if (noSub) noSub.classList.toggle('hidden', !pixel);
   if (help) {
     help.innerHTML = pixel
       ? motionAlgoHelp($('ce-motion-algorithm') ? $('ce-motion-algorithm').value : 'census')


### PR DESCRIPTION
Fixes #522

## The bug

Crumb's pixel motion detector reads the **sub-stream only** — the recorder's
`sub_rtsp_url_opt()` returns `None` for a main-only camera and the motion worker
idles (deliberately, so it does not 404-loop on a synthesised `<name>_sub`).

The camera's Motion tab nevertheless showed **"Pixel analysis (Crumb)" ticked**
with nothing to say about it. The truth existed only on *Detection & clips*
(grey "no local decode" pill, the "Motion detection DOWN" badge) and in a
delayed `motion_detector_unhealthy` event — everywhere except the one page that
offers the setting. A first-time operator ticks the box, saves, sees no
complaint, and reasonably believes motion detection is running.

Plenty of real cameras ship main-only: cheap ONVIF units, older models with the
second stream disabled in firmware defaults, and anything added by hand where
the operator simply did not know to fill in the sub URL.

Footage is not at risk — Motion mode fails open and records everything — but
motion events, the timeline motion track, clips and motion notifications are
silently lost for that camera.

## The fix

`renderCamMotionTab` now renders an inline `warn-note` under the Sources
checkboxes when the camera has no sub-stream, and `ceMotionSourceChanged` shows
it exactly while Pixel analysis is ticked — so it appears the moment the box is
ticked, before the operator ever hits Save, and disappears if they switch to
Frigate / Home Assistant instead.

> **This camera has no sub-stream, so pixel analysis can't run.** Crumb's pixel
> detector reads the sub-stream only, so this camera produces no motion events,
> no timeline motion track and no motion clips — a Motion-mode policy falls back
> to recording continuously. Add a **sub-stream URL** on the **Connection** tab,
> or use Frigate detections / Home Assistant sensors as the motion source
> instead.

It names the consequence and both fixes, rather than just flagging a problem.

The gate is `c.sub_url` — the same value the recorder tests, and one the API
derives from the Connection tab's sub URL at save time, so the warning cannot
lag the setting. It matches the existing `hasSub` gate on the tab's Sub probe
row.

12 added lines, no removals; `warn-note` and `hidden` are existing classes and
no new `on*=` handler is introduced.

## Verification

* `node --check` on the extracted `<script>` block (lines 769–11048) — clean.
* `cargo check -p crumb-api` on the build box — clean (admin.html is
  `include_str!`-embedded, so this confirms it still builds in).

## Deliberately not in this PR

The issue's follow-ups are separate changes and are left to #522's successors:

* carrying `camera_decode_status.fallback_reason` into the
  `motion_detector_unhealthy` alert text (backend, `notifications.rs`);
* the generic `motion_health_reason` for the keyframes-only / very-long-GOP sub
  case (backend, `motion.rs`).

The equivalent warning on the desktop / Android / iOS tuner surfaces is deferred
too, matching how the existing motion-health badge was landed console-first.
