### PR TITLE
fix(desktop): draw bookmark markers on the playback timeline (#616)

### DIFF
--- a/apps/desktop-flutter/lib/ui/motion_timeline/motion_timeline_controller.dart
+++ b/apps/desktop-flutter/lib/ui/motion_timeline/motion_timeline_controller.dart
@@ -13,6 +13,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 
+import '../../api/bookmarks_api.dart';
 import '../../api/crumb_api.dart';
 import '../../api/models.dart';
 import '../../api/motion_timeline_api.dart';
@@ -141,6 +142,10 @@ class MotionTimelineController extends ChangeNotifier {
   final Map<String, IntensityBuckets> intensityByCam = {};
   List<DetectionEvent> detections = const [];
 
+  /// Bookmarks on the loaded cameras (#616) — painted as gold markers at the
+  /// top of the strip, matching Android/iOS. The painter clips to the window.
+  List<Bookmark> bookmarks = const [];
+
   bool loading = false;
   String? error;
 
@@ -226,6 +231,7 @@ class MotionTimelineController extends ChangeNotifier {
     if (camIds.isEmpty) {
       intensityByCam.clear();
       detections = const [];
+      bookmarks = const [];
       _fetchingSig = null;
       _loadedSig = null;
       notifyListeners();
@@ -281,6 +287,21 @@ class MotionTimelineController extends ChangeNotifier {
       // Motion events are already rendered as the intensity ribbon; showing
       // each as a glyph too would flood the row. Object detections only.
       detections = events.where((e) => e.iconKey.isNotEmpty && e.iconKey != 'motion').toList();
+
+      // Bookmarks (#616): gold markers on the strip, parity with Android/iOS.
+      // The server filters bookmarks by camera only (no time range) and they
+      // are sparse, so fetch the caller's full set once and keep those on the
+      // loaded cameras; the painter clips to the visible window. Guarded on its
+      // own so a bookmarks failure (e.g. the platform-wide toggle is off) can
+      // never blank the intensity/detection data that just loaded.
+      try {
+        final all = await api.listBookmarks(session);
+        if (mySeq != _seq) return;
+        bookmarks = all.where((b) => camIds.contains(b.cameraId)).toList();
+      } catch (_) {
+        if (mySeq != _seq) return;
+        bookmarks = const [];
+      }
 
       // Record what's now loaded and clear the in-flight marker. Superseded
       // fetches returned above without touching these, so the newest fetch owns

--- a/apps/desktop-flutter/lib/ui/motion_timeline/motion_timeline_view.dart
+++ b/apps/desktop-flutter/lib/ui/motion_timeline/motion_timeline_view.dart
@@ -22,6 +22,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 
 import '../../api/models.dart';
+import '../../api/bookmarks_api.dart';
 import '../../api/motion_timeline_api.dart';
 import '../live_status/detection_icons.dart';
 import '../playback/playback_timeline_controller.dart';
@@ -439,6 +440,9 @@ class _MotionTimelineViewState extends State<MotionTimelineView> {
   /// glyph, a detail chip (what + WHERE it was detected); otherwise the
   /// "which cameras had motion here" chip.
   Widget _buildHover(Offset local, double width) {
+    // Bookmark markers sit on top (band top), so they win the hit-test.
+    final bm = _bookmarkNear(local);
+    if (bm != null) return _buildBookmarkOverlay(local, width, bm);
     final det = _detectionNear(local);
     if (det != null) return _buildDetectionOverlay(local, width, det);
     return _buildHoverOverlay(local, width);
@@ -475,12 +479,103 @@ class _MotionTimelineViewState extends State<MotionTimelineView> {
     return best;
   }
 
+  /// The bookmark whose marker sits under [local], or null (#616). Mirrors the
+  /// painter's placement: a downward triangle at the top of the motion band
+  /// (`y ∈ [motionTop, motionTop + 10]`, `motionTop = rulerH + 1`).
+  Bookmark? _bookmarkNear(Offset local) {
+    final t = widget.timeline;
+    final winStart = t.windowStart.millisecondsSinceEpoch;
+    final winEnd = t.windowEnd.millisecondsSinceEpoch;
+    final winDur = winEnd - winStart;
+    if (winDur <= 0 || _width <= 0) return null;
+    const motionTop = _TimelinePainter.rulerH + 1;
+    if (local.dy < motionTop - 2 || local.dy > motionTop + 12) return null;
+    final soloActive = widget.motion.isSoloActive;
+    final selCamId = widget.motion.selectedCameraId;
+    Bookmark? best;
+    double bestDx = 7; // px hit radius (marker half-width is 5)
+    for (final bm in widget.motion.bookmarks) {
+      if (soloActive && bm.cameraId != selCamId) continue;
+      final ms = bm.ts.millisecondsSinceEpoch;
+      if (ms < winStart || ms > winEnd) continue;
+      final x = ((ms - winStart) / winDur) * _width;
+      final dx = (x - local.dx).abs();
+      if (dx <= bestDx) {
+        bestDx = dx;
+        best = bm;
+      }
+    }
+    return best;
+  }
+
   static String _titleCase(String s) =>
       s.isEmpty ? s : s[0].toUpperCase() + s.substring(1);
 
   /// Detail chip for a hovered detection glyph: icon + label, the zone(s) where
   /// it was detected (Frigate zones) plus the camera, confidence, and time.
   /// Answers the operator's "where was the person detected?" at a glance.
+  /// Detail chip for a hovered bookmark marker (#616): the note (or "Bookmark"),
+  /// the camera, and the bookmarked time. Same chip shape as detections.
+  Widget _buildBookmarkOverlay(Offset local, double width, Bookmark bm) {
+    const gold = _TimelinePainter.bookmarkColor;
+    final note = (bm.description ?? '').trim();
+    final title = note.isEmpty ? 'Bookmark' : note;
+    final ts = bm.ts.toLocal();
+    String p2(int v) => v.toString().padLeft(2, '0');
+    final time = '${p2(ts.hour)}:${p2(ts.minute)}:${p2(ts.second)}';
+    const chipW = 220.0;
+    final left = (local.dx - chipW / 2).clamp(
+      0.0,
+      (width - chipW).clamp(0.0, double.infinity),
+    );
+    return Positioned(
+      left: left,
+      top: 0,
+      child: IgnorePointer(
+        child: Container(
+          width: chipW,
+          padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 4),
+          decoration: BoxDecoration(
+            color: Colors.black.withValues(alpha: 0.9),
+            borderRadius: BorderRadius.circular(4),
+            border: Border.all(color: gold.withValues(alpha: 0.7)),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.bookmark, size: 13, color: gold),
+                  const SizedBox(width: 5),
+                  Flexible(
+                    child: Text(
+                      title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 11,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              Text(
+                '${_nameFor(bm.cameraId)} · $time',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(color: Colors.white70, fontSize: 10),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
   Widget _buildDetectionOverlay(Offset local, double width, DetectionEvent det) {
     final spec = detectionIconFor(det.iconKey);
     final label = det.label.isEmpty ? det.iconKey : det.label;
@@ -652,6 +747,8 @@ class _TimelinePainter extends CustomPainter {
   static const Color futureDim = Color(0x73000000);
   static const Color laneLabel = Color(0x59FFFFFF);
   static const Color selColor = Color(0xFFE8A33D);
+  /// Saved-bookmark markers — the same gold Android uses (`TimelineColors.bookmark`).
+  static const Color bookmarkColor = Color(0xFFF5C518);
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -734,6 +831,8 @@ class _TimelinePainter extends CustomPainter {
     _drawActiveEventSpans(canvas, msToX, selCamId, soloActive, motionTop,
         motionBottom, size.width);
     _drawDetectionGlyphs(canvas, msToX, selCamId, soloActive, motionBottom);
+    // Bookmarks last so the gold markers stay crisp on top of everything (#616).
+    _drawBookmarkMarkers(canvas, msToX, selCamId, soloActive, motionTop);
 
     // ── recording-coverage line (bottom): where footage exists ──────────────
     final recPaint = Paint()..color = recColor;
@@ -937,6 +1036,46 @@ class _TimelinePainter extends CustomPainter {
 
   /// Frigate detection markers: the actual type icon on a dark disc + ring,
   /// just above the coverage line, collision-thinned.
+  /// Saved-bookmark markers (#616): a gold downward triangle at the TOP of the
+  /// motion band, the same glyph Android (`CenteredTimeline` 2c) and iOS
+  /// (`CenteredTimelineView` 2c) draw, with a dark halo so it reads against
+  /// bright motion bars. Hidden cameras' bookmarks are skipped in solo mode,
+  /// exactly like detection glyphs; the selected camera's are drawn prominent.
+  void _drawBookmarkMarkers(
+    Canvas canvas,
+    double Function(int) msToX,
+    String? selCamId,
+    bool soloActive,
+    double motionTop,
+  ) {
+    if (motion.bookmarks.isEmpty) return;
+    final winStart = timeline.windowStart.millisecondsSinceEpoch;
+    final winEnd = timeline.windowEnd.millisecondsSinceEpoch;
+    final halo = Paint()
+      ..color = const Color(0xE60A0E16)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2.5;
+    final tri = Path();
+    for (final bm in motion.bookmarks) {
+      if (soloActive && bm.cameraId != selCamId) continue;
+      final ms = bm.ts.millisecondsSinceEpoch;
+      if (ms < winStart || ms > winEnd) continue;
+      final x = msToX(ms);
+      final prominent = selCamId == null || bm.cameraId == selCamId;
+      tri
+        ..reset()
+        ..moveTo(x, motionTop + 10) // apex, pointing down into the band
+        ..lineTo(x - 5, motionTop)
+        ..lineTo(x + 5, motionTop)
+        ..close();
+      canvas.drawPath(tri, halo);
+      canvas.drawPath(
+        tri,
+        Paint()..color = bookmarkColor.withValues(alpha: prominent ? 1.0 : 0.6),
+      );
+    }
+  }
+
   void _drawDetectionGlyphs(
     Canvas canvas,
     double Function(int) msToX,

--- a/apps/desktop-flutter/lib/ui/playback/playback_screen.dart
+++ b/apps/desktop-flutter/lib/ui/playback/playback_screen.dart
@@ -710,7 +710,7 @@ class _PlaybackScreenState extends State<PlaybackScreen> {
 
   /// Bookmark the current moment on the selected camera (opens the dialog).
   Future<void> _addBookmark() async {
-    await showAddBookmarkDialog(
+    final added = await showAddBookmarkDialog(
       context,
       api: widget.api,
       session: widget.session,
@@ -718,6 +718,9 @@ class _PlaybackScreenState extends State<PlaybackScreen> {
       cameras: _cameras,
       at: _timeline.playhead,
     );
+    // A new bookmark should show up on the timeline right away, not on the
+    // next periodic re-fetch (#616).
+    if (added != null && mounted) await _motion.refresh(force: true);
   }
 
   /// Hand the Shift+drag selection off to the Export tab as a pre-filled clip.


### PR DESCRIPTION
Fixes #616.

**Bug:** a bookmark (e.g. added on Android) shows in the desktop Bookmarks screen but has no indicator on the playback timeline.

**Cause:** parity gap, not a sync issue. Android (`CenteredTimeline` 2c) and iOS (`CenteredTimelineView` 2c) draw saved bookmarks as gold downward triangles at the top of the band; the desktop motion timeline fetched intensity + detections only and had no bookmark glyph, so no bookmark ever appeared there, whichever client created it.

**Fix:**
- controller: fetch the caller's bookmarks with the window data and keep the loaded cameras' entries; guarded on its own so a bookmarks failure (platform toggle off) never blanks the intensity/detections that just loaded
- painter: gold marker (Android's `TimelineColors.bookmark`) with a dark halo at the band top; solo-mode visibility and selected-camera prominence match the detection glyphs; drawn last so it stays on top
- hover: bookmark chip (note or "Bookmark", camera, time) wins the hit-test over detections
- playback: refresh the timeline right after a successful add so the marker shows immediately

**Verify:** `flutter build windows --debug` green on winbuild. The marker itself is desktop UI, so the visual check is running the app with a bookmarked camera.