### PR TITLE
fix(clients): space the plate-report heading off the date-time line

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesPdf.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/plates/PlatesPdf.kt
@@ -394,7 +394,10 @@ private fun drawReport(
         textAlign = Paint.Align.RIGHT
     }
     c.drawText("Confidence ${confidenceLabel(read.confidence)}", contentRight, y + 14f, confPaint)
-    y += 34f
+    // The plate baseline sits at y + 26 in the 34pt face, so its descenders reach
+    // ~y + 34. Advance clear of that (plus a comfortable gap) before the date/time
+    // line so the small subtitle never rides up into the big plate glyphs.
+    y += 52f
     val cameraName = input.cameraNames[read.cameraId] ?: "(unknown camera)"
     c.drawText(fmtTs(read.ts, tsFmt), contentLeft, y, cellPaint)
     y += 14f


### PR DESCRIPTION
The single-plate LPR report's big plate-number heading had no clear gap
beneath it, so the date-time / camera subtitle rode up into the plate
glyphs' baseline and descenders.

## Per-client change

- **Android (Kotlin)** — `apps/android/.../feature/plates/PlatesPdf.kt`.
  The report drew the 34pt plate number at baseline `y + 26` (descenders
  reaching ~`y + 34`) but advanced the cursor only `y += 34f` before the
  11pt date-time subtitle, so the subtitle's ascenders rose back up to
  ~`y + 26` and collided with the plate. Advance `y += 52f` instead, so
  the date-time / camera line clears the plate descenders with a
  comfortable gap. Compiles clean and unit tests pass on the dev2 build
  box.

- **Desktop (Flutter)** — no change. This generator
  (`apps/desktop-flutter/lib/ui/plates/plate_pdf_report.dart`) lays the
  plate heading and the subtitle out side by side in a `pw.Row` (a
  bordered plate box on the left, the confidence / date-time / camera
  column on the right), so the two never stack and never touch. The
  reported screenshot's format (`EEE, MMM d yyyy · HH:mm:ss z`, title
  "CrumbVMS — License Plate Report") is the Android renderer's; the
  desktop uses a different string and a horizontal card, so the collision
  does not occur there.

- **iOS / macOS (SwiftUI)** — no change. `apps/ios` has no plate-report
  PDF generator (no `UIGraphicsPDFRenderer` / PDF drawing anywhere; the
  Plates feature only renders plates on screen), so there is nothing to
  space here.

No shared template exists — each client composes its own report.

## Verification

- Android: `./gradlew :app:compileDebugKotlin` and the `PlatesPdfTest`
  unit tests pass on dev2.
