### PR TITLE
fix(android): try the repaired main (mainv) before the doomed raw main

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveStreamFallback.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveStreamFallback.kt
@@ -88,33 +88,39 @@ private fun LiveStreamsResponse.chainOf(vararg order: StreamTier): List<StreamTi
  *
  * The wall is low-res by design (N tiles, N decoders), so a camera with a sub
  * starts on it and never escalates to the main's bitrate: `subv → sub → mobile`.
- * A camera with no sub at all keeps today's behaviour of playing the main, with
- * the repaired main (when the server publishes one) and the transcode as its
- * fallbacks: `main → mainv → mobile`.
+ * A camera with no sub at all plays the main. When the server publishes a
+ * repaired main (`mainv`) it is tried FIRST — its presence means the raw main is
+ * unplayable here, so leading with the raw main would just be a doomed connect —
+ * then the raw main, then the transcode: `mainv → main → mobile`. With no repair
+ * `mainv` is absent and this is the unchanged `main → mobile`.
  */
 fun LiveStreamsResponse.wallStreamChain(): List<StreamTier> =
     if (subStreamUrl() != null) {
         chainOf(StreamTier.SUBV, StreamTier.SUB, StreamTier.MOBILE)
     } else {
-        chainOf(StreamTier.MAIN, StreamTier.MAINV, StreamTier.MOBILE)
+        chainOf(StreamTier.MAINV, StreamTier.MAIN, StreamTier.MOBILE)
     }
 
 /**
  * Fallback ladder for **fullscreen live**.
  *
  * Off a metered link fullscreen is the one place HD is worth it, so it starts on
- * the main and walks down: `main → mainv → subv → sub → mobile`. The repaired main
- * (`mainv`) sits right after the raw main so a camera whose main is unplayable for
- * a fmtp/packetization reason gets HD from the server-side repair before dropping
- * to an SD rung. On a metered link the data-saver order applies (low-res first, the
- * transcode when the camera has no sub), with both HD mains kept as the last
- * resort so a broken sub still leaves something to watch rather than a spinner.
+ * the HD main and walks down: `mainv → main → subv → sub → mobile`. The repaired
+ * main (`mainv`) sits BEFORE the raw main, not after it: the server publishes
+ * `mainv` ONLY for a main it has positively detected this device cannot play
+ * (missing served `fmtp`), so trying the raw main first would be a guaranteed
+ * doomed connect on every open — the LPR startup lag. Leading with `mainv` gets HD
+ * straight away and never loses a main that would have worked (a camera with no
+ * repair has no `mainv` rung and starts on the raw main exactly as before). On a
+ * metered link the data-saver order applies (low-res first, the transcode when the
+ * camera has no sub), with both HD mains kept as the last resort — `mainv` still
+ * ahead of the doomed raw main — so a broken sub still leaves something to watch.
  */
 fun LiveStreamsResponse.fullscreenStreamChain(metered: Boolean): List<StreamTier> =
     if (metered) {
-        chainOf(StreamTier.SUBV, StreamTier.SUB, StreamTier.MOBILE, StreamTier.MAIN, StreamTier.MAINV)
+        chainOf(StreamTier.SUBV, StreamTier.SUB, StreamTier.MOBILE, StreamTier.MAINV, StreamTier.MAIN)
     } else {
-        chainOf(StreamTier.MAIN, StreamTier.MAINV, StreamTier.SUBV, StreamTier.SUB, StreamTier.MOBILE)
+        chainOf(StreamTier.MAINV, StreamTier.MAIN, StreamTier.SUBV, StreamTier.SUB, StreamTier.MOBILE)
     }
 
 /**

--- a/apps/android/app/src/test/java/video/crumb/app/feature/live/LiveStreamFallbackTest.kt
+++ b/apps/android/app/src/test/java/video/crumb/app/feature/live/LiveStreamFallbackTest.kt
@@ -128,14 +128,14 @@ class LiveStreamFallbackTest {
     }
 
     @Test
-    fun `fullscreen chain puts the repaired main right after the raw main`() {
+    fun `fullscreen chain puts the repaired main before the doomed raw main`() {
         val chain = streams(
             mainv = "rtsp://u:p@host:18554/drive_mainv",
             subv = "rtsp://u:p@host:18554/drive_subv",
         ).fullscreenStreamChain(metered = false)
         assertEquals(
             listOf(
-                StreamTier.MAIN, StreamTier.MAINV,
+                StreamTier.MAINV, StreamTier.MAIN,
                 StreamTier.SUBV, StreamTier.SUB, StreamTier.MOBILE,
             ),
             chain,
@@ -145,20 +145,32 @@ class LiveStreamFallbackTest {
     }
 
     @Test
-    fun `metered fullscreen keeps the repaired main a last resort with the raw main`() {
+    fun `a camera with a repaired main starts on it, not the doomed raw main`() {
+        // The whole point of leading with mainv: the server only publishes it for a
+        // main it has proven unplayable here, so the first attach must be mainv and
+        // never waste a doomed connect on the raw main first.
+        val chain = streams(
+            mainv = "rtsp://u:p@host:18554/drive_mainv",
+            subv = "rtsp://u:p@host:18554/drive_subv",
+        ).fullscreenStreamChain(metered = false)
+        assertEquals(StreamTier.MAINV, startTier(chain, emptySet()))
+    }
+
+    @Test
+    fun `metered fullscreen keeps the repaired main a last resort ahead of the raw main`() {
         val chain = streams(mainv = "rtsp://u:p@host:18554/drive_mainv")
             .fullscreenStreamChain(metered = true)
         assertEquals(
-            listOf(StreamTier.SUB, StreamTier.MOBILE, StreamTier.MAIN, StreamTier.MAINV),
+            listOf(StreamTier.SUB, StreamTier.MOBILE, StreamTier.MAINV, StreamTier.MAIN),
             chain,
         )
     }
 
     @Test
-    fun `a no-sub camera puts the repaired main before the transcode on the wall`() {
+    fun `a no-sub camera puts the repaired main before the raw main on the wall`() {
         val chain = streams(mainv = "rtsp://u:p@host:18554/drive_mainv", sub = null)
             .wallStreamChain()
-        assertEquals(listOf(StreamTier.MAIN, StreamTier.MAINV, StreamTier.MOBILE), chain)
+        assertEquals(listOf(StreamTier.MAINV, StreamTier.MAIN, StreamTier.MOBILE), chain)
     }
 
     @Test


### PR DESCRIPTION
Speeds up fullscreen startup for a camera with a server-repaired main (e.g. the Uniview LPR).

## Problem
On fullscreen the ladder was `main → mainv → subv → sub → mobile`, starting on the **raw main**. The server publishes `rtsp_mainv_url` **only** for a main it has positively detected this device cannot play (missing served `fmtp`). So for exactly those cameras, leading with the raw main is a **guaranteed** RTSP connect+DESCRIBE+reject on every open before `mainv` is even tried — the startup lag felt on the LPR.

## Fix
Order `mainv` ahead of `main` in every chain that carries both (fullscreen metered and not; the no-sub wall). Because `chainOf()` drops a null rung:
- A camera with **no** repair has no `mainv` rung → starts on the raw main **exactly as today** (no behavior change).
- A camera the server **has** flagged → attaches to `mainv` first, skipping the doomed raw main.

Never loses a main that would have worked: `mainv` present ⟺ the raw main is unplayable here. If `mainv` itself hiccups it still falls through to the raw main then SD, same as before.

Scope: this removes the pure-waste failed-main round trip. It does **not** touch the transcode cold-start (a separate, smaller lever, deliberately left for later). Unit tests updated + a new one asserting a repaired-main camera's first attach is `mainv`, not the doomed raw main.