### PR TITLE
fix(desktop): retention days unit, accurate policy-source labels, scrollable Cameras tab

### DIFF
--- a/apps/desktop-flutter/lib/api/server_dashboard_api.dart
+++ b/apps/desktop-flutter/lib/api/server_dashboard_api.dart
@@ -132,6 +132,32 @@ extension ServerDashboardApi on CrumbApi {
         .toList(growable: false);
   }
 
+  /// GET /config/groups → camera groups (admin only). Returns a bare JSON array
+  /// of `CameraGroupDto`; the dashboard/motion-tuner use it to name the group a
+  /// camera belongs to (group-managed cameras cannot edit their own policy).
+  Future<List<CameraGroupSummary>> listGroups(Session s) async {
+    final resp = await _client(this).get(
+      Uri.parse('${s.base}/config/groups'),
+      headers: {'authorization': 'Bearer ${s.token}'},
+    );
+    if (resp.statusCode == 403) {
+      throw CrumbApiException(
+        'Administrator account required.',
+        statusCode: 403,
+      );
+    }
+    if (resp.statusCode != 200) {
+      throw CrumbApiException(
+        'Failed to load groups (HTTP ${resp.statusCode}).',
+        statusCode: resp.statusCode,
+      );
+    }
+    final list = jsonDecode(resp.body) as List<dynamic>;
+    return list
+        .map((e) => CameraGroupSummary.fromJson(e as Map<String, dynamic>))
+        .toList(growable: false);
+  }
+
   /// GET /config/policy/default → the global default recording policy.
   Future<RecordingPolicy> getDefaultPolicy(Session s) =>
       _get(s, '/config/policy/default', RecordingPolicy.fromJson);

--- a/apps/desktop-flutter/lib/api/server_dashboard_models.dart
+++ b/apps/desktop-flutter/lib/api/server_dashboard_models.dart
@@ -368,6 +368,87 @@ class CameraConfigSummary {
   bool get hasOwnPolicy => policyId != null;
 }
 
+/// A camera group summary from `GET /config/groups` (`CameraGroupDto`). The
+/// dashboard/motion-tuner only need identity + name to name the group a camera
+/// belongs to; `policy_id`/`camera_ids` are ignored here.
+class CameraGroupSummary {
+  CameraGroupSummary({required this.id, required this.name});
+
+  final String id;
+  final String name;
+
+  factory CameraGroupSummary.fromJson(Map<String, dynamic> j) =>
+      CameraGroupSummary(
+        id: j['id'] as String,
+        name: (j['name'] as String?) ?? '',
+      );
+}
+
+/// Where a camera's effective recording policy actually comes from. Under the
+/// ratified policy model `policy_id != null` no longer means "custom": a camera
+/// "on Default" and one pinned to a shared named policy both carry a non-null
+/// `policy_id`, and a grouped camera's settings come from its group profile.
+enum PolicySourceKind { group, defaultPolicy, named, custom }
+
+/// The resolved policy source + a human label for one camera. See
+/// [resolvePolicySource] for the precedence.
+class PolicySource {
+  const PolicySource(this.kind, {this.groupName, this.policyName});
+
+  final PolicySourceKind kind;
+  final String? groupName; // set when kind == group
+  final String? policyName; // set when kind == named
+
+  /// True when the camera's recording settings are owned by a group profile and
+  /// therefore must not be edited from the per-camera editor (the server 400s).
+  bool get isGroupManaged => kind == PolicySourceKind.group;
+
+  /// Short subtitle for the camera tile.
+  String get label {
+    switch (kind) {
+      case PolicySourceKind.group:
+        return groupName != null && groupName!.isNotEmpty
+            ? 'Group: $groupName'
+            : 'Group profile';
+      case PolicySourceKind.defaultPolicy:
+        return 'Default policy';
+      case PolicySourceKind.named:
+        return policyName != null && policyName!.isNotEmpty
+            ? 'Policy: $policyName'
+            : 'Named policy';
+      case PolicySourceKind.custom:
+        return 'Custom policy';
+    }
+  }
+}
+
+/// Decide how a camera's effective recording policy is sourced, by precedence:
+///   1. member of a group  -> `Group: <name>` (group profile owns the settings)
+///   2. resolved policy is the default -> `Default policy`
+///   3. resolved policy is a named policy -> `Policy: <name>`
+///   4. otherwise (anonymous per-camera fork) -> `Custom policy`
+///
+/// [groupNamesById] maps group id -> name (from `listGroups()`); an unknown id
+/// falls back to a generic "Group profile" label.
+PolicySource resolvePolicySource(
+  CameraConfigSummary camera,
+  Map<String, String> groupNamesById,
+) {
+  if (camera.groupId != null) {
+    return PolicySource(
+      PolicySourceKind.group,
+      groupName: groupNamesById[camera.groupId],
+    );
+  }
+  if (camera.policy.isDefault) {
+    return const PolicySource(PolicySourceKind.defaultPolicy);
+  }
+  if (camera.policy.name != null && camera.policy.name!.isNotEmpty) {
+    return PolicySource(PolicySourceKind.named, policyName: camera.policy.name);
+  }
+  return const PolicySource(PolicySourceKind.custom);
+}
+
 /// A partial update body for `PUT /config/policy/default` or
 /// `PUT /config/cameras/{id}/policy` (`UpdatePolicyRequest`, dto.rs).
 ///

--- a/apps/desktop-flutter/lib/ui/server/server_dashboard_screen.dart
+++ b/apps/desktop-flutter/lib/ui/server/server_dashboard_screen.dart
@@ -93,6 +93,45 @@ String fmtRetentionHours(double? hours) {
 
 String fmtPct(double? pct) => pct == null ? '—' : '${pct.round()}%';
 
+// ─── retention unit conversion (raw hours <-> hours/days editor) ──────────────
+// The backend stores retention in HOURS; the editor lets the operator work in
+// hours or whole days so they don't do day-math in their head (e.g. 336 -> 14
+// days). These are pure, testable, and unit-tested in
+// test/retention_units_test.dart.
+
+const retentionUnitHours = 'hours';
+const retentionUnitDays = 'days';
+
+/// The friendlier initial unit for showing a raw-hours retention: whole days
+/// when it divides evenly and is at least a day, else hours (336 -> days;
+/// 36 -> hours).
+String retentionInitialUnit(int hours) =>
+    (hours >= 24 && hours % 24 == 0) ? retentionUnitDays : retentionUnitHours;
+
+/// The numeric value to show in [unit] for a raw-hours retention.
+num retentionDisplayValue(int hours, String unit) =>
+    unit == retentionUnitDays ? hours / 24 : hours;
+
+/// Convert a typed [value] in [unit] back to whole hours (rounded).
+int retentionToHours(num value, String unit) =>
+    unit == retentionUnitDays ? (value * 24).round() : value.round();
+
+/// Format a display value without a trailing `.0` for whole numbers.
+String retentionValueField(num value) =>
+    value == value.roundToDouble() ? value.round().toString() : '$value';
+
+/// Live "= N days" / "= N h" helper showing the OTHER unit, so a hand-typed
+/// value stays self-explanatory ("14" days -> "= 336 h"; "336" hours ->
+/// "= 14 days"). Empty when the value is non-positive.
+String retentionHelperText(num value, String unit) {
+  final hours = retentionToHours(value, unit);
+  if (hours <= 0) return '';
+  if (unit == retentionUnitDays) return '= $hours h';
+  final days = hours / 24;
+  final s = hours % 24 == 0 ? '${hours ~/ 24}' : days.toStringAsFixed(1);
+  return '= $s ${s == '1' ? 'day' : 'days'}';
+}
+
 String fmtAgo(DateTime? t) {
   if (t == null) return '—';
   final d = DateTime.now().toUtc().difference(t.toUtc());
@@ -311,6 +350,13 @@ class _CameraStatsSection extends StatefulWidget {
 class _CameraStatsSectionState extends State<_CameraStatsSection> {
   _StatsCol _sortCol = _StatsCol.disk;
   bool _sortAsc = false;
+  final ScrollController _vCtrl = ScrollController();
+
+  @override
+  void dispose() {
+    _vCtrl.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -354,10 +400,15 @@ class _CameraStatsSectionState extends State<_CameraStatsSection> {
               ),
             ),
             Expanded(
-              child: SingleChildScrollView(
-                scrollDirection: Axis.horizontal,
-                child: DataTable(
-                  sortColumnIndex: _StatsCol.values.indexOf(_sortCol),
+              child: Scrollbar(
+                thumbVisibility: true,
+                controller: _vCtrl,
+                child: SingleChildScrollView(
+                  controller: _vCtrl,
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: DataTable(
+                      sortColumnIndex: _StatsCol.values.indexOf(_sortCol),
                   sortAscending: _sortAsc,
                   columns: [
                     DataColumn(
@@ -415,6 +466,8 @@ class _CameraStatsSectionState extends State<_CameraStatsSection> {
                         ],
                       ),
                   ],
+                    ),
+                  ),
                 ),
               ),
             ),
@@ -756,10 +809,14 @@ class _PolicyEditorTabState extends State<_PolicyEditorTab> {
     final results = await Future.wait([
       widget.api.getDefaultPolicy(widget.session),
       widget.api.listConfigCameras(widget.session),
+      widget.api.listGroups(widget.session),
     ]);
     return _EditorData(
       defaultPolicy: results[0] as RecordingPolicy,
       cameras: results[1] as List<CameraConfigSummary>,
+      groupNames: {
+        for (final g in results[2] as List<CameraGroupSummary>) g.id: g.name,
+      },
     );
   }
 
@@ -796,13 +853,14 @@ class _PolicyEditorTabState extends State<_PolicyEditorTab> {
               },
             ),
             const SizedBox(height: 24),
-            Text('Per-camera overrides', style: Theme.of(context).textTheme.titleMedium),
+            Text('Per-camera policies', style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 8),
             for (final cam in data.cameras)
               _CameraPolicyTile(
                 api: widget.api,
                 session: widget.session,
                 camera: cam,
+                source: resolvePolicySource(cam, data.groupNames),
                 onSaved: _reload,
               ),
           ],
@@ -813,9 +871,16 @@ class _PolicyEditorTabState extends State<_PolicyEditorTab> {
 }
 
 class _EditorData {
-  _EditorData({required this.defaultPolicy, required this.cameras});
+  _EditorData({
+    required this.defaultPolicy,
+    required this.cameras,
+    required this.groupNames,
+  });
   final RecordingPolicy defaultPolicy;
   final List<CameraConfigSummary> cameras;
+
+  /// group id -> group name, for labeling group-managed cameras.
+  final Map<String, String> groupNames;
 }
 
 class _CameraPolicyTile extends StatelessWidget {
@@ -823,12 +888,14 @@ class _CameraPolicyTile extends StatelessWidget {
     required this.api,
     required this.session,
     required this.camera,
+    required this.source,
     required this.onSaved,
   });
 
   final CrumbApi api;
   final Session session;
   final CameraConfigSummary camera;
+  final PolicySource source;
   final VoidCallback onSaved;
 
   @override
@@ -838,26 +905,81 @@ class _CameraPolicyTile extends StatelessWidget {
       child: ExpansionTile(
         title: Text(camera.name),
         subtitle: Text(
-          camera.hasOwnPolicy
-              ? 'Custom policy'
-              : (camera.groupId != null
-                    ? 'Inherits from group'
-                    : 'Inherits from default'),
+          source.label,
           style: Theme.of(context).textTheme.bodySmall,
         ),
         children: [
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-            child: _PolicyEditorCard(
-              policy: camera.policy,
-              onSave: (patch) async {
-                await api.updateCameraPolicy(session, camera.id, patch);
-                onSaved();
-              },
-            ),
+            // A grouped camera's recording settings are owned by its group
+            // profile; the per-camera policy PUT would 400. Show a read-only
+            // summary + explanation instead of an editor that can only fail.
+            child: source.isGroupManaged
+                ? _GroupManagedNotice(
+                    policy: camera.policy,
+                    groupName: source.groupName,
+                  )
+                : _PolicyEditorCard(
+                    policy: camera.policy,
+                    onSave: (patch) async {
+                      await api.updateCameraPolicy(session, camera.id, patch);
+                      onSaved();
+                    },
+                  ),
           ),
         ],
       ),
+    );
+  }
+}
+
+/// Read-only summary shown for a camera whose recording settings are managed by
+/// a group profile (editing them per-camera is rejected server-side).
+class _GroupManagedNotice extends StatelessWidget {
+  const _GroupManagedNotice({required this.policy, this.groupName});
+
+  final RecordingPolicy policy;
+  final String? groupName;
+
+  @override
+  Widget build(BuildContext context) {
+    final group = (groupName != null && groupName!.isNotEmpty)
+        ? groupName!
+        : 'its group';
+    final retention = fmtRetentionHours(policy.liveRetentionHours.toDouble());
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.surfaceContainerHighest,
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Icon(Icons.group, size: 18),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  "Recording settings are managed by group '$group'. "
+                  "Edit the group's profile, or ungroup the camera to "
+                  'customize.',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 10),
+        Text(
+          'Mode: ${policy.mode} · Live retention: $retention'
+          "${policy.liveMaxBytes != null ? ' · Live cap: ${fmtBytes(policy.liveMaxBytes)}' : ''}",
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+      ],
     );
   }
 }
@@ -877,8 +999,17 @@ class _PolicyEditorCard extends StatefulWidget {
 
 class _PolicyEditorCardState extends State<_PolicyEditorCard> {
   late String _mode = widget.policy.mode;
-  late final TextEditingController _liveRetentionHours =
-      TextEditingController(text: widget.policy.liveRetentionHours.toString());
+  // Retention is stored in hours but edited in hours OR whole days (a bare
+  // "336" made the operator do day-math). Initial unit picks days when it
+  // divides evenly.
+  late String _retentionUnit = retentionInitialUnit(
+    widget.policy.liveRetentionHours,
+  );
+  late final TextEditingController _retentionValue = TextEditingController(
+    text: retentionValueField(
+      retentionDisplayValue(widget.policy.liveRetentionHours, _retentionUnit),
+    ),
+  );
   late final TextEditingController _liveMaxGb = TextEditingController(
     text: widget.policy.liveMaxBytes != null
         ? (widget.policy.liveMaxBytes! / 1e9).toStringAsFixed(1)
@@ -893,20 +1024,39 @@ class _PolicyEditorCardState extends State<_PolicyEditorCard> {
 
   @override
   void dispose() {
-    _liveRetentionHours.dispose();
+    _retentionValue.dispose();
     _liveMaxGb.dispose();
     _motionPre.dispose();
     _motionPost.dispose();
     super.dispose();
   }
 
+  /// Switch the retention unit while keeping the same real duration, e.g.
+  /// "14 days" -> "336 hours".
+  void _changeRetentionUnit(String unit) {
+    if (unit == _retentionUnit) return;
+    final val = double.tryParse(_retentionValue.text.trim());
+    setState(() {
+      if (val != null) {
+        final hours = retentionToHours(val, _retentionUnit);
+        _retentionValue.text = retentionValueField(
+          retentionDisplayValue(hours, unit),
+        );
+      }
+      _retentionUnit = unit;
+    });
+  }
+
   Future<void> _save() async {
     final patch = PolicyPatch();
     if (_mode != widget.policy.mode) patch.mode(_mode);
 
-    final hours = int.tryParse(_liveRetentionHours.text.trim());
-    if (hours != null && hours != widget.policy.liveRetentionHours) {
-      patch.liveRetentionHours(hours);
+    final retVal = double.tryParse(_retentionValue.text.trim());
+    if (retVal != null) {
+      final hours = retentionToHours(retVal, _retentionUnit);
+      if (hours != widget.policy.liveRetentionHours) {
+        patch.liveRetentionHours(hours);
+      }
     }
 
     final gbText = _liveMaxGb.text.trim();
@@ -961,16 +1111,44 @@ class _PolicyEditorCardState extends State<_PolicyEditorCard> {
         ),
         const SizedBox(height: 12),
         Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Expanded(
               child: TextField(
-                controller: _liveRetentionHours,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(
-                  labelText: 'Live retention (hours)',
-                  isDense: true,
-                  border: OutlineInputBorder(),
+                controller: _retentionValue,
+                keyboardType: const TextInputType.numberWithOptions(
+                  decimal: true,
                 ),
+                onChanged: (_) => setState(() {}),
+                decoration: InputDecoration(
+                  labelText: 'Live retention',
+                  isDense: true,
+                  border: const OutlineInputBorder(),
+                  helperText: retentionHelperText(
+                    double.tryParse(_retentionValue.text.trim()) ?? 0,
+                    _retentionUnit,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: DropdownButton<String>(
+                value: _retentionUnit,
+                onChanged: (u) {
+                  if (u != null) _changeRetentionUnit(u);
+                },
+                items: const [
+                  DropdownMenuItem(
+                    value: retentionUnitHours,
+                    child: Text('hours'),
+                  ),
+                  DropdownMenuItem(
+                    value: retentionUnitDays,
+                    child: Text('days'),
+                  ),
+                ],
               ),
             ),
             const SizedBox(width: 12),

--- a/apps/desktop-flutter/test/policy_source_label_test.dart
+++ b/apps/desktop-flutter/test/policy_source_label_test.dart
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Unit tests for the per-camera policy-source label precedence on the Server
+// dashboard. Under the ratified policy model a non-null `policy_id` no longer
+// means "custom": a camera on Default and one pinned to a shared named policy
+// both carry a non-null id, so the label must be decided by GROUP -> DEFAULT ->
+// NAMED -> CUSTOM precedence, not by `policy_id != null`.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:crumb_desktop/api/server_dashboard_models.dart';
+
+CameraConfigSummary _cam({
+  String? groupId,
+  String? policyId,
+  bool isDefault = false,
+  String? policyName,
+}) {
+  return CameraConfigSummary.fromJson({
+    'id': 'cam-1',
+    'name': 'Cam',
+    'enabled': true,
+    'policy_id': policyId,
+    'group_id': groupId,
+    'policy': {
+      'id': 'pol-1',
+      'name': policyName,
+      'is_default': isDefault,
+      'mode': 'continuous',
+      'live_retention_hours': 336,
+      'archive_enabled': false,
+      'motion_pre_seconds': 0,
+      'motion_post_seconds': 0,
+      'motion_sensitivity': 'dynamic',
+      'motion_keyframes_only': false,
+      'record_stream': 'main',
+      'record_audio': false,
+    },
+  });
+}
+
+void main() {
+  group('resolvePolicySource precedence', () {
+    test('grouped camera -> Group: <name>, group-managed', () {
+      final s = resolvePolicySource(_cam(groupId: 'g1', isDefault: true), {
+        'g1': 'Motion Cameras',
+      });
+      expect(s.kind, PolicySourceKind.group);
+      expect(s.label, 'Group: Motion Cameras');
+      expect(s.isGroupManaged, isTrue);
+    });
+
+    test(
+      'grouped camera with unknown group id falls back to a generic label',
+      () {
+        final s = resolvePolicySource(_cam(groupId: 'g-missing'), const {});
+        expect(s.kind, PolicySourceKind.group);
+        expect(s.label, 'Group profile');
+        expect(s.isGroupManaged, isTrue);
+      },
+    );
+
+    test('group wins even when the resolved policy is the default', () {
+      // A grouped camera resolves to the default policy row (is_default=true)
+      // but must still read as group-managed, never "Default policy".
+      final s = resolvePolicySource(_cam(groupId: 'g1', isDefault: true), {
+        'g1': 'Front',
+      });
+      expect(s.kind, PolicySourceKind.group);
+    });
+
+    test(
+      'camera on Default (non-null policy_id = Default.id) -> Default policy',
+      () {
+        final s = resolvePolicySource(
+          _cam(policyId: 'default-id', isDefault: true),
+          const {},
+        );
+        expect(s.kind, PolicySourceKind.defaultPolicy);
+        expect(s.label, 'Default policy');
+        expect(s.isGroupManaged, isFalse);
+      },
+    );
+
+    test('camera on a shared named policy -> Policy: <name>', () {
+      final s = resolvePolicySource(
+        _cam(policyId: 'p-24x7', policyName: '24x7 High'),
+        const {},
+      );
+      expect(s.kind, PolicySourceKind.named);
+      expect(s.label, 'Policy: 24x7 High');
+      expect(s.isGroupManaged, isFalse);
+    });
+
+    test(
+      'anonymous per-camera fork (name null, not default) -> Custom policy',
+      () {
+        final s = resolvePolicySource(_cam(policyId: 'fork-id'), const {});
+        expect(s.kind, PolicySourceKind.custom);
+        expect(s.label, 'Custom policy');
+      },
+    );
+  });
+}

--- a/apps/desktop-flutter/test/retention_units_test.dart
+++ b/apps/desktop-flutter/test/retention_units_test.dart
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Pure unit tests for the retention hours<->days conversion used by the Server
+// dashboard's policy editor. The backend stores retention in HOURS; the editor
+// lets the operator work in whole days so 336 no longer needs mental day-math.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:crumb_desktop/ui/server/server_dashboard_screen.dart';
+
+void main() {
+  group('retentionInitialUnit', () {
+    test('whole multiples of a day (>= 1 day) show as days', () {
+      expect(retentionInitialUnit(336), retentionUnitDays); // 14 days
+      expect(retentionInitialUnit(24), retentionUnitDays); // 1 day
+      expect(retentionInitialUnit(48), retentionUnitDays);
+    });
+    test('non-whole-day values and sub-day values show as hours', () {
+      expect(retentionInitialUnit(36), retentionUnitHours);
+      expect(retentionInitialUnit(12), retentionUnitHours);
+      expect(retentionInitialUnit(0), retentionUnitHours);
+    });
+  });
+
+  group('retentionDisplayValue', () {
+    test('days divides by 24', () {
+      expect(retentionDisplayValue(336, retentionUnitDays), 14);
+      expect(retentionDisplayValue(48, retentionUnitDays), 2);
+    });
+    test('hours pass through', () {
+      expect(retentionDisplayValue(36, retentionUnitHours), 36);
+    });
+  });
+
+  group('retentionToHours', () {
+    test('days multiply by 24', () {
+      expect(retentionToHours(2, retentionUnitDays), 48);
+      expect(retentionToHours(14, retentionUnitDays), 336);
+      expect(retentionToHours(1.5, retentionUnitDays), 36);
+    });
+    test('hours round to whole hours', () {
+      expect(retentionToHours(36, retentionUnitHours), 36);
+      expect(retentionToHours(36.4, retentionUnitHours), 36);
+    });
+  });
+
+  group('round trip preserves the stored value', () {
+    for (final hours in [336, 36, 24, 720, 1]) {
+      test('$hours h survives display -> edit -> save', () {
+        final unit = retentionInitialUnit(hours);
+        final shown = retentionDisplayValue(hours, unit);
+        expect(retentionToHours(shown, unit), hours);
+      });
+    }
+  });
+
+  group('retentionValueField trims trailing .0', () {
+    test('whole numbers have no decimal', () {
+      expect(retentionValueField(14), '14');
+      expect(retentionValueField(14.0), '14');
+    });
+    test('fractional values keep the decimal', () {
+      expect(retentionValueField(1.5), '1.5');
+    });
+  });
+
+  group('retentionHelperText shows the OTHER unit', () {
+    test('days value spells out hours', () {
+      expect(retentionHelperText(14, retentionUnitDays), '= 336 h');
+      expect(retentionHelperText(2, retentionUnitDays), '= 48 h');
+    });
+    test('hours value spells out days', () {
+      expect(retentionHelperText(336, retentionUnitHours), '= 14 days');
+      expect(retentionHelperText(24, retentionUnitHours), '= 1 day');
+      expect(retentionHelperText(36, retentionUnitHours), '= 1.5 days');
+    });
+    test('non-positive value yields empty helper', () {
+      expect(retentionHelperText(0, retentionUnitHours), '');
+      expect(retentionHelperText(0, retentionUnitDays), '');
+    });
+  });
+}


### PR DESCRIPTION
Fixes #580

Three Server-dashboard fixes in the native Flutter desktop client. No server or API change; the client only adds a read-only `GET /config/groups` consumption (already authed + admin-RBAC'd).

## 1. Retention days unit

The per-policy retention editor showed a bare "Live retention (hours)" field holding a raw hours value (336). Replaced with a numeric value + unit dropdown (hours/days) and a live helper that shows the other unit ("= 336 h" / "= 14 days"), so a hand-typed hours value stays self-explanatory. The initial unit is days when the stored hours divide evenly and are at least a day. On save the value converts back to whole hours and, as before, only emits the patch when it actually changed. Backend storage unit is unchanged.

## 2. Accurate policy-source labels + read-only grouped cameras

`policy_id != null` no longer means "custom": a camera on Default and one pinned to a shared named policy both carry a non-null policy id, so non-custom cameras were labeled "Custom policy". The row is now labeled by precedence:

1. member of a group -> `Group: <name>` (falls back to `Group profile` if the name is unknown)
2. resolved policy is the default -> `Default policy`
3. resolved policy is a named policy -> `Policy: <name>`
4. otherwise (anonymous per-camera fork) -> `Custom policy`

A grouped camera's tile is now read-only: it shows a summary plus "Recording settings are managed by group '<X>'. Edit the group's profile, or ungroup the camera to customize." This removes the editor path that would 400 for a grouped camera. The section heading is now "Per-camera policies".

The precedence lives in a pure `resolvePolicySource()` in `server_dashboard_models.dart`, and a small `listGroups()` was added to the client API over the existing `GET /config/groups`.

## 3. Scrollable Cameras tab

The Cameras stats table was wrapped only in a horizontal scroll view inside an `Expanded`, clipping rows past the fold. It is now nested inside a vertical `SingleChildScrollView` with a visible `Scrollbar` (horizontal scroll and column sort preserved). The other tabs (Connection, Storage, Retention usage, Edit policies) already use `ListView` and were verified unaffected.

## Tests

- `test/retention_units_test.dart` covers the hours<->days conversion (initial-unit choice, display value, to-hours, round trips, helper text).
- `test/policy_source_label_test.dart` covers the label precedence, including group-wins-over-default and the unknown-group fallback.

`flutter analyze` adds no new issues on the changed files; the full `flutter test` suite is green (209 tests).

## What to eyeball on hardware

- Retention editor shows a value + hours/days dropdown with a live conversion helper; an existing 336-hour policy shows 14 days.
- Per-camera rows read as `Group: <name>` / `Default policy` / `Policy: <name>` / `Custom policy` accurately.
- A grouped camera's tile is read-only with the group explanation and no Save.
- The Cameras tab scrolls to the last camera on a short window.
