### PR TITLE
fix(frigate): raise the MQTT packet limit so Frigate motion and detection ingest work at all

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -236,6 +236,10 @@ ONVIF_CONFIG_B64=
 # FRIGATE_API_BASE=http://<frigate-host>:5000
 # FRIGATE_MIN_SCORE=0.3
 # FRIGATE_CATCHUP_HOURS=24
+# Largest single MQTT packet Crumb will accept, in bytes (default 262144 = 256 KiB).
+# Escape hatch only: an event larger than this drops the broker connection, and Frigate
+# motion + detection ingest stop entirely until it is raised. Clamped to 10240..16777216.
+# FRIGATE_MQTT_MAX_PACKET_BYTES=262144
 
 # --- Crumb-native LPR worker (ALL OPTIONAL; opt-in `alpr` compose profile) ---
 # Crumb's own local plate OCR (fast-alpr) — no cloud, no third-party agent. Only

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,10 @@ services:
       HA_BASE_URL: ${HA_BASE_URL:-}
       HA_TOKEN: ${HA_TOKEN:-}
       HA_TOKEN_FILE: ${HA_TOKEN_FILE:-}
+      # Largest single MQTT packet accepted from the Frigate broker (bytes). A
+      # bigger event drops the connection on every reconnect, so Frigate motion
+      # stops entirely; raise only if the logs say so. Clamped 10240..16777216.
+      FRIGATE_MQTT_MAX_PACKET_BYTES: ${FRIGATE_MQTT_MAX_PACKET_BYTES:-262144}
       DB_POOL_SIZE: ${DB_POOL_SIZE:-}                   # sqlx pool size (empty = default 32)
       # Retention low-disk safety floor: eviction keeps at least this much free
       # on the physical disk. Empty = defaults (5% / 50 GiB). (#241)
@@ -165,6 +169,10 @@ services:
       FRIGATE_API_BASE: ${FRIGATE_API_BASE:-}
       FRIGATE_MIN_SCORE: ${FRIGATE_MIN_SCORE:-0.3}
       FRIGATE_CATCHUP_HOURS: ${FRIGATE_CATCHUP_HOURS:-24}
+      # Largest single MQTT packet accepted from the broker (bytes). A bigger
+      # event drops the connection on every reconnect, so detection ingest stops
+      # entirely; raise only if the logs say so. Clamped 10240..16777216.
+      FRIGATE_MQTT_MAX_PACKET_BYTES: ${FRIGATE_MQTT_MAX_PACKET_BYTES:-262144}
       ALERT_WEBHOOK_URL: ${ALERT_WEBHOOK_URL:-}         # Discord/Slack webhook on recorder-heartbeat stall; empty = silent
       UPDATE_CHECK_ENABLED: ${UPDATE_CHECK_ENABLED:-false}   # opt-in (issue #7); false = zero github.com requests
       RUST_LOG: ${RUST_LOG:-info}

--- a/docs-site/docs/configuration/environment-reference.md
+++ b/docs-site/docs/configuration/environment-reference.md
@@ -259,6 +259,7 @@ for the full setup.
 | `FRIGATE_API_BASE` | empty | fallback; the admin console setting overrides it |
 | `FRIGATE_MIN_SCORE` | `0.3` | detection confidence floor |
 | `FRIGATE_CATCHUP_HOURS` | `24` | how far back to backfill on startup |
+| `FRIGATE_MQTT_MAX_PACKET_BYTES` | `262144` (256 KiB) | largest single MQTT packet Crumb will accept. An event bigger than this **drops the broker connection**, and it recurs on every reconnect, so Frigate motion and Frigate detection ingest both stop until the limit is raised. Crumb logs the exact byte count and names this key when it happens. Values are clamped to `10240`–`16777216`; you should not normally need to change it. |
 
 ## Crumb-native LPR worker (optional, `alpr` profile)
 

--- a/docs-site/docs/integrations/frigate.md
+++ b/docs-site/docs/integrations/frigate.md
@@ -220,6 +220,19 @@ disabled: no background task runs, and the events surface simply returns
 empty results. The behavior of pixel motion detection, recording, and
 everything else is completely unaffected either way.
 
+## If nothing arrives and the log mentions an oversized message
+
+MQTT limits how large a single message Crumb will read, and a Frigate event
+larger than that limit drops the broker connection rather than being skipped.
+Because the message is still waiting on the broker, the same thing happens on
+every reconnect: Frigate motion sources and detection ingest both go quiet and
+stay quiet. Crumb says so explicitly, naming the size of the message, the
+current limit, and the setting to change: `FRIGATE_MQTT_MAX_PACKET_BYTES` (see
+the [environment reference](/configuration/environment-reference)). The default
+of 256 KiB is many times larger than a normal Frigate event, so if you hit this,
+raise the limit, restart, and then look at whether something upstream is
+publishing unusually large events.
+
 ## What you're responsible for
 
 If you enable named recognition (identifying specific people or license

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -70,6 +70,71 @@ for "all".
 
 ---
 
+## 2026-08-07, MQTT packet limit: a generous fixed default with an env escape hatch, and oversize payloads treated as a latched condition, not a disconnect
+
+**Context.** rumqttc 0.24 defaults `max_incoming_packet_size` to 10 KiB and
+treats an over-limit incoming packet as a **fatal event-loop error**, not a
+skipped message. Neither MQTT client set the option, so both inherited that
+default. A real `frigate/events` payload measured 11409 bytes on a live install:
+the event loop died, the supervisor reconnected, the still-queued message killed
+it again — Frigate motion and Frigate detection ingest were both 100% dead, in a
+loop, on a v0.2.0 release candidate.
+
+**Decision 1: a fixed 256 KiB default, plus `FRIGATE_MQTT_MAX_PACKET_BYTES`.**
+
+| # | Option | Verdict |
+|---|--------|---------|
+| 1 | Raise the limit to a fixed value, no knob | Rejected: the envelope is Frigate's, not Crumb's — it grows with attributes, plate arrays and tracked-object path data — so "big enough" is not a claim Crumb can make permanently. A payload past the ceiling would again need a rebuild to fix. |
+| 2 | **Fixed 256 KiB default + env override, clamped 10 KiB–16 MiB** | **CHOSEN.** ~23x the observed payload, so nobody should ever touch the knob; the knob exists so that if they must, the log line that reports the failure also names the fix. Clamped at both ends: below rumqttc's own default would re-create this bug, and an unbounded value would remove the only thing stopping a hostile or broken broker from making Crumb buffer without limit. |
+| 3 | A DB-backed setting in the Frigate settings panel | Rejected for now: a migration, a DTO, an admin-console field and a hot-reload path, all for a value whose correct setting is "don't touch it". Config precedence (DB wins over env) exists for settings operators tune; this is an escape hatch. |
+| 4 | No limit at all (`usize::MAX`) | Rejected: the limit is a memory-safety bound on untrusted broker input. |
+
+The value is read at connect time rather than cached at startup, so each
+reconnect re-reads it and a restart is all that is needed to apply a change.
+
+**Decision 2: an oversize payload is a latched, non-transient condition.**
+
+The API ingester's back-off reset on `ConnAck` was correct for a broker outage
+and actively wrong here: the failure happens *after* `ConnAck`, so the delay
+reset to 1s on every cycle — a permanent condition retried once a second,
+forever. Worse, the same `ConnAck` set `healthy = true` and stamped the
+`frigate_heartbeat`, so `frigate_disconnected` never fired and the console
+showed a perfectly healthy integration ingesting nothing. That invisibility is
+why the bug survived to a release candidate.
+
+Rejected: **stop retrying entirely** (a dead provider cannot self-heal when the
+operator raises the limit, and it would need a restart to recover). Rejected:
+**skip the oversized message and continue** (rumqttc gives no such hook at 0.24;
+the framing error is fatal by construction). Chosen instead: latch on the
+oversize error, jump straight to the maximum back-off, withhold health and the
+heartbeat until a publish is actually received, and clear the latch on the first
+successful publish. The recorder side needs no retry change (its supervisor
+already backs off to 30s) but reports the specific cause through the existing
+`note_unhealthy_cause` slot, because a source that is broken from its first
+connection never transitions and so would otherwise show only the generic
+"not delivering frames".
+
+**Trades knowingly accepted:**
+
+- A limit raise still requires a restart (env-only, by decision 1).
+- While latched with a broker that publishes nothing at all, the API reports
+  Frigate disconnected even if the oversize condition has since resolved. Any
+  restart or any received publish clears it; reporting a stuck ingest as an
+  outage is the honest direction to err in.
+- Fail-open recording is untouched: a Motion-mode camera whose Frigate source
+  is dead keeps recording continuously, exactly as before.
+
+**Revisit triggers:**
+
+- Anyone actually needing `FRIGATE_MQTT_MAX_PACKET_BYTES` in the field → the
+  default is wrong; raise it, and reconsider option 3 (a real setting).
+- A rumqttc version that can skip an over-limit packet instead of failing the
+  connection → the latch becomes unnecessary; drop it and just log.
+- A second Crumb subsystem gaining an MQTT client → move the limit off the
+  `FRIGATE_`-prefixed key onto a neutral one, keeping the old key as an alias.
+
+---
+
 ## 2026-08-07, The HA placement PUT stays a whole-object REPLACE, against the `PUT /config/server` merge convention (issue #552)
 
 **Context.** The v0.2.0 release-prep API audit flagged `PUT

--- a/services/api/src/detection/frigate.rs
+++ b/services/api/src/detection/frigate.rs
@@ -27,6 +27,17 @@
 //! exponential back-off (1s → 30s, reset on a successful `ConnAck`) in the
 //! disconnect/error arm, raced against the stop signal so shutdown stays prompt.
 //!
+//! One failure is deliberately *not* treated as a transient disconnect: a
+//! `frigate/events` payload larger than the configured incoming packet limit
+//! (see [`crumb_common::mqtt`]). rumqttc fails the whole event loop on it, and
+//! the offending message is still queued/retained, so it recurs on every
+//! reconnect — a permanent condition with a one-line fix, not a flaky broker.
+//! It therefore latches: the connection goes straight to the longest back-off,
+//! `healthy` stays false and the connectivity heartbeat is withheld (so
+//! `frigate_disconnected` reports the outage instead of the `ConnAck` masking it),
+//! and the log names the byte counts and the env knob. Receiving any publish
+//! clears the latch.
+//!
 //! # HTTP backfill
 //!
 //! On startup (before entering the MQTT loop) the provider fetches
@@ -49,7 +60,7 @@ use deadpool_postgres::Pool;
 use rumqttc::{AsyncClient, Event, MqttOptions, Packet, QoS};
 use serde::Deserialize;
 use tokio::sync::mpsc;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crumb_common::db::load_camera_name_map;
@@ -363,25 +374,22 @@ impl DetectionSource for FrigateProvider {
         // rumqttc expects host/port separately.
         let endpoint = parse_mqtt_url(&self.cfg.mqtt_url)?;
 
-        let mut mqttoptions = MqttOptions::new(
+        // Broker authentication (optional). A broker Frigate publishes to may
+        // require credentials; an anonymous broker leaves these unset. The
+        // explicit `mqtt_user`/`mqtt_password` config fields win; otherwise fall
+        // back to credentials embedded in the URL (`mqtt://user:pass@host`).
+        let mqtt_user = self.cfg.mqtt_user.clone().or(endpoint.username);
+        let mqtt_password = self.cfg.mqtt_password.clone().or(endpoint.password);
+
+        let max_packet = crumb_common::mqtt::max_packet_bytes();
+        let mqttoptions = build_mqtt_options(
             format!("crumb-api-{}", uuid::Uuid::new_v4()),
             &endpoint.host,
             endpoint.port,
+            mqtt_user,
+            mqtt_password,
+            max_packet,
         );
-        mqttoptions.set_keep_alive(Duration::from_secs(30));
-        mqttoptions.set_clean_session(true);
-        // Allow internal reconnection queue depth.
-        mqttoptions.set_inflight(100);
-        // Broker authentication (optional). The homelab broker Frigate already
-        // publishes to requires credentials; an anonymous broker leaves these
-        // unset. The explicit `mqtt_user`/`mqtt_password` config fields win;
-        // otherwise fall back to credentials embedded in the URL
-        // (`mqtt://user:pass@host`).
-        let mqtt_user = self.cfg.mqtt_user.clone().or(endpoint.username);
-        let mqtt_password = self.cfg.mqtt_password.clone().or(endpoint.password);
-        if let Some(user) = mqtt_user {
-            mqttoptions.set_credentials(user, mqtt_password.unwrap_or_default());
-        }
 
         let (client, mut event_loop) = AsyncClient::new(mqttoptions, 512);
 
@@ -412,6 +420,17 @@ impl DetectionSource for FrigateProvider {
         let hb_pool = self.pool.clone();
         let mut last_hb: Option<std::time::Instant> = None;
 
+        // Latched "the broker is sending packets we refuse to read". Set by the
+        // oversize-payload arm, cleared only by a Publish we actually managed to
+        // receive. It exists because that failure happens AFTER `ConnAck`, which
+        // made the two bookkeeping rails below lie:
+        //   * the back-off reset on ConnAck turned a permanent condition into a
+        //     ~1s reconnect loop hammering the broker forever, and
+        //   * `healthy` + the heartbeat were stamped on that same ConnAck, so
+        //     `frigate_disconnected` never fired and the console showed a
+        //     perfectly healthy integration that was ingesting nothing.
+        let mut oversize_latched = false;
+
         // Drive the event loop.
         loop {
             tokio::select! {
@@ -430,7 +449,17 @@ impl DetectionSource for FrigateProvider {
                     // — so frigate_disconnected doesn't false-fire during a
                     // connected-but-quiet period. On an Err (disconnect) we skip,
                     // letting the heartbeat go stale so the watchdog sees the outage.
+                    // While `oversize_latched`, a ConnAck/PingResp proves only
+                    // that the socket works, not that events can be ingested —
+                    // stamping a heartbeat on it would keep the watchdog quiet
+                    // through a total ingest outage. Withhold it so
+                    // `frigate_disconnected` fires, which is the truth.
+                    let oversize_bytes = notification
+                        .as_ref()
+                        .err()
+                        .and_then(oversize_payload_bytes);
                     if notification.is_ok()
+                        && !oversize_latched
                         && last_hb.is_none_or(|t| t.elapsed() >= HEARTBEAT_INTERVAL)
                     {
                         if let Err(e) = crumb_common::db::write_frigate_heartbeat(&hb_pool).await {
@@ -441,13 +470,28 @@ impl DetectionSource for FrigateProvider {
                     match notification {
                         Ok(Event::Incoming(Packet::ConnAck(_))) => {
                             info!("FrigateProvider: MQTT connected, subscribing to {}", topic_clone);
-                            healthy_clone.store(true, Ordering::Relaxed);
-                            reconnect_delay = Duration::from_secs(1); // connected → reset back-off
+                            // Connecting is not the same as ingesting: while the
+                            // oversize condition is latched the link comes up and
+                            // dies again on the first event, so neither the health
+                            // flag nor the back-off may be reset by it.
+                            healthy_clone.store(!oversize_latched, Ordering::Relaxed);
+                            if !oversize_latched {
+                                reconnect_delay = Duration::from_secs(1); // connected → reset back-off
+                            }
                             if let Err(e) = client.subscribe(&topic_clone, QoS::AtLeastOnce).await {
                                 warn!(error = %e, "FrigateProvider: subscribe failed");
                             }
                         }
                         Ok(Event::Incoming(Packet::Publish(publish))) => {
+                            // A message we actually received: whatever was too big
+                            // is gone (or the limit was raised), so un-latch and
+                            // let health/heartbeat/back-off behave normally again.
+                            if oversize_latched {
+                                info!("FrigateProvider: oversized-payload condition cleared, ingest resumed");
+                                oversize_latched = false;
+                                healthy_clone.store(true, Ordering::Relaxed);
+                                reconnect_delay = Duration::from_secs(1);
+                            }
                             // Read the maps under scoped guards so they're
                             // dropped before the `.await` below (RwLock guard
                             // is !Send).
@@ -478,6 +522,18 @@ impl DetectionSource for FrigateProvider {
                         }
                         Ok(Event::Incoming(Packet::Disconnect)) | Err(_) => {
                             healthy_clone.store(false, Ordering::Relaxed);
+                            if let Some(bytes) = oversize_bytes {
+                                // Distinct from a broker outage, and permanent
+                                // until an operator acts: go straight to the
+                                // longest back-off instead of retrying every
+                                // second forever, and say exactly what to do.
+                                oversize_latched = true;
+                                reconnect_delay = MAX_RECONNECT_DELAY;
+                                error!(
+                                    "FrigateProvider: {}",
+                                    crumb_common::mqtt::oversize_payload_message(bytes, max_packet)
+                                );
+                            }
                             // rumqttc 0.24 retries with NO delay, so without this
                             // back-off an unreachable broker hot-spins the loop and
                             // steals CPU from the co-located recorder. Wait (capped,
@@ -1301,11 +1357,104 @@ fn parse_mqtt_url(url: &str) -> Result<MqttEndpoint> {
     })
 }
 
+// ── MQTT client options ───────────────────────────────────────────────────────
+
+/// Build the rumqttc options for the detection ingester's broker connection.
+///
+/// Split out of [`FrigateProvider::start`] so the packet-size limit is
+/// assertable without a broker: rumqttc 0.24 caps incoming packets at 10 KiB by
+/// default and treats an over-limit packet as a **fatal event-loop error**, so a
+/// Frigate whose `frigate/events` payloads are larger than that could never be
+/// ingested at all (see `crumb_common::mqtt::DEFAULT_MAX_PACKET_BYTES`).
+fn build_mqtt_options(
+    client_id: String,
+    host: &str,
+    port: u16,
+    username: Option<String>,
+    password: Option<String>,
+    max_packet: usize,
+) -> MqttOptions {
+    let mut opts = MqttOptions::new(client_id, host, port);
+    opts.set_keep_alive(Duration::from_secs(30));
+    opts.set_clean_session(true);
+    // Allow internal reconnection queue depth.
+    opts.set_inflight(100);
+    // Outgoing is raised to the same value for symmetry; the ingester only sends
+    // CONNECT/SUBSCRIBE/PINGREQ, so nothing depends on it today.
+    opts.set_max_packet_size(max_packet, max_packet);
+    if let Some(user) = username {
+        opts.set_credentials(user, password.unwrap_or_default());
+    }
+    opts
+}
+
+/// `Some(payload_bytes)` when a rumqttc connection error is really "the broker
+/// sent a packet bigger than our incoming limit".
+///
+/// Matched structurally rather than by string so a rumqttc bump that reworded
+/// the `Display` impl fails to compile instead of silently folding this back
+/// into the generic "disconnected/unreachable" it was indistinguishable from.
+fn oversize_payload_bytes(e: &rumqttc::ConnectionError) -> Option<usize> {
+    match e {
+        rumqttc::ConnectionError::MqttState(rumqttc::StateError::Deserialization(
+            rumqttc::mqttbytes::Error::PayloadSizeLimitExceeded(bytes),
+        )) => Some(*bytes),
+        _ => None,
+    }
+}
+
 // ── unit tests ────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mqtt_options_apply_the_configured_packet_limit() {
+        // Guard the premise: rumqttc's stock incoming limit is smaller than a
+        // real frigate/events payload (11409 bytes, measured), and an over-limit
+        // packet kills the event loop rather than being skipped.
+        let stock = MqttOptions::new("probe", "192.0.2.10", 1883);
+        assert_eq!(stock.max_packet_size(), 10 * 1024, "rumqttc default moved");
+
+        let opts = build_mqtt_options(
+            "crumb-api-test".to_owned(),
+            "192.0.2.10",
+            1883,
+            Some("frigate".to_owned()),
+            Some("secret".to_owned()),
+            crumb_common::mqtt::DEFAULT_MAX_PACKET_BYTES,
+        );
+        assert_eq!(
+            opts.max_packet_size(),
+            crumb_common::mqtt::DEFAULT_MAX_PACKET_BYTES
+        );
+        assert!(
+            opts.max_packet_size() > 11409,
+            "the observed payload must fit"
+        );
+        assert_eq!(opts.keep_alive(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn oversize_payload_is_classified_apart_from_a_broker_outage() {
+        use rumqttc::{ConnectionError, StateError};
+
+        let oversize = ConnectionError::MqttState(StateError::Deserialization(
+            rumqttc::mqttbytes::Error::PayloadSizeLimitExceeded(11409),
+        ));
+        assert_eq!(oversize_payload_bytes(&oversize), Some(11409));
+
+        // These are the "broker is down" cases the oversize error used to be
+        // reported as; they must keep the generic back-off path.
+        for other in [
+            ConnectionError::NetworkTimeout,
+            ConnectionError::MqttState(StateError::AwaitPingResp),
+            ConnectionError::Io(std::io::Error::from(std::io::ErrorKind::ConnectionRefused)),
+        ] {
+            assert_eq!(oversize_payload_bytes(&other), None, "{other}");
+        }
+    }
 
     #[test]
     fn ts_from_f64_round_trip() {

--- a/services/common/src/mqtt.rs
+++ b/services/common/src/mqtt.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! Shared MQTT URL guards.
+//! Shared MQTT guards and limits.
 //!
 //! Crumb's MQTT clients (the API's Frigate detection ingester and the
 //! recorder's Frigate-as-motion-source loop) both build a **plaintext** rumqttc
@@ -52,6 +52,94 @@ pub fn check_plaintext_scheme(url: &str) -> Result<(), &'static str> {
     Ok(())
 }
 
+// ── incoming packet-size limit ────────────────────────────────────────────────
+
+/// Env override for the MQTT packet-size limit, in bytes. Escape hatch only —
+/// [`DEFAULT_MAX_PACKET_BYTES`] is meant to be large enough that nobody needs
+/// this, but a payload that outgrows even that must be fixable without a
+/// rebuild. Named in every oversize-payload log line so the message is
+/// self-service.
+pub const MAX_PACKET_ENV: &str = "FRIGATE_MQTT_MAX_PACKET_BYTES";
+
+/// Crumb's incoming/outgoing MQTT packet-size limit, in bytes (256 KiB).
+///
+/// rumqttc 0.24 defaults **both** limits to 10 KiB (`10 * 1024`, see
+/// `MqttOptions::default`), and a single incoming packet over that limit is not
+/// skipped — it fails the whole event loop with
+/// `StateError::Deserialization(PayloadSizeLimitExceeded)`, which tears the
+/// connection down. Because the offending message is still queued (or retained)
+/// on the broker, every reconnect hits it again: an infinite
+/// connect → oversize → disconnect loop in which no Frigate event is ever
+/// ingested (issue: Frigate MQTT payloads exceed the default limit).
+///
+/// A real `frigate/events` payload measured **11409 bytes** — barely over the
+/// default — and that envelope is not bounded by anything Crumb controls: it
+/// carries `before` *and* `after` full object state, per-object attribute lists,
+/// recognized-plate arrays, and (on newer Frigate) tracked-object path data, all
+/// of which grow with the number of detected attributes. 256 KiB is ~23x the
+/// observed payload, leaves headroom for Frigate versions that add fields, and
+/// still bounds a single connection's read buffer to something trivial next to
+/// the recorder's frame buffers. It is a ceiling, not an allocation: rumqttc
+/// only ever buffers what the broker actually sends.
+pub const DEFAULT_MAX_PACKET_BYTES: usize = 256 * 1024;
+
+/// Floor for [`MAX_PACKET_ENV`]: rumqttc's own default. Refusing to go below it
+/// means a fat-fingered override can never make the situation *worse* than the
+/// stock library behaviour this fix exists to correct.
+pub const MIN_MAX_PACKET_BYTES: usize = 10 * 1024;
+
+/// Ceiling for [`MAX_PACKET_ENV`] (16 MiB): the limit is what stops a hostile or
+/// broken broker from making Crumb buffer without bound, so the escape hatch
+/// must not be able to remove the bound entirely. Also the MQTT 3.1.1 maximum
+/// packet size is 256 MiB, so this stays comfortably inside the protocol.
+pub const MAX_MAX_PACKET_BYTES: usize = 16 * 1024 * 1024;
+
+/// Resolve the packet-size limit from a raw env value.
+///
+/// Split from [`max_packet_bytes`] so the parsing/clamping rules are unit
+/// testable without mutating process environment. Anything unparseable, zero, or
+/// out of range falls back to (or is clamped into) the supported window rather
+/// than failing the connection: an operator typo must not take Frigate ingest
+/// down, which is the exact failure mode being fixed here.
+#[must_use]
+pub fn resolve_max_packet_bytes(raw: Option<&str>) -> usize {
+    raw.map(str::trim)
+        .filter(|v| !v.is_empty())
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|v| *v > 0)
+        .map_or(DEFAULT_MAX_PACKET_BYTES, |v| {
+            v.clamp(MIN_MAX_PACKET_BYTES, MAX_MAX_PACKET_BYTES)
+        })
+}
+
+/// The packet-size limit both MQTT clients apply, honouring [`MAX_PACKET_ENV`].
+///
+/// Read at connect time (not once at startup) so a restart is the only thing
+/// needed to pick up a changed value, and so each reconnect re-reads it.
+#[must_use]
+pub fn max_packet_bytes() -> usize {
+    resolve_max_packet_bytes(std::env::var(MAX_PACKET_ENV).ok().as_deref())
+}
+
+/// The one operator-facing sentence for "a broker message was bigger than our
+/// limit", shared by the API ingester and the recorder motion source so both
+/// say the same diagnosable thing.
+///
+/// Deliberately spells out the consequence (nothing is ingested / the loop
+/// restarts forever) and names the knob: the failure this replaces was a raw
+/// rumqttc string on one side and a generic "disconnected/unreachable" on the
+/// other, indistinguishable from the broker simply being down.
+#[must_use]
+pub fn oversize_payload_message(payload_bytes: usize, limit_bytes: usize) -> String {
+    format!(
+        "a Frigate MQTT message of {payload_bytes} bytes exceeded Crumb's incoming MQTT packet \
+         limit of {limit_bytes} bytes, so the broker connection was dropped. This repeats on \
+         every reconnect while the oversized message is queued or retained, and NO Frigate \
+         events are processed meanwhile. Raise the limit by setting {MAX_PACKET_ENV} (bytes, \
+         max {MAX_MAX_PACKET_BYTES}) and restarting Crumb."
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -97,5 +185,57 @@ mod tests {
         // The operator has to be able to act on this without reading the source.
         assert!(MQTT_TLS_UNSUPPORTED.contains("mqtts://"));
         assert!(MQTT_TLS_UNSUPPORTED.contains("mqtt://"));
+    }
+
+    #[test]
+    fn default_limit_clears_a_real_frigate_payload() {
+        // The payload measured on the live instance that triggered this fix, and
+        // rumqttc 0.24's own default that failed on it.
+        const OBSERVED: usize = 11409;
+        const RUMQTTC_DEFAULT: usize = 10 * 1024;
+        const { assert!(OBSERVED > RUMQTTC_DEFAULT, "the bug premise") };
+        const { assert!(DEFAULT_MAX_PACKET_BYTES > OBSERVED * 20) };
+    }
+
+    #[test]
+    fn unset_or_junk_falls_back_to_the_default() {
+        for raw in [
+            None,
+            Some(""),
+            Some("   "),
+            Some("lots"),
+            Some("-1"),
+            Some("0"),
+        ] {
+            assert_eq!(
+                resolve_max_packet_bytes(raw),
+                DEFAULT_MAX_PACKET_BYTES,
+                "expected {raw:?} to fall back"
+            );
+        }
+    }
+
+    #[test]
+    fn override_is_honoured_and_clamped() {
+        assert_eq!(resolve_max_packet_bytes(Some("524288")), 524_288);
+        assert_eq!(resolve_max_packet_bytes(Some(" 524288 ")), 524_288);
+        // Below rumqttc's own default → clamped up, never worse than stock.
+        assert_eq!(resolve_max_packet_bytes(Some("1")), MIN_MAX_PACKET_BYTES);
+        // Absurdly large → clamped down; the bound must stay a bound.
+        assert_eq!(
+            resolve_max_packet_bytes(Some("999999999999")),
+            MAX_MAX_PACKET_BYTES
+        );
+    }
+
+    #[test]
+    fn oversize_message_names_the_sizes_and_the_knob() {
+        let msg = oversize_payload_message(11409, DEFAULT_MAX_PACKET_BYTES);
+        assert!(msg.contains("11409"), "{msg}");
+        assert!(msg.contains("262144"), "{msg}");
+        assert!(msg.contains(MAX_PACKET_ENV), "{msg}");
+        // The consequence must be spelled out — the whole point is that this is
+        // NOT confusable with a broker being down.
+        assert!(msg.contains("NO Frigate"), "{msg}");
     }
 }

--- a/services/recorder/src/frigate_motion.rs
+++ b/services/recorder/src/frigate_motion.rs
@@ -37,7 +37,7 @@ use deadpool_postgres::Pool;
 use rumqttc::{AsyncClient, Event, MqttOptions, Packet, QoS, SubscribeReasonCode};
 use serde::Deserialize;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use crumb_common::{types::Camera, MotionSignal};
@@ -380,13 +380,14 @@ pub async fn run_frigate_motion_loop(
     let topic = format!("{}/events", cfg.mqtt_prefix);
     let (host, port) = parse_mqtt_url(&cfg.mqtt_url)?;
 
-    let mut opts = MqttOptions::new(format!("crumb-recorder-mot-{}", camera.id), &host, port);
-    opts.set_keep_alive(Duration::from_secs(30));
-    opts.set_clean_session(true);
-    opts.set_inflight(100);
-    if let Some(user) = &cfg.mqtt_user {
-        opts.set_credentials(user, cfg.mqtt_password.clone().unwrap_or_default());
-    }
+    let max_packet = crumb_common::mqtt::max_packet_bytes();
+    let opts = build_mqtt_options(
+        format!("crumb-recorder-mot-{}", camera.id),
+        &host,
+        port,
+        cfg,
+        max_packet,
+    );
     let (client, mut event_loop) = AsyncClient::new(opts, 256);
 
     let mut tracker = CameraTracker::default();
@@ -418,6 +419,13 @@ pub async fn run_frigate_motion_loop(
     let cam_id = camera.id;
     let (ev_tx, mut ev_rx) = tokio::sync::mpsc::channel::<Event>(256);
     let poll_cancel = cancel.clone();
+    // The poll task's exit reason, handed back to the main loop (which only sees
+    // "channel closed"). Set BEFORE the sender is dropped, so a `recv() == None`
+    // always observes a fully-written slot. Used to turn the oversize-payload
+    // case — otherwise a raw rumqttc string in the log and a generic error out —
+    // into one actionable message.
+    let exit_reason: std::sync::Arc<std::sync::OnceLock<String>> = std::sync::Arc::default();
+    let poll_reason = std::sync::Arc::clone(&exit_reason);
     let poll_task = tokio::spawn(async move {
         loop {
             tokio::select! {
@@ -432,7 +440,16 @@ pub async fn run_frigate_motion_loop(
                     Err(e) => {
                         // Connection lost / keepalive failed: drop the sender so the
                         // main loop sees the disconnect and fails the camera OPEN.
-                        warn!(camera_id = %cam_id, error = %e, "frigate motion: MQTT connection error");
+                        if let Some(bytes) = oversize_payload_bytes(&e) {
+                            // NOT a flaky broker: a permanent condition that will
+                            // repeat on every reconnect until the limit is raised.
+                            // Say so, with the knob, at ERROR.
+                            let msg = crumb_common::mqtt::oversize_payload_message(bytes, max_packet);
+                            error!(camera_id = %cam_id, "frigate motion: {msg}");
+                            let _ = poll_reason.set(msg);
+                        } else {
+                            warn!(camera_id = %cam_id, error = %e, "frigate motion: MQTT connection error");
+                        }
                         break;
                     }
                 }
@@ -517,6 +534,16 @@ pub async fn run_frigate_motion_loop(
                         // Poll task ended: a connection error (or shutdown). Treat as
                         // a lost connection → `Err` so the supervisor backs off and
                         // fails the camera OPEN.
+                        if let Some(msg) = exit_reason.get() {
+                            // A cause specific enough to act on (today: oversize
+                            // payload). Park it on the alert gate as well as the
+                            // error: the source went unhealthy at "frigate
+                            // connecting" and never transitions again, so without
+                            // this the console would only ever show the generic
+                            // reason for a failure that has a precise fix.
+                            alert_gate.note_unhealthy_cause(msg);
+                            break Err(anyhow!("frigate motion MQTT connection lost: {msg}"));
+                        }
                         break Err(anyhow!("frigate motion MQTT connection lost"));
                     }
                 }
@@ -532,6 +559,49 @@ pub async fn run_frigate_motion_loop(
         emit(motion_tx, camera.id, t);
     }
     result
+}
+
+/// Build the rumqttc options for one camera's Frigate motion subscription.
+///
+/// Split out of [`run_frigate_motion_loop`] purely so the packet-size limit —
+/// the thing this file got wrong, silently, for every Frigate deployment whose
+/// events exceed 10 KiB — is assertable in a unit test with no broker.
+fn build_mqtt_options(
+    client_id: String,
+    host: &str,
+    port: u16,
+    cfg: &FrigateMotionConfig,
+    max_packet: usize,
+) -> MqttOptions {
+    let mut opts = MqttOptions::new(client_id, host, port);
+    opts.set_keep_alive(Duration::from_secs(30));
+    opts.set_clean_session(true);
+    opts.set_inflight(100);
+    // rumqttc 0.24 caps BOTH directions at 10 KiB by default and treats an
+    // over-limit incoming packet as a fatal event-loop error, not a skipped
+    // message — see `crumb_common::mqtt::DEFAULT_MAX_PACKET_BYTES`. Outgoing is
+    // raised to the same value for symmetry; the recorder only ever sends
+    // CONNECT/SUBSCRIBE/PINGREQ, so nothing depends on it today.
+    opts.set_max_packet_size(max_packet, max_packet);
+    if let Some(user) = &cfg.mqtt_user {
+        opts.set_credentials(user, cfg.mqtt_password.clone().unwrap_or_default());
+    }
+    opts
+}
+
+/// `Some(payload_bytes)` when a rumqttc connection error is really "the broker
+/// sent a packet bigger than our incoming limit".
+///
+/// Matched structurally rather than by string so a rumqttc bump that reworded
+/// the `Display` impl fails to compile instead of silently reverting the
+/// operator-facing message to the raw library text.
+fn oversize_payload_bytes(e: &rumqttc::ConnectionError) -> Option<usize> {
+    match e {
+        rumqttc::ConnectionError::MqttState(rumqttc::StateError::Deserialization(
+            rumqttc::mqttbytes::Error::PayloadSizeLimitExceeded(bytes),
+        )) => Some(*bytes),
+        _ => None,
+    }
 }
 
 /// Whether a broker `SubAck` actually GRANTED the subscription. Any `Failure`
@@ -584,6 +654,72 @@ mod tests {
         })
         .to_string()
         .into_bytes()
+    }
+
+    fn test_cfg() -> FrigateMotionConfig {
+        FrigateMotionConfig {
+            mqtt_url: "mqtt://192.0.2.10:1883".to_owned(),
+            mqtt_prefix: "frigate".to_owned(),
+            mqtt_user: None,
+            mqtt_password: None,
+            min_score: 0.3,
+        }
+    }
+
+    #[test]
+    fn mqtt_options_apply_the_configured_packet_limit() {
+        // The regression this file exists to prevent: rumqttc 0.24 defaults the
+        // incoming limit to 10 KiB, which a real frigate/events payload
+        // (11409 bytes, observed) exceeds — killing the event loop forever.
+        let stock = MqttOptions::new("probe", "192.0.2.10", 1883);
+        assert_eq!(stock.max_packet_size(), 10 * 1024, "rumqttc default moved");
+
+        let opts = build_mqtt_options(
+            "crumb-recorder-mot-test".to_owned(),
+            "192.0.2.10",
+            1883,
+            &test_cfg(),
+            crumb_common::mqtt::DEFAULT_MAX_PACKET_BYTES,
+        );
+        assert_eq!(
+            opts.max_packet_size(),
+            crumb_common::mqtt::DEFAULT_MAX_PACKET_BYTES
+        );
+        assert!(
+            opts.max_packet_size() > 11409,
+            "the observed payload must fit"
+        );
+        // The rest of the connection contract is unchanged.
+        assert_eq!(opts.keep_alive(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn oversize_payload_is_classified_apart_from_other_failures() {
+        use rumqttc::{ConnectionError, StateError};
+
+        let oversize = ConnectionError::MqttState(StateError::Deserialization(
+            rumqttc::mqttbytes::Error::PayloadSizeLimitExceeded(11409),
+        ));
+        assert_eq!(oversize_payload_bytes(&oversize), Some(11409));
+
+        // A plain broker outage must NOT be reported as an oversize payload.
+        for other in [
+            ConnectionError::NetworkTimeout,
+            ConnectionError::MqttState(StateError::AwaitPingResp),
+            ConnectionError::Io(std::io::Error::from(std::io::ErrorKind::ConnectionRefused)),
+        ] {
+            assert_eq!(oversize_payload_bytes(&other), None, "{other}");
+        }
+    }
+
+    #[test]
+    fn oversize_message_is_actionable() {
+        let msg = crumb_common::mqtt::oversize_payload_message(
+            11409,
+            crumb_common::mqtt::DEFAULT_MAX_PACKET_BYTES,
+        );
+        assert!(msg.contains("11409"), "{msg}");
+        assert!(msg.contains(crumb_common::mqtt::MAX_PACKET_ENV), "{msg}");
     }
 
     #[test]

--- a/services/recorder/src/motion.rs
+++ b/services/recorder/src/motion.rs
@@ -1230,10 +1230,13 @@ impl UnhealthyAlertGate {
     /// (health starts `false`), so the only cause the aggregator would otherwise
     /// have is its generic "not delivering frames". Issue #479's cuda-on-a-
     /// deviceless-host is exactly that shape: the operator-actionable cause is
-    /// learned several seconds in, from ffmpeg's stderr. Telemetry only — same
+    /// learned several seconds in, from ffmpeg's stderr, and so is the Frigate
+    /// source's oversize-MQTT-payload case (the loop reports "frigate
+    /// connecting" ⇒ unhealthy before it can possibly know why it will fail).
+    /// Telemetry only — same
     /// slot, same rules as [`Self::set_unhealthy_reason`]; the fail-open watch
     /// channel is untouched.
-    fn note_unhealthy_cause(&self, reason: &str) {
+    pub(crate) fn note_unhealthy_cause(&self, reason: &str) {
         self.set_unhealthy_reason(reason);
     }
 


### PR DESCRIPTION
Fixes #558

## Impact (release-blocking)

Against a Frigate whose `frigate/events` payloads exceed 10 KiB, **Frigate motion and Frigate detection ingest are both completely non-functional**, and no configuration can fix it. Both MQTT clients inherited rumqttc 0.24's default `max_incoming_packet_size` of `10 * 1024`; rumqttc treats an over-limit incoming packet as a fatal event-loop error rather than a skipped message, and the offending message is still queued or retained on the broker, so it recurs on every reconnect. A payload measured on a live install was **11409 bytes**.

Recording is unaffected: a Motion-mode camera whose Frigate source is dead fails open and records continuously, exactly as before. That behavior is deliberately untouched here.

## Root cause, verified

Read against the pinned `rumqttc 0.24.0` source, not assumed:

- `MqttOptions::default` sets `max_incoming_packet_size: 10 * 1024` and `max_outgoing_packet_size: 10 * 1024`.
- The setter is `set_max_packet_size(incoming, outgoing)`, in that order.
- The error path is `ConnectionError::MqttState(StateError::Deserialization(mqttbytes::Error::PayloadSizeLimitExceeded(n)))`, which matches the recorder's log text verbatim.

The API side was confirmed to be the same root cause, not assumed: its `Err(_)` arm discards the error entirely and logs a generic "MQTT disconnected/unreachable", which is why it looked like a broker outage.

## Changes

**1. Set the limit on both clients — 256 KiB, with an escape hatch.**

`crumb_common::mqtt` gains the shared limit, the env override `FRIGATE_MQTT_MAX_PACKET_BYTES` (clamped `10240`–`16777216`), and the one operator-facing message both services use.

256 KiB is ~23x the observed payload. The event envelope is Frigate's, not Crumb's, and grows with detection attributes, plate arrays and tracked-object path data, so headroom matters; it is still a trivially small per-connection ceiling, and it is a ceiling, not an allocation. The floor of the clamp is rumqttc's own default, so a fat-fingered override can never re-create this bug; the ceiling keeps the limit doing its actual job of bounding untrusted broker input. Both directions are set for symmetry (neither service publishes today).

**2. Make the failure legible.**

The recorder previously surfaced the raw rumqttc string; the API surfaced nothing at all. Both now log the payload size, the current limit, the consequence ("NO Frigate events are processed"), and the env key to raise. The classification matches the error structurally, so a rumqttc bump that rewords its `Display` impl fails to compile rather than silently reverting to the old text.

**3. Treat an oversize payload as a latched condition, not a transient disconnect.**

This was a second, independent defect on the API side. The error arrives *after* `ConnAck`, so:

- the back-off reset on `ConnAck` turned a permanent condition into a roughly once-per-second reconnect loop against the broker, forever, and
- that same `ConnAck` set `healthy = true` and stamped `frigate_heartbeat`, so `frigate_disconnected` never fired and the console showed a healthy integration ingesting nothing — the reason this bug was invisible.

The oversize error now latches: straight to the maximum back-off, `healthy` stays false, and the heartbeat is withheld so `frigate_disconnected` reports the outage honestly. The latch clears on the first publish actually received, so raising the limit self-heals without a code change. Retrying is deliberately **not** abandoned — a provider that gives up cannot recover when the operator fixes the limit.

The recorder needs no retry change (its supervisor already backs off to 30s), but it now reports the specific cause through the existing `note_unhealthy_cause` slot, so the console shows the actionable reason. Without that it would show only the generic fallback: a source broken from its first connection never transitions, so `report_health` has no transition to hang the cause on.

## Tests

New, all passing, none require a broker:

- `crumb_common::mqtt` — the default clears the observed 11409-byte payload with room to spare; unset/blank/junk/zero/negative all fall back to the default; a valid override is honoured and out-of-range values clamp at both ends; the operator message names both byte counts and the env key.
- `crumb-recorder` and `crumb-api` — `build_mqtt_options` actually applies the configured limit (with a guard assertion pinning rumqttc's 10 KiB default, so a dependency bump that changes it is caught), and the oversize error is classified apart from `NetworkTimeout`, `AwaitPingResp` and a refused connection, i.e. the "broker is down" cases it used to be indistinguishable from.

## Gate

Run on the build box against a throwaway Postgres:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --workspace` — all green (16 suites, 0 failed)
- `docker compose config` on a real Docker host — valid, and both the `api` and `recorder` services receive `FRIGATE_MQTT_MAX_PACKET_BYTES: "262144"`

## Docs and config surface (golden rules 5, 7, 8)

- `.env.example` and both `docker-compose.yml` environment blocks (the key is inert in Docker unless it is passed to the containers).
- `docs-site/docs/configuration/environment-reference.md`, plus a troubleshooting section on the Frigate integration page pointing at it.
- `docs/DECISIONS.md` entry covering the fixed-default-plus-escape-hatch choice (against a DB-backed setting, a no-knob constant, and no limit at all) and the latch semantics (against giving up entirely, and against skipping the message, which rumqttc 0.24 offers no hook for), with revisit triggers.

Deliberately not done: no DB-backed setting, no admin-console field, and no `scripts/setup-env.sh` entry. The correct value for this knob is "don't touch it"; it exists so the error message can name a fix, not as something operators tune. `docs/AI-INSTALL.md` needed no change — it does not cover Frigate configuration.
