### PR TITLE
fix(android): reset digital zoom on entering PiP so the window isn't black (#614)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/live/LiveFullscreenScreen.kt
@@ -766,6 +766,7 @@ fun LiveFullscreenScreen(
             ZoomableVideoSurface(
                 modifier = Modifier.fillMaxSize(),
                 suppressPan = ptzVisible,
+                inPip = inPip,
                 onSwipeCamera = { dir ->
                     if (cameraIds.size > 1) {
                         CameraNav.next(cameraIds, currentCameraId, dir)?.let {

--- a/apps/android/app/src/main/java/video/crumb/app/ui/player/ZoomableVideoSurface.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/ui/player/ZoomableVideoSurface.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -127,6 +128,7 @@ fun rememberZoomableSurfaceState(): ZoomableSurfaceState = remember { ZoomableSu
 fun ZoomableVideoSurface(
     modifier: Modifier = Modifier,
     suppressPan: Boolean = false,
+    inPip: Boolean = false,
     onSwipeCamera: ((Int) -> Unit)? = null,
     onTransformChange: ((ViewTransform) -> Unit)? = null,
     state: ZoomableSurfaceState = rememberZoomableSurfaceState(),
@@ -150,6 +152,20 @@ fun ZoomableVideoSurface(
         transformCb.value?.invoke(
             ViewTransform(scale = zoom, offsetX = offset.x, offsetY = offset.y),
         )
+    }
+
+    // Reset the digital zoom when entering Picture-in-Picture (#614). The zoom is a
+    // graphicsLayer transform on the TextureView (scaleX/Y = zoom, translation =
+    // -offset * zoom, with `offset` clamped to the FULLSCREEN size); in the tiny PiP
+    // window that scale+pan maps the content off-viewport and the PiP renders black.
+    // At 1x/no-pan the transform is identity, so PiP shows the full frame — the
+    // known-good zoomed-out case. Exiting PiP leaves it at 1x; the operator re-zooms.
+    LaunchedEffect(inPip) {
+        if (inPip && (zoom != 1f || offset != Offset.Zero)) {
+            zoom = 1f
+            offset = Offset.Zero
+            report()
+        }
     }
 
     Box(


### PR DESCRIPTION
Fixes #614.

**Bug:** a fullscreen Android camera zoomed in *any* amount shows BLACK in Picture-in-Picture; a fully zoomed-out camera works.

**Cause:** the digital zoom is a `graphicsLayer` transform on the fullscreen TextureView (`ZoomableVideoSurface`): `scaleX/Y = zoom`, `translation = -offset * zoom`, with the pan `offset` clamped to the **fullscreen** view size. When PiP shrinks the window, that scale+pan maps the visible content entirely outside the tiny PiP viewport, so it renders black. At 1x the transform is identity, which is why zoomed-out works.

**Fix:** reset the zoom to 1x/no-pan when entering PiP so the PiP window shows the full frame. `ZoomableVideoSurface` gains an `inPip` param and resets on the transition; `LiveFullscreenScreen` passes its existing `inPip` signal (from `MainActivity.onPictureInPictureModeChanged`). Playback is unaffected, `setVideoActive` is live-only, so playback never enters PiP.

**Verify:** compile + unit tests green on dev2. The visual behavior (PiP no longer black when zoomed) is Compose UI and wants an on-device check on a real handset before merge.