### PR TITLE
fix(desktop): keep a maximized live camera maximized across minimize/restore

### DIFF
--- a/apps/desktop-flutter/lib/main.dart
+++ b/apps/desktop-flutter/lib/main.dart
@@ -597,6 +597,16 @@ class _MainShellState extends State<MainShell> with WindowListener {
   /// Playback so switching tabs keeps the same full-pane camera.
   String? _liveMaximizedId;
 
+  /// One-shot: the live-wall camera to re-maximize on the NEXT WallScreen build,
+  /// set in [_clearMinimized] when we un-minimize while the Live tab was showing
+  /// a maximized pane. The minimize placeholder swap tears the wall down and
+  /// restore rebuilds it with fresh players (#91), which otherwise dropped the
+  /// maximize back to the grid (the reported bug). Cleared right after the build
+  /// that consumes it, so an ordinary rebuild (Settings panel, config refresh)
+  /// or a later Live↔Playback tab switch does NOT spuriously re-maximize — the
+  /// re-open is scoped to the minimize→restore recovery alone.
+  String? _restoreLiveMaximizedId;
+
   /// Set from Clips' "View on timeline": open Playback scoped to this single
   /// camera (maximized), not the multi-window view. Cleared on manual tab nav.
   String? _playbackFocusCameraId;
@@ -743,7 +753,29 @@ class _MainShellState extends State<MainShell> with WindowListener {
   /// no-op unless we were actually showing the placeholder.
   void _clearMinimized() {
     if (!mounted || !_minimized) return;
-    setState(() => _minimized = false);
+    // If we were minimized while the Live tab had a maximized pane, carry that
+    // camera across the placeholder swap so the freshly-rebuilt wall re-opens on
+    // it instead of dropping to the grid. Scoped to the Live tab: Playback
+    // carries its own maximize via `initialMaximizedCameraId` already, and a
+    // stale `_liveMaximizedId` must not leak onto any other screen. The first
+    // "we're visible again" event wins — onWindowRestore, onWindowMaximize, or
+    // onWindowUnmaximize (which one fires depends on the pre-minimize window
+    // state, #128); the rest early-return on the `_minimized` guard, so the
+    // carry is captured exactly once regardless of the delivery path.
+    final carry = _index == _liveIndex ? _liveMaximizedId : null;
+    setState(() {
+      _minimized = false;
+      _restoreLiveMaximizedId = carry;
+    });
+    // One-shot: drop it after this frame's build (which rebuilds and re-inits
+    // the WallScreen that consumes it) so a later ordinary rebuild or tab switch
+    // doesn't re-apply a stale maximize. No setState needed — the value only
+    // matters at the wall's initState, already run by the post-frame point.
+    if (carry != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _restoreLiveMaximizedId = null;
+      });
+    }
   }
 
   /// Esc while Playback is showing a clip-originated single-camera focus:
@@ -1417,6 +1449,11 @@ class _MainShellState extends State<MainShell> with WindowListener {
           fullscreen: widget.fullscreen,
           // Remember which pane is maximized so Playback can open on it.
           onMaximizedCameraChanged: (id) => _liveMaximizedId = id,
+          // Re-open on the pane that was maximized before a minimize→restore of
+          // the Live tab (the placeholder swap released its player and rebuilds
+          // the wall fresh, #91). Non-null only for that one build; a plain
+          // first build / tab switch passes null and opens on the grid.
+          initialMaximizedCameraId: _restoreLiveMaximizedId,
           // Perf/debug line → bottom status bar (not a floating wall overlay).
           statsSink: _wallStats,
           // The wall's /status poller detects config_version bumps; bubble that

--- a/apps/desktop-flutter/lib/ui/wall_screen.dart
+++ b/apps/desktop-flutter/lib/ui/wall_screen.dart
@@ -72,6 +72,22 @@ void _disposePlayerDetached(Player? p) {
   if (p != null) unawaited(Future(() => p.dispose()));
 }
 
+/// Decide whether a host-provided [WallScreen.initialMaximizedCameraId] should
+/// re-open the wall maximized after a minimize→restore: only when it names a
+/// camera still present in [shown] (the enabled cameras the wall renders).
+/// Returns the camera to maximize, or null to stay on the grid (id null, or the
+/// camera was removed/disabled while minimized). Pure so the decision is unit
+/// tested headlessly — the window-event path that feeds the id needs on-hardware
+/// verification (see `main.dart`'s minimize/restore handlers).
+@visibleForTesting
+Camera? resolveInitialMaximize(String? id, List<Camera> shown) {
+  if (id == null) return null;
+  for (final c in shown) {
+    if (c.id == id) return c;
+  }
+  return null;
+}
+
 class WallScreen extends StatefulWidget {
   const WallScreen({
     super.key,
@@ -90,6 +106,7 @@ class WallScreen extends StatefulWidget {
     this.shortcuts,
     this.fullscreen,
     this.onMaximizedCameraChanged,
+    this.initialMaximizedCameraId,
     this.statsSink,
     this.onConfigChanged,
     this.onUnauthorized,
@@ -148,6 +165,17 @@ class WallScreen extends StatefulWidget {
   /// Reports which camera is currently maximized (full-pane) on the wall, or
   /// null when restored — so the host can carry that maximize into Playback.
   final ValueChanged<String?>? onMaximizedCameraChanged;
+
+  /// Open the wall already maximized on this camera (if it is still present and
+  /// enabled), instead of on the grid. The host sets this ONLY across a
+  /// minimize→restore of the Live tab: the minimize placeholder swap releases
+  /// every pane's player and rebuilds the wall fresh (#91), which otherwise
+  /// dropped a pane that was maximized before minimizing back to the grid. The
+  /// fresh players are re-created either way, so this re-enters the SAME
+  /// maximize path a user tap uses (via `initState`, post-first-frame) rather
+  /// than resurrecting the released pre-minimize controller. Null (the usual
+  /// case) → the wall opens on the grid.
+  final String? initialMaximizedCameraId;
 
   /// Sink for the perf/debug line (camera count + CPU/GPU/NVDEC/RSS). The host
   /// renders it in the bottom status bar on the Live tab instead of a floating
@@ -294,6 +322,25 @@ class _WallScreenState extends State<WallScreen> {
     // Feed carousel/hotspot resolution from the live-status motion signal.
     _liveStatus.addListener(_onLiveStatusTick);
     _applyViewSpecs();
+    // Re-open on a camera that was maximized before a minimize→restore of the
+    // Live tab (the host passes it only for that path). Deferred to
+    // post-first-frame so the tile GlobalKeys exist (warm-start handoff) and
+    // `_maximize`'s setState is legal outside build. Goes through the SAME
+    // maximize path a user tap uses so the pane, PTZ panel, HA overlay,
+    // warm-start, audio, and the report-to-host callback all initialize; if the
+    // camera is gone (removed/disabled while minimized) it falls back to the
+    // grid. No-op (null) on an ordinary first build.
+    final restoreCam =
+        resolveInitialMaximize(widget.initialMaximizedCameraId, _shown);
+    if (restoreCam != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        // Re-check against the live list — a config refresh between build and
+        // this callback could have dropped the camera.
+        final cam = resolveInitialMaximize(restoreCam.id, _shown);
+        if (cam != null && _maximized == null) _maximize(cam);
+      });
+    }
   }
 
   @override

--- a/apps/desktop-flutter/test/wall_maximize_restore_test.dart
+++ b/apps/desktop-flutter/test/wall_maximize_restore_test.dart
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Regression test for "maximized live camera drops back to the wall after a
+// window minimize→restore".
+//
+// A camera maximized on the live wall (full-pane, not OS fullscreen) was lost
+// when the window was minimized and restored: the minimize placeholder swap
+// (#91) tears the wall down and restore rebuilds it with fresh players, so the
+// new State started with nothing maximized and showed the grid. The fix carries
+// the maximized camera id across that rebuild and re-applies it in the wall's
+// initState via `resolveInitialMaximize`.
+//
+// The window-event delivery that feeds the id is platform-specific and needs
+// on-hardware verification; this covers the pure re-apply DECISION headlessly:
+// a stored id whose camera is still present ⇒ maximize it; id null or the
+// camera gone (removed/disabled while minimized) ⇒ stay on the grid.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:crumb_desktop/api/models.dart';
+import 'package:crumb_desktop/ui/wall_screen.dart';
+
+Camera _cam(String id, {bool enabled = true}) => Camera(
+      id: id,
+      name: 'Camera $id',
+      enabled: enabled,
+      hasSub: true,
+      ptz: false,
+      servedBy: 'crumb',
+    );
+
+void main() {
+  group('resolveInitialMaximize (minimize→restore re-maximize decision)', () {
+    final shown = [_cam('a'), _cam('b'), _cam('c')];
+
+    test('stored id present in the shown list ⇒ maximize that camera', () {
+      final cam = resolveInitialMaximize('b', shown);
+      expect(cam, isNotNull);
+      expect(cam!.id, 'b');
+    });
+
+    test('null id (nothing was maximized) ⇒ stay on the grid', () {
+      expect(resolveInitialMaximize(null, shown), isNull);
+    });
+
+    test('camera removed while minimized ⇒ stay on the grid', () {
+      expect(resolveInitialMaximize('gone', shown), isNull);
+    });
+
+    test('camera disabled while minimized (not in shown) ⇒ stay on grid', () {
+      // The wall's `_shown` already filters to enabled cameras, so a disabled
+      // camera simply isn't in the list passed here.
+      final onlyEnabled =
+          shown.where((c) => c.enabled).toList(growable: false);
+      expect(resolveInitialMaximize('a', onlyEnabled), isNotNull);
+      // Same list with 'a' disabled+filtered out ⇒ no match.
+      final withoutA = [_cam('b'), _cam('c')];
+      expect(resolveInitialMaximize('a', withoutA), isNull);
+    });
+
+    test('empty shown list ⇒ stay on the grid', () {
+      expect(resolveInitialMaximize('a', const []), isNull);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #569.

## Problem

A camera maximized full-pane on the Live wall (not OS fullscreen) reverted to the grid after the OS window was minimized and restored. The minimize placeholder swap (#91) tears the wall down to release its libmpv players, and restore rebuilds a brand-new `WallScreen` whose State starts with `_maximized == null`, so the wall came back on the grid and the maximized selection was lost.

## Fix

The shell already tracks the maximized camera via `onMaximizedCameraChanged` (it uses that to carry a maximize into Playback). This reuses that signal to persist the maximize across the minimize/restore rebuild.

- `WallScreen` gains a nullable `initialMaximizedCameraId`. In `initState`, a new pure helper `resolveInitialMaximize(id, shown)` decides whether to re-open maximized (id names a camera still present + enabled) or fall back to the grid. When it should, the wall re-enters the **same** `_maximize` path a user tap uses, deferred to a post-first-frame callback so the fresh tile's warm-start controller, PTZ panel, HA overlay, audio, and the report-to-host callback all initialize correctly. It does **not** resurrect the released pre-minimize controller (the players are new either way).
- `_MainShellState` captures the maximized camera into a one-shot `_restoreLiveMaximizedId` inside `_clearMinimized()` and passes it to the rebuilt Live `WallScreen`. The field is cleared right after the consuming build so an ordinary rebuild (Settings panel, config refresh) or a later Live↔Playback tab switch does not spuriously re-maximize.

## Both window-event restore paths

`window_manager` delivers the un-minimize differently depending on the pre-minimize window state: a plain restore emits `onWindowRestore`, but a window that was maximized-in-OS when minimized comes back via `onWindowMaximize` (#128). All of `onWindowRestore` / `onWindowMaximize` / `onWindowUnmaximize` already route through the single `_clearMinimized()` choke point, so the carry is captured regardless of which event fires. The `_minimized` guard means the first "we're visible again" event captures exactly once and the rest early-return — the carry is never lost to whichever event does not fire.

## Scope / edge cases

- Minimize while **not** maximized → carry is null → restores to the plain wall.
- Camera removed or disabled while minimized → `resolveInitialMaximize` returns null → falls back to the grid, no crash (re-checked again in the post-frame callback).
- Carry is only taken when the Live tab is showing; Playback keeps its own `initialMaximizedCameraId` carry unchanged.
- Only the Live-wall maximize path is touched. The OS-window fullscreen (`fullscreen/fullscreen_controller.dart`) and the Playback-carry behavior are unchanged.

## Verification

On winbuild (Windows release):
- `flutter build windows --release` — succeeds (`build\windows\x64\runner\Release\crumb_desktop.exe`).
- `flutter analyze` — no issues in the changed files (`wall_screen.dart`, `main.dart`, `wall_maximize_restore_test.dart`); remaining output is pre-existing `rust_builder/cargokit` third-party noise unrelated to this change.
- `flutter test` — full suite green (182 tests), including the 5 new `resolveInitialMaximize` cases.

Added `test/wall_maximize_restore_test.dart` covering the pure re-apply decision (stored id present + camera in list ⇒ maximize; id null / camera gone / empty list ⇒ grid).

**Still needs the maintainer's eyes (winbuild is headless — native window-manager minimize/restore events cannot be driven there):** on a real desktop against a live server, confirm both restore paths — (a) plain minimize→restore and (b) minimize-while-maximized→restore — keep the camera maximized; that the maximized pane's video actually plays after restore (proving the fresh players re-initialize); that minimizing when not maximized restores to the plain wall; and that the Playback maximize-carry still works.
