### PR TITLE
fix(api): honor the Enabled checkbox on notification-channel create (#600)

### DIFF
--- a/services/api/src/notifications.rs
+++ b/services/api/src/notifications.rs
@@ -483,10 +483,21 @@ pub struct CreateChannelRequest {
     /// Legacy snapshot toggle (`true → vehicle`, `false → none`). Kept for
     /// back-compat with clients that predate `snapshot_mode`.
     pub include_snapshot: Option<bool>,
+    /// Whether the channel starts enabled. Absent → `true`, so legacy clients and
+    /// the "leave it on" default are unchanged; sending `false` (an operator
+    /// unchecking **Enabled** on the create form) is now honored (#600).
+    #[serde(default = "default_true")]
+    pub enabled: bool,
     /// Admin-only: set to `true` to make the channel global (no owner).
     /// Ignored for non-Admin callers (the channel is always owned by the caller).
     #[serde(default)]
     pub global: bool,
+}
+
+/// serde default for [`CreateChannelRequest::enabled`]: a channel is enabled
+/// unless the create payload explicitly says otherwise.
+fn default_true() -> bool {
+    true
 }
 
 /// `PUT /notifications/channels/:id` body.
@@ -650,7 +661,7 @@ async fn create_channel(
         user_id: owner,
         kind: body.kind,
         name: body.name.trim().to_owned(),
-        enabled: true,
+        enabled: body.enabled,
         config: body.config,
         camera_ids: body.camera_ids,
         snapshot_mode,

--- a/services/api/tests/notification_pane.rs
+++ b/services/api/tests/notification_pane.rs
@@ -260,6 +260,68 @@ async fn admin_can_toggle_global_and_it_round_trips() {
     );
 }
 
+/// #600: unchecking **Enabled** on the CREATE form must produce a disabled
+/// channel. `CreateChannelRequest` had no `enabled` field, so serde dropped it
+/// and create hardcoded `enabled: true`. Now the field is honored on create, and
+/// an absent `enabled` still defaults to true (legacy clients are unchanged).
+#[tokio::test]
+async fn create_honors_enabled_false_and_defaults_true() {
+    let app = TestApp::new().await;
+    let admin = seed_admin(app.pool()).await;
+    let token = login(&app, &admin.username, &admin.password).await;
+
+    // enabled:false on create -> the channel is created disabled.
+    let create = serde_json::json!({
+        "kind": "webhook",
+        "name": unique("disabled-ch"),
+        "config": {},
+        "enabled": false,
+    });
+    let resp = app
+        .send(post_auth_json("/notifications/channels", &token, &create))
+        .await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let created = into_json(resp).await;
+    assert_eq!(
+        created["enabled"].as_bool(),
+        Some(false),
+        "enabled:false on create must be honored (#600), not forced true"
+    );
+    let disabled_id = created["id"].as_str().expect("id").to_owned();
+
+    // Absent enabled -> defaults to true (the common case / legacy clients).
+    let create_default =
+        serde_json::json!({ "kind": "webhook", "name": unique("default-ch"), "config": {} });
+    let resp = app
+        .send(post_auth_json(
+            "/notifications/channels",
+            &token,
+            &create_default,
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let created_default = into_json(resp).await;
+    assert_eq!(
+        created_default["enabled"].as_bool(),
+        Some(true),
+        "an absent enabled still defaults to true"
+    );
+
+    // The disabled channel stays disabled across a reload.
+    let list = into_json(app.send(get_auth("/notifications/channels", &token)).await).await;
+    let row = list
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|c| c["id"].as_str() == Some(disabled_id.as_str()))
+        .expect("channel present");
+    assert_eq!(
+        row["enabled"].as_bool(),
+        Some(false),
+        "disabled-on-create persisted across a reload"
+    );
+}
+
 #[tokio::test]
 async fn non_admin_cannot_toggle_global() {
     let app = TestApp::new().await;


### PR DESCRIPTION
Fixes #600.

The new-channel form sends `enabled`, but `CreateChannelRequest` had no such field, so serde dropped it and create hardcoded `enabled: true`. Unchecking **Enabled** while creating a channel produced an enabled channel anyway.

**Fix:** add `enabled` to `CreateChannelRequest` with a serde default of `true` (legacy clients and the common case are byte-for-byte unchanged) and honor it in the create handler. No client change, the form already sends the field.

**Test:** `create_honors_enabled_false_and_defaults_true` in `notification_pane.rs` covers enabled:false honored, absent-defaults-true, and persistence across a reload.

Gate green on dev2: fmt + clippy -D warnings + `cargo test --workspace`.