### PR TITLE
fix(api): PUT /config/server merges instead of replacing the whole row

### DIFF
--- a/docs/AI-INSTALL.md
+++ b/docs/AI-INSTALL.md
@@ -472,6 +472,10 @@ All wizard steps have API equivalents. Do them in order:
    gate; `GET /auth/setup-status` reports `beta_terms_accepted`).
 2. **Server address.** `PUT /config/server` with the host's **LAN** address
    (`server_address`, `crumb_rtsp_base`, …). Use the LAN IP, never a public one.
+   The PUT merges: send only the keys you are setting, and every other column
+   keeps its stored value. (Sending a key as `""` is an explicit clear that falls
+   the setting back to its container-environment default, so do not pad the body
+   with empty strings for fields you are not changing.)
    (`GET /auth/setup-status` returns a suggested address derived from the request,
    plus `suggested_scan_range`, the server's own `/24`, a good default for the
    discovery scan below. It's `null` when the console was reached by hostname.)
@@ -549,12 +553,13 @@ All wizard steps have API equivalents. Do them in order:
    motion-only; members = the group's existing ids ∪ the new ids).
    For an already-added ONVIF camera you can re-probe with
    `POST /config/cameras/:id/redetect`.
-7. **Motion decode backend (optional).** `PUT /config/server` with the full body
-   from `GET /config/server`, overriding only `motion_hwaccel`
-   (`"auto"|"cpu"|"vaapi"|"cuda"`) and `motion_vaapi_device` (e.g.
-   `"/dev/dri/renderD128"`, only meaningful for vaapi). The PUT is a
-   **whole-row replace**, always send back every field you fetched, changing
-   only these two. Then **verify the truth** with `GET /config/decode-status`:
+7. **Motion decode backend (optional).** `PUT /config/server` with just
+   `motion_hwaccel` (`"auto"|"cpu"|"vaapi"|"cuda"`) and `motion_vaapi_device`
+   (e.g. `"/dev/dri/renderD128"`, only meaningful for vaapi). The PUT **merges**:
+   a key you omit is left exactly as stored, so you do not have to round-trip the
+   whole row. A key sent as `""` is a deliberate **clear**, which resets that
+   setting to its container-environment default, so only send `""` when that is
+   what you mean. Then **verify the truth** with `GET /config/decode-status`:
    per camera it reports `requested` vs `active` plus a human `fallback_reason`
    when they differ (e.g. the render node isn't mapped into the recorder
    container, see "Hardware-accelerated motion decode" below). `capabilities:

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,96 @@ revisit.
 
 ---
 
+## 2026-08-06, `PUT /config/server` MERGES: omitted key = leave alone, `""` = clear (issue #472)
+
+**Context.** `PUT /config/server` was a whole-row replace whose DTO carried
+`#[serde(default)]` on most fields. A programmatic caller sending a partial body
+(`{"motion_hwaccel": "vaapi"}`) got every unmentioned field deserialized to `""`
+and written, silently resetting the Frigate bases, the stream bases and the
+VAAPI device to their env fallbacks. The console and first-run wizard were safe
+only by convention: they use a full-body stash pattern that round-trips every
+key. The exposure was scripts and third-party integrations, and
+`docs/AI-INSTALL.md` step 7 was literally instructing agents to work around it.
+
+PR #518 had already solved this for exactly one field: `frigate_api_base` became
+`Option<String>` so an omitted key could mean "leave the stored legacy column
+alone" rather than "wipe the value a pre-0014 install still resolves from".
+
+**Decision.** Generalize #518's semantics to the whole DTO. Every settable field
+is `Option<String>` with `#[serde(default)]`, and the three states are distinct:
+
+| Body | Meaning |
+|---|---|
+| key omitted / `null` ⇒ `None` | leave the stored column alone |
+| `"value"` ⇒ `Some(v)` | set it (trimmed) |
+| `""` ⇒ `Some("")` | clear it ⇒ falls back to the container env |
+
+`Some("")` is deliberately NOT collapsed into "omitted". Crumb's config
+precedence is *admin-set DB value wins over env; EMPTY DB value falls back to
+env*, so an empty string is the operator's way of saying "go back to the env
+default". Merging it away would remove the only way to undo a setting through
+the API.
+
+The DB layer expresses it directly: `COALESCE($n::text, column)`, one parameter
+per field, `None` binding SQL `NULL`. `version` is still bumped on every call,
+so a no-op merge still tells the recorder and clients to re-read.
+
+**Rejected:**
+
+- **Drop `#[serde(default)]` so a partial body 422s loudly** (the issue's other
+  option). Honest, but it makes the endpoint *harder* to use correctly rather
+  than easier — every caller must fetch-then-echo nine fields to change one, and
+  a fetch/PUT race then clobbers a concurrent edit with stale values. It also
+  contradicts the direction #518 already set for `frigate_api_base`, leaving one
+  field with merge semantics and eight without.
+- **PATCH as a separate route, leaving PUT a replace.** Strictly correct REST,
+  but it doubles the surface and leaves the footgun armed on the route every
+  existing caller uses. Nothing in the codebase relies on PUT's replace
+  semantics: the only clients that call it send full rows.
+- **Rewrite the console/wizard to send minimal per-pane bodies.** Tempting now
+  that merging works, and it would honor "wizard/console code must only ever
+  write the specific fields it edits" more literally. Deliberately NOT done in
+  this change: a full body means the same thing under both semantics, so keeping
+  the stash pattern makes this a pure server-side fix with zero console
+  behavior change to re-verify. Doing both at once would make a console
+  regression indistinguishable from a DTO regression.
+- **Treat `""` as "leave alone" too** (i.e. only non-empty values write). Would
+  make "reset this back to the env default" unreachable through the API and
+  quietly break the console's existing "clear the field" behavior.
+
+**Trades knowingly accepted:**
+
+- Four fields that were structurally required (`server_address`,
+  `crumb_rtsp_base`, `crumb_api_base`, `frigate_rtsp_base`) are now optional, so
+  a body that omits them succeeds instead of 422ing. That is the point, but it
+  does mean a caller with a typo'd key name now silently no-ops that field
+  instead of erroring. Accepted: the same is already true of every
+  `#[serde(default)]` field on every other config route, and the alternative
+  costs the merge.
+- The `frigate_go2rtc_api_base` seeding rule gets one more state to reason
+  about. `Some("")` still falls back to a legacy value in the same body (the
+  pre-0014 client contract, unchanged); only a fully absent key means "leave
+  alone". Both branches are unit-tested.
+- The legacy column's "clear the old console's go2rtc duplicate" cleanup only
+  fires when the body actually decides the go2rtc base. A PUT that mentions
+  neither column can't tell a duplicate from operator intent, so it touches
+  neither — a stale duplicate now survives such a request instead of being
+  cleaned up as a side effect.
+
+**Revisit triggers:**
+
+- A field where `""` becomes a meaningful *value* rather than "fall back to
+  env" ⇒ that field needs `Option<Option<String>>` (or a sentinel) and this
+  three-state table stops being sufficient.
+- The generated OpenAPI spec (ROADMAP initiative 4) landing ⇒ the three states
+  must be expressible in it, or the endpoint's contract goes back to living only
+  in doc comments.
+- Any second config route growing the same partial-body hazard ⇒ factor the
+  `Option<String>` + `COALESCE` pattern into a shared helper instead of
+  hand-rolling it a third time.
+
+---
+
 ## 2026-08-06, The storage preflight infers recorder writability from the folder's OWNERSHIP when its own write probe is inconclusive, rather than asking the recorder
 
 **Context.** `POST /config/fs/check` is the wizard's gate on "this disk will

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -772,8 +772,11 @@ code{background:var(--surface2);padding:1px 5px;border-radius:4px;font-size:12px
 let TOKEN = localStorage.getItem('crumb_admin_token') || '';
 let CAMS = [], STORAGES = [], POLICIES = [], DEFAULT_POLICY = null, GROUPS = [], USERS = [], ROLES = [];
 /* Server settings last fetched, so the Detection & clips and Server panes can
-   each send a COMPLETE /config/server body (the PUT is a whole-row replace) while
-   editing only their own subset of columns. */
+   each send a COMPLETE /config/server body while editing only their own subset
+   of columns. The PUT now MERGES (an omitted key leaves the stored column alone,
+   issue #472), so the full-body stash is belt-and-braces rather than required —
+   it is kept as-is because it is the behavior these panes were written against
+   and a full body means the same thing under both semantics. */
 let DETECTION_SERVER = null;
 let SERVER_SETTINGS = null;
 /* Frigate integration settings last fetched by the Detection & clips pane, so
@@ -7361,11 +7364,12 @@ async function mirrorFrigateHttpToServerSettings(v) {
   body.frigate_http_api_base = v;
   DETECTION_SERVER = await api('/config/server', { method: 'PUT', body: JSON.stringify(body) }) || DETECTION_SERVER;
 }
-/* A COMPLETE /config/server body built from the fetched settings (the PUT is a
-   whole-row replace with required Crumb fields). The deprecated
-   `frigate_api_base` key is deliberately NOT sent: the server treats an omitted
-   key as "leave the stored legacy column alone", and sending the go2rtc base in
-   it is exactly what used to poison frigate_http_api_base. */
+/* A COMPLETE /config/server body built from the fetched settings. The PUT merges
+   (an omitted key leaves the stored column alone, issue #472), so this is no
+   longer strictly required — but a full body is unambiguous under both
+   semantics, so it stays. The deprecated `frigate_api_base` key is deliberately
+   NOT sent: an omitted key leaves the stored legacy column alone, and sending the
+   go2rtc base in it is exactly what used to poison frigate_http_api_base. */
 function detectionServerBody(s) {
   return {
     server_address:          s.server_address || '',

--- a/services/api/src/config_routes.rs
+++ b/services/api/src/config_routes.rs
@@ -4029,7 +4029,9 @@ async fn get_server_settings(
 /// Resolve the three Frigate base-URL columns for a `PUT /config/server`.
 ///
 /// Returns `(frigate_api_base, frigate_go2rtc_api_base, frigate_http_api_base)`
-/// — legacy, go2rtc REST (:1984), Frigate HTTP (:5000).
+/// — legacy, go2rtc REST (:1984), Frigate HTTP (:5000). Each is an
+/// `Option<String>`: `Some(v)` is the value to write (`Some("")` clears the
+/// column), `None` means **leave the stored column untouched** (issue #472).
 ///
 /// Migration 0014 split the legacy `frigate_api_base` in two because one field
 /// could not mean both services. The old back-compat rule copied the legacy
@@ -4044,60 +4046,69 @@ async fn get_server_settings(
 /// * **go2rtc** — the split field wins; an old client that only sends the legacy
 ///   field still seeds it. Safe: the console has always kept legacy == the
 ///   go2rtc base, and the go2rtc readers already fall back to legacy themselves.
+///   A body that omits the key entirely AND carries no legacy value leaves the
+///   stored column alone rather than clearing it.
 /// * **HTTP** — the split field, and nothing else. The legacy value is never
-///   copied here. Empty means "fall back at read time" (`frigate_config.api_base`,
-///   then the `FRIGATE_API_BASE` env), which is what an operator who configured
-///   only the Frigate integration row actually wants.
+///   copied here. `Some("")` means "fall back at read time"
+///   (`frigate_config.api_base`, then the `FRIGATE_API_BASE` env), which is what
+///   an operator who configured only the Frigate integration row actually wants.
+///   `None` leaves the stored column alone.
 /// * **legacy** — `None` (current clients omit the key) leaves the stored value
 ///   alone, so a whole-row PUT from a new client cannot wipe a value a pre-0014
 ///   install still resolves its Frigate HTTP base from. The one exception is the
-///   known-bad write: a stored legacy value identical to the go2rtc base is the
-///   old console's "keep in sync" copy, not operator intent, and leaving it would
-///   let the read-side legacy→HTTP fallback keep resolving :1984. That case is
-///   cleared — the value survives in the go2rtc column, which is where every
-///   go2rtc reader looks first.
+///   known-bad write: a stored legacy value identical to the go2rtc base being
+///   written is the old console's "keep in sync" copy, not operator intent, and
+///   leaving it would let the read-side legacy→HTTP fallback keep resolving
+///   :1984. That case is cleared — the value survives in the go2rtc column,
+///   which is where every go2rtc reader looks first. A body that says nothing
+///   about either column can't make that judgement, so it touches neither.
 fn resolve_frigate_bases(
     body_legacy: Option<&str>,
-    body_go2rtc: &str,
-    body_http: &str,
+    body_go2rtc: Option<&str>,
+    body_http: Option<&str>,
     stored_legacy: &str,
-) -> (String, String, String) {
+) -> (Option<String>, Option<String>, Option<String>) {
     let body_legacy = body_legacy.map(str::trim);
-    let go2rtc = {
-        let v = body_go2rtc.trim();
-        if v.is_empty() {
-            body_legacy.unwrap_or("")
-        } else {
-            v
-        }
+    // A non-empty legacy value in the body still seeds the go2rtc column (the
+    // pre-0014 client contract). Otherwise: present-but-empty clears, omitted
+    // preserves.
+    let seed = body_legacy.filter(|v| !v.is_empty());
+    let go2rtc: Option<String> = match body_go2rtc.map(str::trim) {
+        Some(v) if !v.is_empty() => Some(v.to_owned()),
+        Some(_) => Some(seed.unwrap_or("").to_owned()),
+        None => seed.map(ToOwned::to_owned),
     };
     // Never seeded from the legacy field — that is the whole point of this fix.
-    let http = body_http.trim();
-    let legacy = if let Some(v) = body_legacy {
-        v
-    } else {
-        let stored = stored_legacy.trim();
-        if !stored.is_empty() && stored == go2rtc {
-            ""
-        } else {
-            stored
-        }
+    let http = body_http.map(|v| v.trim().to_owned());
+    let legacy = match body_legacy {
+        Some(v) => Some(v.to_owned()),
+        // Only clear the old console's duplicate when this PUT actually decides
+        // what the go2rtc base is; otherwise leave the column untouched.
+        None => go2rtc.as_deref().and_then(|g| {
+            let stored = stored_legacy.trim();
+            (!stored.is_empty() && stored == g).then(String::new)
+        }),
     };
-    (legacy.to_owned(), go2rtc.to_owned(), http.to_owned())
+    (legacy, go2rtc, http)
 }
 
 /// `PUT /config/server` — update server & streaming base-URL settings.
 ///
-/// All fields accept an empty string to fall back to the container environment
-/// / internal docker service-name default.  Bumps the version counter so
-/// downstream consumers (recorder, API, clients) can detect and reload.
+/// A **merge**, not a whole-row replace (issue #472). A field the body omits is
+/// left exactly as stored; a field sent as `""` is cleared, which is how an
+/// operator returns it to the container environment / internal docker
+/// service-name default. See [`UpdateServerSettingsRequest`].
+///
+/// Bumps the version counter so downstream consumers (recorder, API, clients)
+/// can detect and reload.
 async fn update_server_settings(
     _admin: AdminUser,
     State(state): State<AppState>,
     Json(body): Json<UpdateServerSettingsRequest>,
 ) -> Result<Json<ServerSettingsDto>, ApiError> {
-    // Trim each field; allow empty (means "fall back to env / docker service
-    // name").  No homelab IPs baked in here — the operator provides them.
+    // Trim each supplied field; an explicit empty means "fall back to env /
+    // docker service name". No homelab IPs baked in here — the operator
+    // provides them.
     //
     // The legacy `frigate_api_base` column is only ever preserved/seeded now, so
     // read the stored row to decide what to write back for it.
@@ -4108,24 +4119,29 @@ async fn update_server_settings(
         .unwrap_or_default();
     let (legacy, go2rtc_api, http_api) = resolve_frigate_bases(
         body.frigate_api_base.as_deref(),
-        &body.frigate_go2rtc_api_base,
-        &body.frigate_http_api_base,
+        body.frigate_go2rtc_api_base.as_deref(),
+        body.frigate_http_api_base.as_deref(),
         &stored_legacy,
     );
 
+    /// `Some(field)` → the trimmed value to write; `None` → leave it alone.
+    fn set(v: Option<&String>) -> Option<&str> {
+        v.map(|s| s.trim())
+    }
+
     let s = crumb_common::db::update_server_settings(
         state.pool(),
-        body.server_address.trim(),
-        body.crumb_rtsp_base.trim(),
-        body.crumb_api_base.trim(),
-        body.frigate_rtsp_base.trim(),
-        &legacy,
-        &go2rtc_api,
-        &http_api,
+        set(body.server_address.as_ref()),
+        set(body.crumb_rtsp_base.as_ref()),
+        set(body.crumb_api_base.as_ref()),
+        set(body.frigate_rtsp_base.as_ref()),
+        legacy.as_deref(),
+        go2rtc_api.as_deref(),
+        http_api.as_deref(),
         // Motion decode backend (admin-editable, hot-reloaded by the recorder).
         // Empty ⇒ recorder falls back to its MOTION_HWACCEL / MOTION_VAAPI_DEVICE env.
-        body.motion_hwaccel.trim(),
-        body.motion_vaapi_device.trim(),
+        set(body.motion_hwaccel.as_ref()),
+        set(body.motion_vaapi_device.as_ref()),
     )
     .await
     .context("update_server_settings")?;
@@ -5293,24 +5309,28 @@ mod frigate_base_tests {
     /// through to `frigate_config.api_base` / the env.
     #[test]
     fn legacy_never_seeds_the_http_base() {
-        let (_, _, http) = resolve_frigate_bases(Some(GO2RTC), GO2RTC, "", GO2RTC);
-        assert_eq!(http, "");
+        let (_, _, http) = resolve_frigate_bases(Some(GO2RTC), Some(GO2RTC), Some(""), GO2RTC);
+        assert_eq!(http.as_deref(), Some(""));
 
         // Same for an old client that sends ONLY the legacy field.
-        let (_, go2rtc, http) = resolve_frigate_bases(Some(GO2RTC), "", "", "");
-        assert_eq!(go2rtc, GO2RTC, "legacy may still seed the go2rtc base");
-        assert_eq!(http, "");
+        let (_, go2rtc, http) = resolve_frigate_bases(Some(GO2RTC), Some(""), Some(""), "");
+        assert_eq!(
+            go2rtc.as_deref(),
+            Some(GO2RTC),
+            "legacy may still seed the go2rtc base"
+        );
+        assert_eq!(http.as_deref(), Some(""));
 
         // And for a stored legacy value with nothing about it in the body.
-        let (_, _, http) = resolve_frigate_bases(None, GO2RTC, "", GO2RTC);
-        assert_eq!(http, "");
+        let (_, _, http) = resolve_frigate_bases(None, Some(GO2RTC), Some(""), GO2RTC);
+        assert_eq!(http.as_deref(), Some(""));
     }
 
     #[test]
     fn explicit_http_value_is_kept_verbatim() {
-        let (_, go2rtc, http) = resolve_frigate_bases(None, GO2RTC, HTTP, "");
-        assert_eq!(go2rtc, GO2RTC);
-        assert_eq!(http, HTTP);
+        let (_, go2rtc, http) = resolve_frigate_bases(None, Some(GO2RTC), Some(HTTP), "");
+        assert_eq!(go2rtc.as_deref(), Some(GO2RTC));
+        assert_eq!(http.as_deref(), Some(HTTP));
     }
 
     #[test]
@@ -5318,10 +5338,10 @@ mod frigate_base_tests {
         // Pre-0014 install: the legacy column holds a Frigate HTTP base and the
         // split columns are empty. A whole-row PUT from a new client (which omits
         // the key) must not wipe it — the read side still resolves from it.
-        let (legacy, go2rtc, http) = resolve_frigate_bases(None, "", "", HTTP);
-        assert_eq!(legacy, HTTP);
-        assert_eq!(go2rtc, "");
-        assert_eq!(http, "");
+        let (legacy, go2rtc, http) = resolve_frigate_bases(None, Some(""), Some(""), HTTP);
+        assert_eq!(legacy, None, "None = leave the stored legacy column alone");
+        assert_eq!(go2rtc.as_deref(), Some(""));
+        assert_eq!(http.as_deref(), Some(""));
     }
 
     #[test]
@@ -5329,29 +5349,62 @@ mod frigate_base_tests {
         // Legacy == the go2rtc base is the old console's "keep in sync" copy.
         // Clearing it stops the read-side legacy→HTTP fallback from resolving
         // :1984; the value itself survives in the go2rtc column.
-        let (legacy, go2rtc, http) = resolve_frigate_bases(None, GO2RTC, "", GO2RTC);
-        assert_eq!(legacy, "");
-        assert_eq!(go2rtc, GO2RTC);
-        assert_eq!(http, "");
+        let (legacy, go2rtc, http) = resolve_frigate_bases(None, Some(GO2RTC), Some(""), GO2RTC);
+        assert_eq!(legacy.as_deref(), Some(""));
+        assert_eq!(go2rtc.as_deref(), Some(GO2RTC));
+        assert_eq!(http.as_deref(), Some(""));
     }
 
     #[test]
     fn explicit_empty_legacy_clears_it() {
-        let (legacy, _, _) = resolve_frigate_bases(Some(""), GO2RTC, HTTP, GO2RTC);
-        assert_eq!(legacy, "");
+        let (legacy, _, _) = resolve_frigate_bases(Some(""), Some(GO2RTC), Some(HTTP), GO2RTC);
+        assert_eq!(legacy.as_deref(), Some(""));
     }
 
     #[test]
     fn split_fields_win_over_legacy_and_everything_is_trimmed() {
         let (legacy, go2rtc, http) = resolve_frigate_bases(
             Some("  http://old-frigate:1984  "),
-            "  http://frigate-host:1984  ",
-            "  http://frigate-host:5000  ",
+            Some("  http://frigate-host:1984  "),
+            Some("  http://frigate-host:5000  "),
             "",
         );
-        assert_eq!(legacy, "http://old-frigate:1984");
-        assert_eq!(go2rtc, GO2RTC);
-        assert_eq!(http, HTTP);
+        assert_eq!(legacy.as_deref(), Some("http://old-frigate:1984"));
+        assert_eq!(go2rtc.as_deref(), Some(GO2RTC));
+        assert_eq!(http.as_deref(), Some(HTTP));
+    }
+
+    // ── #472: omitted ≠ cleared ───────────────────────────────────────────────
+
+    /// A partial body that mentions none of the three Frigate columns must leave
+    /// all three alone. Before #472 an omitted split field deserialized to `""`
+    /// and wiped the stored value.
+    #[test]
+    fn a_body_that_omits_every_frigate_key_touches_nothing() {
+        let (legacy, go2rtc, http) = resolve_frigate_bases(None, None, None, GO2RTC);
+        assert_eq!(legacy, None);
+        assert_eq!(go2rtc, None);
+        assert_eq!(http, None);
+    }
+
+    /// Omitting only the HTTP key preserves it; the go2rtc key it DOES send
+    /// still applies, and the legacy duplicate is still cleared.
+    #[test]
+    fn omitting_only_the_http_key_preserves_it() {
+        let (legacy, go2rtc, http) = resolve_frigate_bases(None, Some(GO2RTC), None, GO2RTC);
+        assert_eq!(legacy.as_deref(), Some(""));
+        assert_eq!(go2rtc.as_deref(), Some(GO2RTC));
+        assert_eq!(http, None);
+    }
+
+    /// A pre-0014 client sends ONLY the legacy key (no split keys at all). It
+    /// must still seed the go2rtc column, exactly as before.
+    #[test]
+    fn legacy_only_body_still_seeds_go2rtc_when_split_keys_are_absent() {
+        let (legacy, go2rtc, http) = resolve_frigate_bases(Some(GO2RTC), None, None, "");
+        assert_eq!(legacy.as_deref(), Some(GO2RTC));
+        assert_eq!(go2rtc.as_deref(), Some(GO2RTC));
+        assert_eq!(http, None, "the HTTP column is never seeded from legacy");
     }
 }
 

--- a/services/api/src/dto.rs
+++ b/services/api/src/dto.rs
@@ -973,16 +973,44 @@ pub struct ServerSettingsDto {
     pub tz: String,
 }
 
-/// `PUT /config/server` request body.
+/// `PUT /config/server` request body — a **merge**, not a whole-row replace.
 ///
-/// All fields are required. Pass empty strings to fall back to the container
-/// environment / internal docker service-name defaults.
+/// Every field is `Option<String>` with `#[serde(default)]`, and the two states
+/// mean different things (issue #472). This is the generalization of the rule
+/// `frigate_api_base` already had:
+///
+/// | Body | Meaning |
+/// |---|---|
+/// | key omitted (or `null`) ⇒ `None` | **leave the stored value alone** |
+/// | `"some value"` ⇒ `Some(v)` | set it (trimmed) |
+/// | `""` ⇒ `Some("")` | **clear** it, which means "fall back to the container env / internal docker service-name default" |
+///
+/// `Some("")` is a real, distinct state, not a synonym for omitted: the config
+/// precedence rule is that an admin-set DB value wins over the env default and
+/// an EMPTY DB value falls back to env, so clearing a field is how an operator
+/// returns it to the env default. Omitting it must not do that silently.
+///
+/// The whole-row bodies the console and first-run wizard send today are
+/// unaffected: every key is present, so every field is `Some(...)` and the write
+/// is byte-identical to the old behavior. The fix is for programmatic callers
+/// that send a partial body and previously had every unmentioned
+/// `#[serde(default)]` field silently reset.
 #[derive(Debug, Deserialize)]
 pub struct UpdateServerSettingsRequest {
-    pub server_address: String,
-    pub crumb_rtsp_base: String,
-    pub crumb_api_base: String,
-    pub frigate_rtsp_base: String,
+    /// Externally reachable address of this server (what clients are told to
+    /// use). Empty ⇒ derived/env default.
+    #[serde(default)]
+    pub server_address: Option<String>,
+    /// RTSP base for Crumb's own go2rtc restream. Empty ⇒ env.
+    #[serde(default)]
+    pub crumb_rtsp_base: Option<String>,
+    /// REST base for Crumb's own go2rtc (`http://go2rtc:1984` by default).
+    /// Empty ⇒ env. Never point this at the Crumb API itself.
+    #[serde(default)]
+    pub crumb_api_base: Option<String>,
+    /// RTSP base for an external Frigate's restream. Empty ⇒ env.
+    #[serde(default)]
+    pub frigate_rtsp_base: Option<String>,
     /// Legacy combined Frigate API base — DEPRECATED, do not send from new
     /// clients. Migration 0014 split it into `frigate_go2rtc_api_base` (:1984)
     /// and `frigate_http_api_base` (:5000) because one field could not mean
@@ -992,27 +1020,31 @@ pub struct UpdateServerSettingsRequest {
     /// `None` (key omitted, what current clients do) means "leave the stored
     /// legacy column alone" — a whole-row PUT from a new client must not wipe a
     /// value an old install still relies on. `Some("")` explicitly clears it.
+    /// This field is where the omitted-≠-cleared rule was first established;
+    /// every other field above now follows it.
     #[serde(default)]
     pub frigate_api_base: Option<String>,
     /// HTTP API base for the external Frigate go2rtc REST endpoint (:1984).
-    /// When omitted/empty the handler falls back to the legacy `frigate_api_base`.
+    /// `Some("")` (present but empty) still falls back to the legacy
+    /// `frigate_api_base` when the body supplies one, which is how a pre-0014
+    /// client seeds this column; `None` leaves the stored value alone.
     #[serde(default)]
-    pub frigate_go2rtc_api_base: String,
+    pub frigate_go2rtc_api_base: Option<String>,
     /// HTTP base for the Frigate HTTP event/snapshot API (:5000).
-    /// Empty ⇒ fall back to `frigate_config.api_base` / the `FRIGATE_API_BASE`
-    /// env at read time. Deliberately NOT seeded from the legacy field.
+    /// `Some("")` ⇒ fall back to `frigate_config.api_base` / the
+    /// `FRIGATE_API_BASE` env at read time. Deliberately NOT seeded from the
+    /// legacy field. `None` leaves the stored value alone.
     #[serde(default)]
-    pub frigate_http_api_base: String,
-    /// Motion-decode backend: `"auto"`/`"cuda"`/`"vaapi"`/`"cpu"`. Empty ⇒ the
-    /// recorder's `MOTION_HWACCEL` env default. `#[serde(default)]` only avoids a
-    /// deserialization error when the field is omitted — `PUT /config/server` is a
-    /// WHOLE-ROW replace, so the client must send a complete body (see admin.html's
-    /// stash pattern); the server does NOT merge omitted fields.
+    pub frigate_http_api_base: Option<String>,
+    /// Motion-decode backend: `"auto"`/`"cuda"`/`"vaapi"`/`"cpu"`.
+    /// `Some("")` ⇒ the recorder's `MOTION_HWACCEL` env default;
+    /// `None` ⇒ leave the stored value alone.
     #[serde(default)]
-    pub motion_hwaccel: String,
-    /// DRI render node for VAAPI decode (e.g. `/dev/dri/renderD128`). Empty ⇒ env.
+    pub motion_hwaccel: Option<String>,
+    /// DRI render node for VAAPI decode (e.g. `/dev/dri/renderD128`).
+    /// `Some("")` ⇒ env default; `None` ⇒ leave the stored value alone.
     #[serde(default)]
-    pub motion_vaapi_device: String,
+    pub motion_vaapi_device: Option<String>,
 }
 
 // ─── motion-decode truth (decode-status panel) ────────────────────────────────

--- a/services/api/tests/server_settings_partial_put.rs
+++ b/services/api/tests/server_settings_partial_put.rs
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! `PUT /config/server` merge semantics (issue #472).
+//!
+//! The endpoint used to be a whole-row replace whose DTO carried
+//! `#[serde(default)]`, so a partial programmatic body silently reset every
+//! field it did not mention back to `""` (⇒ the container env fallback). This
+//! suite pins the three states the request DTO now distinguishes:
+//!
+//! | Body | Meaning |
+//! |---|---|
+//! | key omitted / `null` | leave the stored column alone |
+//! | `"value"` | set it |
+//! | `""` | clear it ⇒ fall back to the container env |
+//!
+//! `""` deliberately stays a real, distinct state: Crumb's config precedence is
+//! "admin-set DB value wins over env, EMPTY DB value falls back to env", so
+//! clearing a field is the only way to undo a setting through the API.
+//!
+//! `docs/DECISIONS.md` (2026-08-06) records the alternatives that were rejected.
+//!
+//! # Concurrency
+//!
+//! `server_settings` is a singleton row. Every test here takes
+//! [`SERVER_SETTINGS_LOCK`] so they cannot interleave with each other. The
+//! columns they touch (`server_address`, the stream/Frigate bases, the motion
+//! decode pair) are disjoint from the `thumb_*` / `beta_terms_*` columns the
+//! scrub-preview and beta-terms tests in `auth_rbac.rs` mutate, so a
+//! concurrently-running test BINARY cannot perturb these assertions either.
+
+mod support;
+
+use axum::body::to_bytes;
+use axum::http::StatusCode;
+use serde_json::{json, Value};
+use support::*;
+
+async fn body_json(resp: axum::http::Response<axum::body::Body>) -> Value {
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice(&bytes).expect("response body is JSON")
+}
+
+/// Every settable key, with a distinct recognizable value per field so a
+/// cross-wired assignment shows up as a wrong value rather than a passing test.
+fn full_body() -> Value {
+    json!({
+        "server_address":          "http://192.0.2.9:8080",
+        "crumb_rtsp_base":         "rtsp://192.0.2.9:18554",
+        "crumb_api_base":          "http://192.0.2.9:1984",
+        "frigate_rtsp_base":       "rtsp://192.0.2.8:8554",
+        "frigate_go2rtc_api_base": "http://192.0.2.8:1984",
+        "frigate_http_api_base":   "http://192.0.2.8:5000",
+        "motion_hwaccel":          "cpu",
+        "motion_vaapi_device":     "/dev/dri/renderD128",
+    })
+}
+
+/// Keys the DTO accepts and echoes back, in the order a caller thinks about
+/// them. Used to assert "everything except X is untouched" without listing the
+/// fields eight times.
+const SETTABLE: [&str; 8] = [
+    "server_address",
+    "crumb_rtsp_base",
+    "crumb_api_base",
+    "frigate_rtsp_base",
+    "frigate_go2rtc_api_base",
+    "frigate_http_api_base",
+    "motion_hwaccel",
+    "motion_vaapi_device",
+];
+
+/// PUT the full baseline body and return the resulting settings DTO.
+async fn seed_baseline(app: &TestApp, token: &str) -> Value {
+    let resp = app
+        .send(put_auth_json("/config/server", token, &full_body()))
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK, "baseline PUT must succeed");
+    body_json(resp).await
+}
+
+/// Assert every settable field except those in `except` is byte-identical
+/// between two settings DTOs.
+fn assert_unchanged_except(before: &Value, after: &Value, except: &[&str]) {
+    for key in SETTABLE {
+        if except.contains(&key) {
+            continue;
+        }
+        assert_eq!(
+            before[key], after[key],
+            "field `{key}` must survive a body that never mentions it"
+        );
+    }
+}
+
+/// The bug: a partial body must not reset the fields it omits.
+#[tokio::test]
+async fn partial_put_preserves_unmentioned_fields() {
+    let _guard = SERVER_SETTINGS_LOCK.lock().await;
+    let app = TestApp::new().await;
+    let admin = seed_admin(app.pool()).await;
+    let token = login(&app, &admin.username, &admin.password).await;
+
+    let before = seed_baseline(&app, &token).await;
+
+    // The exact shape a script would send to switch the decode backend.
+    let resp = app
+        .send(put_auth_json(
+            "/config/server",
+            &token,
+            &json!({ "motion_hwaccel": "vaapi" }),
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let after = body_json(resp).await;
+
+    assert_eq!(after["motion_hwaccel"], "vaapi", "the one sent key applies");
+    assert_unchanged_except(&before, &after, &["motion_hwaccel"]);
+
+    // And it is actually persisted, not just echoed.
+    let reread = body_json(app.send(get_auth("/config/server", &token)).await).await;
+    assert_eq!(reread["motion_hwaccel"], "vaapi");
+    assert_unchanged_except(&before, &reread, &["motion_hwaccel"]);
+}
+
+/// An explicit empty string is a CLEAR, not a no-op: that is how an operator
+/// returns a setting to its container-environment default.
+#[tokio::test]
+async fn explicit_empty_string_clears_the_field() {
+    let _guard = SERVER_SETTINGS_LOCK.lock().await;
+    let app = TestApp::new().await;
+    let admin = seed_admin(app.pool()).await;
+    let token = login(&app, &admin.username, &admin.password).await;
+
+    let before = seed_baseline(&app, &token).await;
+    assert_eq!(before["crumb_rtsp_base"], "rtsp://192.0.2.9:18554");
+
+    let resp = app
+        .send(put_auth_json(
+            "/config/server",
+            &token,
+            &json!({ "crumb_rtsp_base": "" }),
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let after = body_json(resp).await;
+
+    assert_eq!(
+        after["crumb_rtsp_base"], "",
+        "an explicit \"\" must clear the column (⇒ env fallback), not merge away"
+    );
+    assert_unchanged_except(&before, &after, &["crumb_rtsp_base"]);
+}
+
+/// `null` is JSON's way of omitting a key; it must behave like omission, NOT
+/// like `""`. Otherwise a client that spreads a partial object over defaults
+/// would clear fields by accident.
+#[tokio::test]
+async fn explicit_null_behaves_like_an_omitted_key() {
+    let _guard = SERVER_SETTINGS_LOCK.lock().await;
+    let app = TestApp::new().await;
+    let admin = seed_admin(app.pool()).await;
+    let token = login(&app, &admin.username, &admin.password).await;
+
+    let before = seed_baseline(&app, &token).await;
+
+    let resp = app
+        .send(put_auth_json(
+            "/config/server",
+            &token,
+            &json!({ "server_address": "http://192.0.2.11:8080", "crumb_rtsp_base": null }),
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let after = body_json(resp).await;
+
+    assert_eq!(after["server_address"], "http://192.0.2.11:8080");
+    assert_unchanged_except(&before, &after, &["server_address"]);
+}
+
+/// Regression guard for the console and first-run wizard, which both send a
+/// COMPLETE body: the whole-row path must behave exactly as it did before the
+/// DTO changed.
+#[tokio::test]
+async fn full_row_put_is_unchanged() {
+    let _guard = SERVER_SETTINGS_LOCK.lock().await;
+    let app = TestApp::new().await;
+    let admin = seed_admin(app.pool()).await;
+    let token = login(&app, &admin.username, &admin.password).await;
+
+    // Start from a different row so "unchanged" can't pass vacuously.
+    seed_baseline(&app, &token).await;
+
+    let body = json!({
+        "server_address":          "http://192.0.2.20:8080",
+        "crumb_rtsp_base":         "rtsp://192.0.2.20:18554",
+        "crumb_api_base":          "http://192.0.2.20:1984",
+        "frigate_rtsp_base":       "",
+        "frigate_go2rtc_api_base": "",
+        "frigate_http_api_base":   "",
+        "motion_hwaccel":          "auto",
+        "motion_vaapi_device":     "",
+    });
+    let resp = app
+        .send(put_auth_json("/config/server", &token, &body))
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let after = body_json(resp).await;
+
+    for key in SETTABLE {
+        assert_eq!(
+            after[key], body[key],
+            "a full-row PUT must write `{key}` verbatim, including empties"
+        );
+    }
+}
+
+/// A partial PUT still bumps `version`, so the recorder and clients re-read.
+#[tokio::test]
+async fn partial_put_still_bumps_the_version_counter() {
+    let _guard = SERVER_SETTINGS_LOCK.lock().await;
+    let app = TestApp::new().await;
+    let admin = seed_admin(app.pool()).await;
+    let token = login(&app, &admin.username, &admin.password).await;
+
+    let before = seed_baseline(&app, &token).await;
+    let v0 = before["version"].as_i64().expect("version is an integer");
+
+    let resp = app
+        .send(put_auth_json(
+            "/config/server",
+            &token,
+            &json!({ "motion_vaapi_device": "/dev/dri/renderD129" }),
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let after = body_json(resp).await;
+
+    assert_eq!(after["version"].as_i64(), Some(v0 + 1));
+    assert_eq!(after["motion_vaapi_device"], "/dev/dri/renderD129");
+}
+
+/// An empty body `{}` is a legal no-op merge: nothing changes but the version.
+#[tokio::test]
+async fn empty_body_changes_nothing_but_the_version() {
+    let _guard = SERVER_SETTINGS_LOCK.lock().await;
+    let app = TestApp::new().await;
+    let admin = seed_admin(app.pool()).await;
+    let token = login(&app, &admin.username, &admin.password).await;
+
+    let before = seed_baseline(&app, &token).await;
+
+    let resp = app
+        .send(put_auth_json("/config/server", &token, &json!({})))
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let after = body_json(resp).await;
+
+    assert_unchanged_except(&before, &after, &[]);
+    assert_eq!(
+        after["version"].as_i64(),
+        before["version"].as_i64().map(|v| v + 1)
+    );
+}

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -9939,13 +9939,21 @@ pub async fn server_settings_version(pool: &Pool) -> Result<i64> {
 /// Update the singleton server settings and BUMP `version` (so any future
 /// hot-reload pollers pick up the change).  Returns the updated settings.
 ///
-/// All settable fields are replaced; pass the current values for fields the
-/// caller does not want to change.  Empty strings are valid (mean "fall back to
-/// env").
+/// Every settable field is `Option<&str>` and the two states mean different
+/// things (issue #472):
 ///
-/// The two new fields added by migration 0014 (`frigate_go2rtc_api_base` and
-/// `frigate_http_api_base`) are also updated.  The API-routes caller must include
-/// them in `UpdateServerSettingsRequest`; see the contract in the audit.
+/// * `Some(v)` — write `v`. `Some("")` is a real value: an EMPTY column is what
+///   "fall back to the env default" means under Crumb's config-precedence rule,
+///   so clearing a field is how an operator returns it to the env.
+/// * `None` — **leave the stored column untouched** (`COALESCE($n, column)`).
+///   This is what lets `PUT /config/server` merge a partial body instead of
+///   resetting every field the caller did not mention.
+///
+/// The version counter is bumped on every call regardless, so a no-op merge
+/// still signals "re-read" to the recorder / clients exactly as before.
+///
+/// The two fields added by migration 0014 (`frigate_go2rtc_api_base` and
+/// `frigate_http_api_base`) are updated the same way.
 ///
 /// `frigate_api_base` is the deprecated pre-0014 column. The caller decides what
 /// to write back for it (`config_routes::resolve_frigate_bases`) — it is never
@@ -9959,30 +9967,34 @@ pub async fn server_settings_version(pool: &Pool) -> Result<i64> {
 #[allow(clippy::too_many_arguments)]
 pub async fn update_server_settings(
     pool: &Pool,
-    server_address: &str,
-    crumb_rtsp_base: &str,
-    crumb_api_base: &str,
-    frigate_rtsp_base: &str,
-    frigate_api_base: &str,
-    frigate_go2rtc_api_base: &str,
-    frigate_http_api_base: &str,
-    motion_hwaccel: &str,
-    motion_vaapi_device: &str,
+    server_address: Option<&str>,
+    crumb_rtsp_base: Option<&str>,
+    crumb_api_base: Option<&str>,
+    frigate_rtsp_base: Option<&str>,
+    frigate_api_base: Option<&str>,
+    frigate_go2rtc_api_base: Option<&str>,
+    frigate_http_api_base: Option<&str>,
+    motion_hwaccel: Option<&str>,
+    motion_vaapi_device: Option<&str>,
 ) -> Result<ServerSettings> {
     let client = get_conn(pool).await?;
+    // COALESCE($n::text, col): a NULL parameter (the field was omitted from the
+    // request body) keeps the stored value; a non-NULL one — INCLUDING the empty
+    // string — overwrites it. The explicit ::text casts keep Postgres from having
+    // to infer a parameter type it can't see through COALESCE.
     let row = client
         .query_one(
             r"
             UPDATE server_settings SET
-                server_address          = $1,
-                crumb_rtsp_base         = $2,
-                crumb_api_base          = $3,
-                frigate_rtsp_base       = $4,
-                frigate_api_base        = $5,
-                frigate_go2rtc_api_base = $6,
-                frigate_http_api_base   = $7,
-                motion_hwaccel          = $8,
-                motion_vaapi_device     = $9,
+                server_address          = COALESCE($1::text, server_address),
+                crumb_rtsp_base         = COALESCE($2::text, crumb_rtsp_base),
+                crumb_api_base          = COALESCE($3::text, crumb_api_base),
+                frigate_rtsp_base       = COALESCE($4::text, frigate_rtsp_base),
+                frigate_api_base        = COALESCE($5::text, frigate_api_base),
+                frigate_go2rtc_api_base = COALESCE($6::text, frigate_go2rtc_api_base),
+                frigate_http_api_base   = COALESCE($7::text, frigate_http_api_base),
+                motion_hwaccel          = COALESCE($8::text, motion_hwaccel),
+                motion_vaapi_device     = COALESCE($9::text, motion_vaapi_device),
                 version                 = version + 1,
                 updated_at              = now()
             WHERE id = 1


### PR DESCRIPTION
## Summary

`PUT /config/server` was a whole-row replace whose DTO carried `#[serde(default)]`. A partial programmatic body — `{"motion_hwaccel": "vaapi"}` — deserialized every unmentioned key to `""` and wrote it, silently resetting the stream bases, the Frigate bases and the VAAPI device to their env fallbacks. The console and first-run wizard were safe only by convention (a full-body stash pattern). The exposure was scripts and third-party integrations — and `docs/AI-INSTALL.md` step 7 was literally instructing agents to round-trip the whole row as a workaround.

This generalizes the semantics **PR #518** established for `frigate_api_base` to the rest of the request DTO.

## The three states

Every settable field is now `Option<String>` with `#[serde(default)]`:

| Body | Meaning |
|---|---|
| key omitted, or `null` → `None` | **leave the stored column alone** |
| `"value"` → `Some(v)` | set it (trimmed) |
| `""` → `Some("")` | **clear** it ⇒ fall back to the container env |

`Some("")` is deliberately **not** folded into "omitted". Crumb's config precedence is *admin-set DB value wins over env; EMPTY DB value falls back to env*, so an empty string is how an operator returns a setting to its env default. Merging it away would remove the only way to undo a setting through the API. That precedence rule is preserved exactly.

## Implementation

- **`dto.rs`** — all eight settable fields become `Option<String>`; doc comment carries the state table.
- **`db.rs::update_server_settings`** — takes `Option<&str>` per field and writes `COALESCE($n::text, column)`, so a NULL parameter keeps the stored value while an empty string overwrites it. `version` is still bumped on every call, so a no-op merge still signals "re-read" to the recorder and clients.
- **`config_routes.rs::resolve_frigate_bases`** — same three states, returning `Option<String>` per column. Its two existing contracts are unchanged: a present-but-empty `frigate_go2rtc_api_base` is still seeded from a legacy value in the same body (the pre-0014 client path), and the HTTP base is still never seeded from legacy.

## Behavioral exception, documented

The legacy column's "clear the old console's go2rtc duplicate" cleanup now fires **only when the body actually decides the go2rtc base**. A PUT that mentions neither column cannot distinguish a stale duplicate from operator intent, so it touches neither. Previously that cleanup ran on every PUT as a side effect. This is the one place where a no-longer-full body does less than it used to; it is covered by a unit test and called out in the DECISIONS entry.

Every other field got clean `Option` semantics with no ambiguity.

## Call-site verification (no regression)

All five `PUT /config/server` call sites in `admin.html` send a **complete** body, so every field arrives as `Some(...)` and the write is byte-identical to the old behavior:

- wizard `server` step, wizard `frigate` step, wizard `detect-hw` step (all spread `wizardServerBody()`)
- `saveDetectionServer()` (spreads `detectionServerBody()`)
- `saveServerSettings()`
- plus `mirrorFrigateHttpToServerSettings()`

The stash pattern is **deliberately left in place** rather than slimmed to per-pane bodies, so this stays a pure server-side change with no console behavior to re-verify. The desktop client embeds the same `/admin` page and needs nothing — no native client (desktop, Android, iOS) PUTs this route at all.

## Tests

New `services/api/tests/server_settings_partial_put.rs` (6 tests):

- partial body preserves every unmentioned field, and the re-read `GET` confirms it persisted (not just echoed)
- explicit `""` clears the field and leaves the rest alone
- explicit `null` behaves like an omitted key, not like `""`
- **full-row PUT unchanged** — the console/wizard regression guard, asserting every key is written verbatim including empties
- a partial PUT still bumps `version`
- `{}` is a legal no-op merge

Plus 3 new `resolve_frigate_bases` unit tests for the omitted-key cases (all three keys absent; only the HTTP key absent; a pre-0014 legacy-only body still seeding go2rtc). The 6 existing ones were updated for the new signature with their assertions preserved.

These tests take the existing `SERVER_SETTINGS_LOCK` so they cannot interleave; the columns they touch are disjoint from the `thumb_*` / `beta_terms_*` columns `auth_rbac.rs` mutates, so a concurrently-running test binary cannot perturb them either.

Full gate green on a Linux build box against a throwaway Postgres 16:

```
cargo fmt --all -- --check              clean
cargo clippy --all-targets -D warnings  clean
cargo test --workspace                  all suites pass (0 failed)
```

`node --check` on the extracted `admin.html` script block: OK.

## Docs

- `docs/DECISIONS.md` — the choice, the rejected alternatives (422-on-partial, a separate `PATCH` route, rewriting the console to per-pane bodies, treating `""` as "leave alone"), the accepted trades, and revisit triggers.
- `docs/AI-INSTALL.md` steps 2 and 7 — no longer tell API callers to echo the whole row, and warn that padding a body with empty strings is now an explicit clear.
- `admin.html` comments updated so the stash pattern reads as belt-and-braces rather than a requirement.

Fixes #472
