### PR TITLE
perf(desktop): Engine Benchmark plate crops decode via the engine codec, not pure-Dart

### DIFF
--- a/apps/desktop-flutter/lib/ui/plates/plate_crop.dart
+++ b/apps/desktop-flutter/lib/ui/plates/plate_crop.dart
@@ -1,13 +1,14 @@
 // Shared license-plate crop helper: crop a detection snapshot down to the
-// plate's normalized bbox, off the UI isolate, with a small result cache.
+// plate's normalized bbox, with a small result cache.
 //
-// Used by the PDF report (plate_report_dialog.dart) and the Plates UI
-// gallery/detail crop (plates_screen.dart) so all three share ONE crop
-// implementation + cache rather than each re-deriving (and re-decoding) the
-// same plate region.
+// Used by the PDF report (plate_report_dialog.dart), the Plates UI
+// gallery/detail crop (plates_screen.dart), and the Engine Benchmark rows
+// (ab_benchmark.dart) so all three share ONE crop implementation + cache
+// rather than each re-deriving (and re-decoding) the same plate region.
 
 import 'dart:isolate';
 import 'dart:typed_data';
+import 'dart:ui' as ui;
 
 import 'package:image/image.dart' as img;
 
@@ -22,32 +23,79 @@ import 'package:image/image.dart' as img;
 /// without the snapshot's real dimensions (which vary by camera — never assume
 /// 16:9), and callers must not re-derive it from a hard-coded frame aspect.
 ///
-/// The decode/crop/encode (all `package:image`, which is isolate-safe) runs on
-/// a background isolate via [Isolate.run] so a full-frame JPEG doesn't freeze
-/// the UI isolate. The closure captures only sendable data (the byte list + the
-/// bbox doubles) and calls a top-level function.
+/// Decode goes through the engine's native codec, NOT package:image: the
+/// pure-Dart decoder was the Engine Benchmark's measured bottleneck (#391) at
+/// ~130 ms per 1080p frame (~260 ms at 4 MP) against ~18 ms native, paid per
+/// newly-mounted row. Only the bbox region is rasterized and read back, so the
+/// full decoded frame never crosses into Dart; package:image touches just the
+/// small crop (near-black guard + JPEG re-encode, single-digit ms). If the
+/// engine can't decode the bytes at all, the old pure-Dart path
+/// ([cropPlateToBboxSync], on a background isolate) is the fallback.
 Future<(Uint8List, int, int)?> cropPlateToBbox(
   Uint8List fullBytes,
   List<double> bbox,
-) {
-  return Isolate.run(() => cropPlateToBboxSync(fullBytes, bbox));
+) async {
+  ui.Codec? codec;
+  ui.Image? image;
+  try {
+    final buffer = await ui.ImmutableBuffer.fromUint8List(fullBytes);
+    codec = await ui.instantiateImageCodecWithSize(buffer);
+    image = (await codec.getNextFrame()).image;
+  } catch (_) {
+    // Engine codec can't decode these bytes — the pure-Dart decoder handles
+    // more formats, so keep it as the (slow, off-UI-isolate) fallback.
+    codec?.dispose();
+    return Isolate.run(() => cropPlateToBboxSync(fullBytes, bbox));
+  }
+  try {
+    final w = image.width;
+    final h = image.height;
+    final (cx, cy, cw, ch) = _clampBbox(bbox, w, h);
+    // Rasterize just the bbox region: the readback (and everything package:
+    // image sees) is crop-sized, not frame-sized.
+    final recorder = ui.PictureRecorder();
+    ui.Canvas(recorder).drawImageRect(
+      image,
+      ui.Rect.fromLTWH(
+        cx.toDouble(),
+        cy.toDouble(),
+        cw.toDouble(),
+        ch.toDouble(),
+      ),
+      ui.Rect.fromLTWH(0, 0, cw.toDouble(), ch.toDouble()),
+      ui.Paint(),
+    );
+    final picture = recorder.endRecording();
+    final small = await picture.toImage(cw, ch);
+    picture.dispose();
+    final raw = await small.toByteData(format: ui.ImageByteFormat.rawRgba);
+    small.dispose();
+    if (raw == null) return null;
+    final cropped = img.Image.fromBytes(
+      width: cw,
+      height: ch,
+      bytes: raw.buffer,
+      order: img.ChannelOrder.rgba,
+    );
+    if (_isNearlyBlack(cropped)) return null;
+    return (img.encodeJpg(cropped, quality: 90), cw, ch);
+  } finally {
+    image.dispose();
+    codec.dispose();
+  }
 }
 
-/// The synchronous crop, safe to run inside a background isolate. The rect is
-/// clamped into the image so an out-of-range or degenerate box still yields a
-/// crop. Returns `(jpegBytes, width, height)` — see [cropPlateToBbox].
+/// The pure-Dart (package:image) crop, safe to run inside a background
+/// isolate. Reference implementation and decode fallback for
+/// [cropPlateToBbox]; the clamping and near-black semantics there must match
+/// this. Returns `(jpegBytes, width, height)` — see [cropPlateToBbox].
 (Uint8List, int, int)? cropPlateToBboxSync(
   Uint8List fullBytes,
   List<double> bbox,
 ) {
   final decoded = img.decodeImage(fullBytes);
   if (decoded == null) return null;
-  final w = decoded.width;
-  final h = decoded.height;
-  final cx = (bbox[0] * w).round().clamp(0, w - 1);
-  final cy = (bbox[1] * h).round().clamp(0, h - 1);
-  final cw = (bbox[2] * w).round().clamp(1, w - cx);
-  final ch = (bbox[3] * h).round().clamp(1, h - cy);
+  final (cx, cy, cw, ch) = _clampBbox(bbox, decoded.width, decoded.height);
   final cropped = img.copyCrop(decoded, x: cx, y: cy, width: cw, height: ch);
   // Defense-in-depth (issue #179): if the box landed on a near-black region
   // (a frame-mismatched box that points off the actual plate), treat it as a
@@ -57,6 +105,17 @@ Future<(Uint8List, int, int)?> cropPlateToBbox(
   // full frame still contains the plate somewhere.
   if (_isNearlyBlack(cropped)) return null;
   return (img.encodeJpg(cropped, quality: 90), cropped.width, cropped.height);
+}
+
+/// Clamp the normalized [bbox] into a [w]x[h] frame as integer pixels, so an
+/// out-of-range or degenerate box still yields a crop. One implementation for
+/// both the engine path and the pure-Dart path — they must agree on the rect.
+(int, int, int, int) _clampBbox(List<double> bbox, int w, int h) {
+  final cx = (bbox[0] * w).round().clamp(0, w - 1);
+  final cy = (bbox[1] * h).round().clamp(0, h - 1);
+  final cw = (bbox[2] * w).round().clamp(1, w - cx);
+  final ch = (bbox[3] * h).round().clamp(1, h - cy);
+  return (cx, cy, cw, ch);
 }
 
 /// True when [im] is almost entirely black — the signature of a crop box that
@@ -101,8 +160,8 @@ final Map<String, double> _plateCropAspect = {};
 final Uint8List _cropFailed = Uint8List(0);
 
 /// Return the cached crop for [key], or compute it once from [fullBytes]+[bbox]
-/// (off the UI isolate) and cache the result. Returns null when the crop failed
-/// (the caller falls back to the full frame). Never does any network I/O.
+/// and cache the result. Returns null when the crop failed (the caller falls
+/// back to the full frame). Never does any network I/O.
 Future<Uint8List?> cachedPlateCrop(
   String key,
   Uint8List fullBytes,

--- a/apps/desktop-flutter/lib/ui/plates/plates_screen.dart
+++ b/apps/desktop-flutter/lib/ui/plates/plates_screen.dart
@@ -1381,7 +1381,7 @@ class _PlateThumb extends StatefulWidget {
   final double iconSize;
 
   /// Which image(s) to show — the full frame, the plate crop, or both. The crop
-  /// is derived client-side from the fetched snapshot (off the UI isolate,
+  /// is derived client-side from the fetched snapshot (engine-native decode,
   /// cached) and always falls back to the full frame when the read has no bbox
   /// or the crop fails.
   final PlateImageDisplay imageMode;
@@ -1446,8 +1446,8 @@ class _PlateThumbState extends State<_PlateThumb> {
 
   /// Derive the plate-region crop from [bytes] (no network) when this thumb is
   /// a cropping one and the read has a bbox. Uses the shared crop cache: a hit
-  /// is applied synchronously; a miss computes off the UI isolate and then
-  /// setState-s. Keyed by read id (bbox belongs to the read).
+  /// is applied synchronously; a miss computes via the engine's native codec
+  /// and then setState-s. Keyed by read id (bbox belongs to the read).
   void _maybeCrop(Uint8List bytes) {
     if (widget.imageMode == PlateImageDisplay.fullOnly || _disposed) return;
     final bbox = widget.read.bbox;
@@ -2618,9 +2618,9 @@ class _PlateClipPlayerState extends State<_PlateClipPlayer> {
 /// The prominent plate crop shown in the detail pop-up: the plate region
 /// cropped from the snapshot bytes already fetched for this read's tile (read
 /// straight from the shared snapshot cache — no network). The crop itself is
-/// computed off the UI isolate and cached (see plate_crop.dart). Renders
-/// nothing when there's no cached snapshot or no bbox, so the pop-up simply
-/// shows the clip in that case.
+/// computed with the engine's native codec and cached (see plate_crop.dart).
+/// Renders nothing when there's no cached snapshot or no bbox, so the pop-up
+/// simply shows the clip in that case.
 class _PlateDetailCrop extends StatefulWidget {
   const _PlateDetailCrop({
     required this.read,

--- a/apps/desktop-flutter/test/plate_crop_region_test.dart
+++ b/apps/desktop-flutter/test/plate_crop_region_test.dart
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Content-correctness lock for cropPlateToBbox's engine-native decode path
+// (issue #391). The crop used to be derived entirely with package:image; its
+// pure-Dart JPEG decode of the full frame (~130 ms at 1080p, ~260 ms at 4 MP,
+// per newly-mounted benchmark row) was the Engine Benchmark's measured
+// client-side bottleneck, so cropPlateToBbox now decodes with the engine's
+// native codec and rasterizes only the bbox region. These tests pin that the
+// fast path still crops the RIGHT region with the right dimensions, agrees
+// with the pure-Dart reference implementation (cropPlateToBboxSync), and
+// keeps the near-black rejection semantics.
+
+import 'dart:typed_data';
+
+import 'package:crumb_desktop/ui/plates/plate_crop.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+
+/// A [w]x[h] mid-gray JPEG with a solid red rectangle covering exactly the
+/// normalized [bbox] — cropping to that bbox must yield an all-red image.
+Uint8List _frameWithRedBox(int w, int h, List<double> bbox) {
+  final im = img.Image(width: w, height: h);
+  img.fill(im, color: img.ColorRgb8(128, 128, 128));
+  final x0 = (bbox[0] * w).round(), y0 = (bbox[1] * h).round();
+  final x1 = x0 + (bbox[2] * w).round(), y1 = y0 + (bbox[3] * h).round();
+  for (var y = y0; y < y1; y++) {
+    for (var x = x0; x < x1; x++) {
+      im.setPixelRgb(x, y, 220, 30, 30);
+    }
+  }
+  return img.encodeJpg(im, quality: 95);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const bbox = [0.25, 0.5, 0.25, 0.125];
+
+  test('engine path crops the correct region at the correct dimensions',
+      () async {
+    final frame = _frameWithRedBox(640, 360, bbox);
+    final res = await cropPlateToBbox(frame, bbox);
+    expect(res, isNotNull);
+    final (bytes, cw, ch) = res!;
+    expect(cw, 160); // 0.25 * 640
+    expect(ch, 45); // 0.125 * 360
+    final crop = img.decodeImage(bytes)!;
+    expect(crop.width, 160);
+    expect(crop.height, 45);
+    // The bbox region is solid red — if the fast path cropped the right
+    // pixels, red must dominate; a mis-mapped rect would pull in gray.
+    var r = 0.0, g = 0.0, n = 0;
+    for (var y = 0; y < crop.height; y += 3) {
+      for (var x = 0; x < crop.width; x += 3) {
+        final p = crop.getPixel(x, y);
+        r += p.r.toDouble();
+        g += p.g.toDouble();
+        n++;
+      }
+    }
+    expect(r / n, greaterThan(180), reason: 'crop should be the red region');
+    expect(g / n, lessThan(90), reason: 'crop should not include gray frame');
+  });
+
+  test('engine path agrees with the pure-Dart reference on dimensions',
+      () async {
+    // Deliberately non-16:9 and an out-of-range box — the clamping must match.
+    const wild = [0.9, 0.85, 0.4, 0.4];
+    final frame = _frameWithRedBox(500, 500, const [0.9, 0.85, 0.1, 0.15]);
+    final fast = await cropPlateToBbox(frame, wild);
+    final reference = cropPlateToBboxSync(frame, wild);
+    expect(fast, isNotNull);
+    expect(reference, isNotNull);
+    expect(fast!.$2, reference!.$2);
+    expect(fast.$3, reference.$3);
+  });
+
+  test('engine path still rejects a near-black crop', () async {
+    // Gray frame with a BLACK box at the bbox: the crop lands on near-pure
+    // black, which plate_crop must reject (null) so callers fall back to the
+    // full frame instead of showing a black thumbnail (issue #179 semantics).
+    final im = img.Image(width: 640, height: 360);
+    img.fill(im, color: img.ColorRgb8(128, 128, 128));
+    final x0 = (bbox[0] * 640).round(), y0 = (bbox[1] * 360).round();
+    for (var y = y0; y < y0 + (bbox[3] * 360).round(); y++) {
+      for (var x = x0; x < x0 + (bbox[2] * 640).round(); x++) {
+        im.setPixelRgb(x, y, 0, 0, 0);
+      }
+    }
+    final frame = img.encodeJpg(im, quality: 95);
+    expect(await cropPlateToBbox(frame, bbox), isNull);
+  });
+
+  test('undecodable bytes fall back and still return null, not a throw',
+      () async {
+    final garbage = Uint8List.fromList(List.filled(64, 7));
+    expect(await cropPlateToBbox(garbage, bbox), isNull);
+  });
+}

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,46 @@ revisit.
 
 ---
 
+## 2026-08-07, Plate-crop images: fix the client's decode (engine codec), not the payload (server-side derivatives)
+
+**Context.** The LPR Engine Benchmark's pass images loaded slowly (issue #391).
+The first diagnosis blamed the ~148 KB stored frames and produced server-side
+downscale/tight-crop derivatives (PR #394); live measurement then falsified the
+premise — the API answers the report in 3 ms and a full frame in 8 ms, so on a
+LAN the bytes cost ~1-2 ms and #394 was closed unmerged. A client-side
+measurement pass (real dialog mounted against an in-process server, plus
+micro-benchmarks of `plate_crop.dart`) found the actual cost: `package:image`'s
+pure-Dart JPEG decode of the full frame, run per newly-mounted row to derive
+the plate crop — ~130 ms per 1080p frame (~260 ms at 4 MP) vs ~18 ms for the
+engine's native codec. A 10-row screenful spent 478 ms wall on images, only
+43 ms of it fetch.
+
+**Decision.** Fix the decode where it happens (PR #545): `cropPlateToBbox`
+decodes with the engine codec and rasterizes only the bbox region, so the full
+decoded frame never crosses into Dart; `package:image` handles just the small
+crop (near-black guard + JPEG re-encode). The pure-Dart path stays as the
+reference implementation and decode fallback. Screenful: 478 → 156 ms. The
+list itself was already lazy (`ListView.separated`, ~7 rows mounted, ~10
+fetches) — the other #391 candidates (eager 165-row build, client fetch
+stampede) were measured and refuted.
+
+**Rejected.**
+
+- *Server-side derivatives as the fix (#394's framing).* Attacks transfer
+  size, which is ~43 ms of a ~478 ms problem on a LAN, and trades a ~1 ms
+  transfer saving for a 40 ms cold ffmpeg spawn per image server-side.
+- *Bounding client fetch concurrency / restructuring the list.* Measured fast
+  already; nothing to fix.
+- *Keeping the whole crop in `package:image` but skipping the isolate.* The
+  decode itself is the cost; where it runs doesn't change it.
+
+**Revisit if:** remote viewing over VPN/cellular becomes a priority — then
+#394's derivatives become a genuine transfer-cost win (its closing comment has
+the details, including the `?tight=1` serde-bool trap) and they compose fine
+with the engine-decode path; or the engine codec proves unable to decode some
+camera's snapshots in the field (the fallback logs nothing today — it would
+just be slow again for that camera).
+
 ## 2026-08-06, HA badge pill layout: a four-value width mode in units of the badge HEIGHT (not free pixels, not a max-width)
 
 **Context.** Live testing of the v0.2.0 overlay editor (issue #497) turned up two


### PR DESCRIPTION
## The client was finally measured, and the bottleneck is the pure-Dart decode

#391's correction said to start by measuring the client, not the server. Done: a harness that mounts the **real** benchmark dialog (widget test against an in-process HTTP server serving a 165-pass report + realistic ~150-175 KB 1080p JPEG frames), plus micro-benchmarks of the exact `plate_crop.dart` pipeline. All numbers from the same 8-core Windows build machine, Flutter 3.44.6.

### What the dialog actually does (measured, not assumed)

- The pass list is a lazy `ListView.separated`: only **7 rows mount** at the default dialog size, **10 snapshot fetches** go out (visible + cache extent) — there is **no 165-row build and no 165-request stampede**. Two of the issue's three candidates are refuted.
- The report fetch and dialog build are fast (3 ms server-side per #391's table; first render a few hundred ms in the harness including test overhead).
- What remains, per newly-mounted row: fetch the full frame, then `package:image`'s **pure-Dart JPEG decode** of that frame to derive the plate crop, in a fresh isolate. That decode is the bottleneck.

### Where the time goes (before)

| operation (per image) | time |
|---|---|
| fetch full frame, loopback + 8 ms simulated LAN | ~10-70 ms (43 ms wall for 10 concurrent) |
| `img.decodeImage`, 1080p | **~130 ms** |
| `img.decodeImage`, 4 MP | **~262 ms** |
| `copyCrop` + `encodeJpg` (the rest of the crop) | ~5-14 ms |
| engine (`dart:ui`) decode of the same 1080p bytes | **18 ms** |
| engine decode at thumbnail size (`cacheWidth`) | 5 ms |
| `Isolate.run` spawn overhead | ~1 ms |

**A 10-row screenful, current pipeline: 478 ms wall — of which fetch-only is 43 ms.** ~90% of image latency is the client decode, paid again for every screenful scrolled.

### Change

`cropPlateToBbox` now decodes with the engine's native codec (`instantiateImageCodecWithSize`) and rasterizes **only the bbox region** (`drawImageRect` → `toImage` → small readback), so the full decoded frame never crosses into Dart. `package:image` still handles the near-black guard and the JPEG re-encode, but only ever sees the tiny crop. The pure-Dart path is kept unchanged as the reference implementation and as the fallback when the engine can't decode the bytes.

Callers are untouched: same signature, same JPEG bytes out, same `(bytes, w, h)` dimensions/aspect contract, same null-on-near-black semantics (issue #179), same crop cache. The Plates gallery/detail crops and the PDF report ride the same helper, so they get the same win.

### After (same harness, same machine)

| measurement | before | after |
|---|---|---|
| single crop, 1080p (`cropPlateToBbox`) | 141 ms | **32 ms** |
| 12 concurrent crops | 429 ms | **156 ms** |
| **10-row screenful (fetch + crop wall)** | **478 ms** | **156 ms** |
| crop cost per row (median, concurrent) | 292 ms | 52 ms |

The 43 ms fetch floor is unchanged; thumbs now land ~3x sooner per screenful, and the per-row cost no longer scales with camera resolution nearly as hard (the 4 MP pure-Dart decode was 2x the 1080p one; native decode is a fraction of either).

### Tests

- New `test/plate_crop_region_test.dart` locks the fast path: crops the **correct region** at the correct dimensions (red-box frame), agrees with the pure-Dart reference on clamped dimensions for an out-of-range box, still rejects a near-black crop, and degrades (not throws) on undecodable bytes.
- Existing `plate_crop_aspect_test.dart` passes unchanged on the new path.
- `flutter analyze`: no new issues (224 pre-existing infos before and after).
- `flutter test`: **157/157 pass** (153 existing + 4 new).

### On #394 (closed server-side derivatives)

Nothing here changes that verdict. With the bottleneck confirmed client-side, the derivatives were solving the wrong problem for LAN use; they remain a legitimate future win for VPN/cellular where 148 KB/row is real transfer cost, and would compose fine with this change if revived.

Fixes #391
