### PR TITLE
fix(desktop): collapse long Server-dashboard lists by default

### DIFF
--- a/apps/desktop-flutter/lib/ui/server/server_dashboard_screen.dart
+++ b/apps/desktop-flutter/lib/ui/server/server_dashboard_screen.dart
@@ -141,6 +141,25 @@ String fmtAgo(DateTime? t) {
   return '${d.inDays}d ago';
 }
 
+// ─── collapse-section summaries (settings-UX: collapse long secondary lists) ───
+// Long lists on the Server dashboard are collapsed by default; the header keeps
+// the at-a-glance counts so the summary is useful without expanding. Pure and
+// unit-tested in test/dashboard_collapse_summary_test.dart.
+
+/// Header for the collapsible "Per-camera policies" section on the Retention
+/// editor, e.g. "Per-camera policies (5)".
+String perCameraPoliciesSummary(int count) => 'Per-camera policies ($count)';
+
+/// Sub-header for the collapsible camera-status list on the Connection tab.
+/// Keeps the counts visible even while collapsed, e.g.
+/// "9 recording · 1 disabled" (the "disabled" clause is dropped when none are).
+String cameraStatusSummary(int total, int recording, int disabled) {
+  if (total == 0) return 'No cameras';
+  final parts = <String>['$recording recording'];
+  if (disabled > 0) parts.add('$disabled disabled');
+  return parts.join(' · ');
+}
+
 /// Generic "loading / error / content" wrapper matching this file's sections'
 /// common shape — avoids repeating the same three states in every section.
 class _AsyncSection<T> extends StatefulWidget {
@@ -266,46 +285,82 @@ class _ConnectionSection extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 12),
-            Card(
-              child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text('Cameras', style: Theme.of(context).textTheme.titleMedium),
-                    const SizedBox(height: 12),
-                    for (final c in status.cameras)
-                      Padding(
-                        padding: const EdgeInsets.symmetric(vertical: 3),
-                        child: Row(
-                          children: [
-                            Icon(
-                              c.recording ? Icons.fiber_manual_record : Icons.circle_outlined,
-                              size: 12,
-                              color: !c.enabled
-                                  ? Colors.grey
-                                  : (c.recording ? Colors.redAccent : Colors.grey),
-                            ),
-                            const SizedBox(width: 8),
-                            Expanded(child: Text(c.name)),
-                            if (c.recentMotion)
-                              const Padding(
-                                padding: EdgeInsets.only(right: 8),
-                                child: Icon(Icons.directions_run, size: 14, color: Colors.amber),
+            // Collapsed by default: on a many-camera deployment this list
+            // dominates the tab and forces scroll. The header keeps the live
+            // counts so the at-a-glance value survives while collapsed.
+            Builder(
+              builder: (context) {
+                final recording =
+                    status.cameras.where((c) => c.enabled && c.recording).length;
+                final disabled = status.cameras.where((c) => !c.enabled).length;
+                return Card(
+                  child: Theme(
+                    data: Theme.of(context)
+                        .copyWith(dividerColor: Colors.transparent),
+                    child: ExpansionTile(
+                      key: const PageStorageKey('conn-cameras'),
+                      initiallyExpanded: false,
+                      tilePadding:
+                          const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                      childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+                      title: Text(
+                        'Cameras (${status.cameras.length})',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      subtitle: status.cameras.isEmpty
+                          ? null
+                          : Text(
+                              cameraStatusSummary(
+                                status.cameras.length,
+                                recording,
+                                disabled,
                               ),
-                            Text(
-                              c.enabled
-                                  ? (c.recording ? 'recording' : 'idle')
-                                  : 'disabled',
                               style: Theme.of(context).textTheme.bodySmall,
                             ),
-                          ],
-                        ),
-                      ),
-                    if (status.cameras.isEmpty) const Text('No cameras.'),
-                  ],
-                ),
-              ),
+                      children: [
+                        for (final c in status.cameras)
+                          Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 3),
+                            child: Row(
+                              children: [
+                                Icon(
+                                  c.recording
+                                      ? Icons.fiber_manual_record
+                                      : Icons.circle_outlined,
+                                  size: 12,
+                                  color: !c.enabled
+                                      ? Colors.grey
+                                      : (c.recording
+                                          ? Colors.redAccent
+                                          : Colors.grey),
+                                ),
+                                const SizedBox(width: 8),
+                                Expanded(child: Text(c.name)),
+                                if (c.recentMotion)
+                                  const Padding(
+                                    padding: EdgeInsets.only(right: 8),
+                                    child: Icon(Icons.directions_run,
+                                        size: 14, color: Colors.amber),
+                                  ),
+                                Text(
+                                  c.enabled
+                                      ? (c.recording ? 'recording' : 'idle')
+                                      : 'disabled',
+                                  style: Theme.of(context).textTheme.bodySmall,
+                                ),
+                              ],
+                            ),
+                          ),
+                        if (status.cameras.isEmpty)
+                          const Align(
+                            alignment: Alignment.centerLeft,
+                            child: Text('No cameras.'),
+                          ),
+                      ],
+                    ),
+                  ),
+                );
+              },
             ),
             const SizedBox(height: 12),
             Align(
@@ -853,16 +908,48 @@ class _PolicyEditorTabState extends State<_PolicyEditorTab> {
               },
             ),
             const SizedBox(height: 24),
-            Text('Per-camera policies', style: Theme.of(context).textTheme.titleMedium),
-            const SizedBox(height: 8),
-            for (final cam in data.cameras)
-              _CameraPolicyTile(
-                api: widget.api,
-                session: widget.session,
-                camera: cam,
-                source: resolvePolicySource(cam, data.groupNames),
-                onSaved: _reload,
+            // Collapsed by default (settings-UX: collapse long secondary
+            // lists). A many-camera deployment otherwise renders every override
+            // fully expanded. The count summary shows how many are inside; each
+            // camera keeps its own tile with the policy-source label and the
+            // group-managed notice once expanded.
+            Theme(
+              data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+              child: ExpansionTile(
+                key: const PageStorageKey('retention-per-camera'),
+                initiallyExpanded: false,
+                tilePadding: EdgeInsets.zero,
+                childrenPadding: EdgeInsets.zero,
+                expandedCrossAxisAlignment: CrossAxisAlignment.stretch,
+                title: Text(
+                  perCameraPoliciesSummary(data.cameras.length),
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                subtitle: data.cameras.isEmpty
+                    ? null
+                    : Text(
+                        'Per-camera overrides, group profiles, and custom '
+                        'policies. Tap to expand.',
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                children: [
+                  const SizedBox(height: 8),
+                  if (data.cameras.isEmpty)
+                    const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 8),
+                      child: Text('No cameras.'),
+                    ),
+                  for (final cam in data.cameras)
+                    _CameraPolicyTile(
+                      api: widget.api,
+                      session: widget.session,
+                      camera: cam,
+                      source: resolvePolicySource(cam, data.groupNames),
+                      onSaved: _reload,
+                    ),
+                ],
               ),
+            ),
           ],
         );
       },

--- a/apps/desktop-flutter/test/dashboard_collapse_summary_test.dart
+++ b/apps/desktop-flutter/test/dashboard_collapse_summary_test.dart
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Unit tests for the Server dashboard collapse-section header summaries. The
+// long secondary lists (Retention per-camera policies, Connection camera
+// status) are collapsed by default, so their headers must carry the counts that
+// otherwise only show when expanded. These are pure, deterministic assertions
+// on the header text.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:crumb_desktop/ui/server/server_dashboard_screen.dart';
+
+void main() {
+  group('perCameraPoliciesSummary', () {
+    test('shows the camera count', () {
+      expect(perCameraPoliciesSummary(5), 'Per-camera policies (5)');
+      expect(perCameraPoliciesSummary(0), 'Per-camera policies (0)');
+      expect(perCameraPoliciesSummary(1), 'Per-camera policies (1)');
+    });
+  });
+
+  group('cameraStatusSummary', () {
+    test('no cameras', () {
+      expect(cameraStatusSummary(0, 0, 0), 'No cameras');
+    });
+
+    test('recording count only when none are disabled', () {
+      expect(cameraStatusSummary(5, 3, 0), '3 recording');
+    });
+
+    test('appends the disabled clause when some are disabled', () {
+      expect(cameraStatusSummary(5, 3, 1), '3 recording · 1 disabled');
+    });
+
+    test('all recording, none disabled', () {
+      expect(cameraStatusSummary(4, 4, 0), '4 recording');
+    });
+  });
+}


### PR DESCRIPTION
Fixes #588

## What

Collapse long secondary lists on the native desktop Server dashboard by default, matching the settings-UX principle already applied to the Notifications pane (collapsed-by-default with a summary header).

**Collapsed by default (new):**

- **Retention -> Edit policies -> "Per-camera policies"** (the reported case). The whole per-camera override list is now a collapsed `ExpansionTile` with a count summary ("Per-camera policies (N)"), expandable on tap. Each camera keeps its own tile, its policy-source label (Group / Default / Policy / Custom), and the read-only group-managed notice once expanded.
- **Connection tab -> camera-status list**, another long secondary list. Collapsed behind a header that keeps the live counts visible while collapsed ("Cameras (N)" + "9 recording . 1 disabled"), so the at-a-glance value survives.

**Deliberately left expanded (judgement calls):**

- **Cameras tab** stats `DataTable` - it is the primary content the tab exists to show (and is already scrollable).
- **Storage tab** volumes list - short primary list (typically 1-4 volumes).
- **Retention -> Usage & forecast** policy cards - primary content of that sub-tab.
- **Default policy** editor - a single primary card.

## Pattern / persistence

Uses `ExpansionTile` (the app's existing collapsible pattern; already used in this file for per-camera tiles and in the plates screen), wrapped in `Theme(dividerColor: transparent)` to match that look. Expansion state is preserved within a session via `PageStorageKey`, and collapses again on a fresh open - there is no cross-launch UI-state store for these panels.

## Tests

- New `test/dashboard_collapse_summary_test.dart` unit-tests the pure header-summary helpers (`perCameraPoliciesSummary`, `cameraStatusSummary`).
- `flutter analyze`: no new issues attributable to this change (0 issues reference the touched files; the pre-existing lib/test/rust_builder counts are unchanged).
- `flutter test`: full suite green (221 passed).

## Stacking

This **stacks on #587 and #581** (both already touch this file) and must merge **after** them. It preserves #581's accurate policy-source labels and scrollable stats table, and #587's motion-tuner group gating.

Desktop-only change; no backend, API, install-guide, or migration impact.
