### PR TITLE
Use the authorization header for export downloads and a one-time code for browser handoff

### DIFF
--- a/apps/desktop-flutter/lib/api/admin_console_api.dart
+++ b/apps/desktop-flutter/lib/api/admin_console_api.dart
@@ -1,41 +1,86 @@
-// Embedded /admin console URL building — no HTTP calls of its own.
+// Embedded /admin console URL building, plus the single-use handoff code that
+// opens the console in the operator's real browser.
 //
 // The server serves its ENTIRE web admin console (services/api/src/admin.html,
 // `include_str!`-embedded) at the root route `GET /admin` (services/api/src/
 // main.rs `.route("/admin", get(serve_admin))`). admin.html's `bootSSO` reads a
-// `#token=<jwt>` URL FRAGMENT (never a query param — fragments aren't sent to
-// the server or logged) to adopt the desktop client's existing bearer session
-// instead of showing its own login form, then scrubs the fragment from the
-// visible URL. `&embed=1` tells admin.html it's hosted inside another client
-// shell (old Tauri client: an <iframe>; here: an embedded WebView) so it can
-// hide its own top-level chrome that would duplicate ours.
+// URL FRAGMENT (never a query param, fragments aren't sent to the server or
+// logged) to adopt a session instead of showing its own login form, then scrubs
+// the fragment from the visible URL. `&embed=1` tells admin.html it's hosted
+// inside another client shell (old Tauri client: an <iframe>; here: an embedded
+// WebView) so it can hide its own top-level chrome that would duplicate ours.
+//
+// Two fragment shapes, for two very different destinations:
+//   #token=<jwt>      our OWN embedded WebView: same process, same session.
+//   #handoff=<code>   an external browser, which trades the single-use code for
+//                     its own session via POST /auth/handoff/exchange.
+// A browser keeps history and profile storage we don't control, so the session
+// token never goes there; the code is good once and for about a minute.
 //
 // See the old client's `srvEnterAdmin()` in apps/desktop/src/app.js (~line
 // 10946) for the reference implementation this ports.
 
+import 'dart:convert';
+
+import 'http_client.dart';
 import 'models.dart';
 
 /// Builds the `{server}/admin?embedded=1#token=<jwt>&embed=1` URL for
-/// [session].
+/// [session], for THIS app's embedded WebView only.
 ///
 /// Deliberately takes the *full* bearer JWT (matching the old client), not a
 /// scoped media token — the admin console needs the operator's real
 /// privileges (it's the same RBAC-gated admin UI, not a media stream) and
-/// admin.html's `bootSSO` expects a bearer-shaped token in the fragment.
+/// admin.html's `bootSSO` expects a bearer-shaped token in the fragment. The
+/// webview runs in this process and stores nothing we don't control, so the
+/// token never leaves the client. For an EXTERNAL browser use
+/// [adminConsoleBrowserUrl] instead.
 ///
-/// `?embedded=1` (default) makes admin.html hide its own top header chrome
-/// (back arrow / title bar) so it doesn't double up with the Flutter shell's
-/// header around the webview; the legacy `&embed=1` fragment flag is kept so
-/// older servers that only understand it still get the old embed behavior.
-/// Pass `embedded: false` when the console will live in a real browser tab
-/// ("Open in browser") — there's no shell header there, so the console keeps
-/// its own.
-String adminConsoleUrl(Session session, {bool embedded = true}) {
-  final base = session.base.endsWith('/')
+/// `?embedded=1` makes admin.html hide its own top header chrome (back arrow /
+/// title bar) so it doesn't double up with the Flutter shell's header around
+/// the webview; the legacy `&embed=1` fragment flag is kept so older servers
+/// that only understand it still get the old embed behavior.
+String adminConsoleUrl(Session session) {
+  return '${_trimmedBase(session)}/admin?embedded=1'
+      '#token=${Uri.encodeComponent(session.token)}&embed=1';
+}
+
+/// Asks the server for a single-use console-handoff code and builds the
+/// `{server}/admin#handoff=<code>` URL for a REAL browser tab.
+///
+/// The browser trades the code for its own session (admin.html's `bootSSO` →
+/// `POST /auth/handoff/exchange`), so this client's session token never reaches
+/// a browser's history, profile storage, or extensions. The code is good once
+/// and expires in about a minute, so mint a fresh one per launch.
+///
+/// No `?embedded=1`: a real browser tab has no Flutter shell header, so the
+/// console keeps its own chrome there.
+///
+/// Returns `null` when the server declines or is unreachable (including older
+/// servers with no handoff route, which answer 404), so the caller can report a
+/// launch failure rather than open a console the operator can't sign in to.
+Future<String?> adminConsoleBrowserUrl(Session session) async {
+  final base = _trimmedBase(session);
+  try {
+    final resp = await sharedHttpClient.post(
+      Uri.parse('$base/auth/handoff'),
+      headers: {'authorization': 'Bearer ${session.token}'},
+    );
+    if (resp.statusCode != 200) return null;
+    final body = jsonDecode(resp.body);
+    if (body is! Map<String, dynamic>) return null;
+    final code = body['code'];
+    if (code is! String || code.isEmpty) return null;
+    return '$base/admin#handoff=${Uri.encodeComponent(code)}';
+  } catch (_) {
+    return null;
+  }
+}
+
+String _trimmedBase(Session session) {
+  return session.base.endsWith('/')
       ? session.base.substring(0, session.base.length - 1)
       : session.base;
-  final q = embedded ? '?embedded=1' : '';
-  return '$base/admin$q#token=${Uri.encodeComponent(session.token)}&embed=1';
 }
 
 /// The console's hostname, for display next to the pane (e.g. in a header

--- a/apps/desktop-flutter/lib/api/export_api.dart
+++ b/apps/desktop-flutter/lib/api/export_api.dart
@@ -13,12 +13,11 @@
 //   GET    /media-token?camera=<id>                -> scoped short-lived token
 //
 // The export create/poll/cancel/download routes are authenticated with the
-// bearer JWT (Authorization header) exactly like the rest of CrumbApi — the
-// old Tauri client kept those on the full-JWT pattern deliberately (see
-// apps/desktop/src/app.js:1954-1956, and `LegacyQueryTokenUser` in
-// services/api/src/auth_mw.rs) because a multi-camera archive has no single
-// scoped camera and there's no browser <a download> element here forcing a
-// URL-embedded token. The filmstrip PREVIEW frames, however, are per-camera
+// bearer JWT (Authorization header) exactly like the rest of CrumbApi: a
+// multi-camera archive has no single scoped camera, and every client fetches
+// the bytes itself rather than handing a URL to a browser <a download>
+// element, so the server accepts the header only (services/api/src/export.rs).
+// The filmstrip PREVIEW frames, however, are per-camera
 // media and MUST use the short-lived `?token=` media claim (golden rule 1,
 // never the bearer JWT) — this file mints and caches those via GET
 // /media-token, mirroring apps/desktop/src/app.js's getMediaToken/-cache.

--- a/apps/desktop-flutter/lib/ui/admin_console/admin_console_screen.dart
+++ b/apps/desktop-flutter/lib/ui/admin_console/admin_console_screen.dart
@@ -11,6 +11,9 @@
 // old client's `invoke('open_url', { url })` fallback (apps/desktop/src-tauri/
 // src/lib.rs ~line 1317) for operators who'd rather use their real browser
 // (bookmarks, extensions, a second monitor, etc.) or if WebView2 isn't usable.
+// That path hands the browser a single-use handoff code instead of this
+// client's token (see `adminConsoleBrowserUrl`); only the in-process webview
+// gets the token itself.
 //
 // NOTE (integration): this file assumes the `webview_windows` and
 // `url_launcher` packages are added to pubspec.yaml — see this feature's
@@ -109,11 +112,21 @@ class _AdminConsoleScreenState extends State<AdminConsoleScreen> {
   }
 
   Future<void> _openInBrowser() async {
-    // A real browser tab has no Flutter shell header, so let the console keep
-    // its own chrome there.
-    final uri = Uri.parse(adminConsoleUrl(widget.session, embedded: false));
+    // A browser is a different process with its own history and profile
+    // storage, so it gets a single-use handoff code rather than this client's
+    // session token; the console trades the code for its own session on load.
+    // A null URL means the server declined or is unreachable.
+    final url = await adminConsoleBrowserUrl(widget.session);
+    if (!mounted) return;
+    if (url == null) {
+      _showLaunchFailure();
+      return;
+    }
     try {
-      final ok = await launchUrl(uri, mode: LaunchMode.externalApplication);
+      final ok = await launchUrl(
+        Uri.parse(url),
+        mode: LaunchMode.externalApplication,
+      );
       if (!ok && mounted) _showLaunchFailure();
     } catch (_) {
       if (mounted) _showLaunchFailure();

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1464,9 +1464,12 @@ async fn pick_export_folder() -> Option<String> {
     Some(canon.to_string_lossy().into_owned())
 }
 
-/// Stream an exported clip (its authed `?token=` download URL) straight to a
-/// chosen folder, bypassing the browser Downloads path. Returns the written
-/// file path on success.
+/// Stream an exported clip straight to a chosen folder, bypassing the browser
+/// Downloads path. Returns the written file path on success.
+///
+/// `token` is the caller's session token, sent as an `Authorization: Bearer`
+/// header: the export download routes take the header only, never a `?token=`
+/// query (a login token in a URL lands in the server's access log).
 ///
 /// `dest_dir` is validated against the folder [`pick_export_folder`] actually
 /// returned last (rather than trusted as-is) — the webview only ever ROUND-TRIPS
@@ -1476,6 +1479,7 @@ async fn pick_export_folder() -> Option<String> {
 #[tauri::command]
 async fn save_export_file(
     url: String,
+    token: String,
     dest_dir: String,
     filename: String,
 ) -> Result<String, String> {
@@ -1514,6 +1518,7 @@ async fn save_export_file(
 
     let mut resp = HTTP
         .get(&url)
+        .bearer_auth(&token)
         .send()
         .await
         .map_err(|e| format!("request failed: {e}"))?;

--- a/apps/desktop/src/app.js
+++ b/apps/desktop/src/app.js
@@ -10173,12 +10173,13 @@ function exportFmtOffset(ms) {
 }
 
 /**
- * Build the absolute, authed download URL for an output_file entry.
+ * Build the absolute download URL for an output_file entry.
  * The spec says download_url is relative (e.g. "/export/<job>/files/<cam>").
+ * No token in the URL: the export download routes authenticate from the
+ * Authorization header, which both download paths below send.
  */
 function exportAbsoluteUrl(relUrl) {
-  const sep = relUrl.includes('?') ? '&' : '?';
-  return state.server + relUrl + sep + 'token=' + encodeURIComponent(state.token);
+  return state.server + relUrl;
 }
 
 /**
@@ -10709,16 +10710,16 @@ async function exportDownloadFiles(outputFiles, startMs) {
     if (destDir) {
       // Stream straight to the chosen folder via the Rust saver (no browser download).
       try {
-        await invoke('save_export_file', { url: absUrl, destDir, filename });
+        await invoke('save_export_file', { url: absUrl, token: state.token, destDir, filename });
         downloaded++;
       } catch (e) {
         lastErr = e;
         console.warn('save_export_file failed:', e);
       }
     } else {
-      // Default: blob download into the browser Downloads folder. Authenticate via
-      // the Authorization header (not just the URL's ?token=) so this download
-      // doesn't depend on the token-in-URL escape hatch.
+      // Default: blob download into the browser Downloads folder. Authenticate
+      // via the Authorization header, which is the only credential the export
+      // download routes accept.
       try {
         const res = await fetchWithTimeout(absUrl, { headers: authHeaders() });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -10733,9 +10734,9 @@ async function exportDownloadFiles(outputFiles, startMs) {
         setTimeout(() => { URL.revokeObjectURL(objectUrl); document.body.removeChild(a); }, 2000);
         downloaded++;
       } catch (blobErr) {
-        // No window.open() fallback here: that would hand a `?token=` download
-        // URL out of the app (a new browser window/tab, outside our control) —
-        // an auth escape hatch we don't want. Surface the failure instead.
+        // No window.open() fallback here: a browser window outside this app
+        // cannot send the Authorization header, so it would just 401. Surface
+        // the failure instead.
         console.warn('blob download failed:', blobErr);
         lastErr = blobErr;
       }

--- a/apps/ios/Crumb/App/AppContainer.swift
+++ b/apps/ios/Crumb/App/AppContainer.swift
@@ -119,6 +119,6 @@ final class AppContainer: ObservableObject {
     }
 
     func mediaUrls() -> MediaUrls {
-        MediaUrls(serverUrl: store.serverUrl, token: store.token, tokenCache: mediaTokens)
+        MediaUrls(serverUrl: store.serverUrl, tokenCache: mediaTokens)
     }
 }

--- a/apps/ios/Crumb/Features/Export/ExportViewModel.swift
+++ b/apps/ios/Crumb/Features/Export/ExportViewModel.swift
@@ -436,9 +436,9 @@ final class ExportViewModel: ObservableObject {
     }
 
     /// [iOS] C1 fix: download an export output file to a local temp file via an
-    /// AUTHENTICATED request (`URLSession.crumbMedia`, token in the URL query —
-    /// same server-side auth scheme as every other media endpoint, but the fetch
-    /// itself never lands in the on-disk URL cache), then hand `UIActivityViewController`
+    /// AUTHENTICATED request (`URLSession.crumbMedia`, session token in the
+    /// `Authorization` header, and the ephemeral session keeps the fetch out of
+    /// the on-disk URL cache), then hand `UIActivityViewController`
     /// the local `fileURL`. Previously the raw `?token=<JWT>` URL was handed
     /// straight to the share sheet, which could leak the token to whatever
     /// destination (Mail, Messages, a third-party app, iCloud Drive, AirDrop...)
@@ -461,10 +461,7 @@ final class ExportViewModel: ObservableObject {
     /// Downloads one output file to a fresh temp file, returning its local URL.
     /// Shared by C1 (iOS share sheet) and C2 (macOS save-panel) call sites.
     func downloadToTemp(_ file: ExportOutputFile) async throws -> URL {
-        guard let remote = container.mediaUrls().authed(file.downloadUrl) else {
-            throw URLError(.badURL)
-        }
-        var req = URLRequest(url: remote)
+        var req = try container.api.exportDownloadRequest(file.downloadUrl)
         req.timeoutInterval = 300   // exports can be large; give the download room
         // `.download(for:)` streams the response straight to a temp file instead
         // of buffering it in memory like `.data(for:)` did — a batch export is

--- a/apps/ios/Crumb/Networking/CrumbAPI.swift
+++ b/apps/ios/Crumb/Networking/CrumbAPI.swift
@@ -163,6 +163,30 @@ final class CrumbAPI {
         try await get("export/\(jobId)")
     }
 
+    /// Builds an authenticated `URLRequest` for one export output file
+    /// (`/export/{job}/files/{camera}` or `/export/{job}/archive`).
+    ///
+    /// An export can span several cameras, so there is no scoped media token
+    /// that fits it; the session token travels in the `Authorization` header
+    /// instead, never in the URL, where it would land in the server's access
+    /// log and anywhere the URL is later handed. The caller drives the fetch
+    /// itself (`URLSession.download(for:)`) and shares the resulting LOCAL file.
+    ///
+    /// `pathOrUrl` is the server-relative `download_url` from the job status
+    /// (an absolute URL is passed through unchanged).
+    func exportDownloadRequest(_ pathOrUrl: String) throws -> URLRequest {
+        let url: URL
+        if pathOrUrl.hasPrefix("http://") || pathOrUrl.hasPrefix("https://") {
+            guard let absolute = URL(string: pathOrUrl) else { throw APIError.invalidURL }
+            url = absolute
+        } else {
+            url = try buildURL(pathOrUrl.hasPrefix("/") ? String(pathOrUrl.dropFirst()) : pathOrUrl)
+        }
+        var request = URLRequest(url: url)
+        addAuth(&request)
+        return request
+    }
+
     /// Cancel a running/queued export (DELETE /export/{id}; 204, idempotent).
     func cancelExport(jobId: String) async throws {
         let _: EmptyResponse = try await delete("export/\(jobId)")

--- a/apps/ios/Crumb/Networking/MediaUrls.swift
+++ b/apps/ios/Crumb/Networking/MediaUrls.swift
@@ -16,7 +16,6 @@ struct MediaUrls {
     static let scrubThumbWidth = 480
 
     let serverUrl: String
-    let token: String?
     /// Per-camera scoped media-token cache (P0-SESSIONS), owned by
     /// `AppContainer` and shared by every `MediaUrls` value it hands out.
     /// `Optional` only so a bare `MediaUrls` can still be constructed (e.g. a
@@ -24,27 +23,13 @@ struct MediaUrls {
     /// returns `nil` in that case, matching "token mint failed".
     let tokenCache: MediaTokenCache?
 
-    /// Full-JWT-authed URL — for endpoints that are NOT single-camera-scoped
-    /// (export batch downloads, which can span multiple cameras and the
-    /// archive pseudo-camera) or non-media API calls. Do NOT use this for
-    /// per-camera media (frame/segment/clip/filmstrip) — use `scopedURL`.
-    func authed(_ pathOrUrl: String) -> URL? {
-        let absolute = toAbsolute(pathOrUrl)
-        guard var components = URLComponents(string: absolute) else { return URL(string: absolute) }
-        if let token, !token.isEmpty {
-            var items = components.queryItems ?? []
-            items.append(URLQueryItem(name: "token", value: token))
-            components.queryItems = items
-        }
-        return components.url
-    }
-
     /// Camera-scoped media URL carrying a short-lived (~15 min) `?token=` minted
     /// via `GET /media-token?camera=<cameraId>` (cached/refreshed/deduped by
-    /// `MediaTokenCache`), instead of the full login JWT. This is the
-    /// migrated replacement for `authed(_:)` on every per-camera media
-    /// endpoint (live stream proxy, recorded segment, filmstrip/scrub frame,
-    /// clip thumbnail/video, camera snapshot).
+    /// `MediaTokenCache`), instead of the full login JWT. Every per-camera
+    /// media endpoint goes through here (live stream proxy, recorded segment,
+    /// filmstrip/scrub frame, clip thumbnail/video, camera snapshot); the
+    /// non-scoped export downloads use an `Authorization` header instead (see
+    /// `CrumbAPI.exportDownloadRequest`), so no URL here carries a login token.
     ///
     /// Returns `nil` if the token mint fails (offline, camera access revoked,
     /// session expired — the 401 path already routes through

--- a/docs/COMPONENT-MAP.md
+++ b/docs/COMPONENT-MAP.md
@@ -201,7 +201,7 @@ a "new camera capability" is usually also a "new/changed API endpoint" and a
 | The file | `services/api/src/admin.html` | One file, inline script, `include_str!`: rebuild the api image/binary to see changes. Some tools misdetect it as binary (`grep -a`) |
 | Conventions | `esc()` on all interpolation, `api()` for fetches, every `on*=` handler defined, semantic colors, settings-UX principles (sticky header, collapsible, live-preview, tab persistence) | |
 | Syntax check | `node --check` on the extracted script block | Cheapest smoke test for an 8800-line file |
-| Desktop embed | desktop embeds `/admin#token=...&embed=1`; verify the change renders in the embedded WebView too | The console is also a desktop surface |
+| Desktop embed | desktop embeds `/admin#token=...&embed=1` in its own WebView, and opens `/admin#handoff=<single-use code>` in an external browser (`docs/DECISIONS.md` 2026-09-07); verify the change renders in the embedded WebView too | The console is also a desktop surface |
 | Wizard | if onboarding changed: `docs/AI-INSTALL.md` section 6a must match what the wizard actually asks | Golden rule 5 |
 
 ### I. Install, compose, env, secret, or image change (golden rule 5)

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,55 @@ revisit.
 
 ---
 
+## 2026-09-07, Opening the web console in an external browser uses a single-use handoff code, not the desktop client's session token
+
+**Context.** The desktop client can show the server's web admin console two
+ways: embedded in its own WebView, and "Open in browser", which hands the URL to
+whatever browser the OS launches. Both used the same URL shape,
+`/admin#token=<session token>&embed=1`, which `admin.html`'s `bootSSO` reads and
+persists like a login. That is fine for the embedded WebView, which is this
+client's own process, but "Open in browser" crosses a process boundary: the
+token then lives in a browser's history, its profile storage, and within reach
+of whatever extensions the operator has installed, for as long as the session
+lasts.
+
+**Decision.** The embedded WebView keeps `#token=`. "Open in browser" instead
+calls `POST /auth/handoff` (full session required, a scoped media token is
+refused), gets back a single-use code that expires in about a minute, and opens
+`/admin#handoff=<code>`. The console posts the code to
+`POST /auth/handoff/exchange`, which consumes it exactly once and mints the
+browser its OWN session: its own `jti`, its own `sessions` row, normal (not
+"remember me") expiry, so it is listed under "your sessions" and every sign-out
+path reaches it. Codes are held in memory only, bound to the issuing user and
+session; an expired, unknown, reused, or signed-out code is a 401 and the
+console falls through to its normal login form.
+
+**Rejected:**
+
+- *Keep passing the session token in the fragment.* Cheapest, and the fragment
+  never reaches the server, but the credential still lands in browser history
+  and profile storage under a different security boundary than the client that
+  owns it.
+- *Open the console with no credential at all.* Safest and free, but the
+  operator is asked to type their password again to reach a console they are
+  already signed in to on the same machine, which is exactly the friction the
+  handoff exists to remove.
+- *Persist codes in Postgres.* Rejected as unnecessary machinery: a code lives
+  for seconds, and losing the map on a restart only costs a second click.
+
+**Trades knowingly accepted:** codes are per-process, so an install running
+several API replicas behind a load balancer can have the exchange land on a
+replica that never saw the code (the operator clicks again, or the browser shows
+the login form). The browser's session is not the client's session, so signing
+out in one does not sign out the other; both are visible and revocable under
+"your sessions".
+
+**Revisit if:** Crumb starts supporting multiple API replicas behind a shared
+load balancer as a documented deployment, at which point the code store moves to
+Postgres (or a shared cache) with the same single-use semantics.
+
+---
+
 ## 2026-08-10, Home Assistant `climate` (thermostat/HVAC setpoint) control is out of scope
 
 **Context.** #442 introduced value-setting HA controls. Light dimming

--- a/docs/IOS-APP-PLAN.md
+++ b/docs/IOS-APP-PLAN.md
@@ -91,10 +91,12 @@ apps/ios/Crumb/
 - **Auth:** JWT in **Keychain** (`KeychainStore`); `Authorization: Bearer` on every authenticated
   API call. A 401 clears the session (`KeychainStore.clearSession()`), which `AppContainer`
   observes to flip back to `LoginView`.
-- **Media auth:** segment bytes, filmstrip frames, event snapshots, export downloads are tokened
-  URLs (`?token=`) fetched via the ephemeral `.crumbMedia` `URLSession` (never the disk-cached
-  `.shared` session, so the token never touches disk), `AVPlayer`/`AsyncImage`-equivalent
-  (`TokenedAsyncImage`) call sites can't set an `Authorization` header.
+- **Media auth:** segment bytes, filmstrip frames, and event snapshots are scoped-token URLs
+  (`?token=`) fetched via the ephemeral `.crumbMedia` `URLSession` (never the disk-cached
+  `.shared` session, so the token never touches disk), because `AVPlayer`/`AsyncImage`-equivalent
+  (`TokenedAsyncImage`) call sites can't set an `Authorization` header. Export downloads are not
+  single-camera scoped and are fetched with an `Authorization` header instead
+  (`CrumbAPI.exportDownloadRequest`), then shared as a local file.
 - **Server URL** is user-entered and editable in Settings; **LAN auto-discovery**
   (`ServerDiscovery.swift`) scans the device's /24 for `GET /health` matching the
   `"service":"crumb-api"` fingerprint (a unicast TCP scan, not mDNS, the API runs in a bridged

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -12054,8 +12054,9 @@ $('bootstrap-pass2') && $('bootstrap-pass2').addEventListener('keydown', e => { 
    successful login resumes the wizard too when setup is incomplete. */
 (async function boot() {
   // A #handoff= code is redeemed asynchronously by bootSSO; wait for it so the
-  // decision below sees the resulting session.
-  await SSO_READY;
+  // decision below sees the resulting session. Never let that step stop the
+  // console from rendering: the worst case is the normal login form.
+  try { await SSO_READY; } catch (_) { /* fall through to the boot decision */ }
   let status = null;
   try { status = await fetch('/auth/setup-status').then(res => res.ok ? res.json() : null); } catch (_) { /* fall through */ }
   if (status && status.needs_bootstrap) { openWizard(status); return; }

--- a/services/api/src/admin.html
+++ b/services/api/src/admin.html
@@ -11832,13 +11832,23 @@ function renderSnapshot(c) {
 }
 
 /* ── Boot ── */
-// SSO from an embedding host (the Crumb Client). The host loads
-//   /admin#token=<jwt>&embed=1
-// so the operator who's already signed into the desktop doesn't re-authenticate
-// here. Adopt the token, persist it like a normal login, then SCRUB the hash so
-// the credential never lingers in the address bar or history. embed=1 also drops
-// our own topbar/sign-out (the host owns that chrome).
-(function bootSSO() {
+// SSO from an embedding host (the Crumb Client). Two shapes, both fragments
+// (never query params, since fragments aren't sent to the server or logged):
+//   /admin#token=<jwt>&embed=1   the host's own EMBEDDED webview, same process
+//   /admin#handoff=<code>        a real browser the host launched for us
+// The embedded webview shares the host's process, so it simply passes its
+// session token. "Open in browser" crosses a process boundary into a browser's
+// history and profile storage, so it passes a single-use, short-lived code
+// instead and we trade it here for our OWN session via POST
+// /auth/handoff/exchange. Either way we persist the result like a normal login
+// and SCRUB the hash so nothing lingers in the address bar or history; embed=1
+// also drops our own topbar/sign-out (the host owns that chrome).
+//
+// Async because of the exchange: `boot()` at the bottom of this file awaits
+// SSO_READY before deciding between the app and the login screen. A failed
+// exchange (expired, already used, restarted server) leaves TOKEN empty and
+// falls through to the normal login form.
+const SSO_READY = (async function bootSSO() {
   // Chrome-less embed via query param (item #4): the desktop client's webview
   // loads /admin?embedded=1 so the console drops its own topbar (brand, back /
   // sign-out chrome) — the host draws that chrome, and doubling it up gave two
@@ -11857,11 +11867,27 @@ function renderSnapshot(c) {
   if (h.length > 1 && !h.startsWith('#/')) {
     const p = new URLSearchParams(h.slice(1));
     const t = p.get('token');
+    const handoff = p.get('handoff');
     if (t) { TOKEN = t; localStorage.setItem('crumb_admin_token', TOKEN); }
     if (p.get('embed') === '1') document.body.classList.add('embedded');
-    if (t || p.has('embed')) {
+    if (t || handoff || p.has('embed')) {
       try { history.replaceState(null, '', location.pathname + location.search); }
       catch { location.hash = ''; }
+    }
+    // Scrubbed first, redeemed second: the code is single-use and short-lived,
+    // so it must not survive in the address bar even for the exchange round-trip.
+    if (!t && handoff) {
+      try {
+        const res = await fetch('/auth/handoff/exchange', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code: handoff }),
+        });
+        if (res.ok) {
+          const data = await res.json();
+          if (data && data.token) { TOKEN = data.token; localStorage.setItem('crumb_admin_token', TOKEN); }
+        }
+      } catch { /* offline or server restarted: fall through to the login form */ }
     }
   }
 })();
@@ -12027,6 +12053,9 @@ $('bootstrap-pass2') && $('bootstrap-pass2').addEventListener('keydown', e => { 
    wizard if first-run setup was never finished. Otherwise show the login; a
    successful login resumes the wizard too when setup is incomplete. */
 (async function boot() {
+  // A #handoff= code is redeemed asynchronously by bootSSO; wait for it so the
+  // decision below sees the resulting session.
+  await SSO_READY;
   let status = null;
   try { status = await fetch('/auth/setup-status').then(res => res.ok ? res.json() : null); } catch (_) { /* fall through */ }
   if (status && status.needs_bootstrap) { openWizard(status); return; }

--- a/services/api/src/auth.rs
+++ b/services/api/src/auth.rs
@@ -14,6 +14,8 @@
 //! | `POST`   | `/auth/login`              | none        | Verify credentials; issue JWT            |
 //! | `POST`   | `/auth/refresh`            | Bearer      | Re-issue a fresh token for a valid one   |
 //! | `GET`    | `/auth/me`                 | Bearer      | Return the caller's own profile          |
+//! | `POST`   | `/auth/handoff`            | Bearer      | Mint a single-use console-handoff code   |
+//! | `POST`   | `/auth/handoff/exchange`   | the code    | Trade that code for a new session token  |
 //!
 //! User management (create / update / delete / list users) lives exclusively at
 //! `/config/users` in `config_routes.rs`, which enforces the last-admin guard.
@@ -71,7 +73,7 @@ use crumb_common::{
 };
 
 use crate::{
-    auth_mw::{AdminUser, AuthUser, MEDIA_TOKEN_TYP},
+    auth_mw::{AdminUser, AuthUser, FullSessionUser, MEDIA_TOKEN_TYP},
     dto::{
         Claims, LoginRequest, LoginResponse, MeResponse, MediaClaims, MediaTokenResponse,
         SessionDto,
@@ -485,6 +487,9 @@ pub fn routes() -> Router<AppState> {
             axum::routing::delete(revoke_all_my_sessions),
         )
         .route("/sessions/:jti", axum::routing::delete(revoke_my_session))
+        // ── console handoff to an external browser ─────────────────────────
+        .route("/handoff", post(create_handoff))
+        .route("/handoff/exchange", post(exchange_handoff))
         // Admin: sign out every device of an arbitrary user (e.g. a stolen
         // phone reported by a household member).
         .route(
@@ -559,6 +564,113 @@ async fn media_token(
         camera_id: q.camera,
         expires_at: exp,
     }))
+}
+
+// ── console handoff to an external browser ────────────────────────────────────
+
+/// Lifetime of a console-handoff code. Long enough for the OS to start the
+/// operator's browser and for that browser to load `/admin` and post the
+/// exchange, short enough that a code that never gets redeemed is dead almost
+/// immediately. Codes are single-use on top of this.
+const HANDOFF_EXPIRY_SECONDS: u64 = 60;
+
+/// Request body for `POST /auth/handoff/exchange`.
+///
+/// Kept private to this module, like [`BootstrapRequest`] (api-routes owns
+/// `dto.rs`; this module avoids touching that file for its own request shapes).
+#[derive(Debug, Deserialize)]
+struct HandoffExchangeRequest {
+    code: String,
+}
+
+/// `POST /auth/handoff`
+///
+/// Mint a single-use, ~1 minute code that a *separate* process (the desktop
+/// client's "Open in browser") can put in the console URL's fragment in place
+/// of the operator's own session token. The browser trades the code for its own
+/// session at [`exchange_handoff`], so the desktop's token never crosses the
+/// process boundary into a browser's history, profile storage, or extensions.
+///
+/// Requires a full login session ([`FullSessionUser`]): a scoped media token
+/// must never be tradeable for a console session.
+///
+/// # Errors
+///
+/// - `401`: not authenticated.
+/// - `403`: a scoped media token was presented.
+async fn create_handoff(
+    FullSessionUser(user): FullSessionUser,
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let code = state.issue_handoff_code(
+        user.user_id,
+        user.jti,
+        std::time::Duration::from_secs(HANDOFF_EXPIRY_SECONDS),
+    );
+    Ok(Json(
+        json!({ "code": code, "expires_in": HANDOFF_EXPIRY_SECONDS }),
+    ))
+}
+
+/// `POST /auth/handoff/exchange`
+///
+/// Redeem a code from [`create_handoff`] for a NEW session token belonging to
+/// the same user. Unauthenticated by necessity (the caller is a fresh browser
+/// with no credentials of its own); the code IS the one-time credential, and it
+/// is consumed on the first attempt whether or not that attempt succeeds.
+///
+/// The result is an ordinary session: its own `jti`, its own `sessions` row,
+/// normal expiry, so it appears in "your sessions" and every sign-out path
+/// reaches it. The long-lived "remember me" expiry stays login-only, matching
+/// [`refresh`].
+///
+/// # Errors
+///
+/// - `401`: the code is unknown, already redeemed, expired, or the session
+///   that minted it has since been signed out.
+/// - `404`: the user was deleted after the code was minted.
+/// - `500`: database or signing error.
+async fn exchange_handoff(
+    State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
+    Json(body): Json<HandoffExchangeRequest>,
+) -> Result<Json<LoginResponse>, ApiError> {
+    // One message for every failure mode: which one it was tells an unknown
+    // caller something, and tells the operator nothing they can act on.
+    let invalid = || ApiError::Unauthorized("this console link is no longer valid".to_owned());
+
+    let Some((user_id, jti)) = state.consume_handoff_code(body.code.trim()) else {
+        return Err(invalid());
+    };
+
+    // A code can outlive its issuing session in the seconds between a sign-out
+    // and the exchange. Honour the sign-out rather than hand back a fresh one.
+    if let Some(jti) = jti {
+        if state.is_jti_revoked(jti).await {
+            return Err(invalid());
+        }
+    }
+
+    let db_user = db::get_user_by_id(state.pool(), user_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or_else(|| ApiError::NotFound(format!("user {user_id} not found")))?;
+
+    tracing::info!(
+        user_id  = %db_user.id,
+        username = %db_user.username,
+        "console handoff redeemed"
+    );
+
+    mint_token(
+        &state,
+        &db_user,
+        false,
+        device_label(&headers).as_deref(),
+        client_ip(&headers).as_deref(),
+    )
+    .await
+    .map(Json)
 }
 
 // ── session management handlers (P0-SESSIONS) ──────────────────────────────────

--- a/services/api/src/auth_mw.rs
+++ b/services/api/src/auth_mw.rs
@@ -262,21 +262,15 @@ fn fallback_caps(role: UserRole) -> Capabilities {
 }
 
 impl AuthUser {
-    /// Shared authentication core for the [`AuthUser`] (fail-closed) and
-    /// [`ExportDownloadUser`] (permissive) extractors.
+    /// Shared authentication core for the [`AuthUser`] (default) and
+    /// [`MediaOrFullUser`] (media-read) extractors.
     ///
-    /// `allow_full_jwt_via_query` is the fail-closed boundary (audit
-    /// 2026-07-05 #2): a full login JWT presented via `?token=` puts a login
-    /// credential in a URL (proxy/access logs, browser history), so it is
-    /// REJECTED by default and accepted only on the multi-camera export
-    /// download routes (via [`ExportDownloadUser`]) until they move to a scoped
-    /// export token / `Authorization` header. A valid scoped media token via
-    /// `?token=` is always accepted, regardless of this flag.
-    async fn authenticate(
-        parts: &mut Parts,
-        state: &AppState,
-        allow_full_jwt_via_query: bool,
-    ) -> Result<AuthUser, ApiError> {
+    /// A full login JWT presented via `?token=` puts a login credential in a
+    /// URL (proxy/access logs, browser history) and is REJECTED on every route
+    /// (audit 2026-07-05 #2). A valid scoped media token via `?token=` is
+    /// accepted here and turned into a single-camera principal, which the
+    /// default extractor then refuses and [`MediaOrFullUser`] admits.
+    async fn authenticate(parts: &mut Parts, state: &AppState) -> Result<AuthUser, ApiError> {
         // ── 1. extract the token: prefer Authorization: Bearer, else ?token= ──
         // The query-param fallback lets browser <video>/<img>/<a download>
         // elements — which cannot set an Authorization header — authenticate to
@@ -312,9 +306,9 @@ impl AuthUser {
         // Only from `?token=` (a media token has no place in an API Bearer
         // header). If the token is a valid media token we build a principal
         // scoped to exactly its one camera and return — the media handlers'
-        // existing `assert_camera_access` then permits only that camera. A
-        // full JWT arriving via `?token=` (legacy media clients) still works:
-        // media-token decode fails and we fall through to the full-JWT path.
+        // existing `assert_camera_access` then permits only that camera.
+        // Anything else in `?token=` is refused below rather than falling
+        // through to the full-JWT path.
         if from_query {
             if let Some(user) = try_media_token(&token, state) {
                 return Ok(user);
@@ -322,17 +316,14 @@ impl AuthUser {
             // ── fail-closed boundary (audit 2026-07-05 #2) ────────────────
             // The token arrived via ?token= but is NOT a scoped media token, so
             // it is a full login JWT (or garbage). A login credential in a URL
-            // query can leak into proxy/access logs and browser history. Reject
-            // it on every route EXCEPT the export download routes, which opt in
-            // via `ExportDownloadUser` until they move to a scoped export token.
-            if !allow_full_jwt_via_query {
-                return Err(ApiError::Unauthorized(
-                    "a login token in a ?token= query parameter is not accepted on this route; \
-                     mint a scoped media token (GET /media-token) or use an Authorization: \
-                     Bearer header"
-                        .to_owned(),
-                ));
-            }
+            // query can leak into proxy/access logs and browser history, so it
+            // is rejected on EVERY route. The export downloads were the last
+            // exception; every client now sends them an Authorization header.
+            return Err(ApiError::Unauthorized(
+                "a login token in a ?token= query parameter is not accepted; mint a scoped \
+                 media token (GET /media-token) or use an Authorization: Bearer header"
+                    .to_owned(),
+            ));
         }
 
         // ── 2. decode + verify signature and expiry ───────────────────────
@@ -344,24 +335,7 @@ impl AuthUser {
 
         let claims = token_data.claims;
 
-        // ── 2a. legacy full-JWT-via-?token= (permissive routes only) ──────
-        // Only reachable when `allow_full_jwt_via_query` is true — the
-        // fail-closed check above already rejected a full-JWT-via-?token= on
-        // every other route. `debug!` (not `warn!`) because one permissive
-        // caller — the web-console camera snapshot — polls frequently and would
-        // flood the logs; the permissive routes are explicit + documented (see
-        // [`LegacyQueryTokenUser`]), and an *unknown* caller gets the loud 401
-        // from the branch above.
-        if from_query {
-            tracing::debug!(
-                sub = %claims.sub,
-                "full login JWT accepted via ?token= on a legacy permissive route — migrate \
-                 this caller to a scoped media token or an Authorization: Bearer header \
-                 (audit 2026-07-05 #2)"
-            );
-        }
-
-        // ── 2b. revocation check (P0-SESSIONS) ────────────────────────────
+        // ── 2a. revocation check (P0-SESSIONS) ────────────────────────────
         // A token carrying a `jti` is a revocable session (minted at/after
         // P0-SESSIONS). If that jti has been revoked ("sign out this / all
         // devices", or an admin cutting a stolen phone), reject it now even
@@ -455,9 +429,9 @@ impl AuthUser {
             capabilities,
             role_id,
             jti,
-            // Reached only via a full login JWT (Bearer header, or ?token= on
-            // the explicitly-permissive export-download routes). The scoped
-            // media-token path returns earlier, in `try_media_token`.
+            // Reached only via a full login JWT in an Authorization header.
+            // The scoped media-token path returns earlier, in
+            // `try_media_token`.
             media_scoped: false,
         })
     }
@@ -482,7 +456,7 @@ impl FromRequestParts<AppState> for AuthUser {
         // extractor then refuses (safe-by-default; audit 2026-08 follow-up to
         // #516). A genuine media-read endpoint opts back in via
         // [`MediaOrFullUser`]. Bearer-header sessions always pass.
-        let user = AuthUser::authenticate(parts, state, false).await?;
+        let user = AuthUser::authenticate(parts, state).await?;
         if user.media_scoped {
             return Err(ApiError::Forbidden(MEDIA_TOKEN_REJECTED.to_owned()));
         }
@@ -520,36 +494,7 @@ impl FromRequestParts<AppState> for MediaOrFullUser {
         // Same authentication as the default extractor, but a media-scoped
         // principal is ACCEPTED here (this is the media-read surface).
         Ok(MediaOrFullUser(
-            AuthUser::authenticate(parts, state, false).await?,
-        ))
-    }
-}
-
-/// Auth extractor for the export **download** routes, which still accept a full
-/// login JWT via `?token=` pending an export-scoped token.
-///
-/// Identical to [`AuthUser`] except it does NOT fail-close the
-/// full-JWT-via-`?token=` path. Only the export downloads use it (audit
-/// 2026-07-05 #2): a multi-camera archive has no single-camera scoped media
-/// token, and a browser `<a download>` link can't set an `Authorization` header.
-/// (The web-console camera snapshot was migrated to a scoped media token, so
-/// `/cameras/:id/frame.jpg` is now the fail-closed [`AuthUser`].)
-///
-/// Every OTHER media route (segments, playback, filmstrip, clips, camera
-/// snapshot) rejects the full-JWT-via-`?token=` path. Do not widen this
-/// extractor's use without migrating the corresponding client first.
-pub struct LegacyQueryTokenUser(pub AuthUser);
-
-#[async_trait]
-impl FromRequestParts<AppState> for LegacyQueryTokenUser {
-    type Rejection = ApiError;
-
-    async fn from_request_parts(
-        parts: &mut Parts,
-        state: &AppState,
-    ) -> Result<Self, Self::Rejection> {
-        Ok(LegacyQueryTokenUser(
-            AuthUser::authenticate(parts, state, true).await?,
+            AuthUser::authenticate(parts, state).await?,
         ))
     }
 }

--- a/services/api/src/auth_mw.rs
+++ b/services/api/src/auth_mw.rs
@@ -493,9 +493,7 @@ impl FromRequestParts<AppState> for MediaOrFullUser {
     ) -> Result<Self, Self::Rejection> {
         // Same authentication as the default extractor, but a media-scoped
         // principal is ACCEPTED here (this is the media-read surface).
-        Ok(MediaOrFullUser(
-            AuthUser::authenticate(parts, state).await?,
-        ))
+        Ok(MediaOrFullUser(AuthUser::authenticate(parts, state).await?))
     }
 }
 

--- a/services/api/src/export.rs
+++ b/services/api/src/export.rs
@@ -64,7 +64,7 @@ use crumb_common::db;
 use crumb_common::types::Segment;
 
 use crate::{
-    auth_mw::{AuthUser, LegacyQueryTokenUser},
+    auth_mw::AuthUser,
     dto::{
         CreateBatchExportRequest, CreateExportRequest, CreateExportResponse, ExportJob,
         ExportOutputFile, ExportStatus,
@@ -342,10 +342,11 @@ async fn cancel_export(
 /// for the requested camera (e.g. the job used password ZIP mode and the raw
 /// files were deleted).
 async fn download_export_file(
-    // Export downloads keep the legacy full-JWT-via-?token= path (audit
-    // 2026-07-05 #2); every other media route is fail-closed. See
-    // `LegacyQueryTokenUser`.
-    LegacyQueryTokenUser(user): LegacyQueryTokenUser,
+    // Authenticated by the `Authorization: Bearer` header only, like every
+    // other route: a login token in a `?token=` query lands in proxy/access
+    // logs and browser history. Each client fetches the bytes itself and
+    // writes the file, so none of them needs a header-less URL.
+    user: AuthUser,
     State(state): State<AppState>,
     Path((job_id, camera_id)): Path<(Uuid, Uuid)>,
 ) -> Result<impl IntoResponse, ApiError> {
@@ -449,9 +450,10 @@ async fn download_export_file(
 /// files are deleted after the ZIP is built, so this is the only download
 /// endpoint for such jobs.
 async fn download_archive(
-    // Multi-camera archive: keeps the legacy full-JWT-via-?token= path (audit
-    // 2026-07-05 #2) since there's no single-camera scoped token for it yet.
-    LegacyQueryTokenUser(user): LegacyQueryTokenUser,
+    // Multi-camera archive: no single-camera scoped token fits it, so it takes
+    // the full session from the `Authorization: Bearer` header (never a
+    // `?token=` query).
+    user: AuthUser,
     State(state): State<AppState>,
     Path(job_id): Path<Uuid>,
 ) -> Result<impl IntoResponse, ApiError> {

--- a/services/api/src/state.rs
+++ b/services/api/src/state.rs
@@ -48,6 +48,12 @@ const LOGIN_BACKOFF_CAP_SECS: u64 = 900;
 /// entries no longer in backoff are dropped (an active block is always kept).
 const LOGIN_FAILURES_MAX_ENTRIES: usize = 10_000;
 
+/// Prune the console-handoff map once it exceeds this many outstanding codes.
+/// Codes live for seconds and are consumed on first use, so a healthy install
+/// holds a handful; the cap only bounds a pathological caller that mints codes
+/// it never redeems. Only already-expired entries are dropped.
+const HANDOFF_MAX_ENTRIES: usize = 1_000;
+
 /// Backoff duration (seconds) for `failures` consecutive login failures, or
 /// `None` while still under [`LOGIN_FAIL_THRESHOLD`]. The engaged value is
 /// `min(cap, base * 2^(failures - threshold))` — exponential, clamped. Pure and
@@ -86,6 +92,19 @@ struct FailState {
     /// Instant until which new attempts for this username are rejected. A value
     /// at/before `now` means "not currently blocked".
     blocked_until: Instant,
+}
+
+/// One outstanding console-handoff code (see [`AppState::issue_handoff_code`]).
+#[derive(Clone, Copy)]
+struct HandoffEntry {
+    /// The user the code was minted for.
+    user_id: Uuid,
+    /// The `jti` of the session that asked for the code, when it has one
+    /// (pre-P0-SESSIONS tokens do not). The exchange rejects a code whose
+    /// originating session has since been signed out.
+    jti: Option<Uuid>,
+    /// Instant after which the code is no longer redeemable.
+    expires_at: Instant,
 }
 
 /// Inner state, heap-allocated once and reference-counted.
@@ -256,6 +275,12 @@ struct Inner {
     /// shared per-IP request bucket, not a replacement.
     login_failures: DashMap<String, FailState>,
 
+    /// Outstanding single-use console-handoff codes, keyed by the code itself.
+    /// Memory-only and deliberately so: a code is valid for seconds, and losing
+    /// the map on restart only means the operator clicks "Open in browser"
+    /// again (the fail-safe direction).
+    handoff_codes: DashMap<String, HandoffEntry>,
+
     /// Demand-driven cache behind `GET /ha/states` (issue #170). `None` until
     /// the first request. The `tokio::sync::Mutex` makes a refresh single-flight:
     /// concurrent callers on a stale cache collapse to one HA `/api/states`
@@ -334,6 +359,7 @@ impl AppState {
             revoked_jtis_loaded_at: AtomicI64::new(0),
             maintenance_until: Arc::new(AtomicI64::new(maintenance_until)),
             login_failures: DashMap::new(),
+            handoff_codes: DashMap::new(),
             ha_states: tokio::sync::Mutex::new(None),
             event_tx: OnceLock::new(),
         }))
@@ -697,6 +723,52 @@ impl AppState {
     /// counter (and their next fat-finger starts from zero again).
     pub fn record_login_success(&self, username: &str) {
         self.0.login_failures.remove(username);
+    }
+
+    // ── console handoff codes ─────────────────────────────────────────────────
+
+    /// Mint a single-use handoff code for `user_id` (issued by the session
+    /// identified by `jti`, when it has one) and remember it for `ttl`.
+    ///
+    /// The code is ~30 bytes of OS-CSPRNG entropy rendered as lowercase hex, so
+    /// it is URL-safe without escaping. Callers hand it to a browser in a URL
+    /// fragment; the browser trades it for a real session at
+    /// `POST /auth/handoff/exchange`.
+    ///
+    /// `ttl` is a parameter rather than a constant so tests can drive the
+    /// expiry path without sleeping for the production window.
+    pub fn issue_handoff_code(&self, user_id: Uuid, jti: Option<Uuid>, ttl: Duration) -> String {
+        let now = Instant::now();
+
+        // Bound memory: drop codes that can no longer be redeemed anyway.
+        if self.0.handoff_codes.len() > HANDOFF_MAX_ENTRIES {
+            self.0.handoff_codes.retain(|_, e| e.expires_at > now);
+        }
+
+        // Two v4 UUIDs, hex-rendered: `Uuid::new_v4` draws from the OS CSPRNG
+        // (getrandom), and using it keeps this dependency-free.
+        let code = format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
+        self.0.handoff_codes.insert(
+            code.clone(),
+            HandoffEntry {
+                user_id,
+                jti,
+                expires_at: now + ttl,
+            },
+        );
+        code
+    }
+
+    /// Redeem a handoff code, returning the user id and the issuing session's
+    /// `jti` on success. The entry is removed whether or not it was still
+    /// valid, so a code is usable at most once; an expired or unknown code
+    /// yields `None`.
+    pub fn consume_handoff_code(&self, code: &str) -> Option<(Uuid, Option<Uuid>)> {
+        let (_, entry) = self.0.handoff_codes.remove(code)?;
+        if entry.expires_at <= Instant::now() {
+            return None;
+        }
+        Some((entry.user_id, entry.jti))
     }
 }
 

--- a/services/api/tests/auth_handoff.rs
+++ b/services/api/tests/auth_handoff.rs
@@ -179,7 +179,10 @@ async fn handoff_code_exchanges_for_a_working_session() {
         .await;
     assert_eq!(resp.status(), StatusCode::OK, "minting a handoff code");
     let body = body_json(resp).await;
-    let code = body["code"].as_str().expect("code in the response").to_owned();
+    let code = body["code"]
+        .as_str()
+        .expect("code in the response")
+        .to_owned();
     assert!(code.len() >= 32, "the code must not be guessable: {code}");
     assert!(
         body["expires_in"].as_u64().unwrap_or(0) > 0,
@@ -323,7 +326,11 @@ async fn a_media_token_cannot_mint_a_handoff_code() {
             &viewer_token,
         ))
         .await;
-    assert_eq!(resp.status(), StatusCode::OK, "minting a scoped media token");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "minting a scoped media token"
+    );
     let media_token = body_json(resp).await["token"]
         .as_str()
         .expect("token in the media-token response")

--- a/services/api/tests/auth_handoff.rs
+++ b/services/api/tests/auth_handoff.rs
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Integration tests for the two routes that stopped carrying a login token in
+//! a URL: the export downloads (now `Authorization: Bearer` only) and the new
+//! single-use console-handoff code that the desktop client uses to open the web
+//! console in the operator's real browser.
+//!
+//! Same harness as `auth_rbac.rs` (see `tests/support/mod.rs`): the real `src/`
+//! modules recompiled into this test binary, running against a real Postgres.
+//!
+//! # Running locally
+//!
+//! ```sh
+//! cargo test -p crumb-api --test auth_handoff
+//! ```
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::option_option)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::items_after_statements)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::manual_let_else)]
+#![allow(clippy::default_trait_access)]
+#![allow(clippy::struct_excessive_bools)]
+#![allow(clippy::match_same_arms)]
+#![allow(clippy::manual_clamp)]
+#![allow(clippy::format_push_string)]
+
+mod support;
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use axum::body::to_bytes;
+use axum::http::StatusCode;
+use chrono::Utc;
+use uuid::Uuid;
+
+use support::dto::{ExportJob, ExportOutputFile, ExportStatus};
+use support::*;
+
+async fn body_json(resp: axum::http::Response<axum::body::Body>) -> serde_json::Value {
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+}
+
+/// Per-process export directory, pointed at by `EXPORT_DIR` so the download
+/// handler resolves files here instead of the production `/exports` volume.
+///
+/// `get_or_init` blocks every other caller until the first one has both created
+/// the directory and set the env var, so a test that calls this before building
+/// its `TestApp` always sees a config built from it.
+fn export_root() -> &'static Path {
+    static EXPORT_ROOT: OnceLock<PathBuf> = OnceLock::new();
+    EXPORT_ROOT.get_or_init(|| {
+        let mut p = std::env::temp_dir();
+        p.push(format!("crumb-test-exports-{}", Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&p).expect("create temp export dir");
+        std::env::set_var("EXPORT_DIR", &p);
+        p
+    })
+}
+
+/// Register a completed one-camera export job with a real file on disk, so the
+/// download route can stream it. Returns the job id.
+fn seed_done_export_job(app: &TestApp, camera_id: Uuid) -> Uuid {
+    let job_id = Uuid::new_v4();
+    let dir = export_root().join(job_id.to_string());
+    std::fs::create_dir_all(&dir).expect("create job export dir");
+    let filename = format!("{camera_id}.mp4");
+    let bytes: &[u8] = b"crumb test export payload";
+    std::fs::write(dir.join(&filename), bytes).expect("write export output file");
+
+    let now = Utc::now();
+    app.state.export_jobs().insert(
+        job_id,
+        ExportJob {
+            id: job_id,
+            status: ExportStatus::Done,
+            camera_ids: vec![camera_id],
+            start: now,
+            end: now,
+            burn_timestamp: false,
+            created_at: now,
+            output_files: vec![ExportOutputFile {
+                camera_id,
+                download_url: format!("/export/{job_id}/files/{camera_id}"),
+                size_bytes: bytes.len() as u64,
+                filename,
+            }],
+            error: None,
+            progress_pct: 100,
+        },
+    );
+    job_id
+}
+
+/// Build an unauthenticated `POST` with a JSON body (the handoff exchange is
+/// called by a browser that has no credentials yet).
+fn post_json(uri: &str, body: &serde_json::Value) -> axum::http::Request<axum::body::Body> {
+    axum::http::Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(body.to_string()))
+        .unwrap()
+}
+
+// ─── export downloads ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn export_download_rejects_a_login_token_in_the_query() {
+    let _ = export_root();
+    let app = TestApp::new().await;
+    let admin = seed_admin(app.pool()).await;
+    let token = login(&app, &admin.username, &admin.password).await;
+    let camera_id = seed_camera(app.pool()).await;
+    let job_id = seed_done_export_job(&app, camera_id);
+
+    let resp = app
+        .send(get(&format!(
+            "/export/{job_id}/files/{camera_id}?token={token}"
+        )))
+        .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "a login token in the query must not authenticate a per-camera export download"
+    );
+
+    let resp = app
+        .send(get(&format!("/export/{job_id}/archive?token={token}")))
+        .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "a login token in the query must not authenticate an archive download"
+    );
+}
+
+#[tokio::test]
+async fn export_download_accepts_the_authorization_header() {
+    let _ = export_root();
+    let app = TestApp::new().await;
+    let admin = seed_admin(app.pool()).await;
+    let token = login(&app, &admin.username, &admin.password).await;
+    let camera_id = seed_camera(app.pool()).await;
+    let job_id = seed_done_export_job(&app, camera_id);
+
+    let resp = app
+        .send(get_auth(
+            &format!("/export/{job_id}/files/{camera_id}"),
+            &token,
+        ))
+        .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "an export download authenticated with the Authorization header must succeed"
+    );
+}
+
+// ─── console handoff ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn handoff_code_exchanges_for_a_working_session() {
+    let app = TestApp::new().await;
+    let admin = seed_admin(app.pool()).await;
+    let token = login(&app, &admin.username, &admin.password).await;
+
+    let resp = app
+        .send(post_auth_json(
+            "/auth/handoff",
+            &token,
+            &serde_json::json!({}),
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK, "minting a handoff code");
+    let body = body_json(resp).await;
+    let code = body["code"].as_str().expect("code in the response").to_owned();
+    assert!(code.len() >= 32, "the code must not be guessable: {code}");
+    assert!(
+        body["expires_in"].as_u64().unwrap_or(0) > 0,
+        "the response states how long the code lives"
+    );
+
+    let resp = app
+        .send(post_json(
+            "/auth/handoff/exchange",
+            &serde_json::json!({ "code": code }),
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK, "exchanging the handoff code");
+    let handed_off = body_json(resp).await["token"]
+        .as_str()
+        .expect("token in the exchange response")
+        .to_owned();
+    assert_ne!(
+        handed_off, token,
+        "the browser must get its own session, not a copy of the client's"
+    );
+
+    // It really is a session for the same user.
+    let resp = app.send(get_auth("/auth/me", &handed_off)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        body_json(resp).await["id"].as_str(),
+        Some(admin.user_id.to_string().as_str()),
+        "the handed-off session belongs to the user who minted the code"
+    );
+
+    // And it is a real `sessions` row, so "sign out everywhere" reaches it.
+    let resp = app
+        .send(
+            axum::http::Request::builder()
+                .method("DELETE")
+                .uri("/auth/sessions/all")
+                .header("authorization", format!("Bearer {token}"))
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK, "sign out all devices");
+
+    let resp = app.send(get_auth("/auth/me", &handed_off)).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "signing out everywhere must also end the handed-off browser session"
+    );
+}
+
+#[tokio::test]
+async fn a_handoff_code_is_single_use() {
+    let app = TestApp::new().await;
+    let admin = seed_admin(app.pool()).await;
+    let token = login(&app, &admin.username, &admin.password).await;
+
+    let resp = app
+        .send(post_auth_json(
+            "/auth/handoff",
+            &token,
+            &serde_json::json!({}),
+        ))
+        .await;
+    let code = body_json(resp).await["code"]
+        .as_str()
+        .expect("code in the response")
+        .to_owned();
+
+    let first = app
+        .send(post_json(
+            "/auth/handoff/exchange",
+            &serde_json::json!({ "code": code }),
+        ))
+        .await;
+    assert_eq!(first.status(), StatusCode::OK);
+
+    let second = app
+        .send(post_json(
+            "/auth/handoff/exchange",
+            &serde_json::json!({ "code": code }),
+        ))
+        .await;
+    assert_eq!(
+        second.status(),
+        StatusCode::UNAUTHORIZED,
+        "a handoff code must not be redeemable twice"
+    );
+}
+
+#[tokio::test]
+async fn an_expired_handoff_code_is_rejected() {
+    let app = TestApp::new().await;
+    let admin = seed_admin(app.pool()).await;
+
+    // The TTL is a parameter of the mint so this does not have to sleep for the
+    // production window.
+    let code = app
+        .state
+        .issue_handoff_code(admin.user_id, None, Duration::from_millis(1));
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let resp = app
+        .send(post_json(
+            "/auth/handoff/exchange",
+            &serde_json::json!({ "code": code }),
+        ))
+        .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "an expired handoff code must not be redeemable"
+    );
+}
+
+#[tokio::test]
+async fn an_unknown_handoff_code_is_rejected() {
+    let app = TestApp::new().await;
+
+    let resp = app
+        .send(post_json(
+            "/auth/handoff/exchange",
+            &serde_json::json!({ "code": "not-a-real-code" }),
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn a_media_token_cannot_mint_a_handoff_code() {
+    let app = TestApp::new().await;
+    let pool = app.pool().clone();
+    let camera_id = seed_camera(&pool).await;
+    let viewer = seed_viewer(&pool, &[camera_id]).await;
+    let viewer_token = login(&app, &viewer.username, &viewer.password).await;
+
+    let resp = app
+        .send(get_auth(
+            &format!("/media-token?camera={camera_id}"),
+            &viewer_token,
+        ))
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK, "minting a scoped media token");
+    let media_token = body_json(resp).await["token"]
+        .as_str()
+        .expect("token in the media-token response")
+        .to_owned();
+
+    let resp = app
+        .send(
+            axum::http::Request::builder()
+                .method("POST")
+                .uri(format!("/auth/handoff?token={media_token}"))
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a scoped media token must not be tradeable for a console session"
+    );
+}

--- a/services/api/tests/auth_rbac.rs
+++ b/services/api/tests/auth_rbac.rs
@@ -1491,9 +1491,9 @@ async fn full_jwt_via_query_token_is_rejected_on_media_routes() {
     // Fail-closed (audit 2026-07-05 #2): the legacy `?token=<full login JWT>`
     // media path is now REJECTED — a login credential in a URL can leak into
     // proxy/access logs and browser history. Every current client uses a scoped
-    // media token (GET /media-token) for per-camera media; the only remaining
-    // full-JWT-via-?token= callers are the documented permissive exceptions
-    // (export downloads and the web-console camera snapshot, tested separately).
+    // media token (GET /media-token) for per-camera media, and the export
+    // downloads (the last route that accepted a login token in the query) now
+    // take the Authorization header only, see tests/auth_handoff.rs.
     let fx = build_rbac_fixture().await;
     let pool = fx.app.pool().clone();
     let storage_id = seed_storage(&pool, fx.storage_root.path().to_str().unwrap()).await;
@@ -1516,7 +1516,7 @@ async fn full_jwt_via_query_token_is_rejected_on_media_routes() {
 // without auth. axum can't enumerate its own routes, so this table is maintained
 // by hand — WHEN YOU ADD A ROUTE, ADD IT HERE (protected → 401 for no
 // credentials, or the public allowlist → not-401). The auth extractor
-// (AuthUser / AdminUser / LegacyQueryTokenUser) is the FIRST handler parameter
+// (AuthUser / AdminUser / MediaOrFullUser) is the FIRST handler parameter
 // everywhere, so a missing token yields 401 before any path/query/body extractor
 // runs — hence dummy path params are fine. Routed via the full-surface
 // test_router() in support/mod.rs. (audit 2026-07-05: "108 routes / 120 AuthUser
@@ -1545,6 +1545,8 @@ async fn no_protected_route_is_reachable_without_credentials() {
         (Method::DELETE, "/auth/sessions/all".into()),
         (Method::DELETE, format!("/auth/sessions/{u}")),
         (Method::DELETE, format!("/auth/users/{u}/sessions")),
+        // -- single-use console-handoff code mint (the exchange is public) --
+        (Method::POST, "/auth/handoff".into()),
         // -- scoped media-token mint --
         (Method::GET, "/media-token".into()),
         // -- /config/* (admin console; AdminUser) --
@@ -1632,8 +1634,8 @@ async fn no_protected_route_is_reachable_without_credentials() {
         (Method::PUT, format!("/notifications/rules/{u}")),
         (Method::POST, "/presence".into()),
         (Method::DELETE, format!("/notifications/devices/{u}")),
-        // -- media (fail-closed AuthUser / permissive LegacyQueryTokenUser; with
-        //    NO credential at all, both return 401) --
+        // -- media (fail-closed AuthUser / media-token-accepting MediaOrFullUser;
+        //    with NO credential at all, both return 401) --
         (Method::GET, "/play/aligned".into()),
         (Method::GET, format!("/play/{u}")),
         (Method::GET, format!("/segments/{u}")),
@@ -1674,6 +1676,9 @@ async fn no_protected_route_is_reachable_without_credentials() {
         (Method::POST, "/auth/bootstrap".into()),
         (Method::GET, "/auth/setup-status".into()),
         (Method::GET, "/auth/needs-bootstrap".into()),
+        // The handoff exchange is reached by a browser that has no credentials
+        // yet; the single-use code in the body is the credential.
+        (Method::POST, "/auth/handoff/exchange".into()),
     ];
     for (m, path) in &public {
         let st = send_status(&app, m.clone(), path.clone()).await;


### PR DESCRIPTION
## What changed

Two places still put a **login token in a URL**. Both now use a credential that
fits where it is going.

**1. Export downloads take the `Authorization` header only.**

`GET /export/{job}/files/{camera}` and `GET /export/{job}/archive` were the last
routes that accepted a full login token in a `?token=` query parameter (via the
`LegacyQueryTokenUser` extractor). Android and the Flutter desktop client
already sent the header there; iOS/macOS was the last client still building a
tokened URL.

- `LegacyQueryTokenUser` is deleted, and `AuthUser::authenticate` no longer
  takes a permissive flag: a login token in `?token=` is now refused on every
  route. Scoped media tokens in `?token=` are unaffected; that is a different
  mechanism and it stays.
- Both download handlers take `AuthUser`.
- iOS/macOS builds an authenticated `URLRequest` via a new
  `CrumbAPI.exportDownloadRequest`, and the now-unused `MediaUrls.authed` (plus
  its full-token field) is removed.
- The retired Tauri client passes its token to the Rust file saver rather than
  in the URL, so it does not become a stale producer of the pattern.

**2. "Open in browser" hands off a single-use code, not the session token.**

The desktop client showed the console two ways, both with
`/admin#token=<session token>`. That is fine for its own embedded WebView (same
process) but "Open in browser" crosses into a browser's history and profile
storage.

- New `POST /auth/handoff` (full session required; a scoped media token is
  refused) returns `{code, expires_in}`. The code is single-use, expires in
  about a minute, is held in memory only, and is bound to the issuing user and
  session.
- New `POST /auth/handoff/exchange` consumes the code exactly once and mints a
  normal session: its own `jti`, its own `sessions` row, normal (not
  "remember me") expiry, so it is listed under "your sessions" and every
  sign-out path reaches it. Unknown, reused, expired, or signed-out codes are
  401.
- The Flutter client's "Open in browser" opens `/admin#handoff=<code>`;
  `admin.html`'s `bootSSO` recognises the fragment, scrubs it with
  `replaceState` before redeeming it, and falls through to the normal login form
  if the exchange fails. The embedded WebView path is unchanged.

## Why

Anything in a URL travels further than the request: proxy and access logs,
browser history, and, across a process boundary, another application's storage.
The header-only download and the one-time code keep each credential inside the
process that owns it.

## Testing

`services/api/tests/auth_handoff.rs` (new): an export download with a login
token in the query is 401 and with the header is 200; the handoff round trip
yields a working session; "sign out everywhere" ends the handed-off session too;
a code is single use; an expired code is rejected (the TTL is a parameter of the
mint so the test does not sleep for the production window); an unknown code is
rejected; a scoped media token cannot mint a code. The route tables in
`auth_rbac.rs` gained both new routes.

Gate green on the build box at `be989c8`: `cargo fmt --check`,
`cargo clippy --all-targets -D warnings`, `cargo test --workspace` against a
throwaway Postgres, ending `GATE_OK`. `node --check` passes on the extracted
`admin.html` script block. `flutter analyze` on the desktop client reports no
issues under `lib/` (the remaining findings are all in the vendored
`rust_builder/cargokit` build tool and predate this branch).

Not verified: the Apple targets. The Mac build host had no repository share
mounted this session, so `apps/ios` compiles by review only. The change there is
small (one new request builder, one call site, one deleted helper and its unused
field, with its only constructor updated).

## Operator-visible

- No new env keys, no migration, no compose change.
- An old client paired with a new server will fail export downloads until it is
  updated; all shipped clients already send the header, except iOS/macOS, which
  is updated here.
- A new client paired with an old server falls back gracefully: "Open in
  browser" reports that it could not open the console rather than opening one
  the operator cannot sign in to.
- Handoff codes are per-process, so an install running several API replicas
  behind a load balancer may need a second click. Recorded in
  `docs/DECISIONS.md` with the trigger that would move the store to Postgres.
