### PR TITLE
fix(api): gate filmstrip on the playback capability; scope channel-test to current grants

### DIFF
--- a/services/api/src/filmstrip.rs
+++ b/services/api/src/filmstrip.rs
@@ -132,7 +132,9 @@ async fn list_filmstrip(
     Path(camera_id): Path<Uuid>,
     Query(q): Query<FilmstripQuery>,
 ) -> Result<Json<FilmstripResponse>, ApiError> {
-    // Enforce camera access.
+    // Recorded-footage thumbnails: gate on the playback capability, like
+    // /timeline, /play, and /segments, then enforce the per-camera scope.
+    user.require_playback()?;
     user.assert_camera_access(camera_id)?;
 
     if q.start >= q.end {
@@ -223,7 +225,9 @@ async fn serve_frame(
 ) -> Result<impl IntoResponse, ApiError> {
     use tokio_util::io::ReaderStream;
 
-    // Camera access check.
+    // Capability + scope, identical to serve_segment / get_segment_low: the
+    // scoped media token carries the caller's real playback capability.
+    user.require_playback()?;
     user.assert_camera_access(camera_id)?;
 
     // Snap the requested timestamp to a fixed global grid so arbitrary scrub

--- a/services/api/src/notifications.rs
+++ b/services/api/src/notifications.rs
@@ -813,16 +813,20 @@ async fn test_channel(
         .build()
         .map_err(|e| ApiError::Internal(anyhow::anyhow!("build reqwest client: {e}")))?;
 
-    // Fetch a live snapshot if the channel wants one AND is scoped to at least
-    // one camera. With no cameras there's nothing to snapshot — the old code
-    // fell back to `Uuid::nil()`, which just drove a guaranteed DB miss (and, on
-    // a broader lookup, risked resolving an unrelated camera). Send the test
-    // without an image instead.
+    // Fetch a live snapshot only if the channel wants one AND is scoped to at
+    // least one camera the OWNER can still reach. Camera grants can be revoked
+    // after a channel is created, so re-filter the channel's cameras through the
+    // caller's current access before picking one (the engine fan-out re-resolves
+    // grants every tick; this manual test path must do the same). With none left
+    // there is nothing to snapshot: the old code fell back to `Uuid::nil()`,
+    // which drove a guaranteed DB miss and, on a broader lookup, risked resolving
+    // an unrelated camera. Send the test without an image instead.
     let snapshot = match ch
         .camera_ids
         .as_ref()
         .filter(|_| ch.snapshot_mode.wants_image())
-        .and_then(|ids| ids.first().copied())
+        .map(|ids| user.filter_camera_ids(ids))
+        .and_then(|allowed| allowed.first().copied())
     {
         Some(camera_id) => {
             let b = resolve_bases(&state).await;

--- a/services/api/tests/auth_rbac.rs
+++ b/services/api/tests/auth_rbac.rs
@@ -2051,6 +2051,42 @@ async fn live_fmp4_allows_role_without_playback_capability() {
 }
 
 #[tokio::test]
+async fn filmstrip_requires_the_playback_capability() {
+    let app = TestApp::new().await;
+    let cam = seed_camera(app.pool()).await;
+
+    // A live-only role (playback:false) scoped to the camera can watch live but
+    // must NOT reach recorded-footage scrub thumbnails, matching /timeline,
+    // /play, and /segments.
+    let live_only = seed_viewer_caps(&app, &[cam], mk_caps(false, false, false)).await;
+    let lo_token = login(&app, &live_only.username, &live_only.password).await;
+    // Valid time params so extraction passes and the request reaches the
+    // capability check in the handler body (both routes require them).
+    let list_path = format!("/filmstrip/{cam}?start=2026-08-08T00:00:00Z&end=2026-08-08T01:00:00Z");
+    let frame_path = format!("/filmstrip/{cam}/frame?ts=2026-08-08T00:00:00Z");
+    for path in [list_path.as_str(), frame_path.as_str()] {
+        let resp = app.send(get_auth(path, &lo_token)).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "filmstrip must enforce the playback capability ({path})"
+        );
+    }
+
+    // Contrast: a role WITH playback (still scoped to the camera) gets past the
+    // capability gate. Thumbnails may 404 for lack of footage in tests, so the
+    // assertion is only that it is NOT the 403 capability denial.
+    let with_pb = seed_viewer_caps(&app, &[cam], mk_caps(true, false, false)).await;
+    let pb_token = login(&app, &with_pb.username, &with_pb.password).await;
+    let resp = app.send(get_auth(&list_path, &pb_token)).await;
+    assert_ne!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a role with the playback capability must pass the filmstrip cap gate"
+    );
+}
+
+#[tokio::test]
 async fn plate_clip_authorized_by_view_plates_without_clips_capability() {
     let app = TestApp::new().await;
     let cam = seed_camera(app.pool()).await;


### PR DESCRIPTION
Two small capability/scope consistency fixes that bring two endpoints in line with the patterns their siblings already use.

**1. Filmstrip now gates on the playback capability.** `/filmstrip/:camera_id` and `.../frame` enforced camera access but not the `playback` capability, unlike every other recorded-footage route (`/timeline`, `/play`, `/segments`, `/segments/:id/low.mp4`). Added `user.require_playback()?` to both, mirroring `serve_segment` / `get_segment_low`. The scoped media token already carries the caller's real playback capability (the `media_token` minting in `auth.rs` copies `user.capabilities.playback`), so a legitimate playback-holding viewer's preview fetches are unaffected; a role without the capability is now consistently denied.

**2. Channel-test re-filters cameras to the owner's current grant.** `POST /notifications/channels/:id/test` selected the snapshot camera from the channel's stored `camera_ids` without re-checking the owner's current access. It now runs them through `user.filter_camera_ids()` first, matching the notification engine fan-out, which re-resolves grants each tick. With none left in scope it sends the test without an image (the existing no-camera path).

Adds an RBAC regression test: a `playback:false` role is denied both filmstrip routes while a role with `playback` passes the capability gate. Both changes are one-liners against well-tested helpers (`require_playback`, `filter_camera_ids`).