### PR TITLE
fix(web): blank decode backend stays blank instead of pinning 'auto'

### DIFF
--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -1539,7 +1539,9 @@ function wizardBody(key) {
    the wizardServerBody() spread pattern. */
 function wizardDetectHwBody() {
   const s = WZ.server || {};
-  const cur = WZ.hwPick || s.motion_hwaccel || 'auto';
+  // "" (Server default) is a legitimate pick, so probe for a real prior choice
+  // with != null, not `||` (which would treat "" as unset and fall to 'auto').
+  const cur = WZ.hwPick != null ? WZ.hwPick : (s.motion_hwaccel || '');
   WZ.hwPick = cur;
   const opt = (v, title, sub) => `
     <label class="chk" style="display:flex;align-items:flex-start;gap:8px;margin-top:8px">
@@ -1547,7 +1549,8 @@ function wizardDetectHwBody() {
       <span><b>${title}</b><br><span style="color:var(--dim2);font-size:12px">${sub}</span></span>
     </label>`;
   return `
-    ${opt('auto', 'Auto (recommended)', 'Probe NVDEC, else decode on CPU. Safe everywhere.')}
+    ${opt('', 'Server default (recommended)', 'Inherit the recorder\'s MOTION_HWACCEL env default (CPU unless a GPU was set up). Safe everywhere.')}
+    ${opt('auto', 'Auto', 'Probe NVDEC, else decode on CPU.')}
     ${opt('cpu', 'CPU', 'Software decode. On many boxes this is also the most power-efficient choice.')}
     ${opt('vaapi', 'Intel / AMD iGPU, VAAPI', 'Quick Sync / AMD media block. Needs the render node mapped into the recorder container.')}
     ${opt('cuda', 'NVIDIA, NVDEC', 'Discrete NVIDIA GPU. Needs the GPU mapped into the recorder container.')}
@@ -3038,7 +3041,9 @@ async function wizardSave(key) {
     return true;
   }
   if (key === 'detect-hw') {
-    const pick = WZ.hwPick || (WZ.server || {}).motion_hwaccel || 'auto';
+    // "" (Server default) is a real pick — preserve it with != null so we send
+    // "" (inherit env, #533), not a coerced 'auto'.
+    const pick = WZ.hwPick != null ? WZ.hwPick : ((WZ.server || {}).motion_hwaccel || '');
     const dev = $('wz-hw-vaapi-device') ? $('wz-hw-vaapi-device').value.trim() : '';
     // Same rule as the 'server' step: spread wizardServerBody() and override
     // ONLY the fields this step edits, never touch crumb_api_base & friends.
@@ -7243,7 +7248,8 @@ async function renderDetectionClips() {
         <div>
           <label class="field-label" style="margin-top:0">Decode backend</label>
           <select id="srv-hwaccel" class="mono" onchange="onHwaccelChange()">
-            <option value="auto"${(s.motion_hwaccel||'auto')==='auto'?' selected':''}>Auto, probe NVDEC, else CPU</option>
+            <option value=""${!s.motion_hwaccel?' selected':''}>Server default, inherit MOTION_HWACCEL env</option>
+            <option value="auto"${s.motion_hwaccel==='auto'?' selected':''}>Auto, probe NVDEC, else CPU</option>
             <option value="cpu"${s.motion_hwaccel==='cpu'?' selected':''}>CPU, software decode</option>
             <option value="cuda"${s.motion_hwaccel==='cuda'?' selected':''}>NVDEC, NVIDIA discrete GPU</option>
             <option value="vaapi"${s.motion_hwaccel==='vaapi'?' selected':''}>VAAPI, Intel/AMD iGPU (Quick Sync)</option>
@@ -7378,7 +7384,11 @@ function detectionServerBody(s) {
     frigate_rtsp_base:       s.frigate_rtsp_base || '',
     frigate_go2rtc_api_base: s.frigate_go2rtc_api_base || '',
     frigate_http_api_base:   s.frigate_http_api_base || '',
-    motion_hwaccel:          s.motion_hwaccel || 'auto',
+    // Blank means "no DB override, inherit the recorder's MOTION_HWACCEL env
+    // default" (now cpu, #513/#533) — NOT the literal string 'auto'. Coercing a
+    // deliberate blank to 'auto' here silently pinned Auto and clobbered the
+    // GPU-less-upgrader cpu default this save was meant to leave alone (#533).
+    motion_hwaccel:          s.motion_hwaccel || '',
     motion_vaapi_device:     s.motion_vaapi_device || '',
   };
 }
@@ -7397,8 +7407,10 @@ async function saveDetectionServer() {
     frigate_rtsp_base:       $('srv-frigate-rtsp') ? $('srv-frigate-rtsp').value.trim() : (s.frigate_rtsp_base || ''),
     frigate_go2rtc_api_base: ($('srv-frigate-go2rtc-api') && $('srv-frigate-go2rtc-api').value.trim()) || '',
     frigate_http_api_base:   frigateHttp,
-    // Motion decode backend (recorder hot-reloads its workers on change).
-    motion_hwaccel:          $('srv-hwaccel') ? $('srv-hwaccel').value : (s.motion_hwaccel || 'auto'),
+    // Motion decode backend (recorder hot-reloads its workers on change). The
+    // dropdown's blank option sends "" = inherit the MOTION_HWACCEL env default;
+    // never coerce a blank to 'auto' (#533).
+    motion_hwaccel:          $('srv-hwaccel') ? $('srv-hwaccel').value : (s.motion_hwaccel || ''),
     motion_vaapi_device:     $('srv-vaapi-device') ? $('srv-vaapi-device').value.trim() : (s.motion_vaapi_device || ''),
   });
   try {
@@ -7614,7 +7626,9 @@ async function saveServerSettings() {
     frigate_rtsp_base:       s.frigate_rtsp_base || '',
     frigate_go2rtc_api_base: s.frigate_go2rtc_api_base || '',
     frigate_http_api_base:   s.frigate_http_api_base || '',
-    motion_hwaccel:          s.motion_hwaccel || 'auto',
+    // Preserve the fetched decode backend verbatim; a blank stays "" (inherit
+    // the MOTION_HWACCEL env default), never coerced to 'auto' (#533).
+    motion_hwaccel:          s.motion_hwaccel || '',
     motion_vaapi_device:     s.motion_vaapi_device || '',
   };
   try {


### PR DESCRIPTION
Fixes #535

## Problem

Saving the **Server** pane or the **Detection & clips** pane in the web console
rewrote a blank `motion_hwaccel` to the literal `'auto'`. A blank is meant to
mean "no DB override, inherit the recorder's `MOTION_HWACCEL` env default" (now
`cpu`, #513/#533). Coercing it to `'auto'` silently overrode that default for
exactly the GPU-less upgraders it was meant to protect — the operator saves an
unrelated field and their deliberate "inherit cpu" turns into a pinned `auto`
(probe-NVDEC-then-CPU).

Since `PUT /config/server` is a partial merge (#533) where `""` clears a column
back to the env fallback, a blank field should send `""`, not `'auto'`.

## Fix (all three save paths + the dropdown/UI)

- **Detection & clips pane** (`detectionServerBody`, `saveDetectionServer`):
  blank now sends `""` instead of `'auto'`.
- **Server pane** (`saveServerSettings`): the preserved decode field stays `""`
  when blank instead of being coerced to `'auto'`.
- **Setup wizard decode step** (`wizardDetectHwBody`, `wizardSave('detect-hw')`):
  the pick is resolved with `!= null` (so an explicit "Server default" pick of
  `""` survives instead of falling through `||` to `'auto'`), and the step now
  offers a "Server default" radio. `wizardServerBody()` already sent `""`.
- **Dropdown**: added a `Server default, inherit MOTION_HWACCEL env` option
  (value `""`), selected when the stored value is blank. `auto` is now selected
  only on an explicit `'auto'`, so an operator can still pin `auto` on purpose.

Backend semantics confirmed in `config_routes.rs::update_server_settings` (a
JSON `""` → `Some("")` → column cleared) and `HwAccel::from_setting` (empty →
env default; `"auto"` → `Auto`). Explicit `auto`/`cpu`/`cuda`/`vaapi` picks
still round-trip unchanged.

## Verification

- Extracted the inline `<script>` (lines 769–11269) and ran `node --check` — OK.
- `cargo check -p crumb-api` on the build box with the modified `admin.html`
  swapped in — compiles (the `include_str!` embed is a string literal, so this
  is the "embed still builds / valid UTF-8" insurance; `node --check` is what
  validates the JS).
- Manually traced all three save bodies: blank → `""` (clear to env default),
  explicit value → that value; `decodeGuidanceHtml("")` and `onHwaccelChange`
  with `""` both no-op safely; touched `on*=` handlers (`onHwaccelChange`,
  `wizardHwPick`) all still resolve and accept `""`.

Web-console-only change (no endpoint, env key, compose, or install-flow change),
so no `docs/AI-INSTALL.md` update is needed.
