### PR TITLE
Hide camera content in the app switcher on iOS and Android

### DIFF
--- a/apps/android/app/src/main/java/video/crumb/app/MainActivity.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/MainActivity.kt
@@ -8,6 +8,7 @@ import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
 import android.util.Rational
+import android.view.WindowManager
 import androidx.activity.compose.setContent
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -66,6 +67,26 @@ class MainActivity : FragmentActivity() {
         super.onStop()
     }
 
+    // Pre-33 recents fallback (see [RecentsPrivacy]): the recents snapshot is
+    // captured as the activity leaves the foreground, so the window only has to
+    // be secure across that transition. Skipped when the pause is a PiP
+    // transition, which would blank the floating video window.
+    override fun onPause() {
+        super.onPause()
+        if (RecentsPrivacy.secureOnPause(Build.VERSION.SDK_INT, isInPictureInPictureMode)) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
+
+    // Back in the foreground: drop the flag again so the operator can take
+    // screenshots and screen recordings of the app as usual.
+    override fun onResume() {
+        super.onResume()
+        if (RecentsPrivacy.usesSecureWindowFallback(Build.VERSION.SDK_INT)) {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
+
     override fun onStart() {
         super.onStart()
         // A background stint long enough for keep-alive sockets to have died
@@ -94,6 +115,13 @@ class MainActivity : FragmentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Keep camera video out of the recents / app-switcher card. API 33+ has
+        // a switch for exactly that, which leaves ordinary foreground
+        // screenshots and screen recording alone. Older releases fall back to
+        // the onPause/onResume secure-window toggle below (see [RecentsPrivacy]).
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            setRecentsScreenshotEnabled(false)
+        }
         setContent {
             CrumbTheme {
                 CompositionLocalProvider(LocalPipController provides pipController) {
@@ -148,6 +176,14 @@ class MainActivity : FragmentActivity() {
     ) {
         super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
         inPipState.value = isInPictureInPictureMode
+        // Entering PiP is asynchronous, so onPause can run before the activity
+        // reports itself as being in PiP. Clear the pre-33 secure flag here too,
+        // otherwise the floating window would render blank.
+        if (isInPictureInPictureMode &&
+            RecentsPrivacy.usesSecureWindowFallback(Build.VERSION.SDK_INT)
+        ) {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
     }
 }
 

--- a/apps/android/app/src/main/java/video/crumb/app/RecentsPrivacy.kt
+++ b/apps/android/app/src/main/java/video/crumb/app/RecentsPrivacy.kt
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app
+
+import android.os.Build
+
+/**
+ * How the app keeps camera content out of the recents / app-switcher card
+ * without taking ordinary screenshots away from the operator.
+ *
+ * Two mechanisms, picked by API level:
+ *
+ * - **API 33+** has [android.app.Activity.setRecentsScreenshotEnabled], which
+ *   suppresses only the recents snapshot. Foreground screenshots and screen
+ *   recording keep working, which is what we want: the recents card is the
+ *   surface that shows camera video to whoever picks the phone up next, a
+ *   deliberate screenshot is the operator's own choice.
+ * - **Below 33** there is no such switch, so the window is made secure only
+ *   across the leave-the-foreground transition (the snapshot is taken as the
+ *   activity is paused) and cleared again on resume. While the operator is
+ *   looking at the app the window is not secure, so screenshots still work.
+ *
+ * Picture-in-Picture is exempt from the pre-33 path: entering PiP also delivers
+ * `onPause`, and a secure window would blank the floating video window. The
+ * trade-off is that a pre-33 device that leaves the app straight into PiP can
+ * still put a video frame on its recents card; API 33+ devices, which is where
+ * the supported majority sits, use the dedicated switch and are unaffected.
+ *
+ * Pure decision logic, no framework calls, so it is unit-testable. The actual
+ * `setRecentsScreenshotEnabled` call stays inline in `MainActivity` with a
+ * literal `Build.VERSION.SDK_INT` comparison so lint can see the API guard.
+ */
+internal object RecentsPrivacy {
+
+    /** True when the platform offers the dedicated recents-snapshot switch. */
+    fun usesRecentsSwitch(sdkInt: Int): Boolean = sdkInt >= Build.VERSION_CODES.TIRAMISU
+
+    /** True when the pre-33 secure-window fallback applies on this platform. */
+    fun usesSecureWindowFallback(sdkInt: Int): Boolean = !usesRecentsSwitch(sdkInt)
+
+    /**
+     * Whether `onPause` should make the window secure: only on the pre-33
+     * fallback, and never when the pause is a Picture-in-Picture transition.
+     */
+    fun secureOnPause(sdkInt: Int, inPictureInPicture: Boolean): Boolean =
+        usesSecureWindowFallback(sdkInt) && !inPictureInPicture
+}

--- a/apps/android/app/src/test/java/video/crumb/app/RecentsPrivacyTest.kt
+++ b/apps/android/app/src/test/java/video/crumb/app/RecentsPrivacyTest.kt
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package video.crumb.app
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [RecentsPrivacy], the per-API-level choice of how camera
+ * content is kept off the recents / app-switcher card. Pure logic, so these run
+ * as plain JVM tests.
+ */
+class RecentsPrivacyTest {
+
+    @Test
+    fun `api 33 and above uses the dedicated recents switch`() {
+        assertTrue(RecentsPrivacy.usesRecentsSwitch(33))
+        assertTrue(RecentsPrivacy.usesRecentsSwitch(34))
+        assertTrue(RecentsPrivacy.usesRecentsSwitch(35))
+        assertFalse(RecentsPrivacy.usesSecureWindowFallback(33))
+    }
+
+    @Test
+    fun `below api 33 falls back to the secure window`() {
+        assertFalse(RecentsPrivacy.usesRecentsSwitch(26))
+        assertFalse(RecentsPrivacy.usesRecentsSwitch(32))
+        assertTrue(RecentsPrivacy.usesSecureWindowFallback(26))
+        assertTrue(RecentsPrivacy.usesSecureWindowFallback(32))
+    }
+
+    @Test
+    fun `the fallback secures the window only when leaving the foreground`() {
+        // Pre-33, a normal pause is the moment the recents snapshot is taken.
+        assertTrue(RecentsPrivacy.secureOnPause(26, inPictureInPicture = false))
+        assertTrue(RecentsPrivacy.secureOnPause(32, inPictureInPicture = false))
+    }
+
+    @Test
+    fun `picture-in-picture is never secured, it would blank the floating window`() {
+        assertFalse(RecentsPrivacy.secureOnPause(26, inPictureInPicture = true))
+        assertFalse(RecentsPrivacy.secureOnPause(32, inPictureInPicture = true))
+        assertFalse(RecentsPrivacy.secureOnPause(34, inPictureInPicture = true))
+    }
+
+    @Test
+    fun `api 33 and above never touches the secure flag, foreground capture stays available`() {
+        assertFalse(RecentsPrivacy.secureOnPause(33, inPictureInPicture = false))
+        assertFalse(RecentsPrivacy.secureOnPause(34, inPictureInPicture = false))
+    }
+}

--- a/apps/ios/Crumb/App/CrumbApp.swift
+++ b/apps/ios/Crumb/App/CrumbApp.swift
@@ -40,14 +40,17 @@ struct RootView: View {
     /// `BiometricLockView` reports success.
     @State private var isLocked = false
     #if os(iOS)
-    /// Shown (opaque, no re-auth challenge) while the scene is `.inactive` and
-    /// the lock is enabled — purely so the app-switcher snapshot (captured
-    /// around the `.inactive`/`.background` transition, before `.background`
-    /// itself actually fires) can't show live camera content. Distinct from
-    /// `isLocked`: `.inactive` also fires on plenty of harmless momentary
-    /// interruptions (Control Center, an incoming-call banner, a system
-    /// alert) where forcing a full Face ID/passcode challenge every time
-    /// would be obnoxious — this is a passive cover, not a re-auth gate.
+    /// Shown (opaque, no re-auth challenge) whenever the scene stops being
+    /// `.active` — purely so the app-switcher snapshot (captured around the
+    /// `.inactive`/`.background` transition, before `.background` itself
+    /// actually fires) can't show live camera content. Deliberately NOT tied
+    /// to `settings.biometricLockEnabled`: the cover is about what the system
+    /// snapshot records, the lock is about who may resume the session, so
+    /// every signed-in user gets the cover while the lock stays opt-in.
+    /// Distinct from `isLocked`: `.inactive` also fires on plenty of harmless
+    /// momentary interruptions (Control Center, an incoming-call banner, a
+    /// system alert) where forcing a full Face ID/passcode challenge every
+    /// time would be obnoxious, this is a passive cover, not a re-auth gate.
     @State private var privacyShieldVisible = false
     @Environment(\.scenePhase) private var scenePhase
     #endif
@@ -68,7 +71,7 @@ struct RootView: View {
             .animation(.easeInOut(duration: 0.3), value: container.isLoggedIn)
 
             #if os(iOS)
-            if container.isLoggedIn && settings.biometricLockEnabled && privacyShieldVisible && !isLocked {
+            if container.isLoggedIn && privacyShieldVisible && !isLocked {
                 CrumbColors.background.ignoresSafeArea()
                     .transition(.opacity)
             }
@@ -101,10 +104,11 @@ struct RootView: View {
         }
         #if os(iOS)
         .onChange(of: scenePhase) { phase in
-            guard settings.biometricLockEnabled else { return }
             switch phase {
             case .background:
-                isLocked = true
+                // The cover applies to everyone; only the re-auth challenge is
+                // gated on the opt-in lock.
+                if settings.biometricLockEnabled { isLocked = true }
                 privacyShieldVisible = true
             case .inactive:
                 // The app-switcher snapshot is captured around this transition

--- a/apps/ios/Crumb/App/CrumbApp.swift
+++ b/apps/ios/Crumb/App/CrumbApp.swift
@@ -41,7 +41,7 @@ struct RootView: View {
     @State private var isLocked = false
     #if os(iOS)
     /// Shown (opaque, no re-auth challenge) whenever the scene stops being
-    /// `.active` — purely so the app-switcher snapshot (captured around the
+    /// `.active`, purely so the app-switcher snapshot (captured around the
     /// `.inactive`/`.background` transition, before `.background` itself
     /// actually fires) can't show live camera content. Deliberately NOT tied
     /// to `settings.biometricLockEnabled`: the cover is about what the system

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,66 @@ revisit.
 
 ---
 
+## 2026-09-07, The app-switcher cover is unconditional on mobile, and Android hides the recents snapshot without a permanently secure window
+
+**Context.** The operating system takes a picture of the app as it leaves the
+foreground and shows it on the task switcher, so whatever camera was on screen
+stays visible to whoever picks the device up next. iOS already had an opaque
+cover for this (`RootView.privacyShieldVisible`), but it was drawn only when the
+opt-in biometric lock was on, and that setting defaults to off. Android had
+nothing.
+
+**Decision, iOS.** The cover is now drawn for any signed-in session whenever the
+scene stops being `.active`, independent of `biometricLockEnabled`. The two
+concerns are separate: the cover is about what the system snapshot records, the
+lock is about who may resume the session. The lock keeps gating only the Face ID
+/ passcode challenge, and `.inactive` still never triggers that challenge, since
+`.inactive` also fires on harmless momentary interruptions (Control Center, an
+incoming-call banner, a system alert).
+
+**Decision, Android.** API 33+ calls `Activity.setRecentsScreenshotEnabled(false)`
+once in `onCreate`. Below 33 the window is made secure in `onPause` and cleared
+again in `onResume`, so it is secure only across the transition during which the
+snapshot is taken. Picture-in-Picture is exempt from the pre-33 path (a secure
+window would render the floating video window blank), and the flag is cleared
+again in `onPictureInPictureModeChanged` because entering PiP is asynchronous
+and `onPause` can run before the activity reports itself as being in PiP. The
+per-API-level decision lives in `RecentsPrivacy` so it is unit-testable.
+
+**Rejected: a permanently secure Android window** (`FLAG_SECURE` set once in
+`onCreate`). It is the simplest and strongest option and it is what most
+guidance suggests, but it also disables ordinary screenshots and screen
+recording of the app. The maintainer records screenshots and screen captures of
+the Android client for documentation and for the site, and an operator
+photographing an incident off their own phone is a legitimate use. Blocking that
+to protect a preview the operator can also protect by closing the app was judged
+the wrong trade.
+
+**Rejected: a macOS occlusion or resign-active cover.** macOS has no task
+switcher preview of this kind, and a video wall on a second monitor is meant to
+stay readable while another app has focus. macOS behavior is unchanged.
+
+**Trades knowingly accepted:**
+
+- Below API 33 the flag toggles on every pause, which includes pauses that are
+  not "leaving the app" (a system permission dialog, the biometric prompt). The
+  effect is invisible: the flag is cleared again on the next resume.
+- Below API 33, leaving the app straight into PiP can still put a video frame on
+  the recents card, because that path is deliberately exempt. API 33+ devices
+  use the dedicated switch and are unaffected.
+- The iOS cover now appears for users who never asked for a lock. It is a plain
+  opaque background with no interaction, so the only cost is a brief flat colour
+  during multitasking.
+
+**Revisit if:** Android ever gains a pre-33-compatible recents-only switch (it
+will not, but a support library shim would count), or if the minimum supported
+API rises to 33, at which point the `FLAG_SECURE` fallback and `RecentsPrivacy`
+can both be deleted. Also revisit if operators report that the PiP exemption
+matters on old devices, in which case the pre-33 path can drop PiP entirely
+(auto-enter off below 33) instead of exempting it.
+
+---
+
 ## 2026-08-10, Home Assistant `climate` (thermostat/HVAC setpoint) control is out of scope
 
 **Context.** #442 introduced value-setting HA controls. Light dimming


### PR DESCRIPTION
## What changed

The operating system takes a picture of the app as it leaves the foreground and
shows it on the task switcher. On both mobile clients that picture could contain
live camera video. This makes the switcher preview blank on iOS and Android.

**iOS.** `RootView` already had an opaque cover for the `.inactive` /
`.background` transition, but it was drawn only when the opt-in biometric lock
was enabled, and that setting defaults to off, so the default configuration got
no cover at all. The cover is now drawn for any signed-in session whenever the
scene stops being `.active`. The biometric lock is unchanged and keeps gating
only the unlock challenge: `.inactive` still never forces a Face ID / passcode
prompt (it also fires on Control Center, an incoming-call banner, a system
alert), and the existing cold-launch and `.background` lock paths behave exactly
as before.

**Android.** Nothing kept camera video off the recents card. API 33 and above
now call `Activity.setRecentsScreenshotEnabled(false)` once in `onCreate`, which
suppresses only the recents snapshot. Below 33, where no such switch exists, the
window is made secure in `onPause` and cleared again in `onResume`, so it is
secure only across the transition during which the snapshot is taken.

Deliberately preserved:

- **Foreground screenshots and screen recording keep working.** The window is
  never permanently secure, so capturing the app while looking at it (for
  documentation, for the site, or by an operator recording an incident off their
  own phone) is unaffected.
- **Picture-in-Picture keeps rendering.** Entering PiP also delivers `onPause`,
  and a secure window would blank the floating video window, so the pre-33 path
  skips PiP. Because entering PiP is asynchronous and `onPause` can run before
  the activity reports itself as being in PiP, the flag is also cleared in
  `onPictureInPictureModeChanged`.
- **macOS is untouched.** There is no equivalent switcher preview there, and a
  video wall on a second monitor should stay readable while another app has
  focus.

The per-API-level decision is factored into `RecentsPrivacy` so it is pure,
unit-testable logic; the `setRecentsScreenshotEnabled` call stays inline in
`MainActivity` behind a literal `Build.VERSION.SDK_INT` comparison so lint can
see the API guard.

## Files

- `apps/ios/Crumb/App/CrumbApp.swift`
- `apps/android/app/src/main/java/video/crumb/app/MainActivity.kt`
- `apps/android/app/src/main/java/video/crumb/app/RecentsPrivacy.kt` (new)
- `apps/android/app/src/test/java/video/crumb/app/RecentsPrivacyTest.kt` (new)
- `docs/DECISIONS.md` (entry for the two choices above and the rejected
  always-secure-window alternative)

## Testing

Android, on the build box:

```
./gradlew :app:assembleDebug :app:testDebugUnitTest --console=plain
BUILD SUCCESSFUL in 9s
45 actionable tasks: 10 executed, 35 up-to-date
```

`RecentsPrivacyTest`: `tests="5" skipped="0" failures="0" errors="0"`.

Apple, on the Mac host:

```
xcodebuild -project Crumb.xcodeproj -scheme Crumb-mac -configuration Debug \
  -destination "platform=macOS" build CODE_SIGNING_ALLOWED=NO
** BUILD SUCCEEDED **

xcodebuild -project Crumb.xcodeproj -scheme Crumb -configuration Debug \
  -destination "generic/platform=iOS Simulator" build CODE_SIGNING_ALLOWED=NO
** BUILD SUCCEEDED **
```

No Rust, compose, env-key or migration changes, so the Rust gate and the install
guide are untouched. On-device behavior (the switcher card itself, PiP after the
change) has not been checked on hardware; the PiP reasoning is from the
lifecycle contract and the existing `LiveFullscreenScreen` comment that entering
PiP fires `ON_PAUSE` while the activity stays `STARTED`.

## Operator-visible change

The task-switcher preview of the iOS and Android apps is now a flat background
instead of the last screen. No new setting, no new env key, no change to the
biometric lock, no change to screenshots or screen recording, no change on
macOS, Windows or Linux.
