### PR TITLE
fix(recorder): write the storage marker only after a committed segment, not at dir creation

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -725,6 +725,35 @@ Both raise the existing `storage_unwritable` system event.
   → retune `DANGLING_BREAKER_MIN_MISSING` / `DANGLING_BREAKER_MISSING_PCT`, which
   exist as constants for exactly that reason.
 
+**2026-08-07 follow-up — the recording-path marker is written post-commit, not at
+directory creation.** The v0.2.0 re-audit found that the recording path defeated
+its own layer-1 guard: `record_camera` called `ensure_storage_marker` right after
+`create_dir_all` succeeded, BEFORE any footage existed. On the exact failure this
+guard is for — a host reboot where the live disk fails to mount and Docker leaves
+an empty mountpoint directory — `create_dir_all` succeeds on that empty dir and
+the marker was planted there, a FALSE confirmation. The next reconcile pass saw
+`marker_ok` and pruned the (unmounted) real disk's whole segment index; only the
+layer-2 breaker bounded the loss, and only above its 100-row floor. The
+`seed_storage_markers` boot pass had never had this hole because it refuses to
+write a marker unless at least one INDEXED segment is actually present under the
+root. **Fix:** move the marker write into `index_segment`, firing only on a
+genuine commit — a real ≥floor segment fsync'd on disk AND a row in the index for
+it. That is the same "a real indexed segment is present under the root" signal the
+seed pass confirms on, so the two writers are now equally trustworthy. A healthy
+storage still gets its marker the moment it records its first segment (and the
+seed pass still heals pre-existing installs), so normal pruning is unchanged; a
+bare mountpoint the recorder writes into no longer earns a marker until footage is
+genuinely both on disk and indexed there. **Rejected** (again) the direct
+mountpoint / `st_dev` shape check for the recording path, for the same reasons this
+entry rejected it for reconcile: it is unreliable across bind mounts, overlayfs and
+network filesystems. "Confirm via a real indexed segment" reuses the mechanism
+already chosen here rather than adding a second, weaker signal. **Trade-off
+accepted:** the marker now appears a few seconds later (after the first indexed
+segment) than at directory creation — immaterial for a healthy install, and the
+right direction for safety. Guarded by
+`reconcile::tests::recording_path_marker_written_only_after_a_committed_segment`
+and `a_false_marker_below_the_breaker_floor_prunes_the_whole_small_index`.
+
 ---
 
 ## 2026-08-06, setup-env.sh fails the install when uid 1001 cannot write to the media dir (tiered probe, deferred exit)

--- a/docs/RECORDER-CORRECTNESS.md
+++ b/docs/RECORDER-CORRECTNESS.md
@@ -291,15 +291,22 @@ recorder, and later the API) must satisfy these *by construction*.
     layers, both failing toward skip-and-alarm, never toward delete:
 
     - **Marker.** The recorder writes `<storage_root>/.crumb-storage` when it
-      can positively confirm a storage — from the recording path at the moment
-      it is about to write footage there, and from a boot/heal pass that
+      can positively confirm a storage — from the recording path
+      (`index_segment`) only AFTER a real ≥floor segment is fsync'd on disk AND
+      committed to the index under that root, and from a boot/heal pass that
       requires at least one of the storage's newest INDEXED segment files to
-      really be present under the root. It is never invented for a root that
-      holds none of its indexed segments (the unmounted shape), nor for a
-      storage with no indexed segments at all (indistinguishable from an empty
-      foreign directory). The dangling pass deletes NOTHING on a storage whose
-      marker is absent. The marker rides on the storage, so an unmounted disk
-      cannot present one.
+      really be present under the root. Both writers share ONE rule: a marker
+      means a real indexed segment is present. It is deliberately NOT written at
+      directory-creation time — `create_dir_all` succeeding proves only that
+      SOME directory was writable, so a bare unmounted mountpoint (Docker
+      auto-creates an empty bind source) would earn a FALSE marker before any
+      footage exists, defeating this guard in exactly the scenario it is for
+      (the v0.2.0 re-audit defect). It is never invented for a root that holds
+      none of its indexed segments (the unmounted shape), nor for a storage with
+      no indexed segments at all (indistinguishable from an empty foreign
+      directory). The dangling pass deletes NOTHING on a storage whose marker is
+      absent. The marker rides on the storage, so an unmounted disk cannot
+      present one.
     - **Circuit breaker.** Even with a marker (stale marker, repointed path),
       deletions for a storage stop once more than `DANGLING_BREAKER_MIN_MISSING`
       (100) of its rows AND more than `DANGLING_BREAKER_MISSING_PCT` (50 %) of
@@ -318,5 +325,10 @@ recorder, and later the API) must satisfy these *by construction*.
     `reconcile::tests::dangling_pass_skips_storage_without_marker`,
     `dangling_breaker_bounds_deletions_on_mass_missing`,
     `dangling_pass_deletes_genuine_dangling_rows_on_a_confirmed_storage` and
-    `storage_marker_is_seeded_only_when_the_storage_is_confirmable`. See
-    `docs/DECISIONS.md` (2026-08-06) for the rejected mountpoint heuristics.
+    `storage_marker_is_seeded_only_when_the_storage_is_confirmable`; the
+    recording-path writer's confirmable timing (and the danger of a false marker
+    at directory-creation time) by
+    `recording_path_marker_written_only_after_a_committed_segment` and
+    `a_false_marker_below_the_breaker_floor_prunes_the_whole_small_index`. See
+    `docs/DECISIONS.md` (2026-08-06, and the 2026-08-07 follow-up) for the
+    rejected mountpoint heuristics and why the marker is written post-commit.

--- a/services/recorder/src/reconcile.rs
+++ b/services/recorder/src/reconcile.rs
@@ -129,9 +129,10 @@ pub(crate) const SUB_FLOOR_BYTES: u64 = 512;
 ///
 /// It is a dotfile, so the `.mp4`-only [`walk_storage`] never sees it.  It is
 /// written ONLY when the recorder can positively confirm the storage — see
-/// [`ensure_storage_marker`] (called from the recording path, at the moment
-/// footage is about to be written there) and [`seed_storage_markers`] (boot
-/// heal for installs that predate this guard).
+/// [`ensure_storage_marker`] (called from the recording path AFTER a real segment
+/// has been written and indexed under the root, never at directory-creation time)
+/// and [`seed_storage_markers`] (boot heal for installs that predate this guard).
+/// Both writers share one rule: a marker means a real indexed segment is present.
 pub(crate) const STORAGE_MARKER_FILENAME: &str = ".crumb-storage";
 
 /// Contents written into a freshly created [`STORAGE_MARKER_FILENAME`].
@@ -276,9 +277,15 @@ async fn storage_marker_present(storage_root: &Path) -> bool {
 
 /// Create the storage marker at `storage_root` if it is not already there.
 ///
-/// Called from the RECORDING path (`recording.rs`) at the moment the recorder is
-/// about to write footage into that root — actually writing footage there is the
-/// strongest confirmation available that the storage is the real, mounted one.
+/// Called from the RECORDING path (`recording::index_segment`) right after a real
+/// ≥floor segment has been fsync'd on disk AND committed to the index under this
+/// root — a real indexed segment present under the root is the strongest
+/// confirmation available that the storage is the real, mounted one, and is the
+/// SAME signal [`seed_storage_markers`] confirms on. It is deliberately NOT
+/// written at directory-creation time: a bare unmounted mountpoint the recorder
+/// can `create_dir_all` into but has no committed footage on must never earn a
+/// marker (issue #504 — a false marker there lets the dangling pass prune the
+/// real disk's index rows).
 ///
 /// Idempotent and best-effort: an existing marker is never rewritten or
 /// truncated (`create_new`), and any failure is logged and ignored.  A storage
@@ -3722,6 +3729,150 @@ mod tests {
             tokio::fs::read(&marker).await.expect("re-read marker"),
             b"operator note",
             "an existing marker is never rewritten"
+        );
+    }
+
+    /// v0.2.0 re-audit defect, PROVING THE FIX (recording-path side). The
+    /// RECORDING-path marker writer (`recording::index_segment`) must be exactly
+    /// as trustworthy as the seed pass: it writes `.crumb-storage` ONLY after a
+    /// real segment is on disk AND committed to the index under the root — never
+    /// merely because a directory was created. The pre-fix code planted the
+    /// marker at `create_dir_all` time (BEFORE any footage), so a bare unmounted
+    /// mountpoint earned a FALSE marker and the next reconcile pass pruned the
+    /// real disk's index. Here:
+    ///   * a sub-floor (28-byte) segment is NOT committed → NO marker (the
+    ///     bare-mountpoint shape exactly: a writable directory, no real footage),
+    ///   * a genuine ≥floor segment IS committed → the marker appears.
+    #[tokio::test]
+    async fn recording_path_marker_written_only_after_a_committed_segment() {
+        let Some(url) = test_db_url() else {
+            eprintln!("skipping: CRUMB_TEST_DATABASE_URL not set");
+            return;
+        };
+        let fx = setup_reconcile(&url).await;
+
+        let live = crumb_common::db::get_storage_by_name(&fx.pool, "NVMe-Live")
+            .await
+            .expect("get live storage")
+            .expect("live storage exists");
+        let camera = crumb_common::db::get_camera(&fx.pool, fx.camera_id)
+            .await
+            .expect("get camera")
+            .expect("camera exists");
+        let root = fx.live_path.to_str().expect("utf8 root");
+
+        let cam_dir = fx.live_path.join(fx.camera_id.to_string());
+        tokio::fs::create_dir_all(&cam_dir)
+            .await
+            .expect("mkdir cam");
+
+        let marker = fx.live_path.join(STORAGE_MARKER_FILENAME);
+        assert!(
+            !marker.exists(),
+            "creating the camera directory alone must NOT write a marker"
+        );
+
+        // (a) SUB-FLOOR: a 28-byte header-only file. index_segment rejects it
+        //     below the floor and commits NOTHING → no marker. This is the bare
+        //     unmounted-mountpoint shape: a writable dir, but no real indexed
+        //     footage, so the storage must NOT be confirmed.
+        let subfloor_path = cam_dir.join("20260101T000000Z.mp4");
+        tokio::fs::write(&subfloor_path, vec![0u8; 28])
+            .await
+            .expect("write subfloor");
+        let indexed = crate::recording::index_segment(
+            &crate::recording::PendingSegment {
+                path: subfloor_path.to_string_lossy().into_owned(),
+                start_ts: "2026-01-01T00:00:00Z".parse().expect("start"),
+                end_ts: "2026-01-01T00:00:04Z".parse().expect("end"),
+                size_bytes: 28,
+            },
+            &camera,
+            &live.id,
+            root,
+            &fx.pool,
+            &[],
+            false,
+        )
+        .await;
+        assert!(!indexed, "a sub-floor segment must not be committed");
+        assert!(
+            !marker.exists(),
+            "no committed segment ⇒ no marker: a bare mountpoint must never be confirmed"
+        );
+
+        // (b) GENUINE: a ≥floor file → committed to the index → marker written.
+        let good_path = cam_dir.join("20260101T000010Z.mp4");
+        tokio::fs::write(&good_path, vec![0u8; 4096])
+            .await
+            .expect("write good");
+        let indexed = crate::recording::index_segment(
+            &crate::recording::PendingSegment {
+                path: good_path.to_string_lossy().into_owned(),
+                start_ts: "2026-01-01T00:00:10Z".parse().expect("start"),
+                end_ts: "2026-01-01T00:00:14Z".parse().expect("end"),
+                size_bytes: 4096,
+            },
+            &camera,
+            &live.id,
+            root,
+            &fx.pool,
+            &[],
+            false,
+        )
+        .await;
+        assert!(indexed, "a genuine ≥floor segment must be committed");
+        assert!(
+            marker.exists(),
+            "a committed real segment under the root confirms the storage → marker written"
+        );
+    }
+
+    /// v0.2.0 re-audit defect, REPRODUCING THE DANGER (reconcile side). A marker
+    /// present on a storage with index rows but NO files on disk — the
+    /// bare-mountpoint shape the pre-fix recording path produced by writing the
+    /// marker at directory-creation time — lets the dangling pass delete the
+    /// whole index. The layer-2 breaker does NOT save a SMALL storage: it only
+    /// trips ABOVE `DANGLING_BREAKER_MIN_MISSING` (100) rows, so below that floor
+    /// a false marker costs the ENTIRE index (motion flags, bboxes, stage labels,
+    /// clip/bookmark linkage). This is exactly why the marker must be confirmable
+    /// (previous test), not planted on directory creation.
+    #[tokio::test]
+    async fn a_false_marker_below_the_breaker_floor_prunes_the_whole_small_index() {
+        let Some(url) = test_db_url() else {
+            eprintln!("skipping: CRUMB_TEST_DATABASE_URL not set");
+            return;
+        };
+        let fx = setup_reconcile(&url).await;
+        let config = recon_config();
+
+        let live = crumb_common::db::get_storage_by_name(&fx.pool, "NVMe-Live")
+            .await
+            .expect("get live storage")
+            .expect("live storage exists");
+
+        // The FALSE marker the pre-fix recording path wrote at create_dir_all
+        // time, on a root whose indexed footage is all missing (unmounted disk).
+        tokio::fs::write(fx.live_path.join(STORAGE_MARKER_FILENAME), b"")
+            .await
+            .expect("write false marker");
+
+        // Fewer rows than the breaker floor, so layer 2 never trips and cannot
+        // bound the loss.
+        let total = 20i64;
+        assert!(total < DANGLING_BREAKER_MIN_MISSING as i64);
+        insert_fileless_rows(&fx, live.id, total).await;
+
+        run_background(fx.pool.clone(), config, CancellationToken::new()).await;
+
+        let rows = crumb_common::db::list_all_segments_for_camera(&fx.pool, fx.camera_id)
+            .await
+            .expect("list segments");
+        assert!(
+            rows.is_empty(),
+            "a FALSE marker on a small unmounted storage prunes the ENTIRE index (the \
+             breaker only bounds losses above its 100-row floor) — which is precisely why \
+             the marker must be confirmable, not planted at directory creation: {rows:?}"
         );
     }
 

--- a/services/recorder/src/recording.rs
+++ b/services/recorder/src/recording.rs
@@ -954,14 +954,18 @@ async fn run_ffmpeg_loop(
         return Err(anyhow::Error::from(e).context(format!("create_dir_all {camera_dir:?}")));
     }
 
-    // STORAGE MARKER (issue #504): we are about to write footage into this
-    // storage root, which is the strongest confirmation available that it is the
-    // real, mounted storage. Drop the marker reconcile's dangling-row guard keys
-    // off, so an unmounted disk (an empty mountpoint directory, which carries no
-    // marker) can never be mistaken for a disk whose footage was deleted and have
-    // its whole segment index pruned. Idempotent + best-effort: never rewrites an
-    // existing marker, and a failure only costs index PRUNING, never footage.
-    crate::reconcile::ensure_storage_marker(Path::new(&live_storage.path)).await;
+    // STORAGE MARKER (issue #504): the confirmation marker is NOT written here.
+    // `create_dir_all` succeeding proves only that SOME directory was writable —
+    // on a disk that failed to mount, Docker leaves an empty mountpoint directory
+    // and this spot would plant a FALSE `.crumb-storage` on it BEFORE any footage
+    // exists, defeating the guard in exactly the scenario it was built for: the
+    // next reconcile pass would then see a marker and prune the real (unmounted)
+    // disk's segment-index rows as "missing". The marker is instead written by
+    // `index_segment`, only AFTER a real ≥floor segment is fsync'd on disk AND
+    // committed to the index — the very "a real indexed segment is present under
+    // the root" signal the boot/heal pass (`seed_storage_markers`) confirms on,
+    // so the recording-path writer is exactly as trustworthy as the seed pass.
+    // See docs/RECORDER-CORRECTNESS.md item 34 and docs/DECISIONS.md (2026-08-07).
 
     // ── 2b. Motion-mode RAM cache dir (persist-on-motion) ──────────────────────
     //
@@ -2551,7 +2555,17 @@ fn decide_persist_for_segment(
 /// DO-NOTHING insert so an already-indexed segment at the same
 /// `(camera_id, stream, start_ts)` is never repointed/overwritten — used by the
 /// persist path when it detects a backward-clock filename collision.
-async fn index_segment(
+///
+/// On a genuine commit (a NEW row for the file we just fsync'd) this also drops
+/// the `<storage_root>/.crumb-storage` confirmation marker (issue #504). That is
+/// the correct, confirmable moment to write it — a real segment on disk that the
+/// index now knows about — rather than at directory-creation time, where a bare
+/// unmounted mountpoint would earn a false marker (see the note at the
+/// `create_dir_all` call site and docs/RECORDER-CORRECTNESS.md item 34).
+///
+/// `pub(crate)` so the reconcile marker-guard integration test can exercise the
+/// recording-path writer against the shared reconcile fixture.
+pub(crate) async fn index_segment(
     seg: &PendingSegment,
     camera: &Camera,
     storage_id: &uuid::Uuid,
@@ -2662,6 +2676,9 @@ async fn index_segment(
                     start_ts   = %seg.start_ts,
                     "segment indexed (clock-regression: non-colliding key)"
                 );
+                // A real segment is now on disk AND in the index under this root
+                // — confirm the storage (see the normal-path note below).
+                crate::reconcile::ensure_storage_marker(Path::new(storage_root)).await;
                 true
             }
             Ok(None) => {
@@ -2697,6 +2714,16 @@ async fn index_segment(
                 has_motion = has_motion,
                 "segment indexed"
             );
+            // STORAGE MARKER (issue #504 / 2026-08-07 follow-up): a row is now
+            // committed for a real ≥floor file we just fsync'd under this root —
+            // the strongest "this is the real, mounted storage" signal available,
+            // and exactly the condition `seed_storage_markers` confirms on. Writing
+            // it HERE (not at directory creation) means a bare, unmounted mountpoint
+            // the recorder never actually indexed footage on never earns a false
+            // marker that would let reconcile prune the real disk's index rows.
+            // Idempotent + best-effort: never rewrites an existing marker, and a
+            // failure only costs index PRUNING, never footage.
+            crate::reconcile::ensure_storage_marker(Path::new(storage_root)).await;
             true
         }
         Err(e) => {


### PR DESCRIPTION
Fixes #541.

## The bug (recorder-sacred: the segment index is footage metadata)

The recording path defeated PR #515's layer-1 unmounted-disk guard in exactly the scenario #515 was built for. `services/recorder/src/recording.rs` called `ensure_storage_marker(&live_storage.path)` immediately after `create_dir_all` succeeded, **before any footage existed** — whereas the boot/heal `seed_storage_markers` pass refuses to write a marker unless at least one *indexed* segment file is actually present under the root.

Failure sequence:

1. Host reboots; the live disk fails to mount; Docker leaves an empty mountpoint directory.
2. The recorder `create_dir_all`s into that empty dir, records, and writes `.crumb-storage` there — a **false** confirmation, with zero confirmable footage present.
3. The next reconcile pass sees `marker_ok` and prunes that storage's index rows whose files are "missing" (they live on the unmounted real disk).

Layer 1 is bypassed; only the layer-2 breaker bounds the loss, and only above its 100-row floor (a smaller index is pruned entirely). Footage **bytes** survive on the unmounted disk; the index metadata (motion flags, bounding boxes, stage/stream labels, durations, clip/bookmark linkage) is destroyed and not reconstructible.

## The fix

Move the marker write out of the directory-creation site and into `index_segment`, firing **only on a genuine commit** — a real (>= sub-floor) segment fsync'd on disk **and** a row committed to the index for it. That is the same "a real indexed segment is present under the root" signal `seed_storage_markers` confirms on, so the recording-path writer is now exactly as trustworthy as the seed pass:

- A bare unmounted mountpoint the recorder never actually indexed footage on no longer earns a marker.
- A healthy storage still gets its marker the moment it records its first segment (and the seed pass still heals pre-existing installs), so **normal pruning is unchanged**.
- The change only *narrows* when a marker is written; it never deletes or orphans footage.

The direct mountpoint / `st_dev` shape check was rejected again for the recording path, for the same reasons `docs/DECISIONS.md` (2026-08-06) rejected it for reconcile: unreliable across bind mounts, overlayfs, and network filesystems. "Confirm via a real indexed segment" reuses the mechanism already chosen there.

## Tests (mirroring the #515 reconcile suite)

- `recording_path_marker_written_only_after_a_committed_segment` — proves the fix: a sub-floor segment commits nothing and writes no marker (the bare-mountpoint shape); a genuine >= floor segment commits and writes the marker. Exercises the real `recording::index_segment` writer against the shared reconcile fixture.
- `a_false_marker_below_the_breaker_floor_prunes_the_whole_small_index` — reproduces the danger: a false marker on a small unmounted storage prunes the entire index, because the breaker only bounds losses above its 100-row floor.

## Docs

- `docs/RECORDER-CORRECTNESS.md` item 34 updated to state the real post-fix guarantee (marker written post-commit, never at directory creation).
- `docs/DECISIONS.md` gains a 2026-08-07 follow-up note on the unmounted-storage entry.

## Gate

Full gate green on the build box: `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` (zero warnings), and `cargo test --workspace` (all crates pass, including the two new tests) against a throwaway Postgres.
