### PR TITLE
fix(android): treat cancelled exports as terminal; honor server output filename

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/data/Models.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/Models.kt
@@ -397,12 +397,15 @@ data class ExportOutputFile(
     @SerialName("camera_id") val cameraId: String,
     @SerialName("download_url") val downloadUrl: String,
     @SerialName("size_bytes") val sizeBytes: Long,
+    /** Basename of the file on disk, including the real extension (e.g. `.mkv`
+     *  or `crumb_export.zip`). May be blank on old persisted jobs. */
+    @SerialName("filename") val filename: String = "",
 )
 
 @Serializable
 data class ExportJob(
     val id: String,
-    /** "queued" | "running" | "done" | "failed". */
+    /** "queued" | "running" | "done" | "failed" | "cancelled". */
     val status: String,
     @SerialName("camera_ids") val cameraIds: List<String> = emptyList(),
     val start: String,
@@ -413,7 +416,8 @@ data class ExportJob(
 ) {
     val isDone: Boolean get() = status.equals("done", ignoreCase = true)
     val isFailed: Boolean get() = status.equals("failed", ignoreCase = true)
-    val isTerminal: Boolean get() = isDone || isFailed
+    val isCancelled: Boolean get() = status.equals("cancelled", ignoreCase = true)
+    val isTerminal: Boolean get() = isDone || isFailed || isCancelled
 }
 
 // ─── filmstrip ───────────────────────────────────────────────────────────────

--- a/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportScreen.kt
@@ -562,6 +562,7 @@ private fun jobStatusLabel(job: ExportJob?): String = when {
     job == null -> "Queuing export…"
     job.isDone -> "Done"
     job.isFailed -> "Failed"
+    job.isCancelled -> "Cancelled"
     job.status.equals("running", ignoreCase = true) -> "Processing…"
     else -> "Queued…"
 }
@@ -729,6 +730,27 @@ private const val EXPORT_CACHE_SUBDIR = "exports"
 private const val DOWNLOAD_SUBDIR = "CrumbVMS"
 
 /**
+ * Extension (without the dot, lowercased) to save an export output under, taken
+ * from the server-reported basename in [ExportOutputFile.filename]. The server
+ * may hand back `.mkv` (no-transcode passthrough) or a whole-job `.zip`, not
+ * just `.mp4` - saving everything as `.mp4` produced an unplayable/corrupt-looking
+ * file whenever the real container differed. Falls back to "mp4" only when the
+ * server didn't report a filename (old persisted jobs).
+ */
+private fun exportFileExtension(outputFile: ExportOutputFile): String {
+    val name = outputFile.filename
+    val dot = name.lastIndexOf('.')
+    return if (dot in 0 until name.length - 1) name.substring(dot + 1).lowercase() else "mp4"
+}
+
+/** MIME type matching [exportFileExtension]'s output, for MediaStore/share intents. */
+private fun exportMimeType(extension: String): String = when (extension.lowercase()) {
+    "mkv" -> "video/x-matroska"
+    "zip" -> "application/zip"
+    else -> "video/mp4"
+}
+
+/**
  * #134: Save one export output file to the device's **public Downloads** so it's
  * user-findable (Files app, other apps) and not silently purged like the
  * app-private cache the Share path uses.
@@ -764,8 +786,9 @@ private suspend fun saveExportToDownloads(
             val absoluteUrl = "$base$path"
 
             val safeId = outputFile.cameraId.replace(Regex("[^a-zA-Z0-9_-]"), "_")
+            val extension = exportFileExtension(outputFile)
             // Timestamp so repeated downloads don't collide / silently overwrite.
-            val fileName = "crumb-export-$safeId-${System.currentTimeMillis()}.mp4"
+            val fileName = "crumb-export-$safeId-${System.currentTimeMillis()}.$extension"
 
             val request = Request.Builder().url(absoluteUrl).build()
             client.newCall(request).execute().use { response ->
@@ -774,7 +797,7 @@ private suspend fun saveExportToDownloads(
                 }
                 val body = response.body ?: error("Empty response body")
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    writeToMediaStoreDownloads(context, fileName, body.byteStream())
+                    writeToMediaStoreDownloads(context, fileName, exportMimeType(extension), body.byteStream())
                 } else {
                     writeToLegacyDownloads(fileName, body.byteStream())
                 }
@@ -796,12 +819,13 @@ private suspend fun saveExportToDownloads(
 private fun writeToMediaStoreDownloads(
     context: Context,
     fileName: String,
+    mimeType: String,
     input: InputStream,
 ): String {
     val resolver = context.contentResolver
     val values = ContentValues().apply {
         put(MediaStore.Downloads.DISPLAY_NAME, fileName)
-        put(MediaStore.Downloads.MIME_TYPE, "video/mp4")
+        put(MediaStore.Downloads.MIME_TYPE, mimeType)
         put(
             MediaStore.Downloads.RELATIVE_PATH,
             Environment.DIRECTORY_DOWNLOADS + "/" + DOWNLOAD_SUBDIR,
@@ -874,7 +898,7 @@ private suspend fun downloadExportFileToCache(
             val absoluteUrl = "$base$path"
 
             val safeId = outputFile.cameraId.replace(Regex("[^a-zA-Z0-9_-]"), "_")
-            val fileName = "crumb-export-$safeId.mp4"
+            val fileName = "crumb-export-$safeId.${exportFileExtension(outputFile)}"
             val exportDir = File(context.cacheDir, EXPORT_CACHE_SUBDIR).apply { mkdirs() }
             val destFile = File(exportDir, fileName)
 
@@ -908,7 +932,7 @@ private fun shareLocalFile(context: Context, file: File) {
         val authority = "${context.packageName}.fileprovider"
         val uri = FileProvider.getUriForFile(context, authority, file)
         val intent = Intent(Intent.ACTION_SEND).apply {
-            type = "video/mp4"
+            type = exportMimeType(file.extension)
             putExtra(Intent.EXTRA_STREAM, uri)
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             putExtra(Intent.EXTRA_SUBJECT, "CrumbVMS Export")

--- a/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportViewModel.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportViewModel.kt
@@ -174,6 +174,8 @@ class ExportViewModel(private val repo: CrumbRepository) : ViewModel() {
                         _state.update { it.copy(job = job, jobError = null) }
                         if (job.isTerminal) {
                             _state.update { it.copy(polling = false) }
+                            // Cancelled is terminal but user-initiated, not a failure -
+                            // stop polling quietly, no error toast.
                             if (job.isFailed) {
                                 _state.update {
                                     it.copy(jobError = job.error ?: "Export failed.")


### PR DESCRIPTION
## Summary

Two small, verified bugs in the Android export flow (#619).

**1. A cancelled export job polls forever.** The server's `DELETE /export/{job_id}` sets `status = "cancelled"` and the poller is documented to stop on that one terminal state. `ExportJob.isTerminal` in `data/Models.kt` only checked `isDone || isFailed`, so `ExportViewModel.startPolling` never noticed a cancelled job and kept polling indefinitely, with the UI stuck showing a spinner. Fix: add `ExportJob.isCancelled` and fold it into `isTerminal`; the poller now stops without an error toast (cancellation is user-initiated, not a failure), and `ExportScreen`'s status label shows "Cancelled".

**2. Exported files are saved with the wrong extension.** `ExportOutputFile.filename` on the server carries the real on-disk basename (`.mkv` for a no-transcode passthrough, or a whole-job `.zip`), but the Android model never decoded that field, and the save/share code hardcoded a `crumb-export-<id>....mp4` name plus a `video/mp4` MIME type regardless of the actual container. An `.mkv` or `.zip` export was saved/shared as `.mp4`, producing an unplayable/corrupt-looking file. Fix: decode `filename`, derive the extension (and matching MIME type for MediaStore / the share intent) from it at both save sites (Downloads save, and cache-then-share), falling back to `mp4` only when the server didn't report a filename.

## Files changed
- `apps/android/app/src/main/java/video/crumb/app/data/Models.kt`: `ExportOutputFile.filename`, `ExportJob.isCancelled`/`isTerminal`.
- `apps/android/app/src/main/java/video/crumb/app/feature/export/ExportViewModel.kt`: terminal-but-not-failed handling for cancelled jobs.
- `apps/android/app/src/main/java/video/crumb/app/feature/export/ExportScreen.kt`: "Cancelled" status label, `exportFileExtension`/`exportMimeType` helpers used by `saveExportToDownloads`, `downloadExportFileToCache`, and `shareLocalFile`.

## Test plan
- [x] Verified: `./gradlew :app:compileDebugKotlin testDebugUnitTest` green on dev2 (BUILD SUCCESSFUL, exit 0).
- [ ] Manual on-device check: cancel an in-progress export and confirm polling stops with a "Cancelled" status; download an `.mkv`-source export and confirm the saved file keeps the `.mkv` extension.

Fixes #619