### PR TITLE
fix(install): close the four fresh-install-audit findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,10 @@ That is the whole install. A few options if you want them:
   to Docker? This is the hands-off path.
 - **Use native apps** instead of the browser (Windows/macOS desktop, Android). See the
   [client install guide](docs/CLIENTS.md).
+- **Prefer HTTPS?** Caddy also serves the console at `https://<your-server-ip>:8443/admin`, but
+  with an internal self-signed certificate, so your browser warns on the first visit until you
+  trust the CA. Plain `http://<your-server-ip>:8080` on a trusted LAN is fine; for real TLS see
+  [docs/TLS.md](docs/TLS.md).
 - **Build from source** instead of pulling images (you are developing Crumb, running
   air-gapped, or on a fork that has not published images):
   `docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build`

--- a/docs/AI-INSTALL.md
+++ b/docs/AI-INSTALL.md
@@ -541,7 +541,10 @@ All wizard steps have API equivalents. Do them in order:
    with empty strings for fields you are not changing.)
    (`GET /auth/setup-status` returns a suggested address derived from the request,
    plus `suggested_scan_range`, the server's own `/24`, a good default for the
-   discovery scan below. It's `null` when the console was reached by hostname.)
+   discovery scan below. It's `null` when the console was reached by hostname, and
+   it echoes back `localhost` when you call it from the host itself, so on a
+   headless install set `server_address` to the LAN IP or hostname your phone and
+   desktop apps will actually reach, not whatever this suggests.)
 3. **Storage + retention.** Confirm/adjust the disk via `GET`/`POST /config/storages`,
    optionally preflight the path first with `POST /config/fs/check` `{path}` →
    `{status: "ok"|"warn"|"error", writable, free_bytes, total_bytes, message}`.

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -424,7 +424,8 @@ fi
 # instead of assuming, and fail the run when the answer is definitely no.
 # Platform-by-platform notes: docs-site/docs/getting-started/platform-notes.md.
 STORAGE_PREFLIGHT_FAILED=0
-FREE_SPACE_FLOOR_KIB=10485760   # 10 GiB
+FREE_SPACE_FLOOR_KIB=10485760   # 10 GiB (below this: a strong warning)
+ADVISORY_SPACE_KIB=52428800     # 50 GiB (below this but above the floor: a gentle "small for an NVR" note)
 
 # Filesystem type of the mount holding $1. Empty = could not determine (that is
 # a "skip the check", never a failure). GNU stat first, then df -T, then mount.
@@ -563,6 +564,12 @@ if [[ -d "${MEDIA_DIR_HOST}" ]]; then
       log "      Cameras eat terabytes. Point MEDIA_HOST_PATH at a real disk, or set"
       log "      retention low enough that this fills predictably rather than by surprise:"
       log "        MEDIA_HOST_PATH=/mnt/<disk>/crumb scripts/setup-env.sh --force"
+    elif [[ "${MEDIA_FREE_KIB}" -lt "${ADVISORY_SPACE_KIB}" ]]; then
+      log "storage preflight: $(( MEDIA_FREE_KIB / 1048576 )) GiB free at ${MEDIA_DIR_HOST}, which is on"
+      log "      the small side for continuous recording. A single HD camera can use tens of GiB"
+      log "      per day; Crumb evicts oldest footage to stay above its free-space floor, but"
+      log "      plan retention (or point MEDIA_HOST_PATH at a larger disk) so it fills"
+      log "      predictably rather than by surprise."
     else
       log "storage preflight: $(( MEDIA_FREE_KIB / 1048576 )) GiB free at ${MEDIA_DIR_HOST}"
     fi
@@ -655,4 +662,4 @@ if [[ "${STORAGE_PREFLIGHT_FAILED}" -eq 1 ]]; then
   exit 1
 fi
 
-log "NEXT: 'docker compose up -d', then open http://<host>:8080/admin and sign in with the above."
+log "NEXT: 'docker compose pull && docker compose up -d', then open http://<host>:8080/admin and sign in with the above."


### PR DESCRIPTION
An outside-in fresh install (a fresh-context run following only the repo on a clean host) came back **installable, no blockers**. These four polish items close the friction it logged.

**Medium**
1. `scripts/setup-env.sh`'s `NEXT:` hint said only `docker compose up -d`, skipping the README's explicit `docker compose pull`. Now prints `docker compose pull && docker compose up -d` to match the README.
2. The storage preflight had a 10 GiB hard-warning floor and nothing above it, so ~11 GiB free passed silently even though `docs/AI-INSTALL.md` §1 says to warn on a small path. Added an **advisory band**: below 50 GiB (above the floor) it now notes the disk is small for continuous recording and to plan retention / use a larger disk. (Verified: fires at 11 GiB, silent at 60 GiB.)

**Nit**
3. `docs/AI-INSTALL.md`: `GET /auth/setup-status` echoes `localhost` for a host-local request; added a line so a headless installer sets `server_address` to the real LAN address rather than the suggestion.
4. `README.md` install section: added a note that HTTPS on `:8443` uses an internal self-signed cert (browser warns on first visit), and that plain `http://…:8080` on a trusted LAN is fine, pointing at `docs/TLS.md`.

All install-surface files kept consistent (golden rule 5). `bash -n` clean, no em-dashes, advisory logic unit-checked.