### PR TITLE
fix: correct release-prep copy defects and code/compose config drift

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -96,8 +96,8 @@ body:
     id: gpu
     attributes:
       label: GPU and hardware decode
-      description: Leave blank if you are on the CPU default.
-      placeholder: "NVIDIA RTX A2000 with nvidia-container-toolkit, MOTION_HWACCEL=nvdec"
+      description: Leave blank if you are on the default (MOTION_HWACCEL=cpu). Valid values are auto, cpu, cuda, and vaapi.
+      placeholder: "NVIDIA RTX A2000 with nvidia-container-toolkit, MOTION_HWACCEL=cuda"
   - type: input
     id: camera
     attributes:

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -63,8 +63,13 @@ The api container runs as **uid 1001**, so the host directory behind
 sudo chown -R 1001:1001 "${DB_BACKUP_HOST_PATH:-./backups}"
 ```
 
-`scripts/setup-env.sh` prepares the default `./backups` dir for you when it
-can. If the dir is unwritable, the api logs a clear warning, emits one
+`scripts/setup-env.sh` prepares this directory for you when it can. It
+prepares whatever `DB_BACKUP_HOST_PATH` points at, not just the default
+`./backups`, so choose the path up front and the ownership is handled:
+
+```bash
+DB_BACKUP_HOST_PATH=/mnt/nas/crumb-db-backups scripts/setup-env.sh
+``` If the dir is unwritable, the api logs a clear warning, emits one
 `backup_failed` alert, and **disables backups without affecting the api
 itself**, backups being broken never takes the API down.
 
@@ -176,6 +181,10 @@ mount, etc.) on the host and point the existing variable at it:
 # .env
 DB_BACKUP_HOST_PATH=/mnt/nas/crumb-db-backups
 ```
+
+On a fresh install you can pass the same value to `scripts/setup-env.sh` (see
+Permissions above) so it writes that path into `.env` **and** prepares its
+ownership, instead of writing the path and leaving the chown to you.
 
 The api writes its daily/weekly/monthly dumps straight to that mount —
 they're off-host the moment `pg_dump` finishes, with no sync step, no second

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -17,6 +17,11 @@
 #   scripts/setup-env.sh                # generate all secrets, write .env
 #   scripts/setup-env.sh --prompt       # prompt for the admin password instead
 #   scripts/setup-env.sh --force        # overwrite an existing .env
+#
+# Two paths can be chosen up front, as environment variables, so the script
+# writes them into .env AND prepares them (ownership + preflight):
+#   MEDIA_HOST_PATH=/mnt/tank/crumb scripts/setup-env.sh        # footage
+#   DB_BACKUP_HOST_PATH=/mnt/nas/crumb-backups scripts/setup-env.sh  # DB dumps
 # ─────────────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
@@ -179,6 +184,20 @@ case "${MEDIA_HOST_PATH_VALUE}" in
   *)  MEDIA_DIR_HOST="${REPO_ROOT}/${MEDIA_HOST_PATH_VALUE#./}" ;;
 esac
 
+# ── Where the nightly DB dumps will be written ───────────────────────────────
+# Same deal as MEDIA_HOST_PATH, and accepted the same way:
+#
+#   DB_BACKUP_HOST_PATH=/mnt/nas/crumb-backups scripts/setup-env.sh
+#
+# Whatever it points at is written into .env AND gets the uid-1001 prep below.
+# (It used to be hardcoded to ${REPO_ROOT}/backups, so a custom path was written
+# into .env but never prepared, and the operator hit a root-owned bind mount.)
+DB_BACKUP_HOST_PATH_VALUE="${DB_BACKUP_HOST_PATH:-./backups}"
+case "${DB_BACKUP_HOST_PATH_VALUE}" in
+  /*) BACKUP_DIR_HOST="${DB_BACKUP_HOST_PATH_VALUE}" ;;
+  *)  BACKUP_DIR_HOST="${REPO_ROOT}/${DB_BACKUP_HOST_PATH_VALUE#./}" ;;
+esac
+
 # Write atomically: build in a temp file, then move into place.
 TMP="$(mktemp "${ENV_FILE}.XXXXXX")"
 trap 'rm -f "${TMP}"' EXIT
@@ -295,9 +314,10 @@ EXPORT_TTL_SECONDS=86400
 # --- Database backup (built into the api; ON by default -- docs/BACKUP.md) ---
 # The api runs a nightly pg_dump (03:15 local) with rotation into this host
 # dir. Put it on a DIFFERENT disk than MEDIA_HOST_PATH where practical, and
-# keep it writable by uid 1001 (the api's user) -- setup-env.sh prepares the
-# default ./backups dir; if you point this elsewhere, chown it yourself.
-DB_BACKUP_HOST_PATH=./backups
+# keep it writable by uid 1001 (the api's user) -- setup-env.sh prepares
+# whatever this points at. To put it somewhere else, re-run setup-env.sh with
+# DB_BACKUP_HOST_PATH=/your/path so that directory is prepared too.
+DB_BACKUP_HOST_PATH=${DB_BACKUP_HOST_PATH_VALUE}
 
 # --- Off-host backup copy (OPTIONAL; see docs/BACKUP.md "Off-host copies") ---
 # The api's built-in backup job (ON by default) writes dumps to a directory on
@@ -550,12 +570,13 @@ if [[ -d "${MEDIA_DIR_HOST}" ]]; then
 fi
 
 # ── DB-backup directory prep ─────────────────────────────────────────────────
-# The api container (uid 1001) writes nightly pg_dumps into ./backups (see
-# DB_BACKUP_HOST_PATH). If Docker auto-creates the bind-mount dir it ends up
-# root-owned and the api can't write (backups get disabled with a warning), so
-# create it here with the right ownership while we can. Best-effort: a non-root
-# run without sudo still works — the api will say exactly what to fix.
-BACKUP_DIR_HOST="${REPO_ROOT}/backups"
+# The api container (uid 1001) writes nightly pg_dumps into DB_BACKUP_HOST_PATH.
+# If Docker auto-creates the bind-mount dir it ends up root-owned and the api
+# can't write (backups get disabled with a warning), so create it here with the
+# right ownership while we can. Best-effort: a non-root run without sudo still
+# works — the api will say exactly what to fix.
+# (BACKUP_DIR_HOST was resolved from DB_BACKUP_HOST_PATH above, so a custom path
+# is prepared exactly like the default ./backups one.)
 mkdir -p "${BACKUP_DIR_HOST}" 2>/dev/null || true
 if [[ -d "${BACKUP_DIR_HOST}" ]]; then
   if chown 1001:1001 "${BACKUP_DIR_HOST}" 2>/dev/null; then

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -1504,7 +1504,7 @@ function wizardBody(key) {
       <input id="wz-addr" class="mono" value="${esc(addr)}" placeholder="http://198.51.100.50:8080" style="font-size:13px" />
       <label class="field-label" style="margin-top:12px">Camera streaming base, RTSP <span style="color:var(--dim2);font-weight:400">(native desktop / phone apps use this)</span></label>
       <input id="wz-rtsp" class="mono" value="${esc(rtsp)}" placeholder="rtsp://198.51.100.50:18554" style="font-size:13px" />
-      <div class="login-sub" style="margin-top:8px">For encrypted access, use <code>https://&lt;this-host&gt;:8443</code> instead (a Caddy sidecar terminates TLS in front of the console, self-signed by default on a LAN install). See <b>Server</b> → TLS, or docs/TLS.md, to trust the certificate or switch to a real domain.</div>`;
+      <div class="login-sub" style="margin-top:8px">For encrypted access, use <code>https://&lt;this-host&gt;:8443</code> instead (a Caddy sidecar terminates TLS in front of the console, self-signed by default on a LAN install). See the <b>Server</b> section, or docs/TLS.md, to trust the certificate or switch to a real domain.</div>`;
   }
   if (key === 'storage')    return wizardStorageBody();
   if (key === 'cam-find')   return wizardFindBody();
@@ -1586,8 +1586,8 @@ async function wizardDetectHwEnter() {
    Lightweight one-destination form over the SAME channels API the console's
    Notifications panel uses (POST /notifications/channels + .../test). Only the
    simplest providers are offered here; the full surface (per-camera rules,
-   quiet hours, Discord/Slack/Telegram, system alerts) lives in Settings →
-   Notifications. */
+   quiet hours, Discord/Slack/Telegram, system alerts) lives in the console's
+   own Notifications section. */
 const WIZARD_NOTIFY_KINDS = ['ntfy', 'pushover', 'webhook'];
 function wizardNotifyState() {
   if (!WZ.notifyCh) WZ.notifyCh = { kind: 'ntfy', id: null, name: '', vals: {} };
@@ -1612,7 +1612,7 @@ function wizardNotifyBody() {
       <button class="ghost sm" onclick="wizardNotifyTest()">Save &amp; send test</button>
       <span id="wz-nf-test" style="font-size:12px"></span>
     </div>
-    <div class="login-sub" style="margin-top:12px;margin-bottom:0">This destination will cover <b>all cameras</b> and be available to all users. Full options, per-camera rules, quiet hours, more channel types (Discord, Slack, Telegram) and system alerts, live in <b>Settings → Notifications</b>.</div>`;
+    <div class="login-sub" style="margin-top:12px;margin-bottom:0">This destination will cover <b>all cameras</b> and be available to all users. Full options, per-camera rules, quiet hours, more channel types (Discord, Slack, Telegram) and system alerts, live in the <b>Notifications</b> section of this console.</div>`;
 }
 function wizardNotifyKind(k) {
   const st = wizardNotifyState();
@@ -1699,7 +1699,7 @@ function wizardUsersBody() {
         <span id="wz-us-msg" style="font-size:12px;color:var(--danger)"></span>
       </div>
     </div>
-    <div class="login-sub" style="margin-top:12px;margin-bottom:0">Roles decide which cameras a user sees and what they can do. Fine-grained control (custom roles, per-user camera grants) lives in <b>Settings → Users &amp; Security</b>.</div>`;
+    <div class="login-sub" style="margin-top:12px;margin-bottom:0">Roles decide which cameras a user sees and what they can do. Fine-grained control (custom roles, per-user camera grants) lives in the <b>Users &amp; security</b> section of this console.</div>`;
 }
 async function wizardUserAdd() {
   const msg = $('wz-us-msg'); if (msg) msg.textContent = '';
@@ -1832,9 +1832,9 @@ function wizardStorageCheckHtml(res) {
   return `<span style="color:${color};font-weight:700">${mark}</span> <span style="color:var(--dim)">${esc(res.message || '')}</span>`;
 }
 
-/* ── The SAME preflight, for Settings → Storage ──────────────────────────────
+/* ── The SAME preflight, for the Storage section ────────────────────────────
    fs/check used to be called from exactly one place (the wizard), so the
-   Settings pane happily saved a path that does not exist or is not writable and
+   Storage pane happily saved a path that does not exist or is not writable and
    said nothing at all (HTTP 201, silence). Paints a live status line under the
    path box and returns the verdict so add/save can refuse an `error`. */
 let _stCheckSeq = 0;
@@ -9943,7 +9943,7 @@ const SYS_ALERT_META = {
   stream_no_segments:   { title: 'Camera records nothing',            desc: 'A camera keeps connecting but never produces a recordable segment before the stall watchdog reconnects it, so no footage is saved. Usually a long/adaptive keyframe interval (smart codec, e.g. Hikvision/Dahua H.264+/H.265+) or very low fps, exceeding the segment-receipt timeout. Fix the camera’s I-frame interval / disable the smart codec, or raise SEGMENT_RECEIPT_TIMEOUT_SECS.', unit: null },
   storage_unwritable:   { title: 'Storage not writable',              desc: 'The recorder cannot create a camera’s media directory under the storage root (permission denied) — footage is NOT being saved. Usually the host media dir is root-owned while the recorder runs as non-root uid 1001; fix the media dir ownership/permissions.', unit: null },
   plate_watchlist_hit:  { title: 'License-plate watchlist hit',        desc: 'A watchlisted license plate was seen on a camera (managed in LPR → Watchlist).', unit: null },
-  update_available:     { title: 'Crumb update available',             desc: 'A newer Crumb release is available on GitHub. Off by default and only fires when the update-available check is also enabled (Settings → Updates) — notify-only, no download or install. Fires once per new version.', unit: null },
+  update_available:     { title: 'Crumb update available',             desc: 'A newer Crumb release is available on GitHub. Off by default and only fires when the update-available check is also enabled (Server → Update checks) — notify-only, no download or install. Fires once per new version.', unit: null },
 };
 
 /* Per-kind connection-field descriptors. */

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -19,6 +19,15 @@ use std::{collections::HashMap, env, net::SocketAddr};
 
 use crate::ptz::OnvifCameraConfig;
 
+/// Default for `EXPORT_DIR`.
+///
+/// A TOP-LEVEL directory, deliberately NOT under `/data`: the api mounts media
+/// storage READ-ONLY at `/data`, so any default beneath it is unwritable by
+/// construction. `docker-compose.yml` gives exports their own writable
+/// `crumb_exports:/exports` volume; `compose_export_dir_default_matches_the_code`
+/// asserts the two stay equal.
+pub const DEFAULT_EXPORT_DIR: &str = "/exports";
+
 /// Fully-resolved runtime configuration for the API service.
 #[derive(Debug, Clone)]
 pub struct ApiConfig {
@@ -153,7 +162,12 @@ pub struct ApiConfig {
     // -- export -------------------------------------------------------------
     /// `EXPORT_DIR` -- directory where completed export MP4 files are written.
     ///
-    /// Default: `/data/exports`
+    /// Default: `/exports` -- a TOP-LEVEL directory, deliberately NOT under
+    /// `/data`. The api mounts media storage READ-ONLY at `/data`, so a default
+    /// beneath it could never be written to; `docker-compose.yml` gives exports
+    /// their own writable `crumb_exports:/exports` volume and passes
+    /// `${EXPORT_DIR:-/exports}`. The code default matches that so a non-compose
+    /// run lands somewhere writable too.
     pub export_dir: String,
 
     /// `EXPORT_TTL_SECONDS` -- how long export files are kept before cleanup.
@@ -427,7 +441,7 @@ impl ApiConfig {
             go2rtc_pass,
             // Issue #398: secure by default — auth ON unless GO2RTC_AUTH=off.
             go2rtc_rtsp_auth: crumb_common::config::go2rtc_rtsp_auth_enabled_env(),
-            export_dir: optional_env("EXPORT_DIR", "/data/exports"),
+            export_dir: optional_env("EXPORT_DIR", DEFAULT_EXPORT_DIR),
             export_ttl_seconds: parse_env("EXPORT_TTL_SECONDS", 86_400_u64)?,
             export_max_concurrent: parse_env("EXPORT_MAX_CONCURRENT", 2usize)?.max(1),
             clip_gen_max_concurrency: parse_env("CLIP_GEN_MAX_CONCURRENCY", 4usize)?.max(1),
@@ -555,7 +569,7 @@ fn parse_onvif_config() -> Result<HashMap<String, OnvifCameraConfig>> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_env;
+    use super::{parse_env, DEFAULT_EXPORT_DIR};
 
     /// #249: compose forwards keys as `${VAR:-}`, so an unset key arrives as an
     /// empty string. The api's `parse_env` must treat that as "use the default",
@@ -576,5 +590,42 @@ mod tests {
         std::env::remove_var("CRUMB_API_TEST_EMPTY_NUM");
         std::env::remove_var("CRUMB_API_TEST_WS_NUM");
         std::env::remove_var("CRUMB_API_TEST_SET_NUM");
+    }
+
+    /// Read the `${NAME:-default}` fallback compose declares for `key`.
+    /// `None` when `docker-compose.yml` is unreadable or the key is absent.
+    fn compose_default(key: &str) -> Option<String> {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../docker-compose.yml")
+            .canonicalize()
+            .ok()?;
+        let text = std::fs::read_to_string(path).ok()?;
+        let needle = format!("${{{key}:-");
+        let line = text
+            .lines()
+            .find(|l| l.trim_start().starts_with(&format!("{key}:")) && l.contains(&needle))?;
+        let rest = &line[line.find(&needle)? + needle.len()..];
+        Some(rest[..rest.find('}')?].to_owned())
+    }
+
+    /// Drift guard. The code default used to be `/data/exports`, which cannot
+    /// work: the api mounts `/data` READ-ONLY, so a non-compose run wrote (or
+    /// rather failed to write) exports into a read-only tree. Compose has always
+    /// passed `/exports` from its own writable volume; the code now agrees, and
+    /// this test keeps them that way.
+    #[test]
+    fn compose_export_dir_default_matches_the_code() {
+        let Some(export_dir) = compose_default("EXPORT_DIR") else {
+            eprintln!("skipping: docker-compose.yml not readable from this checkout");
+            return;
+        };
+        assert_eq!(
+            export_dir, DEFAULT_EXPORT_DIR,
+            "docker-compose.yml EXPORT_DIR default drifted from the code default"
+        );
+        assert!(
+            !DEFAULT_EXPORT_DIR.starts_with("/data"),
+            "EXPORT_DIR must not default under /data — the api mounts it read-only"
+        );
     }
 }

--- a/services/common/src/config.rs
+++ b/services/common/src/config.rs
@@ -19,6 +19,18 @@ use anyhow::{Context, Result};
 use std::env;
 use std::sync::OnceLock;
 
+/// Default for `LIVE_STORAGE_NAME`.
+///
+/// MUST stay equal to the `${LIVE_STORAGE_NAME:-...}` default in
+/// `docker-compose.yml` — `compose_storage_name_defaults_match_the_code` asserts
+/// it. Compose is what every supported install runs, so a code default that
+/// disagrees only ever shows up on a bare-metal run, as a differently-labelled
+/// storage row that nobody expected.
+pub const DEFAULT_LIVE_STORAGE_NAME: &str = "Live";
+
+/// Default for `ARCHIVE_STORAGE_NAME`. See [`DEFAULT_LIVE_STORAGE_NAME`].
+pub const DEFAULT_ARCHIVE_STORAGE_NAME: &str = "Archive";
+
 /// Fully-resolved runtime configuration.
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -92,7 +104,9 @@ pub struct Config {
 
     /// `LIVE_STORAGE_NAME` — human label inserted/upserted into `storages`.
     ///
-    /// Default: `"NVMe-Live"`
+    /// Default: `"Live"` — the same value `docker-compose.yml` passes
+    /// (`${LIVE_STORAGE_NAME:-Live}`), so a non-compose run produces the same
+    /// storage label the console, the docs and every compose install show.
     pub live_storage_name: String,
 
     /// `ARCHIVE_STORAGE_PATH` — filesystem path for archive recordings.
@@ -102,7 +116,8 @@ pub struct Config {
 
     /// `ARCHIVE_STORAGE_NAME` — human label for the archive storage row.
     ///
-    /// Default: `"Bulk-Archive"`
+    /// Default: `"Archive"` — matches `docker-compose.yml`
+    /// (`${ARCHIVE_STORAGE_NAME:-Archive}`), see [`Config::live_storage_name`].
     pub archive_storage_name: String,
 
     /// `RECORDER_TZ` — IANA timezone the per-camera archive-schedule cron is
@@ -457,9 +472,12 @@ impl Config {
             go2rtc_pass: optional_env("GO2RTC_PASS", ""),
             segment_seconds,
             live_storage_path: optional_env("LIVE_STORAGE_PATH", "/data/live"),
-            live_storage_name: optional_env("LIVE_STORAGE_NAME", "NVMe-Live"),
+            live_storage_name: optional_env("LIVE_STORAGE_NAME", DEFAULT_LIVE_STORAGE_NAME),
             archive_storage_path: optional_env("ARCHIVE_STORAGE_PATH", "/data/archive"),
-            archive_storage_name: optional_env("ARCHIVE_STORAGE_NAME", "Bulk-Archive"),
+            archive_storage_name: optional_env(
+                "ARCHIVE_STORAGE_NAME",
+                DEFAULT_ARCHIVE_STORAGE_NAME,
+            ),
             // RECORDER_TZ wins; otherwise inherit the container's TZ (compose
             // forwards it, and setup-env.sh sets it to the host zone) so a
             // non-US operator's archive/retention cron matches their wall clock.
@@ -634,7 +652,10 @@ fn parse_bool_env(key: &str, default: bool) -> Result<bool> {
 
 #[cfg(test)]
 mod tests {
-    use super::{go2rtc_rtsp_auth_enabled, optional_env, parse_env, parse_tz_env, HwAccel};
+    use super::{
+        go2rtc_rtsp_auth_enabled, optional_env, parse_env, parse_tz_env, HwAccel,
+        DEFAULT_ARCHIVE_STORAGE_NAME, DEFAULT_LIVE_STORAGE_NAME,
+    };
 
     /// Issue #479 — THE DEFECT. `auto` used to resolve through
     /// `nvdec_available()`, i.e. "is cuda COMPILED into this ffmpeg", which is
@@ -669,6 +690,47 @@ mod tests {
             assert_eq!(HwAccel::Vaapi.resolve_auto(probe), HwAccel::Vaapi);
             assert_eq!(HwAccel::Cpu.resolve_auto(probe), HwAccel::Cpu);
         }
+    }
+
+    /// Read the `${NAME:-default}` fallback compose declares for `key`, from the
+    /// repo's `docker-compose.yml`. `None` when the file is unreadable (a
+    /// vendored crate outside the repo) or the key is absent.
+    fn compose_default(key: &str) -> Option<String> {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../docker-compose.yml")
+            .canonicalize()
+            .ok()?;
+        let text = std::fs::read_to_string(path).ok()?;
+        let needle = format!("${{{key}:-");
+        let line = text
+            .lines()
+            .find(|l| l.trim_start().starts_with(&format!("{key}:")) && l.contains(&needle))?;
+        let rest = &line[line.find(&needle)? + needle.len()..];
+        Some(rest[..rest.find('}')?].to_owned())
+    }
+
+    /// Drift guard: the storage-name code defaults MUST equal the values
+    /// `docker-compose.yml` passes. They disagreed once (`NVMe-Live`/
+    /// `Bulk-Archive` in code vs `Live`/`Archive` in compose), which was
+    /// invisible on every compose install and surfaced only as oddly-named
+    /// storage rows on a bare-metal run. This test fails the moment either side
+    /// moves without the other.
+    #[test]
+    fn compose_storage_name_defaults_match_the_code() {
+        let Some(live) = compose_default("LIVE_STORAGE_NAME") else {
+            eprintln!("skipping: docker-compose.yml not readable from this checkout");
+            return;
+        };
+        assert_eq!(
+            live, DEFAULT_LIVE_STORAGE_NAME,
+            "docker-compose.yml LIVE_STORAGE_NAME default drifted from the code default"
+        );
+        let archive =
+            compose_default("ARCHIVE_STORAGE_NAME").expect("ARCHIVE_STORAGE_NAME in compose");
+        assert_eq!(
+            archive, DEFAULT_ARCHIVE_STORAGE_NAME,
+            "docker-compose.yml ARCHIVE_STORAGE_NAME default drifted from the code default"
+        );
     }
 
     /// The admin-editable DB setting round-trips through the same tokens, and an

--- a/services/common/src/db.rs
+++ b/services/common/src/db.rs
@@ -272,6 +272,57 @@ pub async fn upsert_storage(pool: &Pool, name: &str, path: &str) -> Result<Stora
     Ok(storage_from_row(&row))
 }
 
+/// Detect the one way an operator-visible `*_STORAGE_NAME` change can bite: a
+/// row already exists at `path` under a DIFFERENT name, and no row carries
+/// `name` yet, so the next [`upsert_storage`] would INSERT a second row for the
+/// same physical directory instead of reusing the first.
+///
+/// Returns the existing row's name in that case, otherwise `None`.
+///
+/// This is a *detector*, never a fixer. Adopting the existing row by renaming it
+/// was considered and rejected: `PUT /config/storages/{id}` lets an operator
+/// rename a storage deliberately, and a boot-time rename would silently undo
+/// that. Duplicate rows for one path are already a tolerated condition (the
+/// reconcile orphan pass keys on the storage ROOT PATH, not the id, precisely so
+/// duplicates cannot double-index or double-budget a disk), so the safe move is
+/// to say so loudly and let the operator merge them.
+///
+/// # Examples
+///
+/// ```
+/// # use crumb_common::db::duplicate_path_under_other_name;
+/// let rows = [("NVMe-Live".to_owned(), "/data/live".to_owned())];
+/// // Renaming the default would insert a SECOND row for /data/live:
+/// assert_eq!(
+///     duplicate_path_under_other_name(rows.iter().cloned(), "Live", "/data/live"),
+///     Some("NVMe-Live".to_owned())
+/// );
+/// // Once a row already carries the target name there is nothing to warn about.
+/// let rows = [("Live".to_owned(), "/data/live".to_owned())];
+/// assert_eq!(
+///     duplicate_path_under_other_name(rows.iter().cloned(), "Live", "/data/live"),
+///     None
+/// );
+/// ```
+#[must_use]
+pub fn duplicate_path_under_other_name<I>(rows: I, name: &str, path: &str) -> Option<String>
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    let mut clash: Option<String> = None;
+    for (row_name, row_path) in rows {
+        if row_name == name {
+            // The target name already exists: upsert_storage updates it in
+            // place, no new row, nothing to warn about.
+            return None;
+        }
+        if row_path == path && clash.is_none() {
+            clash = Some(row_name);
+        }
+    }
+    clash
+}
+
 /// Fetch a storage row by its UUID.
 ///
 /// Returns `None` if the row does not exist.
@@ -12567,6 +12618,62 @@ pub async fn system_events_since(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The `*_STORAGE_NAME` code defaults were realigned onto the compose
+    /// values (`Live` / `Archive`). On a compose install nothing changes, but a
+    /// non-compose deployment carrying the OLD defaults must not silently gain a
+    /// second `storages` row for the same directory without saying so.
+    #[test]
+    fn duplicate_path_detector_flags_a_renamed_default() {
+        let rows = || {
+            vec![
+                ("NVMe-Live".to_owned(), "/data/live".to_owned()),
+                ("Bulk-Archive".to_owned(), "/data/archive".to_owned()),
+            ]
+        };
+        assert_eq!(
+            duplicate_path_under_other_name(rows(), "Live", "/data/live"),
+            Some("NVMe-Live".to_owned()),
+        );
+        assert_eq!(
+            duplicate_path_under_other_name(rows(), "Archive", "/data/archive"),
+            Some("Bulk-Archive".to_owned()),
+        );
+    }
+
+    /// The common cases stay silent: a fresh DB, an already-migrated DB, and a
+    /// genuinely new path that happens to be seeded alongside an existing one.
+    #[test]
+    fn duplicate_path_detector_is_quiet_when_there_is_no_clash() {
+        // Fresh install: no rows at all.
+        assert_eq!(
+            duplicate_path_under_other_name(Vec::new(), "Live", "/data/live"),
+            None,
+        );
+        // Compose install: the row already carries the target name, so
+        // upsert_storage updates it in place.
+        let rows = vec![("Live".to_owned(), "/data/live".to_owned())];
+        assert_eq!(
+            duplicate_path_under_other_name(rows, "Live", "/data/live"),
+            None,
+        );
+        // A name match anywhere wins even when another row shares the path,
+        // because ON CONFLICT (name) targets that row.
+        let rows = vec![
+            ("NVMe-Live".to_owned(), "/data/live".to_owned()),
+            ("Live".to_owned(), "/data/live".to_owned()),
+        ];
+        assert_eq!(
+            duplicate_path_under_other_name(rows, "Live", "/data/live"),
+            None,
+        );
+        // Different path: seeding Archive must not be blamed on the Live row.
+        let rows = vec![("Live".to_owned(), "/data/live".to_owned())];
+        assert_eq!(
+            duplicate_path_under_other_name(rows, "Archive", "/data/archive"),
+            None,
+        );
+    }
 
     #[test]
     fn levenshtein_treats_confusable_chars_as_free() {

--- a/services/recorder/src/main.rs
+++ b/services/recorder/src/main.rs
@@ -1071,6 +1071,50 @@ impl RecorderSupervisor {
     /// requiring a separate `seed` run for storage rows.  Camera rows still
     /// require the `seed` binary.
     async fn seed_storages(&self) -> Result<()> {
+        // The `*_STORAGE_NAME` code defaults track docker-compose.yml (`Live` /
+        // `Archive`). A deployment that predates that and does NOT get the names
+        // from compose still has rows under the old defaults, so the upsert
+        // below would INSERT a second row for the same directory. That is
+        // tolerated (reconcile keys duplicates by root path) and loses no
+        // footage — existing segments keep their `storage_id` and the default
+        // policy keeps its `live_storage_id` — but it must not happen silently.
+        match db::list_storages(&self.pool).await {
+            Ok(existing) => {
+                let rows: Vec<(String, String)> =
+                    existing.into_iter().map(|s| (s.name, s.path)).collect();
+                for (name, path) in [
+                    (
+                        &self.config.live_storage_name,
+                        &self.config.live_storage_path,
+                    ),
+                    (
+                        &self.config.archive_storage_name,
+                        &self.config.archive_storage_path,
+                    ),
+                ] {
+                    if let Some(other) =
+                        db::duplicate_path_under_other_name(rows.iter().cloned(), name, path)
+                    {
+                        warn!(
+                            path = %path,
+                            existing_name = %other,
+                            configured_name = %name,
+                            "DUPLICATE STORAGE PATH: an existing storage row already points at \
+                             this path under a different name, so seeding the configured name \
+                             adds a SECOND row for the same directory. No footage is affected \
+                             (existing segments keep their storage). To merge them, either set \
+                             LIVE_STORAGE_NAME / ARCHIVE_STORAGE_NAME to the existing name, or \
+                             rename the existing storage in the console."
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                // Advisory only — never block the seed (and therefore recording).
+                warn!(error = %e, "could not list storages to check for duplicate paths before seeding");
+            }
+        }
+
         db::upsert_storage(
             &self.pool,
             &self.config.live_storage_name,

--- a/services/recorder/src/reconcile.rs
+++ b/services/recorder/src/reconcile.rs
@@ -647,7 +647,7 @@ async fn run_background(pool: Pool, config: Config, shutdown: CancellationToken)
             // Record this row's (storage ROOT PATH, rel path) for the orphan pass.
             // Key by the storage PATH, NOT its id: prod has DUPLICATE storage rows
             // for the same /data/live and /data/archive paths (e.g. "2TB NVMe" vs
-            // "NVMe-Live"); segments may reference either, and reconcile looks the
+            // "Live"); segments may reference either, and reconcile looks the
             // storage up by config NAME — keying by id made every file on the
             // other duplicate row look like an orphan (510k false orphans).
             indexed_paths.insert((storage_path.replace('\\', "/"), seg.path.replace('\\', "/")));
@@ -2590,14 +2590,14 @@ mod tests {
         // Storage rows NAMED to match Config defaults so run_background finds them.
         let live_storage = crumb_common::db::upsert_storage(
             &pool,
-            "NVMe-Live",
+            "Live",
             live_dir.path().to_str().expect("utf8"),
         )
         .await
         .expect("live storage");
         crumb_common::db::upsert_storage(
             &pool,
-            "Bulk-Archive",
+            "Archive",
             archive_dir.path().to_str().expect("utf8"),
         )
         .await
@@ -2727,7 +2727,7 @@ mod tests {
             .await
             .expect("mkdir cam");
 
-        let live = crumb_common::db::get_storage_by_name(&fx.pool, "NVMe-Live")
+        let live = crumb_common::db::get_storage_by_name(&fx.pool, "Live")
             .await
             .expect("get live storage")
             .expect("live storage exists");
@@ -2828,7 +2828,7 @@ mod tests {
             .await
             .expect("mkdir cam");
 
-        let live = crumb_common::db::get_storage_by_name(&fx.pool, "NVMe-Live")
+        let live = crumb_common::db::get_storage_by_name(&fx.pool, "Live")
             .await
             .expect("get live storage")
             .expect("live storage exists");
@@ -2902,7 +2902,7 @@ mod tests {
             .await
             .expect("mkdir cam");
 
-        let live = crumb_common::db::get_storage_by_name(&fx.pool, "NVMe-Live")
+        let live = crumb_common::db::get_storage_by_name(&fx.pool, "Live")
             .await
             .expect("get live storage")
             .expect("live storage exists");
@@ -2968,7 +2968,7 @@ mod tests {
         let fx = setup_reconcile(&url).await;
 
         // Disk A: the existing storage the healthy row points at.
-        let disk_a = crumb_common::db::get_storage_by_name(&fx.pool, "NVMe-Live")
+        let disk_a = crumb_common::db::get_storage_by_name(&fx.pool, "Live")
             .await
             .expect("get disk A")
             .expect("disk A exists");
@@ -3086,7 +3086,7 @@ mod tests {
             .await
             .expect("mkdir cam");
 
-        let live = crumb_common::db::get_storage_by_name(&fx.pool, "NVMe-Live")
+        let live = crumb_common::db::get_storage_by_name(&fx.pool, "Live")
             .await
             .expect("get live storage")
             .expect("live storage exists");
@@ -3198,7 +3198,7 @@ mod tests {
             .await
             .expect("mkdir cam");
 
-        let live = crumb_common::db::get_storage_by_name(&fx.pool, "NVMe-Live")
+        let live = crumb_common::db::get_storage_by_name(&fx.pool, "Live")
             .await
             .expect("get live storage")
             .expect("live storage exists");
@@ -3263,7 +3263,7 @@ mod tests {
                 .expect("set record_stream = sub");
         }
 
-        let live = crumb_common::db::get_storage_by_name(&fx.pool, "NVMe-Live")
+        let live = crumb_common::db::get_storage_by_name(&fx.pool, "Live")
             .await
             .expect("get live storage")
             .expect("live storage exists");
@@ -3321,7 +3321,7 @@ mod tests {
         let config = recon_config();
 
         // A per-policy archive disk that is NOT the config-name default
-        // ("Bulk-Archive") — the case the old labelling missed.
+        // ("Archive") — the case the old labelling missed.
         let policy_arch_dir = tempfile::Builder::new()
             .prefix("crumb-recon-policy-arch")
             .tempdir()
@@ -3477,7 +3477,7 @@ mod tests {
         let fx = setup_reconcile(&url).await;
         let config = recon_config();
 
-        let live = crumb_common::db::get_storage_by_name(&fx.pool, "NVMe-Live")
+        let live = crumb_common::db::get_storage_by_name(&fx.pool, "Live")
             .await
             .expect("get live storage")
             .expect("live storage exists");
@@ -3520,7 +3520,7 @@ mod tests {
         let fx = setup_reconcile(&url).await;
         let config = recon_config();
 
-        let live = crumb_common::db::get_storage_by_name(&fx.pool, "NVMe-Live")
+        let live = crumb_common::db::get_storage_by_name(&fx.pool, "Live")
             .await
             .expect("get live storage")
             .expect("live storage exists");
@@ -3581,7 +3581,7 @@ mod tests {
         let fx = setup_reconcile(&url).await;
         let config = recon_config();
 
-        let live = crumb_common::db::get_storage_by_name(&fx.pool, "NVMe-Live")
+        let live = crumb_common::db::get_storage_by_name(&fx.pool, "Live")
             .await
             .expect("get live storage")
             .expect("live storage exists");
@@ -3661,7 +3661,7 @@ mod tests {
         };
         let fx = setup_reconcile(&url).await;
 
-        let live = crumb_common::db::get_storage_by_name(&fx.pool, "NVMe-Live")
+        let live = crumb_common::db::get_storage_by_name(&fx.pool, "Live")
             .await
             .expect("get live storage")
             .expect("live storage exists");
@@ -3751,7 +3751,7 @@ mod tests {
         };
         let fx = setup_reconcile(&url).await;
 
-        let live = crumb_common::db::get_storage_by_name(&fx.pool, "NVMe-Live")
+        let live = crumb_common::db::get_storage_by_name(&fx.pool, "Live")
             .await
             .expect("get live storage")
             .expect("live storage exists");
@@ -3846,7 +3846,7 @@ mod tests {
         let fx = setup_reconcile(&url).await;
         let config = recon_config();
 
-        let live = crumb_common::db::get_storage_by_name(&fx.pool, "NVMe-Live")
+        let live = crumb_common::db::get_storage_by_name(&fx.pool, "Live")
             .await
             .expect("get live storage")
             .expect("live storage exists");


### PR DESCRIPTION
Fixes #556.

Four small release-prep defects. Each was verified against the code before being fixed, and one of the reported items turned out to be partly a false alarm (see "nvdec is valid somewhere" below).

## 1. Bug-report template advertised an invalid `MOTION_HWACCEL` value

`HwAccel::from_str` accepts exactly `cuda | vaapi | cpu | auto`. The template's placeholder said `MOTION_HWACCEL=nvdec`, which parses as unrecognised and silently falls back to the default, so any tester who copied it was describing a configuration that cannot exist.

The placeholder now says `cuda`, and the description names the valid set and the `cpu` default (#513).

**nvdec is valid somewhere, and that was left alone:** `scripts/enable-hwaccel.sh --backend nvdec` is a real script flag that emits `MOTION_HWACCEL: cuda`. README, `docs/AI-INSTALL.md` and the hardware-decode page all reference it in that sense and are correct, so they are untouched.

## 2. Console wizard pointed at navigation that does not exist

The rail has no "Settings" node. It carries nine top-level sections: Cameras, Recording, Storage, Detection & clips, Home Assistant, LPR, Notifications, Users & security, Server.

Every arrow-path string in `admin.html` was checked against `renderTree()`. Corrected:

| where | was | now |
|---|---|---|
| wizard, notifications step | `Settings -> Notifications` | the **Notifications** section of this console |
| wizard, users step | `Settings -> Users & Security` | the **Users & security** section of this console |
| wizard, server step | `Server -> TLS` | the **Server** section (it has no tabs) |
| `SYS_ALERT_META.update_available` | `Settings -> Updates` | `Server -> Update checks` |
| 2 code comments | "Settings pane" | the actual section |

Left alone as correct: `LPR -> Watchlist` (the Watchlist card is inside the LPR section) and the Discord webhook hint's `Settings -> Integrations -> Webhooks`, which describes Discord's own UI, not ours.

Text-only changes inside template literals. No `on*=` handler was added, removed or renamed.

## 3. Code/compose env-default drift

| key | code was | compose / docs | code now |
|---|---|---|---|
| `LIVE_STORAGE_NAME` | `NVMe-Live` | `Live` | `Live` |
| `ARCHIVE_STORAGE_NAME` | `Bulk-Archive` | `Archive` | `Archive` |
| `EXPORT_DIR` | `/data/exports` | `/exports` | `/exports` |

All three confirmed. Compose pins each one, so **no compose install was ever affected**, and `.env.example` plus the environment reference already document the compose values. The code was the drifting side, which is why this is a code-only fix with no doc churn.

`EXPORT_DIR` was the actively-wrong one: the api mounts media storage read-only at `/data`, so `/data/exports` is unwritable by construction.

The three defaults are now named constants (`DEFAULT_LIVE_STORAGE_NAME`, `DEFAULT_ARCHIVE_STORAGE_NAME`, `DEFAULT_EXPORT_DIR`) and each crate has a drift guard that parses `docker-compose.yml` and asserts the `${VAR:-...}` fallback still matches. Both guards were mutation-tested: restore either old value and the test fails with the two values named.

### The storage-name upgrade hazard, and what was decided

Storage rows are looked up and created **by name**, so changing a name default on an **existing non-compose** DB means the next `upsert_storage` INSERTs a second `storages` row pointing at the same directory.

I convinced myself this cannot lose footage:

- existing segments keep their own `storage_id`
- `ensure_default_policy` only backfills `live_storage_id` when it is NULL, so the default policy stays bound to the original row
- the reconcile orphan pass already keys `indexed_paths` on the storage **root path**, not the id, precisely so duplicate rows for one path cannot double-index; the dangling-row breaker (#504) is keyed the same way

so the result is a confusing extra row, not orphaned or deleted footage. But it should not happen silently, so `seed_storages` now detects that exact shape (a row at this path under a different name, and no row carrying the configured name yet) and logs a warning naming both names and the two ways to merge them.

**Rejected: adopting the existing row by renaming it.** `PUT /config/storages/{id}` lets an operator rename a storage deliberately, and a boot-time rename would silently undo that, strictly worse than a loud warning. The detector is a detector only; it never writes.

Reconcile's DB-backed test fixtures seeded rows named to match the config defaults, so those were renamed alongside (`"NVMe-Live"` to `"Live"`, `"Bulk-Archive"` to `"Archive"`). The pure unit tests in `recording.rs` use those strings as arbitrary labels, not defaults, and were left as-is.

## 4. `setup-env.sh` now prepares whatever `DB_BACKUP_HOST_PATH` points at

It hardcoded `${REPO_ROOT}/backups`, so a custom path was written into `.env` but never prepared and the operator hit a root-owned bind mount with backups disabled. It now resolves the path exactly the way `MEDIA_HOST_PATH` is already resolved after #514:

```sh
DB_BACKUP_HOST_PATH=/mnt/nas/crumb-db-backups scripts/setup-env.sh
```

Default behaviour is byte-identical (`./backups`, same chown, same messages). **#514's storage preflight and its exit-code contract are untouched**, this is a separate block further down the script and nothing in the preflight path was modified.

`docs/BACKUP.md` gains the new invocation in the Permissions section and in "Option 1, point DB_BACKUP_HOST_PATH at a NAS/NFS mount".

## Install-guide sync (golden rule 5)

Nothing here changes a fresh install's configuration:

- the code-default realignment makes the code agree with what `.env.example` and the docs already say, so no key, value or doc line changes
- `setup-env.sh` keeps its default output identical; the new behaviour is an opt-in env var, documented in the script header and `docs/BACKUP.md`

`docs/AI-INSTALL.md` and `.env.example` therefore needed no edits and were deliberately not touched.

## Overlap with #544

None, in the end. #544 merged while this was in progress; the branch was rebased onto it and applied with **zero conflicts**. #544 touched `.env.example`, `docs/AI-INSTALL.md`, `docs/COMPOSE.md`, `README.md` and the docs site; this PR touches none of those. `docs/BACKUP.md` was not in #544's file list.

Usefully, #544's rewritten environment reference documents `Live` / `Archive` / `/exports`, independent confirmation that the Rust code, not the docs, was the side that had drifted.

## Test evidence

Full gate on the build box against a throwaway Postgres (removed afterwards, along with the scratch checkout):

- `cargo fmt --all -- --check`, clean
- `cargo clippy --all-targets -- -D warnings`, clean
- `cargo test --workspace`, all green, 0 failed across every target; new tests confirmed by name:
  - `config::tests::compose_storage_name_defaults_match_the_code` (crumb-common)
  - `config::tests::compose_export_dir_default_matches_the_code` (crumb-api)
  - `db::tests::duplicate_path_detector_flags_a_renamed_default`
  - `db::tests::duplicate_path_detector_is_quiet_when_there_is_no_clash`
  - `db::duplicate_path_under_other_name` doctest
- **Mutation test of both drift guards:** restoring `NVMe-Live` fails the common guard, restoring `/data/exports` fails the api guard, each with both values printed.
- `cargo check -p crumb-api`, the `include_str!` embed of the edited `admin.html` builds.
- `node --check` on the extracted inline `<script>` (one block, ~590 KB), OK.
- `.github/ISSUE_TEMPLATE/bug_report.yml` parses under `yaml.safe_load`, and the `gpu` field's attributes were read back and checked.
- `bash -n scripts/setup-env.sh`, OK.
