### PR TITLE
fix(android): fall back to the server H.264 transcode when a camera is H265 all the way down

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveCameraTile.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveCameraTile.kt
@@ -79,6 +79,11 @@ import kotlinx.coroutines.launch
  * - Uses the sub stream when available (low-res, conserves bandwidth in grid
  *   view), otherwise falls back to rtspMainUrl. Which sub is [subStreamUrl]'s
  *   call: the video-only `_subv` when the server offers one, else the raw sub.
+ * - A stream that never produces a playable frame steps DOWN the fallback ladder
+ *   ([wallStreamChain]) instead of reconnect-looping: `subv → sub → mobile`, or
+ *   `main → mobile` on a camera with no sub. Media3's RTSP stack can't decode
+ *   H.265, and a camera that ships H265 on BOTH main and sub (#524) has nothing
+ *   playable until the server's H.264 `_mobile` transcode — the last rung.
  * - The [LiveStreamsResponse] is pre-resolved by [LiveViewModel] so this
  *   composable never performs network I/O.
  * - The ExoPlayer is built once in [remember], starts playing immediately, and
@@ -332,13 +337,22 @@ private fun LiveRtspContent(
     // we show a subtle "Reconnecting…" badge instead of the hard error.
     var isReconnecting by remember { mutableStateOf(false) }
 
-    // Choose sub stream for grid; fall back to main. `subStreamUrl()` prefers the
-    // video-only `_subv` restream, which repairs the missing-fmtp SDP that makes
-    // Media3 reconnect-loop on some cameras (#483), and falls back to the raw sub
-    // when the server has no `_subv` for this camera (unmanaged / older server).
-    val rtspUrl: String? = remember(streams) {
-        streams?.subStreamUrl() ?: streams?.rtspMainUrl
+    // Fallback ladder for this tile: `subv → sub → mobile` when the camera has a
+    // sub (`subStreamUrl()`'s preference for the video-only `_subv` restream,
+    // which repairs the missing-fmtp SDP that makes Media3 reconnect-loop on some
+    // cameras (#483), is the first two rungs), else `main → mobile`. The wall
+    // never escalates to the main's bitrate on a camera that has a sub.
+    val chain: List<StreamTier> = remember(streams) { streams?.wallStreamChain() ?: emptyList() }
+    // Rungs already known unplayable for this camera THIS app run — seeded from
+    // the process-scoped memory so a wall reload (or a return from fullscreen)
+    // reattaches straight to a rung that plays instead of re-walking the ladder.
+    var failedTiers by remember(streams) {
+        mutableStateOf(LiveStreamFallbackMemory.failedTiers(camera.id))
     }
+    var tier by remember(streams) { mutableStateOf(startTier(chain, failedTiers)) }
+    // Derived (not remembered): a fallback swaps `tier`, which must re-key the
+    // player below onto the new URL.
+    val rtspUrl: String? = tier?.let { streams?.urlForTier(it) }
 
     // Device connectivity (#3). While offline, reconnect attempts PAUSE instead of
     // burning the fast-attempt budget against a link that can't reach the server
@@ -422,17 +436,50 @@ private fun LiveRtspContent(
         // Backoff bookkeeping. `attempt` is captured by the listener closure.
         var attempt = 0
         var reconnectJob: Job? = null
+        // Did THIS rung of the ladder ever reach a playable frame? Gates the
+        // fallback: only a stream that never played is treated as undecodable
+        // (one that played and then dropped is a transient blip → reconnect).
+        var everReady = false
 
-        fun scheduleReconnect() {
-            if (player == null || rtspUrl == null) return
-            if (reconnectJob?.isActive == true) return // one in flight already
+        /**
+         * Recover from a failure. Returns true when it stepped DOWN the fallback
+         * ladder (a codec verdict, not a link problem) — the caller uses that to
+         * decide whether the event is worth reporting as a stall.
+         */
+        fun scheduleReconnect(errorCode: Int? = null): Boolean {
+            if (player == null || rtspUrl == null) return false
+            if (reconnectJob?.isActive == true) return false // one in flight already
             // Offline: don't burn the attempt budget on a doomed re-prepare. Park
             // in the reconnecting state (not hard error) — connectivity regained
             // triggers an immediate reset + retry via the DisposableEffect below.
+            // Checked BEFORE the ladder so a dropped Wi-Fi link can't be mistaken
+            // for an undecodable codec and burn every rung.
             if (!isOnline) {
                 isReconnecting = true
                 hasError = false
-                return
+                return false
+            }
+            // ── H265 / unplayable-stream fallback ladder (#524) ──────────────────
+            // Never reached a playable frame ⇒ almost always a codec Media3's RTSP
+            // path can't decode. Step down to the next rung (ending at the server's
+            // H.264 `_mobile` transcode) rather than reconnect-looping forever.
+            val current = tier
+            val next = nextTier(chain, current, failedTiers)
+            if (current != null && next != null &&
+                shouldFallBackToNextTier(hasNextTier = true, everReady = everReady, errorCode = errorCode)
+            ) {
+                LiveStreamFallbackMemory.markFailed(camera.id, current)
+                failedTiers = failedTiers + current
+                tier = next // re-keys the player onto the next rung's URL
+                isReconnecting = false
+                hasError = false
+                return true
+            }
+            // Ladder exhausted with nothing ever playable ⇒ an outage, not a codec
+            // verdict: forget the recorded failures so the next wall load starts
+            // from the top again. Then fall through to the normal backoff.
+            if (next == null && !everReady) {
+                LiveStreamFallbackMemory.clear(camera.id)
             }
             // Past the fast-backoff budget: DON'T stop forever (#2) — fall back to
             // a slow, indefinite retry cadence so the tile keeps quietly trying to
@@ -457,6 +504,7 @@ private fun LiveRtspContent(
                 player.prepare()
                 player.playWhenReady = true
             }.also { trackPlayerJob(it) } // #135: cancellable on ON_STOP
+            return false
         }
 
         val listener = object : Player.Listener {
@@ -476,6 +524,8 @@ private fun LiveRtspContent(
                         isBuffering = false
                         hasError = false
                         isReconnecting = false
+                        // A real frame played — this rung is good, no downgrade.
+                        everReady = true
                     }
                     Player.STATE_ENDED -> {
                         isBuffering = false
@@ -488,13 +538,16 @@ private fun LiveRtspContent(
 
             override fun onPlayerError(error: PlaybackException) {
                 isBuffering = false
-                // Don't go straight to the hard error; try to reconnect first.
-                scheduleReconnect()
+                // Don't go straight to the hard error; try to reconnect first. The
+                // error code goes with it so a decoder/format failure steps down the
+                // fallback ladder even if this rung had been playing.
+                scheduleReconnect(error.errorCode)
             }
 
             override fun onRenderedFirstFrame() {
                 // Live video has painted — cross-fade the snapshot placeholder out.
                 firstFrameSeen = true
+                everReady = true
             }
         }
         player?.addListener(listener)
@@ -534,8 +587,11 @@ private fun LiveRtspContent(
                                 stuckMs += WATCHDOG_TICK_MS
                                 if (stuckMs >= FRAME_STALL_MS) {
                                     stuckMs = 0L; lastPos = -1L; readyHeldMs = 0L
-                                    onStallState.value()   // report to VM for auto-fallback
-                                    scheduleReconnect()
+                                    // Report to the VM for auto-fallback UNLESS this
+                                    // was a codec downgrade — a wall of all-H265
+                                    // cameras walking their ladders is not evidence
+                                    // of a bad link and must not trip low-bw mode.
+                                    if (!scheduleReconnect()) onStallState.value()
                                 }
                             } else {
                                 lastPos = pos
@@ -552,10 +608,19 @@ private fun LiveRtspContent(
                     Player.STATE_BUFFERING -> {
                         lastPos = -1L; stuckMs = 0L; readyHeldMs = 0L
                         bufferingMs += WATCHDOG_TICK_MS
-                        if (bufferingMs >= STALL_BUFFERING_MS) {
+                        // A stream Media3 can't decode (H265 over RTSP) sits in
+                        // BUFFERING without ever erroring. While a fallback rung is
+                        // left, bound that spin instead of waiting out the patient
+                        // stuck-buffering cap; the derived rungs (`_subv`/`_mobile`)
+                        // get longer, since go2rtc spawns their ffmpeg lazily.
+                        val limit = when {
+                            everReady || nextTier(chain, tier, failedTiers) == null -> STALL_BUFFERING_MS
+                            tier == StreamTier.MAIN -> MAIN_FIRSTLOAD_BUFFER_MS
+                            else -> DERIVED_FIRSTLOAD_BUFFER_MS
+                        }
+                        if (bufferingMs >= limit) {
                             bufferingMs = 0L
-                            onStallState.value()       // report to VM for auto-fallback
-                            scheduleReconnect()
+                            if (!scheduleReconnect()) onStallState.value()
                         }
                     }
                     else -> {
@@ -750,6 +815,27 @@ private fun LiveRtspContent(
             TileReconnectingOverlay(modifier = Modifier.align(Alignment.Center))
         }
 
+        // Server-transcode indicator (#524): this camera's own streams turned out
+        // to be undecodable on this device (H.265 over RTSP), so the tile fell all
+        // the way down to the server's H.264 `_mobile` transcode. Teal, not the
+        // amber auto-shed badge — this is a codec accommodation, not backpressure,
+        // and it makes an otherwise invisible degradation legible on the wall.
+        if (tier == StreamTier.MOBILE && !hasError && rtspUrl != null) {
+            Text(
+                text = "SD",
+                style = MaterialTheme.typography.labelSmall,
+                color = TealAccent,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 6.dp)
+                    .background(
+                        color = Color.Black.copy(alpha = 0.55f),
+                        shape = RoundedCornerShape(4.dp),
+                    )
+                    .padding(horizontal = 5.dp, vertical = 1.dp),
+            )
+        }
+
         // Hard error state — no stream URL, or reconnect exhausted its FAST
         // attempts (a slow background retry keeps trying regardless — see
         // scheduleReconnect above). Tap-to-retry (#2): bumping playerGeneration
@@ -807,6 +893,21 @@ private const val FRAME_STALL_MS = 4_000L
 private const val READY_SUSTAINED_MS = 30_000L
 /** Stuck-BUFFERING limit (ms) before forcing a reconnect — the bug #38 spinner cap. */
 private const val STALL_BUFFERING_MS = 15_000L
+
+/**
+ * Shorter buffering limit (ms) for a MAIN stream that has never reached READY and
+ * still has a fallback rung below it. An H265 main the RTSP path can't decode sits
+ * in BUFFERING rather than erroring; this bounds that spin. Mirrors the fullscreen
+ * constant of the same name and value.
+ */
+private const val MAIN_FIRSTLOAD_BUFFER_MS = 6_000L
+
+/**
+ * The same bound for the DERIVED rungs (`_subv`, `_mobile`) of the ladder, more
+ * patient because go2rtc spawns their ffmpeg lazily on first consumer connect, so
+ * a cold one legitimately needs a few seconds plus a keyframe wait (#524).
+ */
+private const val DERIVED_FIRSTLOAD_BUFFER_MS = 10_000L
 
 /**
  * If the app was backgrounded longer than this, re-prepare the RTSP source on

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
@@ -61,10 +61,10 @@ import video.crumb.app.ui.ImmersiveMode
 import video.crumb.app.ui.KeepScreenOn
 import video.crumb.app.data.HaLinkDto
 import video.crumb.app.data.HaStatesResponse
+import video.crumb.app.data.LiveStreamsResponse
 import video.crumb.app.data.PtzPresetDto
 import video.crumb.app.data.controlActions
 import video.crumb.app.data.haPrimaryAction
-import video.crumb.app.data.subStreamUrl
 import video.crumb.app.data.toUserMessage
 import video.crumb.app.di.appContainer
 import video.crumb.app.ui.player.MediaFactory
@@ -84,14 +84,23 @@ import kotlinx.coroutines.launch
  * [CrumbRepository.liveStreams]; a loading spinner is shown while the
  * network call is in-flight and while the player is buffering.
  *
- * H265-main fallback: many cameras (e.g. Uniview LPR) ship an **H265 main +
+ * H265 fallback LADDER: many cameras (e.g. Uniview LPR) ship an **H265 main +
  * H264 sub**, and Media3's RTSP stack can't reliably bring up H265 over RTSP —
  * the main would spin/error forever even though the wall tiles (which play the
- * H264 sub) work fine. So if the main stream never reaches a playable frame we
- * downgrade to the **sub** stream and show a small "SD" badge. A main that
- * plays and *then* drops is treated as a transient blip and reconnects to main
- * (no permanent downgrade). Recorded playback is unaffected (fMP4 over HTTP
- * decodes H265 fine; only the live RTSP path has the depacketizer limitation).
+ * H264 sub) work fine. Some cameras ship H265 on **both** main and sub (#524),
+ * where a single main→sub downgrade lands on a second unplayable stream and the
+ * view spins forever. So the downgrade is a ladder, not a step: each rung that
+ * never reaches a playable frame steps down to the next one this camera exposes
+ * (`main → subv → sub → mobile`, see [fullscreenStreamChain]), ending at the
+ * server's H.264 `_mobile` transcode — a codec Media3 can always decode. A
+ * stream that plays and *then* drops is treated as a transient blip and
+ * reconnects to the same rung (no permanent downgrade) unless the error is
+ * specifically a decoder/format one. Anything below the main shows the "SD"
+ * badge, which names the transcode when that's what is playing. The verdict is
+ * remembered per camera for the app run ([LiveStreamFallbackMemory]) so a
+ * revisit reattaches straight to the rung that worked. Recorded playback is
+ * unaffected (fMP4 over HTTP decodes H265 fine; only the live RTSP path has the
+ * depacketizer limitation).
  *
  * Controls are minimal to preserve immersion: a back arrow (top-left) and a
  * playback shortcut (top-right) float over the black video surface.
@@ -281,17 +290,22 @@ fun LiveFullscreenScreen(
         }
     }
 
-    // Resolved RTSP URLs. `rtspUrl` is the ACTIVE url fed to the player: it starts
-    // as the main (HD) stream and is swapped to `subUrl` if the main can't play on
-    // this device (H265-over-RTSP — see the header). `mainUrl`/`subUrl` are the two
-    // resolved endpoints; all are re-keyed on the shown camera so a swipe resets them.
+    // Resolved live endpoints + where on the fallback ladder we currently are.
+    // `rtspUrl` is the ACTIVE url fed to the player; it is always
+    // `streams.urlForTier(tier)`. The ladder itself (`chain`) and the rungs this
+    // run has already found unplayable (`failedTiers`) come from
+    // [fullscreenStreamChain] / [LiveStreamFallbackMemory]. All are re-keyed on
+    // the shown camera so a swipe resets them.
     var rtspUrl by remember { mutableStateOf<String?>(null) }
-    var mainUrl by remember(currentCameraId) { mutableStateOf<String?>(null) }
-    var subUrl by remember(currentCameraId) { mutableStateOf<String?>(null) }
-    // True once we've downgraded to the sub stream because the main never played.
-    var usingSub by remember(currentCameraId) { mutableStateOf(false) }
-    // Drives the subtle "SD" badge: the main (HD) stream was unplayable, on sub now.
-    var hdUnavailable by remember(currentCameraId) { mutableStateOf(false) }
+    var streams by remember(currentCameraId) { mutableStateOf<LiveStreamsResponse?>(null) }
+    var chain by remember(currentCameraId) { mutableStateOf<List<StreamTier>>(emptyList()) }
+    var failedTiers by remember(currentCameraId) {
+        mutableStateOf(LiveStreamFallbackMemory.failedTiers(currentCameraId))
+    }
+    var tier by remember(currentCameraId) { mutableStateOf<StreamTier?>(null) }
+    // Drives the subtle "SD" badge: anything below the main is a degraded stream
+    // (unplayable main, a metered data-saver start, or the server transcode).
+    val hdUnavailable = tier != null && tier != StreamTier.MAIN
     var resolveError by remember { mutableStateOf<String?>(null) }
     var isResolving by remember { mutableStateOf(true) }
 
@@ -384,30 +398,22 @@ fun LiveFullscreenScreen(
             // (clean swap to a spinner) instead of lingering on the old frame.
             rtspUrl = null
             repo.liveStreams(currentCameraId).fold(
-                onSuccess = { streams ->
-                    mainUrl = streams.rtspMainUrl
-                    // `subStreamUrl()` prefers the video-only `_subv` restream
-                    // (repaired fmtp — without it Media3 rejects the DESCRIBE on
-                    // some cameras, #483) and falls back to the raw sub when the
-                    // server offers no `_subv`. Both the H265-main fallback below
-                    // and the metered start-low path use this one value.
-                    val lowRes = streams.subStreamUrl()
-                    subUrl = lowRes
-                    // On a metered link, start on a data-saver stream: the camera's
-                    // sub when it has one, else the server's on-demand mobile
-                    // transcode. Off metered (Wi-Fi/LAN), start on the main (HD)
-                    // stream. Either way the codec-failure fallback + "tap for HD"
-                    // badge below still apply.
-                    val lowFirst = if (isMetered) (lowRes ?: streams.rtspMobileUrl) else null
-                    if (lowFirst != null) {
-                        usingSub = true
-                        hdUnavailable = true
-                        rtspUrl = lowFirst
-                    } else {
-                        usingSub = false
-                        hdUnavailable = false
-                        rtspUrl = streams.rtspMainUrl
-                    }
+                onSuccess = { resolved ->
+                    streams = resolved
+                    // The ladder for this link: HD-first off a metered link,
+                    // data-saver order on one. `subv` is preferred over the raw
+                    // sub inside it (repaired fmtp — without it Media3 rejects
+                    // the DESCRIBE on some cameras, #483), and the server's
+                    // `_mobile` H.264 transcode is the last rung (#524).
+                    val resolvedChain = resolved.fullscreenStreamChain(metered = isMetered)
+                    chain = resolvedChain
+                    // Skip rungs this run already proved unplayable for this camera,
+                    // so a revisit doesn't re-walk the whole ladder from the top.
+                    val failed = LiveStreamFallbackMemory.failedTiers(currentCameraId)
+                    failedTiers = failed
+                    val start = startTier(resolvedChain, failed)
+                    tier = start
+                    rtspUrl = start?.let { resolved.urlForTier(it) }
                     isResolving = false
                 },
                 onFailure = { cause ->
@@ -452,30 +458,46 @@ fun LiveFullscreenScreen(
         // dropped is transient and reconnects to main).
         var everReady = false
 
-        fun scheduleReconnect() {
+        fun scheduleReconnect(errorCode: Int? = null) {
             if (player == null || url == null) return
             if (reconnectJob?.isActive == true) return // one already in flight
-            // ── H265 / unplayable-main fallback ─────────────────────────────────
-            // If the MAIN stream never reached a playable state, it's almost always a
-            // codec the RTSP path can't handle on this device (Uniview LPR & many cams
-            // ship an H265 main + H264 sub; Media3's RTSP HEVC depacketizer is
-            // unreliable). Reconnecting to main would loop forever, so downgrade to the
-            // sub stream — the same one the wall tiles play successfully.
-            if (!usingSub && !everReady && subUrl != null) {
-                usingSub = true
-                hdUnavailable = true
-                isReconnecting = false
-                playerError = false
-                rtspUrl = subUrl // re-keys remember(rtspUrl,…) → fresh player on sub
-                return
-            }
             // Offline (#3): don't burn the attempt budget on a doomed re-prepare.
             // Park in the reconnecting state; the connectivity-regained effect
             // below kicks a fresh attempt the moment isOnline flips back to true.
+            // Checked BEFORE the ladder below so a dropped Wi-Fi link can't be
+            // mistaken for an undecodable codec and burn the whole ladder.
             if (!isOnline) {
                 isReconnecting = true
                 playerError = false
                 return
+            }
+            // ── H265 / unplayable-stream fallback ladder (#524) ─────────────────
+            // A stream that never reached a playable state is almost always a codec
+            // the RTSP path can't handle on this device (many cameras ship an H265
+            // main, and some ship H265 on the sub too; Media3's RTSP HEVC
+            // depacketizer is unreliable). Reconnecting to it would loop forever, so
+            // step DOWN to the next rung this camera exposes — ending at the
+            // server's H.264 `_mobile` transcode, which always decodes.
+            val current = tier
+            val next = nextTier(chain, current, failedTiers)
+            if (current != null && next != null &&
+                shouldFallBackToNextTier(hasNextTier = true, everReady = everReady, errorCode = errorCode)
+            ) {
+                // Remember the verdict for the app run so a revisit (or the wall)
+                // reattaches straight to a rung that can actually play.
+                LiveStreamFallbackMemory.markFailed(currentCameraId, current)
+                failedTiers = failedTiers + current
+                tier = next
+                isReconnecting = false
+                playerError = false
+                rtspUrl = streams?.urlForTier(next) // re-keys remember(rtspUrl,…)
+                return
+            }
+            // Ladder exhausted with nothing ever playable ⇒ this is an outage, not a
+            // codec verdict. Forget the recorded failures so the next resolve starts
+            // from the top again, and fall through to the normal backoff below.
+            if (next == null && !everReady) {
+                LiveStreamFallbackMemory.clear(currentCameraId)
             }
             // Past the fast-backoff budget: DON'T stop forever (#2) — fall back to
             // a slow, indefinite retry cadence so the view keeps quietly trying to
@@ -528,8 +550,11 @@ fun LiveFullscreenScreen(
 
             override fun onPlayerError(error: PlaybackException) {
                 isBuffering = false
-                // Try to reconnect before showing the hard error.
-                scheduleReconnect()
+                // Try to reconnect before showing the hard error. The error code
+                // goes with it: a decoder/format failure steps down the ladder even
+                // if this stream had been playing, while an IO/timeout failure
+                // reconnects to the same rung (see shouldFallBackToNextTier).
+                scheduleReconnect(error.errorCode)
             }
 
             override fun onVideoSizeChanged(vs: VideoSize) {
@@ -582,13 +607,16 @@ fun LiveFullscreenScreen(
                     Player.STATE_BUFFERING -> {
                         lastPos = -1L; stuckMs = 0L; readyHeldMs = 0L
                         bufferingMs += WATCHDOG_TICK_MS
-                        // A main that never reaches READY can sit in BUFFERING instead
-                        // of erroring (H265 the RTSP path can't decode). Fall back to
-                        // sub fast in that case; once on sub, use the patient threshold.
-                        val limit = if (!everReady && !usingSub && subUrl != null) {
-                            MAIN_FIRSTLOAD_BUFFER_MS
-                        } else {
-                            STALL_BUFFERING_MS
+                        // A stream that never reaches READY can sit in BUFFERING
+                        // instead of erroring (H265 the RTSP path can't decode). While
+                        // there is a rung left to fall back to, bound that spin;
+                        // on the last rung use the patient threshold. The derived
+                        // rungs (`_subv` / `_mobile`) get a longer allowance because
+                        // go2rtc spawns their ffmpeg lazily on first connect.
+                        val limit = when {
+                            everReady || nextTier(chain, tier, failedTiers) == null -> STALL_BUFFERING_MS
+                            tier == StreamTier.MAIN -> MAIN_FIRSTLOAD_BUFFER_MS
+                            else -> DERIVED_FIRSTLOAD_BUFFER_MS
                         }
                         if (bufferingMs >= limit) { bufferingMs = 0L; scheduleReconnect() }
                     }
@@ -763,13 +791,17 @@ fun LiveFullscreenScreen(
             }
         }
 
-        // "SD" badge — running the sub (or mobile) stream rather than HD main,
-        // either because the main couldn't decode on this device (H265-over-RTSP)
-        // or because we're on a metered link (data-saver start). TAPPABLE: forces
-        // the HD (main) stream — the manual HD/SD override. Hidden in PiP.
-        if (!inPip && hdUnavailable && !isResolving && !playerError) {
+        // "SD" badge — running the sub (or the server transcode) rather than the HD
+        // main, either because the main couldn't decode on this device
+        // (H265-over-RTSP) or because we're on a metered link (data-saver start).
+        // The label names the transcode when that's what's playing, so an all-H265
+        // camera reads as "the server is re-encoding this for you" rather than an
+        // ordinary sub downgrade (#524). TAPPABLE: forces the HD (main) stream —
+        // the manual HD/SD override. Hidden in PiP.
+        val sdLabel = sdBadgeLabel(tier)
+        if (!inPip && hdUnavailable && sdLabel != null && !isResolving && !playerError) {
             Text(
-                text = "SD · tap for HD",
+                text = sdLabel,
                 style = MaterialTheme.typography.labelMedium,
                 color = Color.White,
                 modifier = Modifier
@@ -781,9 +813,14 @@ fun LiveFullscreenScreen(
                         shape = androidx.compose.foundation.shape.RoundedCornerShape(6.dp),
                     )
                     .clickable {
-                        mainUrl?.let {
-                            usingSub = false
-                            hdUnavailable = false
+                        streams?.rtspMainUrl?.let {
+                            // An explicit "give me HD" wipes this camera's recorded
+                            // verdicts: the operator may have just re-encoded the
+                            // camera, and the ladder re-walks from the top if the
+                            // main is still unplayable.
+                            LiveStreamFallbackMemory.clear(currentCameraId)
+                            failedTiers = emptySet()
+                            tier = StreamTier.MAIN
                             rtspUrl = it
                             playerGeneration += 1
                         }
@@ -811,12 +848,15 @@ fun LiveFullscreenScreen(
                         if (resolveError != null) {
                             resolveGeneration += 1
                         } else {
-                            // Manual retry gives the HD (main) stream another chance,
-                            // even if we'd previously downgraded to sub.
-                            if (mainUrl != null) {
-                                usingSub = false
-                                hdUnavailable = false
-                                rtspUrl = mainUrl
+                            // Manual retry re-walks the ladder from the top: the HD
+                            // (main) stream gets another chance even if we'd
+                            // previously downgraded away from it.
+                            val main = streams?.rtspMainUrl
+                            if (main != null) {
+                                LiveStreamFallbackMemory.clear(currentCameraId)
+                                failedTiers = emptySet()
+                                tier = StreamTier.MAIN
+                                rtspUrl = main
                             }
                             playerGeneration += 1
                         }
@@ -1142,6 +1182,16 @@ private const val STALL_BUFFERING_MS = 15_000L
  * the HD attempt spins before downgrading to the (H264) sub stream.
  */
 private const val MAIN_FIRSTLOAD_BUFFER_MS = 6_000L
+
+/**
+ * Same idea as [MAIN_FIRSTLOAD_BUFFER_MS] but for the DERIVED rungs (`_subv`,
+ * `_mobile`) of the fallback ladder (#524). More patient than the main's limit
+ * because go2rtc spawns those streams' ffmpeg lazily on first consumer connect,
+ * so a cold one legitimately takes a few seconds plus a keyframe wait — while
+ * still far short of the 15 s stuck-buffering cap, so an all-H265 camera reaches
+ * the playable transcode in seconds instead of spinning forever.
+ */
+private const val DERIVED_FIRSTLOAD_BUFFER_MS = 10_000L
 
 /**
  * If the fullscreen view was stopped (ON_STOP) longer than this, ON_START (#11)

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveScreen.kt
@@ -240,6 +240,10 @@ fun LiveScreen(
                     // Refresh on a CHANGE only (skip the first observation so opening the
                     // screen doesn't double-load). vm.refresh() re-resolves all streams.
                     if (cv.isNotEmpty() && lastConfigVersion != null && cv != lastConfigVersion) {
+                        // A server-side camera edit may have changed the codec, so
+                        // drop the session's per-camera stream-fallback verdicts and
+                        // let every tile re-walk its ladder from the top (#524).
+                        LiveStreamFallbackMemory.clearAll()
                         vm.refresh()
                     }
                     if (cv.isNotEmpty()) lastConfigVersion = cv

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveStreamFallback.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveStreamFallback.kt
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.feature.live
+
+import video.crumb.app.data.LiveStreamsResponse
+import video.crumb.app.data.subStreamUrl
+
+/**
+ * Which of a camera's live endpoints a player is currently attached to — one
+ * rung of the fallback ladder walked when a stream turns out to be unplayable
+ * on this device.
+ *
+ * The ladder exists because Media3's RTSP stack cannot bring up H.265: its HEVC
+ * depacketizer never reaches a playable frame, so an H265 stream spins in
+ * BUFFERING (or errors out) forever while the same camera records fine and
+ * plays fine on desktop. Cameras that ship H265 on the main only were already
+ * handled by the single-step main→sub downgrade; cameras that ship H265 on
+ * **both** main and sub (#524) were not — they exhausted the reconnect ladder
+ * on two unplayable streams and never reached [MOBILE], the server-side H.264
+ * transcode that exists for exactly this case.
+ */
+enum class StreamTier {
+    /** Full-resolution main stream (`rtsp_main_url`). */
+    MAIN,
+
+    /**
+     * The server's video-only sub restream (`rtsp_subv_url`, `<name>_subv`): the
+     * raw sub run through an ffmpeg **copy** so go2rtc republishes a proper
+     * `fmtp` (#483). Same codec as [SUB] — it repairs SDP, not the bitstream.
+     */
+    SUBV,
+
+    /** The camera's raw sub stream (`rtsp_sub_url`). */
+    SUB,
+
+    /**
+     * The server's on-demand H.264 transcode (`rtsp_mobile_url`,
+     * `<name>_mobile`): go2rtc re-encodes the sub (or the main, on a camera with
+     * no sub) to low-res H.264 + AAC. The one rung that is guaranteed to be a
+     * codec Media3 can decode, which is why it is always last: it costs a real
+     * ffmpeg process on the server for as long as a consumer is attached.
+     */
+    MOBILE,
+}
+
+/** The URL for [tier], or `null` when this camera does not expose that rung. */
+fun LiveStreamsResponse.urlForTier(tier: StreamTier): String? = when (tier) {
+    StreamTier.MAIN -> rtspMainUrl
+    StreamTier.SUBV -> rtspSubvUrl
+    StreamTier.SUB -> rtspSubUrl
+    StreamTier.MOBILE -> rtspMobileUrl
+}
+
+/**
+ * Keep the rungs this camera actually exposes, in the given order, and drop any
+ * that would re-dial a URL already in the chain (a server that answers with the
+ * same URL twice must not cost an extra doomed attempt).
+ */
+private fun LiveStreamsResponse.chainOf(vararg order: StreamTier): List<StreamTier> {
+    val seen = HashSet<String>()
+    return order.filter { tier -> urlForTier(tier)?.let { seen.add(it) } == true }
+}
+
+/**
+ * Fallback ladder for a **live-wall tile**.
+ *
+ * The wall is low-res by design (N tiles, N decoders), so a camera with a sub
+ * starts on it and never escalates to the main's bitrate: `subv → sub → mobile`.
+ * A camera with no sub at all keeps today's behaviour of playing the main, with
+ * the transcode as its one fallback: `main → mobile`.
+ */
+fun LiveStreamsResponse.wallStreamChain(): List<StreamTier> =
+    if (subStreamUrl() != null) {
+        chainOf(StreamTier.SUBV, StreamTier.SUB, StreamTier.MOBILE)
+    } else {
+        chainOf(StreamTier.MAIN, StreamTier.MOBILE)
+    }
+
+/**
+ * Fallback ladder for **fullscreen live**.
+ *
+ * Off a metered link fullscreen is the one place HD is worth it, so it starts on
+ * the main and walks down: `main → subv → sub → mobile`. On a metered link the
+ * data-saver order applies (unchanged from before: low-res first, the transcode
+ * when the camera has no sub), with the main kept as the last resort so a broken
+ * sub still leaves something to watch rather than a spinner.
+ */
+fun LiveStreamsResponse.fullscreenStreamChain(metered: Boolean): List<StreamTier> =
+    if (metered) {
+        chainOf(StreamTier.SUBV, StreamTier.SUB, StreamTier.MOBILE, StreamTier.MAIN)
+    } else {
+        chainOf(StreamTier.MAIN, StreamTier.SUBV, StreamTier.SUB, StreamTier.MOBILE)
+    }
+
+/**
+ * Where to attach first: the highest rung this session has not already found
+ * unplayable for this camera. If every rung is marked failed (nothing played at
+ * all last time), start at the top anyway rather than refusing to try.
+ */
+fun startTier(chain: List<StreamTier>, failed: Set<StreamTier>): StreamTier? =
+    chain.firstOrNull { it !in failed } ?: chain.firstOrNull()
+
+/**
+ * The next rung below [current], skipping ones already known to fail, or `null`
+ * when the ladder is exhausted (the caller then falls through to its normal
+ * reconnect backoff instead of re-dialling forever).
+ */
+fun nextTier(chain: List<StreamTier>, current: StreamTier?, failed: Set<StreamTier>): StreamTier? {
+    val idx = chain.indexOf(current)
+    val rest = if (idx < 0) chain else chain.drop(idx + 1)
+    return rest.firstOrNull { it !in failed }
+}
+
+/**
+ * Media3 `PlaybackException` error codes that mean **this device cannot play
+ * this bitstream**, as opposed to a network/transport blip worth retrying.
+ *
+ * Mirrored as plain ints rather than referenced off `PlaybackException` so this
+ * decision logic stays free of Android/Media3 types and is unit-testable on the
+ * JVM. The codes are frozen public API (`androidx.media3.common.PlaybackException`):
+ *
+ * - 1004 `ERROR_CODE_FAILED_RUNTIME_CHECK` — the RTSP client's own
+ *   `IllegalArgumentException`s surface here, including the `missing attribute
+ *   fmtp` rejection that made cameras reconnect-loop in #483.
+ * - 3003 `ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED`
+ * - 4001 `ERROR_CODE_DECODER_INIT_FAILED`
+ * - 4002 `ERROR_CODE_DECODER_QUERY_FAILED`
+ * - 4004 `ERROR_CODE_DECODING_FORMAT_EXCEEDS_CAPABILITIES`
+ * - 4005 `ERROR_CODE_DECODING_FORMAT_UNSUPPORTED`
+ *
+ * Deliberately NOT included: 4003 `ERROR_CODE_DECODING_FAILED` and 3001
+ * `ERROR_CODE_PARSING_CONTAINER_MALFORMED`, which a healthy stream can hit
+ * transiently on a corrupt packet — those stay on the reconnect ladder.
+ */
+private val UNPLAYABLE_FORMAT_ERROR_CODES = setOf(1004, 3003, 4001, 4002, 4004, 4005)
+
+/** True when [errorCode] means the bitstream itself can't be decoded here. */
+fun isUnplayableFormatError(errorCode: Int): Boolean = errorCode in UNPLAYABLE_FORMAT_ERROR_CODES
+
+/**
+ * Should this failure step DOWN the ladder instead of reconnecting to the same
+ * stream?
+ *
+ * - No rung left ⇒ never (fall through to the normal backoff/slow-retry ladder).
+ * - The stream never reached a playable frame ⇒ yes. This is the H265 signature:
+ *   Media3 either errors immediately or sits in BUFFERING, and no amount of
+ *   reconnecting will change the codec. (It is also the pre-existing rule for
+ *   the main→sub downgrade, kept verbatim.)
+ * - The stream DID play and then dropped ⇒ only for a decoder/format error.
+ *   Everything else is a transient blip (camera reboot, AP roam, Wi-Fi drop) and
+ *   must reconnect to the SAME stream — downgrading there would quietly strand a
+ *   healthy camera on the transcode.
+ *
+ * @param errorCode Media3 `PlaybackException.errorCode`, or `null` when the
+ *   failure came from the stall watchdog (which sees no exception at all).
+ */
+fun shouldFallBackToNextTier(hasNextTier: Boolean, everReady: Boolean, errorCode: Int?): Boolean =
+    when {
+        !hasNextTier -> false
+        !everReady -> true
+        else -> errorCode != null && isUnplayableFormatError(errorCode)
+    }
+
+/**
+ * Text for the fullscreen "not on HD" badge, or `null` on the main stream (no
+ * badge). Naming the transcode matters: "SD" on a camera whose sub is also
+ * unplayable would otherwise read as an ordinary sub-stream downgrade, when in
+ * fact the device is watching a server-side re-encode (#524).
+ */
+fun sdBadgeLabel(tier: StreamTier?): String? = when (tier) {
+    null, StreamTier.MAIN -> null
+    StreamTier.SUBV, StreamTier.SUB -> "SD · tap for HD"
+    StreamTier.MOBILE -> "SD transcode · tap for HD"
+}
+
+/**
+ * Per-camera memory of which rungs proved unplayable, for THIS app run.
+ *
+ * Without it every wall recomposition and every fullscreen revisit re-walks the
+ * whole ladder — one unplayable-stream timeout per rung, every time — which is
+ * the "permanent spinner" the operator sees. With it, a camera that settled on
+ * the transcode reattaches straight to the transcode.
+ *
+ * Deliberately process-scoped and NOT persisted: a codec verdict is a guess made
+ * from a failure, and the operator can change the camera's encoder at any time.
+ * It is dropped on app relaunch, on a server config change (a camera edit bumps
+ * `config_version`), and on an explicit Retry — see [LiveViewModel.retry] and
+ * `LiveScreen`'s config-version watch. It is also dropped for a camera whose
+ * ladder is exhausted with nothing playable, since a total outage is no evidence
+ * about codecs.
+ */
+object LiveStreamFallbackMemory {
+
+    private val failedByCamera = HashMap<String, MutableSet<StreamTier>>()
+
+    /** Rungs already known to be unplayable for [cameraId] this run. */
+    @Synchronized
+    fun failedTiers(cameraId: String): Set<StreamTier> =
+        failedByCamera[cameraId]?.toSet() ?: emptySet()
+
+    /** Record that [tier] never produced a playable frame for [cameraId]. */
+    @Synchronized
+    fun markFailed(cameraId: String, tier: StreamTier) {
+        failedByCamera.getOrPut(cameraId) { mutableSetOf() }.add(tier)
+    }
+
+    /** Forget one camera's verdicts (ladder exhausted, or the camera was edited). */
+    @Synchronized
+    fun clear(cameraId: String) {
+        failedByCamera.remove(cameraId)
+    }
+
+    /** Forget every verdict (server config changed, or the user tapped Retry). */
+    @Synchronized
+    fun clearAll() {
+        failedByCamera.clear()
+    }
+}

--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveViewModel.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveViewModel.kt
@@ -126,6 +126,11 @@ class LiveViewModel(
      */
     fun retry() {
         repo.recoverConnections()
+        // An explicit Retry also drops the session's per-camera stream-fallback
+        // verdicts (#524): the operator may have just re-encoded a camera off
+        // H.265, and a tile parked on the server transcode should get its own
+        // (higher quality, cheaper for the server) sub stream back.
+        LiveStreamFallbackMemory.clearAll()
         refresh()
     }
 

--- a/apps/android/app/src/test/java/video/crumb/app/feature/live/LiveStreamFallbackTest.kt
+++ b/apps/android/app/src/test/java/video/crumb/app/feature/live/LiveStreamFallbackTest.kt
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.feature.live
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import video.crumb.app.data.LiveStreamsResponse
+
+/**
+ * The live-stream fallback ladder (#524).
+ *
+ * A camera that emits H.265 on BOTH its main and its sub has nothing Media3's
+ * RTSP stack can decode: the single main→sub downgrade lands on a second
+ * unplayable stream and the client reconnect-loops forever, even though the
+ * server publishes an H.264 `_mobile` transcode for exactly this case. These
+ * tests pin the pure decision logic that walks down to it — chain construction,
+ * where to start, when a failure is a codec verdict rather than a blip, and the
+ * per-run memory that stops every revisit re-walking the whole ladder.
+ */
+class LiveStreamFallbackTest {
+
+    private fun streams(
+        main: String? = "rtsp://u:p@host:18554/drive",
+        sub: String? = "rtsp://u:p@host:18554/drive_sub",
+        subv: String? = null,
+        mobile: String? = "rtsp://u:p@host:18554/drive_mobile",
+    ) = LiveStreamsResponse(
+        cameraId = "8f14e45f-ceea-467a-9f3a-8f14e45fceea",
+        rtspMainUrl = main ?: "rtsp://u:p@host:18554/drive",
+        rtspSubUrl = sub,
+        rtspSubvUrl = subv,
+        rtspMobileUrl = mobile,
+    )
+
+    @Before
+    fun resetMemory() {
+        LiveStreamFallbackMemory.clearAll()
+    }
+
+    // ── chain construction ────────────────────────────────────────────────────
+
+    @Test
+    fun `wall chain prefers subv then sub then the transcode`() {
+        val chain = streams(subv = "rtsp://u:p@host:18554/drive_subv").wallStreamChain()
+        assertEquals(listOf(StreamTier.SUBV, StreamTier.SUB, StreamTier.MOBILE), chain)
+    }
+
+    @Test
+    fun `wall chain never escalates to the main when the camera has a sub`() {
+        // A wall of N tiles must not end up pulling N main-bitrate streams.
+        assertFalse(StreamTier.MAIN in streams().wallStreamChain())
+    }
+
+    @Test
+    fun `wall chain on a camera with no sub is main then the transcode`() {
+        val chain = streams(sub = null).wallStreamChain()
+        assertEquals(listOf(StreamTier.MAIN, StreamTier.MOBILE), chain)
+    }
+
+    @Test
+    fun `chain omits rungs the server does not publish`() {
+        // Mobile transcode disabled server-side, or a Frigate-served camera.
+        val chain = streams(sub = null, mobile = null).wallStreamChain()
+        assertEquals(listOf(StreamTier.MAIN), chain)
+    }
+
+    @Test
+    fun `fullscreen chain off a metered link is HD first then all the way down`() {
+        val chain = streams(subv = "rtsp://u:p@host:18554/drive_subv")
+            .fullscreenStreamChain(metered = false)
+        assertEquals(
+            listOf(StreamTier.MAIN, StreamTier.SUBV, StreamTier.SUB, StreamTier.MOBILE),
+            chain,
+        )
+    }
+
+    @Test
+    fun `fullscreen chain on a metered link keeps the data-saver order`() {
+        val chain = streams().fullscreenStreamChain(metered = true)
+        assertEquals(listOf(StreamTier.SUB, StreamTier.MOBILE, StreamTier.MAIN), chain)
+    }
+
+    @Test
+    fun `metered fullscreen on a camera with no sub still starts on the transcode`() {
+        // Pre-#524 behaviour: `lowRes ?: rtspMobileUrl` on a metered link. Kept.
+        val chain = streams(sub = null).fullscreenStreamChain(metered = true)
+        assertEquals(listOf(StreamTier.MOBILE, StreamTier.MAIN), chain)
+        assertEquals(StreamTier.MOBILE, startTier(chain, emptySet()))
+    }
+
+    @Test
+    fun `a rung that repeats an earlier URL is dropped`() {
+        // Defensive: a server that answers with the same URL twice must not cost
+        // an extra doomed attempt on a stream already known to fail.
+        val dup = "rtsp://u:p@host:18554/drive_sub"
+        val chain = streams(sub = dup, subv = dup).wallStreamChain()
+        assertEquals(listOf(StreamTier.SUBV, StreamTier.MOBILE), chain)
+    }
+
+    // ── walking the ladder ────────────────────────────────────────────────────
+
+    @Test
+    fun `start tier is the top rung when nothing has failed yet`() {
+        val chain = streams().fullscreenStreamChain(metered = false)
+        assertEquals(StreamTier.MAIN, startTier(chain, emptySet()))
+    }
+
+    @Test
+    fun `start tier skips rungs this run already found unplayable`() {
+        val chain = streams().fullscreenStreamChain(metered = false)
+        val failed = setOf(StreamTier.MAIN, StreamTier.SUB)
+        assertEquals(StreamTier.MOBILE, startTier(chain, failed))
+    }
+
+    @Test
+    fun `start tier falls back to the top rung when every rung has failed`() {
+        // Total outage rather than a codec verdict — try again rather than refuse.
+        val chain = streams().fullscreenStreamChain(metered = false)
+        assertEquals(StreamTier.MAIN, startTier(chain, chain.toSet()))
+    }
+
+    @Test
+    fun `start tier is null when the camera exposes nothing`() {
+        assertNull(startTier(emptyList(), emptySet()))
+    }
+
+    @Test
+    fun `next tier is the one below, skipping known-bad rungs`() {
+        val chain = streams(subv = "rtsp://u:p@host:18554/drive_subv")
+            .fullscreenStreamChain(metered = false)
+        assertEquals(StreamTier.SUBV, nextTier(chain, StreamTier.MAIN, emptySet()))
+        assertEquals(
+            StreamTier.MOBILE,
+            nextTier(chain, StreamTier.MAIN, setOf(StreamTier.SUBV, StreamTier.SUB)),
+        )
+    }
+
+    @Test
+    fun `next tier is null on the last rung`() {
+        val chain = streams().fullscreenStreamChain(metered = false)
+        assertNull(nextTier(chain, StreamTier.MOBILE, emptySet()))
+    }
+
+    // ── when a failure is a codec verdict ─────────────────────────────────────
+
+    @Test
+    fun `a stream that never played falls back`() {
+        assertTrue(
+            shouldFallBackToNextTier(hasNextTier = true, everReady = false, errorCode = null),
+        )
+    }
+
+    @Test
+    fun `a stream that played and then dropped reconnects instead of falling back`() {
+        // Camera reboot / AP roam / Wi-Fi blip: an IO timeout on a stream that was
+        // playing must NOT strand a healthy camera on the server transcode.
+        assertFalse(
+            shouldFallBackToNextTier(hasNextTier = true, everReady = true, errorCode = 2003),
+        )
+    }
+
+    @Test
+    fun `a decoder error falls back even on a stream that had been playing`() {
+        assertTrue(
+            shouldFallBackToNextTier(hasNextTier = true, everReady = true, errorCode = 4005),
+        )
+    }
+
+    @Test
+    fun `no rung left means no fallback, whatever the failure`() {
+        assertFalse(
+            shouldFallBackToNextTier(hasNextTier = false, everReady = false, errorCode = 4005),
+        )
+    }
+
+    @Test
+    fun `format and decoder-init errors count as unplayable`() {
+        // 1004 FAILED_RUNTIME_CHECK (the RTSP client's "missing attribute fmtp"),
+        // 3003 PARSING_CONTAINER_UNSUPPORTED, 4001 DECODER_INIT_FAILED,
+        // 4002 DECODER_QUERY_FAILED, 4004 EXCEEDS_CAPABILITIES,
+        // 4005 DECODING_FORMAT_UNSUPPORTED.
+        listOf(1004, 3003, 4001, 4002, 4004, 4005).forEach {
+            assertTrue("code $it should be unplayable", isUnplayableFormatError(it))
+        }
+    }
+
+    @Test
+    fun `transient errors do not count as unplayable`() {
+        // 2001/2002/2003 IO, 1003 timeout, 4003 DECODING_FAILED (a corrupt packet
+        // on an otherwise healthy stream), 3001 CONTAINER_MALFORMED.
+        listOf(1000, 1003, 2001, 2002, 2003, 3001, 4003).forEach {
+            assertFalse("code $it should be retryable", isUnplayableFormatError(it))
+        }
+    }
+
+    // ── the #524 scenario, end to end ─────────────────────────────────────────
+
+    @Test
+    fun `an all-H265 camera walks main to sub to the transcode and stays there`() {
+        val cameraId = "all-h265-cam"
+        val s = streams(subv = "rtsp://u:p@host:18554/drive_subv")
+        val chain = s.fullscreenStreamChain(metered = false)
+
+        // Fullscreen opens on the main; H265, so it never reaches a frame.
+        var tier = startTier(chain, LiveStreamFallbackMemory.failedTiers(cameraId))
+        assertEquals(StreamTier.MAIN, tier)
+
+        // Walk down every unplayable rung exactly as scheduleReconnect() does.
+        var guard = 0
+        while (guard++ < 10) {
+            val failed = LiveStreamFallbackMemory.failedTiers(cameraId)
+            val next = nextTier(chain, tier, failed)
+            // Everything but the transcode is H265 here: only MOBILE ever plays.
+            val everReady = tier == StreamTier.MOBILE
+            if (!shouldFallBackToNextTier(next != null, everReady, errorCode = null)) break
+            LiveStreamFallbackMemory.markFailed(cameraId, tier!!)
+            tier = next
+        }
+
+        // Landed on the server's H.264 transcode instead of looping forever.
+        assertEquals(StreamTier.MOBILE, tier)
+        assertEquals("SD transcode · tap for HD", sdBadgeLabel(tier))
+
+        // And the wall tile for the same camera, resolved independently, opens
+        // straight on the transcode rather than re-walking the whole ladder.
+        val wall = s.wallStreamChain()
+        assertEquals(
+            StreamTier.MOBILE,
+            startTier(wall, LiveStreamFallbackMemory.failedTiers(cameraId)),
+        )
+    }
+
+    @Test
+    fun `an H265-main-only camera still stops at the H264 sub`() {
+        // The pre-existing behaviour must not regress into always transcoding.
+        val cameraId = "h265-main-cam"
+        val chain = streams().fullscreenStreamChain(metered = false)
+        LiveStreamFallbackMemory.markFailed(cameraId, StreamTier.MAIN)
+        val tier = startTier(chain, LiveStreamFallbackMemory.failedTiers(cameraId))
+        assertEquals(StreamTier.SUB, tier)
+        assertEquals("SD · tap for HD", sdBadgeLabel(tier))
+    }
+
+    // ── the per-run memory ────────────────────────────────────────────────────
+
+    @Test
+    fun `memory is per camera and forgettable`() {
+        LiveStreamFallbackMemory.markFailed("cam-a", StreamTier.MAIN)
+        LiveStreamFallbackMemory.markFailed("cam-a", StreamTier.SUB)
+        LiveStreamFallbackMemory.markFailed("cam-b", StreamTier.MAIN)
+
+        assertEquals(
+            setOf(StreamTier.MAIN, StreamTier.SUB),
+            LiveStreamFallbackMemory.failedTiers("cam-a"),
+        )
+        assertEquals(setOf(StreamTier.MAIN), LiveStreamFallbackMemory.failedTiers("cam-b"))
+        assertEquals(emptySet<StreamTier>(), LiveStreamFallbackMemory.failedTiers("cam-c"))
+
+        // A camera edit / exhausted ladder forgets just that camera…
+        LiveStreamFallbackMemory.clear("cam-a")
+        assertEquals(emptySet<StreamTier>(), LiveStreamFallbackMemory.failedTiers("cam-a"))
+        assertEquals(setOf(StreamTier.MAIN), LiveStreamFallbackMemory.failedTiers("cam-b"))
+
+        // …a server config change or an explicit Retry forgets everything.
+        LiveStreamFallbackMemory.clearAll()
+        assertEquals(emptySet<StreamTier>(), LiveStreamFallbackMemory.failedTiers("cam-b"))
+    }
+
+    @Test
+    fun `the main stream shows no SD badge`() {
+        assertNull(sdBadgeLabel(StreamTier.MAIN))
+        assertNull(sdBadgeLabel(null))
+    }
+}

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,85 @@ revisit.
 
 ---
 
+## 2026-08-06, Android walks a reactive fallback LADDER down to the server transcode; it does not ask the server what codec a stream is
+
+**Context.** Media3's RTSP stack cannot bring up H.265: the stream either errors
+with a decoder/format code or sits in BUFFERING and never produces a frame. The
+client already downgraded an unplayable MAIN to the sub, which covers the common
+"H265 main + H264 sub" camera. Cameras that ship H265 on **both** main and sub
+exist (some Uniview, Annke, Reolink, a lot of no-name ONVIF units, and any camera
+whose "smart codec" setting flipped the sub too), and on those the single-step
+downgrade landed on a second undecodable stream: fullscreen spun forever and the
+wall tile reconnect-looped, while the very same server was publishing an H.264
+`<name>_mobile` transcode that Media3 plays fine (#524). Recording, motion,
+desktop and playback were all unaffected — this was purely a live-client
+stream-selection gap.
+
+**Decision.**
+
+- The downgrade becomes a **ladder**, walked one rung per never-played stream:
+  fullscreen `main → subv → sub → mobile` (data-saver order on a metered link),
+  wall `subv → sub → mobile` (or `main → mobile` on a camera with no sub — the
+  wall never escalates to the main's bitrate when a sub exists). The server's
+  `_mobile` H.264 transcode is always the LAST rung, never a starting choice: it
+  costs a real ffmpeg process on the server for as long as a consumer is attached.
+- **Reactive, from playback evidence only.** A rung is abandoned when it never
+  reached a playable frame, or when it fails with a decoder/format `PlaybackException`
+  code. A stream that played and then dropped still reconnects to the same rung —
+  that is a camera reboot or an AP roam, not a codec.
+- The verdict is remembered **per camera, in memory, for the app run**, so a wall
+  reload or a fullscreen revisit reattaches straight to a rung that plays instead
+  of re-walking the ladder. It is dropped on relaunch, on a `config_version`
+  change (a camera edit), on an explicit Retry, and for any camera whose ladder
+  ran out with nothing playable (that is an outage, which is no evidence about
+  codecs).
+- The pure decision logic lives in `apps/android/.../feature/live/LiveStreamFallback.kt`
+  and is unit-tested on the JVM; the composables only wire it to the player.
+
+**Rejected:**
+
+- **Have the server advertise each stream's codec** (`GET /cameras/:id/streams`
+  carrying `main.codec` / `sub.codec`) so the client picks correctly on the first
+  try. This is the better end state and it is a real follow-up — but it is a wire
+  change that only helps clients talking to a NEW server, so the client still needs
+  the reactive ladder for every older server and every unmanaged/Frigate-served
+  camera. Doing the ladder first keeps this fix client-local and version-skew-proof.
+- **Always start Android on the `_mobile` transcode.** Trivially correct, and it
+  makes every Android session pay a server-side re-encode plus a real quality drop
+  for the large majority of cameras that publish a perfectly playable H264 sub.
+- **Add a software HEVC decoder to the client.** Out of proportion to the problem,
+  and it would burn phone battery decoding what the server can remux for free.
+- **Persist the verdict across launches.** A codec guess derived from a failure
+  should not outlive the app: the operator can re-encode a camera at any time, and
+  a stale "this camera is H265" would pin it to the transcode forever.
+
+**Trades knowingly accepted:**
+
+- The ladder costs one bounded unplayable-stream timeout per rung on the FIRST
+  encounter with such a camera (~6 s on the main, ~10 s on the derived rungs,
+  which are more patient because go2rtc spawns their ffmpeg lazily). After that,
+  the session memory makes revisits immediate.
+- A camera whose sub is merely slow to start (rather than undecodable) can be
+  downgraded to the transcode; the operator gets it back with Retry, a camera
+  edit, or a relaunch.
+- Walking the ladder no longer reports stalls to the wall's low-bandwidth
+  auto-fallback, so a wall of all-H265 cameras can't flip itself into
+  snapshot-polling on what is a codec problem, not a link problem.
+
+**Revisit triggers:**
+
+- The server growing per-stream codec metadata ⇒ make the START rung proactive and
+  keep the ladder only as the fallback for old servers / unmanaged cameras.
+- Media3 shipping a working RTSP HEVC depacketizer ⇒ the whole ladder can collapse
+  back to a bandwidth choice.
+- Operators reporting that healthy-but-slow sub streams get transcoded ⇒ raise
+  `DERIVED_FIRSTLOAD_BUFFER_MS`, or require a decoder/format error (not just a
+  timeout) before leaving a rung.
+- WebRTC live on Android being reconsidered (see the 2026-07-02 verdict) ⇒ its
+  codec negotiation would change this calculus entirely.
+
+---
+
 ## 2026-08-06, A non-success go2rtc `PUT` is resolved by ASKING go2rtc what it has, not by reading the status code; and a never-yet-seen camera gets a creation grace
 
 **Context.** Two bugs found by a hostile-camera compatibility matrix against the


### PR DESCRIPTION
Fixes #524

## The bug

A camera that emits **H.265 on both main and sub** leaves the Android client with
nothing playable. Media3's RTSP stack can't bring up H.265, and the client's only
recovery was the single main→sub downgrade added for "H265 main + H264 sub"
cameras — so the downgrade lands on a *second* undecodable stream and the code
falls into the generic reconnect ladder: 1/2/4/8 s backoff, then a permanent slow
retry. `rtsp_mobile_url`, the server's H.264 `<name>_mobile` transcode that Media3
plays fine, was only ever reachable on a metered link *and* only on a camera with
no sub at all, so this camera never got to it.

Recording, motion, desktop and playback were unaffected; this is purely a
live-client stream-selection gap.

## The fix

The downgrade becomes a **ladder**, walked one rung per never-played stream:

| Surface | Chain |
| --- | --- |
| Fullscreen (unmetered) | `main → subv → sub → mobile` |
| Fullscreen (metered) | `subv → sub → mobile → main` (data-saver order unchanged; `main` is now a last resort instead of a dead end) |
| Wall tile (camera has a sub) | `subv → sub → mobile` |
| Wall tile (no sub) | `main → mobile` |

Rungs the camera doesn't publish are dropped, and a rung repeating an earlier URL
is dropped too. The transcode is always **last**, never a starting choice: go2rtc
spawns a real ffmpeg for as long as a consumer is attached, and the wall never
escalates to the main's bitrate on a camera that has a sub.

**When a failure counts as a codec verdict** (`shouldFallBackToNextTier`):

* never reached a playable frame ⇒ step down (this is the H265 signature, and it
  is the pre-existing main→sub rule kept verbatim);
* played and *then* dropped ⇒ reconnect to the **same** rung, unless the error is
  a decoder/format `PlaybackException` code (1004, 3003, 4001, 4002, 4004, 4005).
  Transient codes (IO, timeout, `DECODING_FAILED`, `CONTAINER_MALFORMED`) stay on
  the reconnect ladder, so a camera reboot or an AP roam can't strand a healthy
  camera on the transcode;
* no rung left ⇒ never.

**Session memory.** The verdict is remembered per camera, in memory, for the app
run (`LiveStreamFallbackMemory`), so a wall reload or a fullscreen revisit
reattaches straight to a rung that plays instead of re-walking the ladder. It is
dropped on app relaunch, on a `config_version` change (a camera edit), on an
explicit Retry / "tap for HD", and for any camera whose ladder ran out with
nothing playable — a total outage is no evidence about codecs.

**Other behaviour touched:**

* The offline check now runs **before** the ladder, so a dropped Wi-Fi link can't
  be mistaken for an undecodable codec and burn every rung.
* Walking the ladder no longer reports stalls to the wall's low-bandwidth
  auto-fallback — a wall of all-H265 cameras must not flip itself into snapshot
  polling over what is a codec problem, not a link problem.
* Stuck-BUFFERING bound while a rung remains: 6 s on the main (unchanged
  constant), 10 s on the derived rungs (`_subv`/`_mobile` are lazily spawned by
  go2rtc, so a cold one legitimately needs a few seconds plus a keyframe). On the
  last rung the patient 15 s cap applies exactly as before.
* The fullscreen "SD" badge names the transcode ("SD transcode · tap for HD") so
  the degradation is legible; a tile on the transcode carries a small teal "SD"
  marker, distinct from the amber auto-shed badge.
* Stall watchdog, backoff/slow-retry ladder, connectivity-regained re-prepare,
  release-on-background and the low-latency `newLivePlayer` path are all
  untouched.

## Server-side codec info: checked, deliberately not added here

`GET /cameras/:id/streams` (`LiveStreamsResponse` in `services/api/src/dto.rs` /
`playback.rs`) carries no codec field, and neither does the camera DTO — nothing
on the wire tells the client that a stream is H.265, so **proactive** selection
isn't possible today and this PR is reactive-only.

Advertising per-stream codecs (the API already reads producer SDP for the `_subv`
verdict, so the information is close at hand) is the better end state and is worth
a follow-up issue. It does not remove the need for the ladder: it would only help
clients talking to a new server, and unmanaged / Frigate-served cameras would
still have no codec metadata. Rationale, rejected alternatives and revisit
triggers are recorded in `docs/DECISIONS.md`.

The issue also suggests recording the pattern in `data/camera-compatibility.json`.
That file's schema (v1) is per-make/model with a `match` block, not codec patterns,
so a generic "both streams H265" rule would need a schema change — left out of this
fix on purpose.

## What was verified

* `./gradlew assembleDebug` — **BUILD SUCCESSFUL**, no new warnings.
* `./gradlew testDebugUnitTest` — **105 tests, 0 failures**, of which **24 new**
  in `LiveStreamFallbackTest` covering chain construction per surface (incl. the
  metered / no-sub cases that must keep their old behaviour), URL dedup, start-rung
  selection with and without recorded failures, `nextTier` skipping known-bad rungs,
  the fall-back-or-reconnect decision matrix, the error-code classification (both
  directions), the per-run memory, and an end-to-end walk of the #524 scenario
  (`main → subv → sub → mobile`, then a wall tile for the same camera opening
  straight on the transcode).
* Code-path reasoning against the existing recovery machinery: the ladder is
  evaluated only inside `scheduleReconnect`, i.e. only on a failure, so the
  first-attach path and live latency are unchanged; every existing exit
  (offline park, backoff, slow retry, hard error + tap-to-retry) is still reachable.

## What still needs on-device confirmation

Keeping the `needs-repro` framing honest — **this could not be fully verified
without a real all-H265 camera and a device.** No emulator or unit test can
exercise Media3's RTSP HEVC path. Please check on hardware:

1. An all-H265 camera in **fullscreen on Wi-Fi**: it should visibly step down and
   settle on the transcode within roughly 15–25 s instead of spinning forever, with
   the "SD transcode · tap for HD" badge.
2. The same camera's **wall tile**: it should end up on the transcode with the small
   teal "SD" marker, and the wall must **not** flip into low-bandwidth mode.
3. **Revisit behaviour**: leave fullscreen and come back, and reload the wall — both
   should attach to the transcode immediately, with no second spin.
4. **Recovery**: re-encode the camera's sub to H.264, save it (which bumps
   `config_version`), and confirm the tile returns to its own sub without an app
   restart; "tap for HD" should also re-try the main.
5. **No regression on healthy cameras**: an H264 camera must still start on
   main (fullscreen) / sub (wall), and a camera reboot or Wi-Fi blip must reconnect
   to the same stream rather than downgrading.
6. One edge worth watching: a rung whose **audio** decodes while its H.265 video
   does not would reach `STATE_READY` (so `everReady` latches) and would not step
   down. The reported symptom is "never reaches READY", so this is expected not to
   occur — but a black-with-audio tile on an all-H265 camera would mean the readiness
   signal needs to be a rendered video frame instead.
