### PR TITLE
ci(release): block a release tag whose versions do not match the tag

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -46,8 +46,20 @@ permissions:
   contents: write   # to create/update the GitHub Release and upload the APK
 
 jobs:
+  # Guard: a vX.Y.Z tag whose baked-in versions disagree with the tag must never
+  # ship. Runs on every release workflow; the build job below `needs:` it, so a
+  # mismatch blocks the release before anything is built. No-op on non-tag refs.
+  verify-versions:
+    name: verify versions match the tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: All version surfaces must equal the release tag
+        run: bash scripts/release/check-versions.sh
+
   build-and-sign:
     name: build + sign release APK
+    needs: verify-versions
     # Signing a release APK needs the keystore secrets (see the header). Until
     # they're configured, gate the job off via the ANDROID_RELEASE_ENABLED repo
     # variable so a v* tag doesn't fail — it skips cleanly. Set the variable to

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -24,8 +24,19 @@ permissions:
   contents: write   # attach the app zip to the GitHub Release (tag builds)
 
 jobs:
+  # Guard: block the release if any version surface disagrees with the tag.
+  # No-op on non-tag refs (workflow_dispatch). See scripts/release/check-versions.sh.
+  verify-versions:
+    name: verify versions match the tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: All version surfaces must equal the release tag
+        run: bash scripts/release/check-versions.sh
+
   build:
     name: build macOS app
+    needs: verify-versions
     runs-on: macos-latest
     defaults:
       run:

--- a/.github/workflows/windows-release-flutter.yml
+++ b/.github/workflows/windows-release-flutter.yml
@@ -29,8 +29,19 @@ permissions:
   contents: write   # attach the zip to the GitHub Release on tag builds
 
 jobs:
+  # Guard: block the release if any version surface disagrees with the tag.
+  # No-op on non-tag refs (workflow_dispatch). See scripts/release/check-versions.sh.
+  verify-versions:
+    name: verify versions match the tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: All version surfaces must equal the release tag
+        run: bash scripts/release/check-versions.sh
+
   build:
     name: build Windows (Flutter)
+    needs: verify-versions
     runs-on: windows-latest
     defaults:
       run:

--- a/scripts/release/check-versions.sh
+++ b/scripts/release/check-versions.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Release version guard.
+#
+# Verifies that EVERY version surface in the repo matches the release tag, so a
+# `vX.Y.Z` tag can never ship artifacts whose baked-in version disagrees with the
+# tag. This is the guard against the 0.1.x-era "the app versions did not match the
+# tag" class of mistake. The three *-release.yml workflows run this as a gating
+# job and their build jobs `needs:` it, so a mismatch blocks the release before a
+# single artifact is built.
+#
+# Usage:
+#   scripts/release/check-versions.sh v0.2.0     # explicit tag
+#   scripts/release/check-versions.sh            # reads $GITHUB_REF_NAME (CI)
+#
+# On a ref that is not a vX.Y.Z tag (e.g. a workflow_dispatch run from a branch)
+# it is a no-op success, so the manual re-ship paths keep working.
+set -euo pipefail
+
+tag="${1:-${GITHUB_REF_NAME:-}}"
+want="${tag#v}"
+
+if [[ ! "$want" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "ref '${tag:-<none>}' is not a vX.Y.Z release tag; nothing to check."
+  exit 0
+fi
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fail=0
+
+check() { # label  actual  expected
+  if [[ "$2" == "$3" ]]; then
+    printf 'ok   %-30s %s\n' "$1" "$2"
+  else
+    printf 'FAIL %-30s got %s, expected %s\n' "$1" "${2:-<empty>}" "$3"
+    fail=1
+  fi
+}
+
+check "VERSION" \
+  "$(tr -d ' \t\r\n' < "$root/VERSION")" "$want"
+
+for c in api common recorder; do
+  check "services/$c Cargo.toml" \
+    "$(grep -m1 '^version' "$root/services/$c/Cargo.toml" | sed -E 's/.*"([^"]+)".*/\1/')" "$want"
+done
+
+check "android VERSION_NAME" \
+  "$(grep -m1 '^VERSION_NAME=' "$root/apps/android/version.properties" | cut -d= -f2 | tr -d ' \r')" "$want"
+
+check "ios MARKETING_VERSION" \
+  "$(grep -m1 'MARKETING_VERSION' "$root/apps/ios/project.yml" | sed -E 's/.*MARKETING_VERSION:[[:space:]]*"?([0-9]+\.[0-9]+\.[0-9]+)"?.*/\1/')" "$want"
+
+check "flutter pubspec" \
+  "$(grep -m1 '^version:' "$root/apps/desktop-flutter/pubspec.yaml" | sed -E 's/^version:[[:space:]]*([0-9]+\.[0-9]+\.[0-9]+).*/\1/')" "$want"
+
+echo
+if [[ "$fail" -ne 0 ]]; then
+  echo "Release version guard FAILED for tag $tag."
+  echo "Bump every surface listed above to $want in the SAME commit you tag,"
+  echo "then re-tag. See apps/android/version.properties for the per-surface steps."
+  exit 1
+fi
+echo "Release version guard passed: all surfaces at $want."


### PR DESCRIPTION
Permanent guard against the version-drift mistake from the 0.1.x era (app versions not matching the release tag).

**What it does:** a new `scripts/release/check-versions.sh` verifies that every version surface equals the `vX.Y.Z` tag, and it runs as a gating `verify-versions` job in all three release workflows (`android-release`, `macos-release`, `windows-release-flutter`). Each build job now `needs: verify-versions`, so a tag whose baked-in versions disagree is **blocked before any artifact is built**.

**Surfaces checked (7):** `VERSION`, `services/{api,common,recorder}/Cargo.toml`, `apps/android/version.properties` (`VERSION_NAME`), `apps/ios/project.yml` (`MARKETING_VERSION`), `apps/desktop-flutter/pubspec.yaml`.

**Safe by construction:** invoked via `bash` (no exec-bit dependency, sidesteps the SMB `+x` trap); no-op success on non-tag refs, so the manual re-ship `workflow_dispatch` paths keep working.

Verified locally: passes against the current 0.2.0 tree (all 7 ok), fails on a wrong tag (e.g. v0.3.0), no-ops on a branch ref.

**Merge this before tagging v0.2.0** so the guard is present in the tagged commit and protects this release too (build numbers stay monotonic; this only checks the semver-vs-tag match).