### PR TITLE
feat(android): export redesign, in/out marks on the timeline + export from playback (#617)

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/MainActivity.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/MainActivity.kt
@@ -39,6 +39,7 @@ import video.crumb.app.feature.auth.LoginScreen
 import video.crumb.app.feature.auth.biometricAvailability
 import video.crumb.app.feature.auth.showBiometricPrompt
 import video.crumb.app.feature.clips.ClipsScreen
+import video.crumb.app.feature.export.ExportRange
 import video.crumb.app.feature.export.ExportScreen
 import video.crumb.app.feature.live.LiveFullscreenScreen
 import video.crumb.app.feature.live.LiveScreen
@@ -307,8 +308,16 @@ private fun CrumbNavHost() {
                     )
                 },
                 onOpenBookmarks = { navController.navigate(Routes.BOOKMARKS) },
-                onOpenExport = {
-                    if (store.isAdmin || caps.export) navController.navigate(Routes.EXPORT)
+                // Seed Export with the wall's current time: the hour ending at the
+                // scrub cursor (or at "now" when the wall is parked at Latest). The
+                // wall has no single focused camera, so nothing is pre-selected.
+                onOpenExport = { cursorMs ->
+                    if (store.isAdmin || caps.export) {
+                        val end = if (cursorMs > 0L) cursorMs else System.currentTimeMillis()
+                        navController.navigate(
+                            Routes.export(startMs = end - ExportRange.FALLBACK_WINDOW_MS, endMs = end),
+                        )
+                    }
                 },
                 onOpenClips = {
                     if (store.isAdmin || caps.clips) navigateTab(Routes.CLIPS)
@@ -346,11 +355,39 @@ private fun CrumbNavHost() {
                 initialCameraId = cameraId,
                 initialTimeMs = startMs,
                 onBack = { navController.popBackStack() },
+                // Hand the marked in/out bracket (or the hour ending at the
+                // playhead) to Export, pre-filled with the camera being reviewed.
+                onOpenExport = { camId, exportStartMs, exportEndMs ->
+                    navController.navigate(Routes.export(camId, exportStartMs, exportEndMs))
+                },
             )
         }
 
-        composable(Routes.EXPORT) {
-            ExportScreen(onBack = { navController.popBackStack() })
+        // Export, optionally seeded with a camera + clip window by the entry point
+        // (playback's in/out bracket, or the playback wall's scrub cursor).
+        composable(
+            route = Routes.EXPORT,
+            arguments = listOf(
+                navArgument(Routes.ARG_CAMERA_ID) {
+                    type = NavType.StringType
+                    defaultValue = ""
+                },
+                navArgument(Routes.ARG_START_MS) {
+                    type = NavType.LongType
+                    defaultValue = 0L
+                },
+                navArgument(Routes.ARG_END_MS) {
+                    type = NavType.LongType
+                    defaultValue = 0L
+                },
+            ),
+        ) { entry ->
+            ExportScreen(
+                seedCameraId = entry.arguments?.getString(Routes.ARG_CAMERA_ID).orEmpty(),
+                seedStartMs = entry.arguments?.getLong(Routes.ARG_START_MS) ?: 0L,
+                seedEndMs = entry.arguments?.getLong(Routes.ARG_END_MS) ?: 0L,
+                onBack = { navController.popBackStack() },
+            )
         }
 
         // Clips tab — a thumbnail grid of detection + motion clips with tap-to-play.

--- a/apps/android/app/src/main/java/video/crumb/app/data/CrumbApi.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/CrumbApi.kt
@@ -181,6 +181,14 @@ interface CrumbApi {
     suspend fun exportStatus(@Path("job_id") jobId: String): ExportJob
 
     /**
+     * Cancel a queued/running export job. The server aborts ffmpeg, cleans the
+     * partial output up, and answers `204 No Content`; cancelling an already
+     * terminal job is an idempotent success, so this never needs a status guard.
+     */
+    @DELETE("export/{job_id}")
+    suspend fun cancelExport(@Path("job_id") jobId: String): Response<Unit>
+
+    /**
      * Fetch detection events for one or more cameras over a time window.
      *
      * Returns an empty [DetectionEventsResponse] when the detection plugin is

--- a/apps/android/app/src/main/java/video/crumb/app/data/CrumbRepository.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/CrumbRepository.kt
@@ -417,6 +417,19 @@ class CrumbRepository(private val container: AppContainer) {
     suspend fun exportStatus(jobId: String): Result<ExportJob> = runCatchingCancellable { api.exportStatus(jobId) }
 
     /**
+     * Cancel a queued/running export job (`DELETE /export/{job_id}`).
+     *
+     * The endpoint answers `204 No Content`, so the response body carries nothing;
+     * an unsuccessful status is turned into a failure here rather than silently
+     * reported as a cancel that never happened.
+     */
+    suspend fun cancelExport(jobId: String): Result<Unit> = runCatchingCancellable {
+        val response = api.cancelExport(jobId)
+        if (!response.isSuccessful) error("Server returned HTTP ${response.code()}")
+        Unit
+    }
+
+    /**
      * Fetch detection events for one camera over a time window.
      *
      * Non-fatal: returns [Result.success] with an empty list when the detection

--- a/apps/android/app/src/main/java/video/crumb/app/data/Models.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/data/Models.kt
@@ -397,12 +397,15 @@ data class ExportOutputFile(
     @SerialName("camera_id") val cameraId: String,
     @SerialName("download_url") val downloadUrl: String,
     @SerialName("size_bytes") val sizeBytes: Long,
+    /** Basename of the file on disk, including the real extension (e.g. `.mkv`
+     *  or `crumb_export.zip`). May be blank on old persisted jobs. */
+    @SerialName("filename") val filename: String = "",
 )
 
 @Serializable
 data class ExportJob(
     val id: String,
-    /** "queued" | "running" | "done" | "failed". */
+    /** "queued" | "running" | "done" | "failed" | "cancelled". */
     val status: String,
     @SerialName("camera_ids") val cameraIds: List<String> = emptyList(),
     val start: String,
@@ -413,7 +416,8 @@ data class ExportJob(
 ) {
     val isDone: Boolean get() = status.equals("done", ignoreCase = true)
     val isFailed: Boolean get() = status.equals("failed", ignoreCase = true)
-    val isTerminal: Boolean get() = isDone || isFailed
+    val isCancelled: Boolean get() = status.equals("cancelled", ignoreCase = true)
+    val isTerminal: Boolean get() = isDone || isFailed || isCancelled
 }
 
 // ─── filmstrip ───────────────────────────────────────────────────────────────

--- a/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportRange.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportRange.kt
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.feature.export
+
+/**
+ * Pure time-range helpers shared by the playback in/out bracket and the Export
+ * screen. Kept free of Compose and Android types so the arithmetic is unit
+ * testable, and so the playback screen and the export screen can never drift on
+ * what a "selection" means.
+ *
+ * The model mirrors the desktop client's `playback_timeline_controller`
+ * (`selStartMs`/`selEndMs` as epoch millis, no snapping) and the iOS
+ * `setExportEdge` / `exportRange` pair: the two edges are stored exactly as the
+ * operator placed them and are only ordered when read, so dragging one handle
+ * past the other never swaps which handle the finger is holding.
+ */
+object ExportRange {
+
+    /** Smallest range the server will accept (`start` must be strictly before `end`). */
+    const val MIN_DURATION_MS = 1_000L
+
+    /** Nudge step for the Export screen's fine stepper: ONE second. */
+    const val NUDGE_STEP_MS = 1_000L
+
+    /** Quick-range chip lengths, in minutes, mirroring the desktop export builder. */
+    val QUICK_RANGE_MINUTES = listOf(1, 5, 10, 15)
+
+    /** Fallback export window when nothing is bracketed: the hour ending at the playhead. */
+    const val FALLBACK_WINDOW_MS = 3_600_000L
+
+    /** Order two raw edges into `(start, end)`. */
+    fun normalize(a: Long, b: Long): Pair<Long, Long> =
+        if (a <= b) a to b else b to a
+
+    /**
+     * Place one edge of the bracket, seeding the missing edge from the playhead so
+     * a range is always visible as soon as the first edge is marked (iOS
+     * `setExportEdge`). [nowMs] clamps a mark into the past, since there is no
+     * footage in the future.
+     *
+     * @param currentStart Existing raw start edge, or null when unset.
+     * @param currentEnd Existing raw end edge, or null when unset.
+     * @param isStart True to place the IN point, false for the OUT point.
+     */
+    fun setEdge(
+        currentStart: Long?,
+        currentEnd: Long?,
+        isStart: Boolean,
+        ms: Long,
+        playheadMs: Long,
+        nowMs: Long,
+    ): Pair<Long, Long> {
+        val t = minOf(ms, nowMs)
+        return if (isStart) {
+            t to (currentEnd ?: maxOf(t, playheadMs))
+        } else {
+            (currentStart ?: minOf(t, playheadMs)) to t
+        }
+    }
+
+    /**
+     * The range an export entry point should carry: the bracketed selection when
+     * both edges are set, otherwise the hour ending at the playhead (the prior
+     * Android default, and what iOS `exportRange()` falls back to).
+     */
+    fun forExport(selStartMs: Long?, selEndMs: Long?, playheadMs: Long): Pair<Long, Long> {
+        if (selStartMs != null && selEndMs != null) {
+            val (a, b) = normalize(selStartMs, selEndMs)
+            if (b - a >= MIN_DURATION_MS) return a to b
+        }
+        return (playheadMs - FALLBACK_WINDOW_MS) to playheadMs
+    }
+
+    /** A "Last N minutes" quick range ending at [nowMs]. */
+    fun quickRange(nowMs: Long, minutes: Int): Pair<Long, Long> =
+        (nowMs - minutes * 60_000L) to nowMs
+
+    /** True when the server would accept this range (`start` strictly before `end`). */
+    fun isValid(startMs: Long, endMs: Long): Boolean = endMs - startMs >= MIN_DURATION_MS
+
+    /** Clamp a proposed start so it stays at least [MIN_DURATION_MS] before [endMs]. */
+    fun clampStart(proposedMs: Long, endMs: Long): Long =
+        minOf(proposedMs, endMs - MIN_DURATION_MS)
+
+    /** Clamp a proposed end so it stays at least [MIN_DURATION_MS] after [startMs]. */
+    fun clampEnd(proposedMs: Long, startMs: Long): Long =
+        maxOf(proposedMs, startMs + MIN_DURATION_MS)
+
+    /** "1h 2m 3s" / "2m 3s" / "3s" — always precise to the second. */
+    fun formatDuration(totalSec: Long): String {
+        val safe = if (totalSec < 0) 0L else totalSec
+        val h = safe / 3600
+        val m = (safe % 3600) / 60
+        val s = safe % 60
+        return when {
+            h > 0 -> "${h}h ${m}m ${s}s"
+            m > 0 -> "${m}m ${s}s"
+            else -> "${s}s"
+        }
+    }
+
+    /** Duration label for a millisecond range, rounded down to the second. */
+    fun durationLabel(startMs: Long, endMs: Long): String =
+        formatDuration((endMs - startMs) / 1_000L)
+}

--- a/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -25,7 +26,9 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -76,6 +79,7 @@ import video.crumb.app.data.Network
 import video.crumb.app.di.AppContainer
 import video.crumb.app.di.appContainer
 import video.crumb.app.ui.HintTooltip
+import video.crumb.app.ui.JumpToDateTimeDialog
 import video.crumb.app.ui.Time
 import video.crumb.app.ui.theme.BlueAccent
 import video.crumb.app.ui.theme.DangerRed
@@ -92,14 +96,35 @@ import java.time.Instant
  * Export screen: lets the operator pick cameras, a time window, and burn-in
  * preference, then submits an export job and polls it to completion. Completed
  * output files can be downloaded to the device or shared as a URL.
+ *
+ * The screen can be SEEDED by its entry point so it opens on what the operator
+ * was already looking at: single-camera playback hands over the camera plus the
+ * in/out bracket it marked on the timeline (or the hour ending at the playhead),
+ * and the playback wall hands over the hour ending at its scrub cursor.
+ *
+ * @param onBack Called when the user taps the back arrow.
+ * @param seedCameraId Camera to pre-select; blank pre-selects nothing.
+ * @param seedStartMs Clip-window start (epoch-millis); ≤ 0 keeps the default window.
+ * @param seedEndMs Clip-window end (epoch-millis); ≤ 0 keeps the default window.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ExportScreen(onBack: () -> Unit) {
+fun ExportScreen(
+    onBack: () -> Unit,
+    seedCameraId: String = "",
+    seedStartMs: Long = 0L,
+    seedEndMs: Long = 0L,
+) {
     val container = appContainer()
     val vm: ExportViewModel = viewModel(
+        // Keyed on the seed so navigating in with a DIFFERENT camera/window gets a
+        // ViewModel carrying that seed, instead of silently reusing the previous
+        // screen's state (a retained VM ignores constructor args).
+        key = "export:$seedCameraId:$seedStartMs:$seedEndMs",
         factory = viewModelFactory {
-            initializer { ExportViewModel(container.repository) }
+            initializer {
+                ExportViewModel(container.repository, seedCameraId, seedStartMs, seedEndMs)
+            }
         },
     )
     val state by vm.state.collectAsStateWithLifecycle()
@@ -161,6 +186,7 @@ fun ExportScreen(onBack: () -> Unit) {
                 endMs = state.endMs,
                 onStartChange = vm::setStart,
                 onEndChange = vm::setEnd,
+                onQuickRange = vm::applyQuickRange,
                 disabled = state.polling || state.submitting,
             )
 
@@ -180,7 +206,8 @@ fun ExportScreen(onBack: () -> Unit) {
             // state.submitting covers the gap between tapping Create and the POST
             // round-trip resolving (before state.polling itself flips true) — closes
             // a fast-double-tap window that could otherwise submit two export jobs.
-            val canSubmit = state.selectedCameraIds.isNotEmpty() && !state.polling && !state.submitting
+            val canSubmit = state.selectedCameraIds.isNotEmpty() && state.rangeValid &&
+                !state.polling && !state.submitting
             Button(
                 onClick = vm::createExport,
                 enabled = canSubmit,
@@ -192,7 +219,7 @@ fun ExportScreen(onBack: () -> Unit) {
             // ─── job progress + results ──────────────────────────────────────
             val job = state.job
             val jobError = state.jobError
-            if (state.polling || job != null || jobError != null) {
+            if (state.polling || job != null || jobError != null || state.notice != null) {
                 HorizontalDivider(color = NavySurfaceVariant)
                 SectionHeader("Job Status")
                 JobStatusSection(
@@ -200,6 +227,9 @@ fun ExportScreen(onBack: () -> Unit) {
                     polling = state.polling,
                     job = job,
                     jobError = jobError,
+                    notice = state.notice,
+                    cancelling = state.cancelling,
+                    onCancel = vm::cancelExport,
                     snackbarHostState = snackbarHostState,
                 )
             }
@@ -336,15 +366,19 @@ private fun CameraCheckRow(
     }
 }
 
-// ─── time range stepper ───────────────────────────────────────────────────────
+// ─── time range ───────────────────────────────────────────────────────────────
 
 /**
- * Simple +/- minute steppers for start and end times. Each press moves the
- * boundary by [STEP_MINUTES] minutes. The field shows the device-local time via
- * [Time.dateTime] so the operator sees a human-readable value at a glance.
+ * Clip-window editor: a precise start and end field, quick "Last N minutes"
+ * chips, and a one-SECOND nudge stepper on each boundary.
  *
- * Keeping the implementation self-contained avoids a DatePickerDialog dependency
- * and remains compilable on minSdk 26.
+ * This replaces the old one-minute +/- steppers, which were the only way to move
+ * a boundary and so made a second-accurate window impossible to express even
+ * though the server accepts fractional seconds. Tapping a field opens
+ * [JumpToDateTimeDialog] (`preserveSeconds = true`, so a seeded selection keeps
+ * its seconds through an edit of the date or the hour/minute), and the nudge
+ * buttons trim the boundary a second at a time. The chips mirror the desktop
+ * export builder's Last 1m / 5m / 10m / 15m.
  */
 @Composable
 private fun TimeRangeSection(
@@ -352,41 +386,70 @@ private fun TimeRangeSection(
     endMs: Long,
     onStartChange: (Long) -> Unit,
     onEndChange: (Long) -> Unit,
+    onQuickRange: (Int) -> Unit,
     disabled: Boolean,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        TimeStepperRow(
+        TimeBoundaryRow(
             label = "Start",
             epochMs = startMs,
             onChange = onStartChange,
             disabled = disabled,
         )
-        TimeStepperRow(
+        TimeBoundaryRow(
             label = "End",
             epochMs = endMs,
             onChange = onEndChange,
             disabled = disabled,
         )
-        val durationSec = (endMs - startMs) / 1_000L
-        val durationStr = formatDuration(durationSec)
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            ExportRange.QUICK_RANGE_MINUTES.forEach { minutes ->
+                AssistChip(
+                    onClick = { onQuickRange(minutes) },
+                    enabled = !disabled,
+                    label = { Text("Last ${minutes}m", style = MaterialTheme.typography.labelMedium) },
+                )
+            }
+        }
         Text(
-            text = "Duration: $durationStr",
+            text = "Duration: ${ExportRange.durationLabel(startMs, endMs)}",
             style = MaterialTheme.typography.bodySmall,
             color = TextSecondary,
         )
     }
 }
 
+/**
+ * One clip boundary: a tappable, second-accurate value that opens the date+time
+ * picker, flanked by a one-second nudge in each direction.
+ */
 @Composable
-private fun TimeStepperRow(
+private fun TimeBoundaryRow(
     label: String,
     epochMs: Long,
     onChange: (Long) -> Unit,
     disabled: Boolean,
 ) {
-    val instant = Instant.ofEpochMilli(epochMs)
-    val displayText = Time.dateTime(instant)
-    val stepMs = STEP_MINUTES * 60_000L
+    var showPicker by remember { mutableStateOf(false) }
+
+    if (showPicker) {
+        JumpToDateTimeDialog(
+            initialMs = epochMs,
+            onDismiss = { showPicker = false },
+            onPicked = { picked ->
+                showPicker = false
+                onChange(picked)
+            },
+            // The M3 time step only offers hours and minutes; carry the seconds of
+            // the current boundary through so a second-accurate selection isn't
+            // silently rounded off by opening the picker.
+            preserveSeconds = true,
+            title = "$label time",
+        )
+    }
 
     Card(
         colors = CardDefaults.cardColors(containerColor = NavySurface),
@@ -403,43 +466,49 @@ private fun TimeStepperRow(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                OutlinedButton(
-                    onClick = { onChange(epochMs - stepMs) },
-                    enabled = !disabled,
-                    modifier = Modifier.size(width = 48.dp, height = 36.dp),
-                ) {
-                    Text("-", style = MaterialTheme.typography.labelLarge)
+                HintTooltip("One second earlier") {
+                    OutlinedButton(
+                        onClick = { onChange(epochMs - ExportRange.NUDGE_STEP_MS) },
+                        enabled = !disabled,
+                        contentPadding = PaddingValues(0.dp),
+                        modifier = Modifier.size(width = 44.dp, height = 36.dp),
+                    ) {
+                        Text("-1s", style = MaterialTheme.typography.labelMedium)
+                    }
                 }
-                Text(
-                    text = displayText,
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.weight(1f),
-                )
-                OutlinedButton(
-                    onClick = { onChange(epochMs + stepMs) },
+                TextButton(
+                    onClick = { showPicker = true },
                     enabled = !disabled,
-                    modifier = Modifier.size(width = 48.dp, height = 36.dp),
+                    modifier = Modifier.weight(1f),
                 ) {
-                    Text("+", style = MaterialTheme.typography.labelLarge)
+                    Icon(
+                        imageVector = Icons.Filled.Schedule,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .padding(end = 6.dp)
+                            .size(16.dp),
+                    )
+                    Text(
+                        text = Time.dateTime(Instant.ofEpochMilli(epochMs)),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+                HintTooltip("One second later") {
+                    OutlinedButton(
+                        onClick = { onChange(epochMs + ExportRange.NUDGE_STEP_MS) },
+                        enabled = !disabled,
+                        contentPadding = PaddingValues(0.dp),
+                        modifier = Modifier.size(width = 44.dp, height = 36.dp),
+                    ) {
+                        Text("+1s", style = MaterialTheme.typography.labelMedium)
+                    }
                 }
             }
         }
     }
 }
-
-private fun formatDuration(totalSec: Long): String {
-    val h = totalSec / 3600
-    val m = (totalSec % 3600) / 60
-    val s = totalSec % 60
-    return when {
-        h > 0 -> "${h}h ${m}m ${s}s"
-        m > 0 -> "${m}m ${s}s"
-        else -> "${s}s"
-    }
-}
-
-private const val STEP_MINUTES = 1L
 
 // ─── burn-timestamp switch ────────────────────────────────────────────────────
 
@@ -488,12 +557,16 @@ private fun JobStatusSection(
     polling: Boolean,
     job: ExportJob?,
     jobError: String?,
+    notice: String?,
+    cancelling: Boolean,
+    onCancel: () -> Unit,
     snackbarHostState: SnackbarHostState,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
 
         // Progress bar — shown while polling or while job is non-terminal
-        if (polling || (job != null && !job.isTerminal)) {
+        val running = polling || (job != null && !job.isTerminal)
+        if (running) {
             val progress = job?.progressPct?.let { it / 100f } ?: 0f
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 Row(
@@ -530,12 +603,42 @@ private fun JobStatusSection(
             }
         }
 
+        // Cancel a queued/running job (DELETE /export/{job_id}) — the server aborts
+        // ffmpeg and removes the partial output, so nothing half-written is left on
+        // the box. Only offered while the job can still be stopped.
+        if (running) {
+            OutlinedButton(
+                onClick = onCancel,
+                enabled = !cancelling,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (cancelling) {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .padding(end = 6.dp)
+                            .size(16.dp),
+                        strokeWidth = 2.dp,
+                    )
+                }
+                Text(if (cancelling) "Cancelling..." else "Cancel export")
+            }
+        }
+
         // Error message (job failure or network blip during polling)
         if (jobError != null) {
             Text(
                 text = jobError,
                 style = MaterialTheme.typography.bodyMedium,
                 color = DangerRed,
+            )
+        }
+
+        // Neutral status line (e.g. a deliberate cancel) — not a failure, so not red.
+        if (notice != null) {
+            Text(
+                text = notice,
+                style = MaterialTheme.typography.bodyMedium,
+                color = TextSecondary,
             )
         }
 

--- a/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportScreen.kt
@@ -562,6 +562,7 @@ private fun jobStatusLabel(job: ExportJob?): String = when {
     job == null -> "Queuing export…"
     job.isDone -> "Done"
     job.isFailed -> "Failed"
+    job.isCancelled -> "Cancelled"
     job.status.equals("running", ignoreCase = true) -> "Processing…"
     else -> "Queued…"
 }
@@ -729,6 +730,27 @@ private const val EXPORT_CACHE_SUBDIR = "exports"
 private const val DOWNLOAD_SUBDIR = "CrumbVMS"
 
 /**
+ * Extension (without the dot, lowercased) to save an export output under, taken
+ * from the server-reported basename in [ExportOutputFile.filename]. The server
+ * may hand back `.mkv` (no-transcode passthrough) or a whole-job `.zip`, not
+ * just `.mp4` - saving everything as `.mp4` produced an unplayable/corrupt-looking
+ * file whenever the real container differed. Falls back to "mp4" only when the
+ * server didn't report a filename (old persisted jobs).
+ */
+private fun exportFileExtension(outputFile: ExportOutputFile): String {
+    val name = outputFile.filename
+    val dot = name.lastIndexOf('.')
+    return if (dot in 0 until name.length - 1) name.substring(dot + 1).lowercase() else "mp4"
+}
+
+/** MIME type matching [exportFileExtension]'s output, for MediaStore/share intents. */
+private fun exportMimeType(extension: String): String = when (extension.lowercase()) {
+    "mkv" -> "video/x-matroska"
+    "zip" -> "application/zip"
+    else -> "video/mp4"
+}
+
+/**
  * #134: Save one export output file to the device's **public Downloads** so it's
  * user-findable (Files app, other apps) and not silently purged like the
  * app-private cache the Share path uses.
@@ -764,8 +786,9 @@ private suspend fun saveExportToDownloads(
             val absoluteUrl = "$base$path"
 
             val safeId = outputFile.cameraId.replace(Regex("[^a-zA-Z0-9_-]"), "_")
+            val extension = exportFileExtension(outputFile)
             // Timestamp so repeated downloads don't collide / silently overwrite.
-            val fileName = "crumb-export-$safeId-${System.currentTimeMillis()}.mp4"
+            val fileName = "crumb-export-$safeId-${System.currentTimeMillis()}.$extension"
 
             val request = Request.Builder().url(absoluteUrl).build()
             client.newCall(request).execute().use { response ->
@@ -774,7 +797,7 @@ private suspend fun saveExportToDownloads(
                 }
                 val body = response.body ?: error("Empty response body")
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    writeToMediaStoreDownloads(context, fileName, body.byteStream())
+                    writeToMediaStoreDownloads(context, fileName, exportMimeType(extension), body.byteStream())
                 } else {
                     writeToLegacyDownloads(fileName, body.byteStream())
                 }
@@ -796,12 +819,13 @@ private suspend fun saveExportToDownloads(
 private fun writeToMediaStoreDownloads(
     context: Context,
     fileName: String,
+    mimeType: String,
     input: InputStream,
 ): String {
     val resolver = context.contentResolver
     val values = ContentValues().apply {
         put(MediaStore.Downloads.DISPLAY_NAME, fileName)
-        put(MediaStore.Downloads.MIME_TYPE, "video/mp4")
+        put(MediaStore.Downloads.MIME_TYPE, mimeType)
         put(
             MediaStore.Downloads.RELATIVE_PATH,
             Environment.DIRECTORY_DOWNLOADS + "/" + DOWNLOAD_SUBDIR,
@@ -874,7 +898,7 @@ private suspend fun downloadExportFileToCache(
             val absoluteUrl = "$base$path"
 
             val safeId = outputFile.cameraId.replace(Regex("[^a-zA-Z0-9_-]"), "_")
-            val fileName = "crumb-export-$safeId.mp4"
+            val fileName = "crumb-export-$safeId.${exportFileExtension(outputFile)}"
             val exportDir = File(context.cacheDir, EXPORT_CACHE_SUBDIR).apply { mkdirs() }
             val destFile = File(exportDir, fileName)
 
@@ -908,7 +932,7 @@ private fun shareLocalFile(context: Context, file: File) {
         val authority = "${context.packageName}.fileprovider"
         val uri = FileProvider.getUriForFile(context, authority, file)
         val intent = Intent(Intent.ACTION_SEND).apply {
-            type = "video/mp4"
+            type = exportMimeType(file.extension)
             putExtra(Intent.EXTRA_STREAM, uri)
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             putExtra(Intent.EXTRA_SUBJECT, "CrumbVMS Export")

--- a/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportViewModel.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportViewModel.kt
@@ -39,6 +39,9 @@ import java.time.Instant
  *   a fast double-tap on Create before the first response lands could submit two
  *   export jobs (the guard in [ExportViewModel.createExport] checked [polling] too
  *   late to catch it).
+ * @property cancelling True while a `DELETE /export/{job_id}` is in flight.
+ * @property notice A neutral, non-error status line (e.g. "Export cancelled.").
+ *   Kept apart from [jobError] so a deliberate cancel isn't shown in danger red.
  */
 data class ExportUiState(
     val loadingCameras: Boolean = true,
@@ -52,20 +55,54 @@ data class ExportUiState(
     val jobError: String? = null,
     val polling: Boolean = false,
     val submitting: Boolean = false,
-)
+    val cancelling: Boolean = false,
+    val notice: String? = null,
+) {
+    /** True when the current window is one the server will accept (`start` < `end`). */
+    val rangeValid: Boolean get() = ExportRange.isValid(startMs, endMs)
+}
 
 /**
  * ViewModel for the Export screen.
  *
  * Loads cameras, manages clip-range selection, submits the export job, and
  * polls for completion. Also provides per-output authenticated download URLs.
+ *
+ * @param seedCameraId Camera to pre-select (blank = none). Applied before the
+ *   camera list arrives, so it survives the load.
+ * @param seedStartMs Clip-window start to pre-fill (epoch-millis; ≤ 0 = keep the
+ *   screen's own default).
+ * @param seedEndMs Clip-window end to pre-fill (epoch-millis; ≤ 0 = keep the default).
  */
-class ExportViewModel(private val repo: CrumbRepository) : ViewModel() {
+class ExportViewModel(
+    private val repo: CrumbRepository,
+    seedCameraId: String = "",
+    seedStartMs: Long = 0L,
+    seedEndMs: Long = 0L,
+) : ViewModel() {
 
-    private val _state = MutableStateFlow(ExportUiState())
+    private val _state = MutableStateFlow(
+        ExportUiState().let { base ->
+            val seeded = if (seedStartMs > 0L && seedEndMs > 0L &&
+                ExportRange.isValid(seedStartMs, seedEndMs)
+            ) {
+                base.copy(startMs = seedStartMs, endMs = seedEndMs)
+            } else {
+                base
+            }
+            if (seedCameraId.isNotBlank()) {
+                seeded.copy(selectedCameraIds = setOf(seedCameraId))
+            } else {
+                seeded
+            }
+        },
+    )
     val state: StateFlow<ExportUiState> = _state.asStateFlow()
 
     private var pollJob: Job? = null
+
+    /** Id of the job currently being polled, kept so Cancel works after a poll blip. */
+    private var activeJobId: String? = null
 
     init {
         loadCameras()
@@ -108,17 +145,31 @@ class ExportViewModel(private val repo: CrumbRepository) : ViewModel() {
     fun setStart(epochMs: Long) {
         _state.update { s ->
             // Clamp: start must be before end
-            val clamped = minOf(epochMs, s.endMs - 1_000L)
-            s.copy(startMs = clamped)
+            s.copy(startMs = ExportRange.clampStart(epochMs, s.endMs))
         }
     }
 
     fun setEnd(epochMs: Long) {
         _state.update { s ->
             // Clamp: end must be after start
-            val clamped = maxOf(epochMs, s.startMs + 1_000L)
-            s.copy(endMs = clamped)
+            s.copy(endMs = ExportRange.clampEnd(epochMs, s.startMs))
         }
+    }
+
+    /**
+     * Set both boundaries at once (quick-range chips, or a seeded hand-off). The
+     * pair is ordered and widened to the minimum the server accepts, so a chip can
+     * never produce an inverted or zero-length window.
+     */
+    fun setRange(startEpochMs: Long, endEpochMs: Long) {
+        val (a, b) = ExportRange.normalize(startEpochMs, endEpochMs)
+        _state.update { it.copy(startMs = a, endMs = ExportRange.clampEnd(b, a)) }
+    }
+
+    /** Apply a "Last N minutes" quick range ending now. */
+    fun applyQuickRange(minutes: Int) {
+        val (start, end) = ExportRange.quickRange(Instant.now().toEpochMilli(), minutes)
+        setRange(start, end)
     }
 
     fun setBurn(enabled: Boolean) {
@@ -130,6 +181,7 @@ class ExportViewModel(private val repo: CrumbRepository) : ViewModel() {
     fun createExport() {
         val s = _state.value
         if (s.selectedCameraIds.isEmpty()) return
+        if (!s.rangeValid) return // the server rejects start >= end; don't spend a round-trip
         if (s.polling || s.submitting) return // already running or already in flight
         // Set synchronously, BEFORE the coroutine launch, so a fast double-tap on
         // Create can't slip a second submit in during the POST round-trip (polling
@@ -141,7 +193,8 @@ class ExportViewModel(private val repo: CrumbRepository) : ViewModel() {
 
         viewModelScope.launch {
             // Reset any previous job state before submitting.
-            _state.update { it.copy(job = null, jobError = null, polling = false) }
+            activeJobId = null
+            _state.update { it.copy(job = null, jobError = null, notice = null, polling = false) }
 
             repo.createExport(
                 cameraIds = s.selectedCameraIds.toList(),
@@ -149,11 +202,47 @@ class ExportViewModel(private val repo: CrumbRepository) : ViewModel() {
                 endIso = endIso,
                 burn = s.burn,
             ).onSuccess { response ->
+                activeJobId = response.jobId
                 _state.update { it.copy(polling = true, submitting = false) }
                 startPolling(response.jobId)
             }.onFailure { t ->
                 _state.update { it.copy(jobError = t.toUserMessage(), submitting = false) }
             }
+        }
+    }
+
+    /**
+     * Cancel the job currently being polled (`DELETE /export/{job_id}`). The server
+     * aborts ffmpeg and cleans the partial output up; cancelling a job that has
+     * already finished is an idempotent success, so a race with completion is safe.
+     *
+     * Polling stops locally on success and the job card is cleared back to a plain
+     * "Export cancelled." notice rather than a red failure.
+     */
+    fun cancelExport() {
+        val jobId = activeJobId ?: _state.value.job?.id ?: return
+        if (_state.value.cancelling) return
+        _state.update { it.copy(cancelling = true) }
+        viewModelScope.launch {
+            repo.cancelExport(jobId)
+                .onSuccess {
+                    pollJob?.cancel()
+                    pollJob = null
+                    activeJobId = null
+                    _state.update {
+                        it.copy(
+                            cancelling = false,
+                            polling = false,
+                            submitting = false,
+                            job = null,
+                            jobError = null,
+                            notice = "Export cancelled.",
+                        )
+                    }
+                }
+                .onFailure { t ->
+                    _state.update { it.copy(cancelling = false, jobError = t.toUserMessage()) }
+                }
         }
     }
 
@@ -172,9 +261,17 @@ class ExportViewModel(private val repo: CrumbRepository) : ViewModel() {
                     .onSuccess { job ->
                         failStreak = 0
                         _state.update { it.copy(job = job, jobError = null) }
-                        if (job.isTerminal) {
+                        // A job cancelled server-side (by this client, another
+                        // session, or the operator's own DELETE) is terminal too —
+                        // without this the poll loop would spin forever on it.
+                        if (job.isTerminal || job.looksCancelled) {
+                            activeJobId = null
                             _state.update { it.copy(polling = false) }
-                            if (job.isFailed) {
+                            if (job.looksCancelled) {
+                                _state.update {
+                                    it.copy(job = null, notice = "Export cancelled.")
+                                }
+                            } else if (job.isFailed) {
                                 _state.update {
                                     it.copy(jobError = job.error ?: "Export failed.")
                                 }
@@ -201,3 +298,13 @@ class ExportViewModel(private val repo: CrumbRepository) : ViewModel() {
         private const val POLL_INTERVAL_MS = 1_500L
     }
 }
+
+/**
+ * Whether the server reports this job as cancelled.
+ *
+ * Read off [ExportJob.status] here rather than assuming a model-level flag, so
+ * this compiles against the current [ExportJob] and stays correct once a
+ * dedicated `isCancelled` property lands alongside `isTerminal`.
+ */
+private val ExportJob.looksCancelled: Boolean
+    get() = status.equals("cancelled", ignoreCase = true)

--- a/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportViewModel.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/export/ExportViewModel.kt
@@ -174,6 +174,8 @@ class ExportViewModel(private val repo: CrumbRepository) : ViewModel() {
                         _state.update { it.copy(job = job, jobError = null) }
                         if (job.isTerminal) {
                             _state.update { it.copy(polling = false) }
+                            // Cancelled is terminal but user-initiated, not a failure -
+                            // stop polling quietly, no error toast.
                             if (job.isFailed) {
                                 _state.update {
                                     it.copy(jobError = job.error ?: "Export failed.")

--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/CenteredTimeline.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/CenteredTimeline.kt
@@ -100,6 +100,14 @@ private val ICON_DISC = Color(0xF21A1C22)   // near-opaque dark disc directly be
  * @param onScrub Called continuously with the new playhead time.
  * @param onScrubEnd Called once on release with the final playhead time.
  * @param onSpanChange Called when a pinch changes the visible span.
+ * @param exportSelStartMs Raw IN edge of the export bracket (epoch-millis), or null
+ *   when nothing is marked. Edges are stored as the operator placed them and only
+ *   ordered when drawn, mirroring the desktop selection model.
+ * @param exportSelEndMs Raw OUT edge of the export bracket, or null.
+ * @param onSetExportStart Called while dragging the IN handle. Null (with
+ *   [onSetExportEnd]) disables edge-dragging entirely, which is what the
+ *   multi-camera playback wall wants.
+ * @param onSetExportEnd Called while dragging the OUT handle.
  */
 @Composable
 fun CenteredTimeline(
@@ -117,6 +125,10 @@ fun CenteredTimeline(
     onScrub: (Long) -> Unit,
     onScrubEnd: (Long) -> Unit,
     onSpanChange: (Long) -> Unit,
+    exportSelStartMs: Long? = null,
+    exportSelEndMs: Long? = null,
+    onSetExportStart: ((Long) -> Unit)? = null,
+    onSetExportEnd: ((Long) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val textMeasurer = rememberTextMeasurer()
@@ -127,6 +139,11 @@ fun CenteredTimeline(
     // Latest values readable inside the (Unit-keyed) gesture loop.
     val playhead = rememberUpdatedState(playheadMs)
     val span = rememberUpdatedState(spanMs)
+    // Export bracket, likewise readable from the gesture loop without re-keying it.
+    val selStart = rememberUpdatedState(exportSelStartMs)
+    val selEnd = rememberUpdatedState(exportSelEndMs)
+    val setSelStart = rememberUpdatedState(onSetExportStart)
+    val setSelEnd = rememberUpdatedState(onSetExportEnd)
 
     // Detection-event glyphs, drawn on the timeline tinted per type (created here
     // in composable scope; the Canvas draws them via VectorPainter.draw).
@@ -169,8 +186,64 @@ fun CenteredTimeline(
             modifier = Modifier
                 .fillMaxSize()
                 .pointerInput(Unit) {
+                    // Touch grab radius for an export handle. Desktop uses 7 px
+                    // against a mouse cursor; a fingertip needs a wider target, so
+                    // this is expressed in dp and converted per-device.
+                    val grabPx = 16.dp.toPx()
                     awaitEachGesture {
-                        awaitFirstDown(requireUnconsumed = false)
+                        val down = awaitFirstDown(requireUnconsumed = false)
+
+                        // Time under an x offset for the CURRENT window. Only valid
+                        // while the playhead is NOT moving, which is exactly the
+                        // export-handle drag (it never scrubs).
+                        fun timeAt(x: Float): Long {
+                            val w = size.width.toFloat()
+                            if (w <= 0f) return playhead.value
+                            val frac = (x / w).coerceIn(0f, 1f)
+                            return playhead.value - span.value / 2 +
+                                (frac * span.value).roundToLong()
+                        }
+
+                        // Which export edge (if any) the finger landed on. Nearest
+                        // wins when the two handles overlap; mirrors iOS
+                        // `exportEdge(near:)`.
+                        val edgeSetter: ((Long) -> Unit)? = run {
+                            val s = selStart.value
+                            val e = selEnd.value
+                            val setS = setSelStart.value
+                            val setE = setSelEnd.value
+                            val w = size.width.toFloat()
+                            if (s == null || e == null || setS == null || setE == null ||
+                                w <= 0f || span.value <= 0L
+                            ) {
+                                return@run null
+                            }
+                            val visStart = playhead.value - span.value / 2
+                            fun xOf(ts: Long): Float =
+                                ((ts - visStart).toFloat() / span.value.toFloat()) * w
+                            val dS = abs(xOf(s) - down.position.x)
+                            val dE = abs(xOf(e) - down.position.x)
+                            if (minOf(dS, dE) > grabPx) null else if (dS <= dE) setS else setE
+                        }
+
+                        if (edgeSetter != null) {
+                            // Handle drag: resize the bracket instead of scrubbing.
+                            // The playhead stays exactly where it is, so nothing but
+                            // the marked edge moves.
+                            val nowMs = System.currentTimeMillis()
+                            edgeSetter(timeAt(down.position.x).coerceIn(0L, nowMs))
+                            down.consume()
+                            while (true) {
+                                val event = awaitPointerEvent()
+                                event.changes.firstOrNull { it.pressed }?.let { change ->
+                                    edgeSetter(timeAt(change.position.x).coerceIn(0L, nowMs))
+                                }
+                                event.changes.forEach { if (it.positionChanged()) it.consume() }
+                                if (event.changes.none { it.pressed }) break
+                            }
+                            return@awaitEachGesture
+                        }
+
                         onScrubStart()
                         var acc = playhead.value
                         var sp = span.value
@@ -371,6 +444,34 @@ fun CenteredTimeline(
                                 colorFilter = ColorFilter.tint(lerp(color, Color.White, 0.2f)),
                             )
                         }
+                    }
+                }
+            }
+
+            // 2e. Export in/out bracket — a translucent amber wash over the marked
+            // region with a solid amber handle at each edge (the same "mark for
+            // export" region the desktop and iOS clients draw). Edges are ordered
+            // here, not in state, so dragging one past the other is harmless.
+            val selA = exportSelStartMs
+            val selB = exportSelEndMs
+            if (selA != null && selB != null) {
+                val a = minOf(selA, selB)
+                val b = maxOf(selA, selB)
+                if (b >= visStart && a <= visEnd) {
+                    val xa = xOf(a).coerceIn(0f, w)
+                    val xb = xOf(b).coerceIn(0f, w)
+                    drawRect(
+                        color = TimelineColors.exportFill,
+                        topLeft = Offset(xa, bandTop),
+                        size = Size((xb - xa).coerceAtLeast(1f), bandH),
+                    )
+                    for (hx in listOf(xOf(a), xOf(b))) {
+                        if (hx < 0f || hx > w) continue
+                        drawRect(
+                            color = TimelineColors.exportHandle,
+                            topLeft = Offset(hx - 1.5f, bandTop - 6f),
+                            size = Size(3f, bandH + 12f),
+                        )
                     }
                 }
             }

--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackScreen.kt
@@ -25,7 +25,10 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ArrowDropUp
 import androidx.compose.material.icons.filled.ChevronLeft
 import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.ContentCut
 import androidx.compose.material.icons.filled.DirectionsRun
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.FirstPage
 import androidx.compose.material.icons.filled.LastPage
 import androidx.compose.material.icons.filled.MoreVert
@@ -111,11 +114,13 @@ import video.crumb.app.ui.player.PlayerSurface
 import video.crumb.app.ui.player.ViewTransform
 import video.crumb.app.ui.player.ZoomableVideoSurface
 import video.crumb.app.ui.player.rememberZoomableSurfaceState
+import video.crumb.app.feature.export.ExportRange
 import video.crumb.app.feature.live.rememberIsMetered
 import video.crumb.app.ui.theme.NavyDeep
 import video.crumb.app.ui.theme.NavySurface
 import video.crumb.app.ui.theme.TealAccent
 import video.crumb.app.ui.theme.TextSecondary
+import video.crumb.app.ui.theme.TimelineColors
 import java.time.Instant
 
 /**
@@ -205,6 +210,9 @@ object PlaybackQuality {
  *   set when entered from the playback wall scrubbed to a past moment. ≤ 0 → open
  *   at the camera's latest footage (the standard behaviour).
  * @param onBack Called when the user taps the back arrow.
+ * @param onOpenExport Opens the Export screen seeded with `(cameraId, startMs, endMs)`.
+ *   Null hides every export affordance on this screen (a caller that has nowhere to
+ *   navigate); the capability gate is applied on top of it.
  */
 @OptIn(ExperimentalMaterial3Api::class, UnstableApi::class)
 @Composable
@@ -212,6 +220,7 @@ fun PlaybackScreen(
     initialCameraId: String,
     initialTimeMs: Long = 0L,
     onBack: () -> Unit,
+    onOpenExport: ((String, Long, Long) -> Unit)? = null,
 ) {
     val container = appContainer()
     val repo = container.repository
@@ -689,6 +698,15 @@ fun PlaybackScreen(
         showBookmarkDialog = true
     }
 
+    // Export hand-off: only offered when this account may export AND the host gave
+    // us somewhere to navigate. Carries the in/out bracket when one is marked,
+    // otherwise the hour ending at the playhead (PlaybackViewModel.exportRange).
+    val canExport = (store.isAdmin || store.capabilities.export) && onOpenExport != null
+    val onExportRange: () -> Unit = {
+        val (startMs, endMs) = vm.exportRange()
+        onOpenExport?.invoke(cameraId, startMs, endMs)
+    }
+
     // In landscape the phone is short: a fixed top app bar + bottom transport eat
     // most of the height, leaving the video SMALLER than in portrait. So in
     // landscape we drop the top app bar (Back/Snapshot/Bookmark float over the
@@ -986,6 +1004,18 @@ fun PlaybackScreen(
                 // longer a separate landscape row (that made the bar too tall) — in
                 // landscape they ride along ON the transport row itself; in portrait
                 // they live in the top app bar.
+                // Export-selection bar (mirrors the desktop client's bar): shows the
+                // marked window's start, end and exact duration with Clear and
+                // "Export selection". Only present while a usable bracket exists.
+                if (state.hasExportSelection) {
+                    ExportSelectionBar(
+                        startMs = minOf(state.exportSelStartMs!!, state.exportSelEndMs!!),
+                        endMs = maxOf(state.exportSelStartMs!!, state.exportSelEndMs!!),
+                        canExport = canExport,
+                        onClear = { vm.clearExportSelection() },
+                        onExport = onExportRange,
+                    )
+                }
                 Spacer(Modifier.height(if (isLandscape) 2.dp else 6.dp))
                 PlaybackControls(
                     playing = state.playing,
@@ -1026,6 +1056,19 @@ fun PlaybackScreen(
                     // jump-to-time, speed) collapse into a 3-dot overflow menu. In
                     // landscape they ride inline on the (taller-width) transport row.
                     useOverflowMenu = !isLandscape,
+                    // In/out marking lives with the other secondary actions: touch
+                    // has no Shift+drag, so the bracket is placed at the playhead
+                    // from here and fine-tuned by dragging its handles.
+                    onMarkIn = { vm.markExportIn() },
+                    onMarkOut = { vm.markExportOut() },
+                    onClearSelection = if (state.exportSelStartMs != null ||
+                        state.exportSelEndMs != null
+                    ) {
+                        { vm.clearExportSelection() }
+                    } else {
+                        null
+                    },
+                    onExport = if (canExport) onExportRange else null,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 8.dp),
@@ -1043,6 +1086,10 @@ fun PlaybackScreen(
                     onScrub = { ts -> vm.onScrub(ts) },
                     onScrubEnd = { ts -> vm.onScrubEnd(ts) },
                     onSpanChange = { sp -> vm.setVisibleSpan(sp) },
+                    exportSelStartMs = state.exportSelStartMs,
+                    exportSelEndMs = state.exportSelEndMs,
+                    onSetExportStart = { ts -> vm.setExportEdge(isStart = true, epochMs = ts) },
+                    onSetExportEnd = { ts -> vm.setExportEdge(isStart = false, epochMs = ts) },
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(if (isLandscape) 40.dp else 72.dp)
@@ -1084,6 +1131,78 @@ fun PlaybackScreen(
 }
 
 /**
+ * The "Export selection" bar, shown under the video whenever an in/out bracket is
+ * marked. Mirrors the desktop client's bar: the exact start and end (local time,
+ * to the second) plus the duration, a Clear, and an Export action that hands the
+ * range to the Export screen.
+ *
+ * The end time drops its date when the range stays inside one day, so the common
+ * case reads as `09/06 14:03:12 → 14:05:40 (2m 28s)` rather than repeating it.
+ */
+@Composable
+private fun ExportSelectionBar(
+    startMs: Long,
+    endMs: Long,
+    canExport: Boolean,
+    onClear: () -> Unit,
+    onExport: () -> Unit,
+) {
+    val startInstant = Instant.ofEpochMilli(startMs)
+    val endInstant = Instant.ofEpochMilli(endMs)
+    val sameDay = remember(startMs / 1000, endMs / 1000) {
+        Time.date(startInstant) == Time.date(endInstant)
+    }
+    val startLabel = Time.dateTime(startInstant)
+    val endLabel = if (sameDay) Time.clock(endInstant) else Time.dateTime(endInstant)
+    val durationLabel = ExportRange.durationLabel(startMs, endMs)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(ExportBarBackground)
+            .padding(horizontal = 12.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Default.ContentCut,
+            contentDescription = null,
+            tint = TimelineColors.exportHandle,
+            modifier = Modifier.size(16.dp),
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = "$startLabel  →  $endLabel  ($durationLabel)",
+            style = MaterialTheme.typography.labelMedium,
+            color = Color.White,
+            maxLines = 1,
+            modifier = Modifier.weight(1f),
+        )
+        TextButton(onClick = onClear) { Text("Clear") }
+        Spacer(Modifier.width(4.dp))
+        Button(
+            onClick = onExport,
+            enabled = canExport,
+            colors = ButtonDefaults.buttonColors(
+                containerColor = TimelineColors.exportHandle,
+                contentColor = Color.Black,
+            ),
+            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Download,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+            )
+            Spacer(Modifier.width(4.dp))
+            Text("Export", style = MaterialTheme.typography.labelMedium)
+        }
+    }
+}
+
+/** Muted amber ground for the export-selection bar (matches the desktop's `0xFF2A2410`). */
+private val ExportBarBackground = Color(0xFF2A2410)
+
+/**
  * Row of playback transport controls.
  *
  * PRIMARY controls are always inline: go-to-first, frame step back, prev-motion,
@@ -1121,6 +1240,14 @@ private fun PlaybackControls(
     // too. null hides it (portrait uses the app bar chip).
     quality: String = PlaybackQuality.AUTO,
     onCycleQuality: (() -> Unit)? = null,
+    // Export in/out marking. Touch has no Shift+drag, so the bracket is placed at
+    // the playhead from here (then fine-tuned by dragging its handles on the
+    // timeline). onClearSelection is null while nothing is marked; onExport is
+    // null when this account may not export.
+    onMarkIn: (() -> Unit)? = null,
+    onMarkOut: (() -> Unit)? = null,
+    onClearSelection: (() -> Unit)? = null,
+    onExport: (() -> Unit)? = null,
 ) {
     // Landscape is vertically cramped, so the transport runs a notch smaller there
     // (this is what "shrinks the play/pause bar"). Portrait keeps its roomier sizes.
@@ -1229,6 +1356,13 @@ private fun PlaybackControls(
                         leadingIcon = { Icon(Icons.Default.Schedule, contentDescription = null) },
                         onClick = { menuOpen = false; launchJumpPicker() },
                     )
+                    ExportMarkMenuItems(
+                        onMarkIn = onMarkIn,
+                        onMarkOut = onMarkOut,
+                        onClearSelection = onClearSelection,
+                        onExport = onExport,
+                        onChosen = { menuOpen = false },
+                    )
                     // Speed — a small inline radio-ish list inside the menu (each speed
                     // is its own item; the current one is bold/accented).
                     Box1pxMenuDivider()
@@ -1298,6 +1432,43 @@ private fun PlaybackControls(
             // Jump-to-date-and-time button — DatePicker → TimePicker.
             SmallControl(Icons.Default.Schedule, "Jump to date & time", ctlSize, ctlIcon, launchJumpPicker)
 
+            // Export in/out marking — its own small menu here (landscape hides the
+            // 3-dot overflow that carries these items in portrait).
+            if (onMarkIn != null || onMarkOut != null) {
+                Box {
+                    var markMenuOpen by remember { mutableStateOf(false) }
+                    HintTooltip("Mark for export") {
+                        IconButton(
+                            onClick = { markMenuOpen = true },
+                            modifier = Modifier.size(ctlSize),
+                        ) {
+                            Icon(
+                                Icons.Default.ContentCut,
+                                contentDescription = "Mark for export",
+                                tint = if (onClearSelection != null) {
+                                    TimelineColors.exportHandle
+                                } else {
+                                    MaterialTheme.colorScheme.onSurface
+                                },
+                                modifier = Modifier.size(ctlIcon),
+                            )
+                        }
+                    }
+                    DropdownMenu(
+                        expanded = markMenuOpen,
+                        onDismissRequest = { markMenuOpen = false },
+                    ) {
+                        ExportMarkMenuItems(
+                            onMarkIn = onMarkIn,
+                            onMarkOut = onMarkOut,
+                            onClearSelection = onClearSelection,
+                            onExport = onExport,
+                            onChosen = { markMenuOpen = false },
+                        )
+                    }
+                }
+            }
+
             // Snapshot + Bookmark share this transport row in landscape (the app bar
             // is hidden there). In portrait they live in the overflow menu above.
             if (onSnapshot != null || onBookmark != null || onToggleAudio != null || onCycleQuality != null) {
@@ -1340,6 +1511,53 @@ private fun PlaybackControls(
                 }
             }
         }
+    }
+}
+
+/**
+ * The export in/out items shared by the portrait overflow menu and the landscape
+ * "mark for export" menu, so the two can never drift.
+ *
+ * "Set in point" / "Set out point" place the bracket at the playhead (the touch
+ * stand-in for the desktop's Shift+drag); the timeline handles then fine-tune it.
+ * Clear appears only while something is marked, Export only when the account may
+ * export.
+ */
+@Composable
+private fun ExportMarkMenuItems(
+    onMarkIn: (() -> Unit)?,
+    onMarkOut: (() -> Unit)?,
+    onClearSelection: (() -> Unit)?,
+    onExport: (() -> Unit)?,
+    onChosen: () -> Unit,
+) {
+    onMarkIn?.let { cb ->
+        DropdownMenuItem(
+            text = { Text("Set in point") },
+            leadingIcon = { Icon(Icons.Default.ContentCut, contentDescription = null) },
+            onClick = { onChosen(); cb() },
+        )
+    }
+    onMarkOut?.let { cb ->
+        DropdownMenuItem(
+            text = { Text("Set out point") },
+            leadingIcon = { Icon(Icons.Default.ContentCut, contentDescription = null) },
+            onClick = { onChosen(); cb() },
+        )
+    }
+    onClearSelection?.let { cb ->
+        DropdownMenuItem(
+            text = { Text("Clear selection") },
+            leadingIcon = { Icon(Icons.Default.Clear, contentDescription = null) },
+            onClick = { onChosen(); cb() },
+        )
+    }
+    onExport?.let { cb ->
+        DropdownMenuItem(
+            text = { Text("Export...") },
+            leadingIcon = { Icon(Icons.Default.Download, contentDescription = null) },
+            onClick = { onChosen(); cb() },
+        )
     }
 }
 

--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackViewModel.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackViewModel.kt
@@ -12,6 +12,7 @@ import video.crumb.app.data.CrumbRepository
 import video.crumb.app.data.isNotFound
 import video.crumb.app.data.runCatchingCancellable
 import video.crumb.app.data.toUserMessage
+import video.crumb.app.feature.export.ExportRange
 import video.crumb.app.ui.Time
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -126,7 +127,26 @@ data class PlaybackUiState(
      * events exist. The timeline icon layer is invisible when this list is empty.
      */
     val detectionEvents: List<DetectionEvent> = emptyList(),
-)
+    /**
+     * Raw IN edge of the export bracket ("mark for export"), epoch-millis, or null
+     * when nothing is marked. Held exactly as the operator placed it and ordered
+     * only when read ([ExportRange.normalize]) so dragging one handle past the
+     * other never swaps which handle the finger is holding — the same model the
+     * desktop timeline controller and the iOS timeline use.
+     */
+    val exportSelStartMs: Long? = null,
+    /** Raw OUT edge of the export bracket, epoch-millis, or null. */
+    val exportSelEndMs: Long? = null,
+) {
+    /** True once BOTH edges are marked and the range is long enough to export. */
+    val hasExportSelection: Boolean
+        get() {
+            val s = exportSelStartMs ?: return false
+            val e = exportSelEndMs ?: return false
+            val (a, b) = ExportRange.normalize(s, e)
+            return ExportRange.isValid(a, b)
+        }
+}
 
 private val SPEED_STEPS = listOf(0.5f, 1f, 2f, 4f, 8f)
 private const val DEFAULT_WINDOW_HOURS = 6L
@@ -1128,6 +1148,48 @@ class PlaybackViewModel(
     /** Clear a transient error so the UI can retry. */
     fun clearError() {
         _state.update { it.copy(error = null) }
+    }
+
+    // ─── export in/out bracket ──────────────────────────────────────────────
+
+    /**
+     * Place one edge of the export bracket. The missing edge is seeded from the
+     * playhead so a range is visible as soon as the first mark lands, and a mark
+     * is clamped to "now" because there is no footage in the future. Mirrors the
+     * desktop `pbSetExportEdge` and iOS `setExportEdge`.
+     */
+    fun setExportEdge(isStart: Boolean, epochMs: Long) {
+        _state.update { s ->
+            val (start, end) = ExportRange.setEdge(
+                currentStart = s.exportSelStartMs,
+                currentEnd = s.exportSelEndMs,
+                isStart = isStart,
+                ms = epochMs,
+                playheadMs = s.playheadMs,
+                nowMs = Instant.now().toEpochMilli(),
+            )
+            s.copy(exportSelStartMs = start, exportSelEndMs = end)
+        }
+    }
+
+    /** Mark IN at the current playhead (touch equivalent of the desktop shift-drag). */
+    fun markExportIn() = setExportEdge(isStart = true, epochMs = _state.value.playheadMs)
+
+    /** Mark OUT at the current playhead. */
+    fun markExportOut() = setExportEdge(isStart = false, epochMs = _state.value.playheadMs)
+
+    fun clearExportSelection() {
+        _state.update { it.copy(exportSelStartMs = null, exportSelEndMs = null) }
+    }
+
+    /**
+     * The range an Export hand-off should carry: the bracketed selection when one
+     * exists, otherwise the hour ending at the playhead (the prior default, and
+     * what iOS `exportRange()` falls back to).
+     */
+    fun exportRange(): Pair<Long, Long> {
+        val s = _state.value
+        return ExportRange.forExport(s.exportSelStartMs, s.exportSelEndMs, s.playheadMs)
     }
 
     override fun onCleared() {

--- a/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackWallScreen.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/feature/playback/PlaybackWallScreen.kt
@@ -122,7 +122,9 @@ private const val WALL_MAX_SPAN_MS = WALL_WINDOW_HOURS * 3600_000L
  *   another tab that happens to be under Playback on the back stack).
  * @param onOpenPlayback Called with `(cameraId, startMs)`; `startMs ≤ 0` means
  *   "open at the camera's latest footage".
- * @param onOpenExport Opens the Export screen (export lives under Playback).
+ * @param onOpenExport Opens the Export screen (export lives under Playback), passing
+ *   the wall's current scrub cursor (epoch-millis, `0` when parked at Latest) so
+ *   the export window can be seeded with the moment being reviewed.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -130,7 +132,7 @@ fun PlaybackWallScreen(
     onOpenLive: () -> Unit,
     onOpenPlayback: (String, Long) -> Unit,
     onOpenBookmarks: () -> Unit,
-    onOpenExport: () -> Unit,
+    onOpenExport: (Long) -> Unit,
     onOpenClips: () -> Unit = {},
     onOpenPlates: () -> Unit = {},
 ) {
@@ -355,7 +357,7 @@ fun PlaybackWallScreen(
                     }
                     if (caps.export || store.isAdmin) {
                         HintTooltip("Export footage") {
-                            IconButton(onClick = onOpenExport) {
+                            IconButton(onClick = { onOpenExport(if (atLatest) 0L else cursorMs) }) {
                                 Icon(Icons.Default.Download, contentDescription = "Export footage")
                             }
                         }

--- a/apps/android/app/src/main/java/video/crumb/app/ui/JumpToDateTimeDialog.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/ui/JumpToDateTimeDialog.kt
@@ -37,6 +37,12 @@ import java.util.TimeZone
  * @param initialMs Pre-selects this instant in both steps.
  * @param onDismiss Cancelled / dismissed without choosing.
  * @param onPicked  Called once with the combined date+time as epoch-millis.
+ * @param preserveSeconds Carry the seconds (and milliseconds) of [initialMs]
+ *   through to the result instead of truncating to the minute. The M3 time step
+ *   only offers hours and minutes, so an export boundary picked from a
+ *   second-accurate selection would otherwise silently lose its seconds. Off by
+ *   default: jumping the playhead to a whole minute is the desired behaviour there.
+ * @param title Heading for the time step.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -44,6 +50,8 @@ fun JumpToDateTimeDialog(
     initialMs: Long,
     onDismiss: () -> Unit,
     onPicked: (Long) -> Unit,
+    preserveSeconds: Boolean = false,
+    title: String = "Jump to time",
 ) {
     val initCal = remember(initialMs) { Calendar.getInstance().apply { timeInMillis = initialMs } }
     var pickingTime by rememberSaveable { mutableStateOf(false) }
@@ -70,7 +78,7 @@ fun JumpToDateTimeDialog(
     } else {
         AlertDialog(
             onDismissRequest = onDismiss,
-            title = { Text("Jump to time") },
+            title = { Text(title) },
             text = {
                 Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
                     TimeInput(state = timeState)
@@ -90,9 +98,12 @@ fun JumpToDateTimeDialog(
                             utc.get(Calendar.DAY_OF_MONTH),
                             timeState.hour,
                             timeState.minute,
-                            0,
+                            if (preserveSeconds) initCal.get(Calendar.SECOND) else 0,
                         )
-                        set(Calendar.MILLISECOND, 0)
+                        set(
+                            Calendar.MILLISECOND,
+                            if (preserveSeconds) initCal.get(Calendar.MILLISECOND) else 0,
+                        )
                     }.timeInMillis
                     onPicked(target)
                 }) { Text("Go") }

--- a/apps/android/app/src/main/java/video/crumb/app/ui/nav/Routes.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/ui/nav/Routes.kt
@@ -10,7 +10,28 @@ object Routes {
     const val LOGIN = "login"
     const val LIVE = "live"
     const val CLIPS = "clips"
-    const val EXPORT = "export"
+
+    // Export takes THREE optional query args so an entry point can seed the screen
+    // with what the operator was already looking at: a camera to pre-select, and a
+    // start/end (epoch-millis) to pre-fill the clip window. All absent / ≤ 0 means
+    // "open blank", which is the plain `export` route the old entry point used.
+    const val EXPORT = "export?cameraId={cameraId}&startMs={startMs}&endMs={endMs}"
+
+    /**
+     * Build a seeded Export route. A blank [cameraId] pre-selects nothing; a
+     * [startMs]/[endMs] pair of 0 leaves the screen's own default window.
+     */
+    fun export(cameraId: String = "", startMs: Long = 0L, endMs: Long = 0L): String =
+        "export?cameraId=${encodeArg(cameraId)}&startMs=$startMs&endMs=$endMs"
+
+    /**
+     * Percent-encode a value for use in a route query string. [java.net.URLEncoder]
+     * is `application/x-www-form-urlencoded`, which encodes a space as `+`;
+     * Navigation-Compose decodes routes as URIs, where `+` is a literal plus, so
+     * spaces are re-written to `%20`.
+     */
+    internal fun encodeArg(raw: String): String =
+        java.net.URLEncoder.encode(raw, "UTF-8").replace("+", "%20")
 
     // Playback is a STANDALONE top-level mode (like Live). PLAYBACK_STANDALONE
     // enters the multi-camera PLAYBACK WALL (a grid of latest-image snapshots with
@@ -43,4 +64,6 @@ object Routes {
 
     const val ARG_CAMERA_ID = "cameraId"
     const val ARG_TIME = "t"
+    const val ARG_START_MS = "startMs"
+    const val ARG_END_MS = "endMs"
 }

--- a/apps/android/app/src/main/java/video/crumb/app/ui/theme/Color.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/ui/theme/Color.kt
@@ -35,6 +35,13 @@ object TimelineColors {
     val grid = Color(0xFF33363F)           // hour/tick gridlines
     val bookmark = Color(0xFFF5C518)       // saved-bookmark markers (gold)
 
+    // Export in/out bracket ("mark for export"). Same amber family as the
+    // playhead, so the selection reads as an operator mark rather than data:
+    // a translucent fill for the region and a solid handle at each edge.
+    // Matches the iOS client's TLColors.exportFill / exportHandle.
+    val exportFill = Color(0x38E8A33D)     // ~22% amber wash over the selected region
+    val exportHandle = Color(0xFFE8A33D)   // solid amber edge handles
+
     // Detection-event icon colors (per icon_key, mirroring desktop + web clients).
     val eventPerson = Color(0xFF34AADC)    // blue circle
     val eventVehicle = Color(0xFFFF9500)   // amber square

--- a/apps/android/app/src/test/java/video/crumb/app/feature/export/ExportRangeTest.kt
+++ b/apps/android/app/src/test/java/video/crumb/app/feature/export/ExportRangeTest.kt
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.feature.export
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the shared export-range arithmetic: the in/out bracket on the
+ * playback timeline and the Export screen's clip window both run through
+ * [ExportRange], so a regression here would desync the two.
+ */
+class ExportRangeTest {
+
+    private val now = 1_700_000_000_000L
+
+    // ── normalize ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `normalize orders an inverted pair`() {
+        assertEquals(100L to 500L, ExportRange.normalize(500L, 100L))
+    }
+
+    @Test
+    fun `normalize leaves an ordered pair alone`() {
+        assertEquals(100L to 500L, ExportRange.normalize(100L, 500L))
+    }
+
+    @Test
+    fun `normalize is stable for equal edges`() {
+        assertEquals(100L to 100L, ExportRange.normalize(100L, 100L))
+    }
+
+    // ── setEdge ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `setting the in point seeds the out point from the playhead`() {
+        val playhead = now - 10_000L
+        val (start, end) = ExportRange.setEdge(
+            currentStart = null,
+            currentEnd = null,
+            isStart = true,
+            ms = now - 60_000L,
+            playheadMs = playhead,
+            nowMs = now,
+        )
+        assertEquals(now - 60_000L, start)
+        assertEquals(playhead, end)
+    }
+
+    @Test
+    fun `setting the out point seeds the in point from the playhead`() {
+        val playhead = now - 60_000L
+        val (start, end) = ExportRange.setEdge(
+            currentStart = null,
+            currentEnd = null,
+            isStart = false,
+            ms = now - 10_000L,
+            playheadMs = playhead,
+            nowMs = now,
+        )
+        assertEquals(playhead, start)
+        assertEquals(now - 10_000L, end)
+    }
+
+    @Test
+    fun `setting one edge leaves the other edge untouched`() {
+        val (start, end) = ExportRange.setEdge(
+            currentStart = 1_000L,
+            currentEnd = 9_000L,
+            isStart = true,
+            ms = 3_000L,
+            playheadMs = 5_000L,
+            nowMs = now,
+        )
+        assertEquals(3_000L, start)
+        assertEquals(9_000L, end)
+    }
+
+    @Test
+    fun `a mark in the future is clamped to now`() {
+        val (_, end) = ExportRange.setEdge(
+            currentStart = now - 60_000L,
+            currentEnd = now - 10_000L,
+            isStart = false,
+            ms = now + 90_000L,
+            playheadMs = now - 10_000L,
+            nowMs = now,
+        )
+        assertEquals(now, end)
+    }
+
+    @Test
+    fun `dragging an edge past the other does not swap the raw edges`() {
+        // The raw edges stay as placed; ordering happens only on read, so the
+        // finger keeps holding the handle it grabbed.
+        val (start, end) = ExportRange.setEdge(
+            currentStart = 1_000L,
+            currentEnd = 5_000L,
+            isStart = true,
+            ms = 9_000L,
+            playheadMs = 5_000L,
+            nowMs = now,
+        )
+        assertEquals(9_000L, start)
+        assertEquals(5_000L, end)
+        assertEquals(5_000L to 9_000L, ExportRange.normalize(start, end))
+    }
+
+    // ── forExport ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `forExport uses the bracketed selection when one exists`() {
+        val range = ExportRange.forExport(
+            selStartMs = now - 30_000L,
+            selEndMs = now - 5_000L,
+            playheadMs = now,
+        )
+        assertEquals((now - 30_000L) to (now - 5_000L), range)
+    }
+
+    @Test
+    fun `forExport orders an inverted selection`() {
+        val range = ExportRange.forExport(
+            selStartMs = now - 5_000L,
+            selEndMs = now - 30_000L,
+            playheadMs = now,
+        )
+        assertEquals((now - 30_000L) to (now - 5_000L), range)
+    }
+
+    @Test
+    fun `forExport falls back to the hour ending at the playhead`() {
+        val range = ExportRange.forExport(selStartMs = null, selEndMs = null, playheadMs = now)
+        assertEquals((now - 3_600_000L) to now, range)
+    }
+
+    @Test
+    fun `forExport ignores a degenerate selection`() {
+        // A single tap that placed both edges on the same instant is not a range.
+        val range = ExportRange.forExport(selStartMs = now, selEndMs = now, playheadMs = now)
+        assertEquals((now - 3_600_000L) to now, range)
+    }
+
+    // ── quick ranges ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `quick ranges end now and run back the requested minutes`() {
+        for (minutes in ExportRange.QUICK_RANGE_MINUTES) {
+            val (start, end) = ExportRange.quickRange(now, minutes)
+            assertEquals(now, end)
+            assertEquals(minutes * 60_000L, end - start)
+            assertTrue(ExportRange.isValid(start, end))
+        }
+    }
+
+    @Test
+    fun `the quick range chips match the desktop builder`() {
+        assertEquals(listOf(1, 5, 10, 15), ExportRange.QUICK_RANGE_MINUTES)
+    }
+
+    // ── validation + clamping ────────────────────────────────────────────────
+
+    @Test
+    fun `a range shorter than one second is rejected`() {
+        assertFalse(ExportRange.isValid(now, now))
+        assertFalse(ExportRange.isValid(now, now + 999L))
+        assertTrue(ExportRange.isValid(now, now + 1_000L))
+    }
+
+    @Test
+    fun `an inverted range is rejected`() {
+        assertFalse(ExportRange.isValid(now, now - 60_000L))
+    }
+
+    @Test
+    fun `clampStart keeps the start strictly before the end`() {
+        assertEquals(now - 1_000L, ExportRange.clampStart(now + 5_000L, now))
+        // A start already well before the end is untouched.
+        assertEquals(now - 60_000L, ExportRange.clampStart(now - 60_000L, now))
+    }
+
+    @Test
+    fun `clampEnd keeps the end strictly after the start`() {
+        assertEquals(now + 1_000L, ExportRange.clampEnd(now - 5_000L, now))
+        assertEquals(now + 60_000L, ExportRange.clampEnd(now + 60_000L, now))
+    }
+
+    // ── duration formatting ──────────────────────────────────────────────────
+
+    @Test
+    fun `durations are precise to the second`() {
+        assertEquals("0s", ExportRange.formatDuration(0))
+        assertEquals("45s", ExportRange.formatDuration(45))
+        assertEquals("2m 3s", ExportRange.formatDuration(123))
+        assertEquals("1h 2m 3s", ExportRange.formatDuration(3_723))
+    }
+
+    @Test
+    fun `a negative duration renders as zero rather than a minus sign`() {
+        assertEquals("0s", ExportRange.formatDuration(-5))
+    }
+
+    @Test
+    fun `durationLabel truncates milliseconds down to the second`() {
+        assertEquals("1m 1s", ExportRange.durationLabel(now, now + 61_999L))
+    }
+}

--- a/apps/android/app/src/test/java/video/crumb/app/ui/nav/RoutesExportTest.kt
+++ b/apps/android/app/src/test/java/video/crumb/app/ui/nav/RoutesExportTest.kt
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app.ui.nav
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The seeded Export route has to round-trip through Navigation-Compose's URI
+ * parsing, so its query string must be built with real percent-encoding (and
+ * NOT form-encoding's `+` for a space, which a URI reads as a literal plus).
+ */
+class RoutesExportTest {
+
+    @Test
+    fun `the registered route declares all three optional args`() {
+        assertEquals("export?cameraId={cameraId}&startMs={startMs}&endMs={endMs}", Routes.EXPORT)
+        assertTrue(Routes.EXPORT.contains("{${Routes.ARG_CAMERA_ID}}"))
+        assertTrue(Routes.EXPORT.contains("{${Routes.ARG_START_MS}}"))
+        assertTrue(Routes.EXPORT.contains("{${Routes.ARG_END_MS}}"))
+    }
+
+    @Test
+    fun `an unseeded export route carries empty defaults`() {
+        assertEquals("export?cameraId=&startMs=0&endMs=0", Routes.export())
+    }
+
+    @Test
+    fun `a seeded export route carries the camera and the window`() {
+        assertEquals(
+            "export?cameraId=front-door&startMs=1700000000000&endMs=1700000060000",
+            Routes.export("front-door", 1_700_000_000_000L, 1_700_000_060_000L),
+        )
+    }
+
+    @Test
+    fun `a space in a camera id is percent-encoded, never a plus`() {
+        val route = Routes.export("Front Door")
+        assertEquals("export?cameraId=Front%20Door&startMs=0&endMs=0", route)
+    }
+
+    @Test
+    fun `reserved characters in a camera id are escaped`() {
+        val route = Routes.export("a/b?c&d=e")
+        assertTrue(route.startsWith("export?cameraId="))
+        // None of the escaped characters may leak into the query structure: after
+        // the camera-id value there must be exactly the two known separators.
+        val cameraValue = route.removePrefix("export?cameraId=").substringBefore("&startMs=")
+        assertEquals("a%2Fb%3Fc%26d%3De", cameraValue)
+        assertEquals(2, route.count { it == '&' })
+    }
+
+    @Test
+    fun `encodeArg leaves an ordinary uuid untouched`() {
+        val uuid = "6f1f8e2a-1c34-4a5f-9a1e-2b7c8d9e0f11"
+        assertEquals(uuid, Routes.encodeArg(uuid))
+    }
+}

--- a/docs-site/docs/clients/android.md
+++ b/docs-site/docs/clients/android.md
@@ -22,7 +22,10 @@ slug: /clients/android
 Android is the other client I use daily, so it's close to feature-complete.
 Live wall, timeline playback with an Auto / Full / Data-saver quality control
 (Data-saver plays a 640p transcode and shows an "SD" badge; Auto uses full
-quality on Wi-Fi and Data-saver on a metered connection), clips and export,
+quality on Wi-Fi and Data-saver on a metered connection), clips and export
+(mark an in and an out point on the timeline, then export that window straight
+from playback, with second-accurate start and end times and a Cancel button
+while the job runs),
 per-camera PTZ, a snapshot button (single-camera views), the LPR license-plate
 reads tab, and Home Assistant: on-video badges plus a per-camera entity sheet,
 both able to operate a linked Control entity directly, not just show its

--- a/docs-site/docs/playback/export.md
+++ b/docs-site/docs/playback/export.md
@@ -10,6 +10,22 @@ When you need to hand footage to someone (a neighbor, an insurer, the police),
 Crumb lets you pull the relevant moments out and save them as ordinary video
 files, without giving anyone access to your system.
 
+## Marking the moment you want
+
+The quickest way to start an export is from playback itself. While you are
+reviewing a camera, mark an **in point** and an **out point** on the timeline.
+The marked window is drawn as an amber bracket, and a bar appears under the
+video showing its exact start, end and length, down to the second. Drag either
+end of the bracket to trim it, then press Export and the export opens already
+filled in with that camera and that window, so you are not retyping times you
+just scrubbed to.
+
+On the desktop that mark is a Shift+drag across the timeline. On Android, where
+there is no Shift key, "Set in point" and "Set out point" in the playback
+controls menu place each end at the playhead, and you drag the bracket's handles
+to fine-tune. If you press Export without marking anything, Crumb offers the
+hour ending at wherever you were looking, which you can then adjust.
+
 ## Building an export list
 
 Rather than exporting one clip at a time, Crumb works from a list. As you review

--- a/docs/COMPONENT-MAP.md
+++ b/docs/COMPONENT-MAP.md
@@ -292,7 +292,7 @@ is not. The web admin console doubles as the desktop's management surface
 | Live wall / viewing | live section | wall builder, carousels, hotspot, PTZ tiles | `live/` | `Live/` |
 | Playback + timeline | playback section | timeline, scrub, prefetch, zoom | `playback/` | `Playback/` |
 | Clips | clips section | clips view | `clips/` | `Clips/` |
-| Export | export section | export list | `export/` | `Export/` |
+| Export | export section | export list; timeline Shift+drag selection → "Export selection" bar | `export/` (single-shot window; in/out bracket on `playback/CenteredTimeline.kt` + seeded `Routes.export(...)`; batch list still deferred, issue #617) | `Export/` (batch list) |
 | Bookmarks | bookmarks UI | bookmark UI | `AddBookmarkDialog.kt` (in `ui/`) | `Bookmarks/` |
 | PTZ / imaging | camera controls | on-video PTZ panel (customizable) | `live/` player controls | `Live/` |
 | Motion tuner | tuner section | inline tuner | `tuner/` | `Tuner/` |


### PR DESCRIPTION
Phase 1 of the Android export redesign (#617): bring Android's export flow in line with the desktop and iOS clients.

## The problem

Android export was a stand-alone screen (`feature/export/`) whose **only** entry point was the Download icon on the playback *wall*. The single-camera playback screen had no export entry at all. The route took no arguments, so even the wall entry dropped the camera and moment being reviewed. The time range was editable solely by two `[-] [+]` steppers moving in **one-minute** steps, which made a second-accurate window impossible to express, even though the ViewModel already clamps to a 1 s minimum and the server accepts RFC-3339 with fractional seconds. There was also no way to stop a running job.

## What this does

**1. In/out selection on the playback timeline.** `PlaybackUiState` gains raw `exportSelStartMs` / `exportSelEndMs` epoch millis. They are stored exactly as the operator placed them and ordered only when read, so dragging one handle past the other never swaps which handle the finger is holding, the same model as the desktop `playback_timeline_controller` (`selStartMs`/`selEndMs`, no snapping) and the iOS `CenteredTimelineView`. `CenteredTimeline` draws the bracket as a translucent amber region with a solid handle at each edge (mirrors iOS 2c/2e; new `TimelineColors.exportFill`/`exportHandle` in the existing amber family), and a press landing within grab range of a handle resizes that edge instead of scrubbing. Nearest handle wins on overlap, as on iOS.

Scrub and pinch behaviour is unchanged: the handle path returns from the gesture before `onScrubStart()` is ever called, and it never moves the playhead.

**2. Touch-friendly marking.** There is no Shift+drag on a phone, so **Set in point** / **Set out point** / **Clear selection** live with the other secondary actions (the 3-dot overflow in portrait, a "mark for export" menu on the transport row in landscape). Each places its end at the playhead and seeds the other end from the playhead, matching iOS `setExportEdge`; the timeline handles then fine-tune it.

**3. "Export selection" bar.** While a bracket exists, a bar under the video shows the exact start, end and duration to the second, with Clear and Export, mirroring the desktop's bar (same muted amber ground). The end drops its date when the range stays inside one day.

**4. Seeded export route.** `Routes.EXPORT` now takes optional `cameraId`, `startMs`, `endMs`, with a `Routes.export(...)` builder that percent-encodes the camera id (never form-encoding's `+`, which a URI reads as a literal plus). Playback passes the marked bracket, or the hour ending at the playhead when nothing is marked (iOS `exportRange()`); the wall passes the hour ending at its scrub cursor (the wall has no single focused camera, so it seeds the window only). `ExportScreen` opens pre-filled.

**5. The one-minute steppers are gone.** Each boundary is now a tappable second-accurate field backed by `JumpToDateTimeDialog` (new opt-in `preserveSeconds`, so opening the picker on a seeded selection does not silently round its seconds off), plus **Last 1m / 5m / 10m / 15m** quick chips (the desktop export builder's set) and a **one-second** nudge stepper on each side. `start < end` is enforced in the ViewModel and now gates Create.

**6. Cancel a running job.** `DELETE /export/{job_id}` is bound in `CrumbApi`/`CrumbRepository` (an unsuccessful status becomes a failure rather than a silent no-op) and surfaced as a Cancel button while the job is still stoppable. The poll loop also treats a server-side `cancelled` status as terminal, so it can't spin forever on one, and a deliberate cancel shows as a neutral notice rather than a red failure.

Selection arithmetic lives in one new pure object, `feature/export/ExportRange.kt`, shared by the timeline and the export screen so the two cannot drift.

## Deferred to a follow-up (Phase 2, still under #617)

- Batch clip list via `POST /export/batch` (Android remains single-shot; desktop/iOS have the list).
- Output options: codec/container, audio, ZIP password.
- Filmstrip preview in the export builder.

## Notes for review

- `Models.kt`'s `ExportJob`/`ExportOutputFile` and `ExportScreen`'s hardcoded `.mp4` save names are deliberately untouched (a concurrent change owns those). The cancel path therefore reads `status == "cancelled"` through a local private extension rather than assuming a model-level flag, and composes with an `isCancelled` property landing later.
- Docs updated in the same change: `docs/COMPONENT-MAP.md` export row, `docs-site/docs/playback/export.md` (new "Marking the moment you want" section) and `docs-site/docs/clients/android.md`.

## Verification

Verified: compile + unit tests green on dev2 (`:app:compileDebugKotlin testDebugUnitTest`, BUILD SUCCESSFUL); 27 new unit tests cover selection normalization, edge seeding/clamping/future-clamping, the export-range fallback, range validation, quick-chip math and route arg encoding. On-device visual check recommended (bracket rendering, handle drag vs. scrub, the selection bar in both orientations).

Part of #617
