### PR TITLE
Bound media request queues, filmstrip cache keys, and export job sizes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,6 +128,8 @@ API_BIND=0.0.0.0:8080
 EXPORT_DIR=/exports                       # top-level (own volume), NOT under the /data:ro mount
 EXPORT_TTL_SECONDS=86400
 # EXPORT_CACHE_MAX_BYTES=21474836480       # 20 GiB budget for the export cache
+# EXPORT_MAX_CONCURRENT=2                  # export jobs allowed to be queued/running at once
+# EXPORT_MAX_RANGE_SECONDS=86400           # longest window one export may cover (1 day); raise for multi-day exports
 
 # --- Server-generated streams + caches (optional) ---
 # MOBILE_STREAM_ENABLED=true               # on-demand H.264 transcode mobile clients fall back to when a
@@ -141,6 +143,8 @@ EXPORT_TTL_SECONDS=86400
                                            # Media3 can't read), so this is a real re-encode: leave off and
                                            # Android just uses the H.264 sub (SD); on = HD at recorder CPU cost.
 # SEGMENT_LOW_CACHE_MAX_BYTES=2147483648   # 2 GiB budget for the low-res playback segment cache
+# FRAME_PROXY_MAX_CONCURRENCY=             # env-only; unset → one per CPU core, clamped 8..32. Caps how many
+                                           # live camera stills are fetched at once (the low-bandwidth tile walls)
 
 # --- Scrub-preview cache (optional; five of these are also editable in the console, which wins) ---
 # THUMB_PREGEN_ENABLED=false               # build previews in the background so the FIRST drag is instant too

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,6 +152,8 @@ services:
       ARCHIVE_STORAGE_PATH: ${ARCHIVE_STORAGE_PATH:-/data/archive}
       EXPORT_DIR: ${EXPORT_DIR:-/exports}               # top-level, NOT under /data:ro (can't nest a mount there)
       EXPORT_TTL_SECONDS: ${EXPORT_TTL_SECONDS:-86400}
+      EXPORT_MAX_CONCURRENT: ${EXPORT_MAX_CONCURRENT:-}   # queued+running export jobs allowed at once (empty = 2)
+      EXPORT_MAX_RANGE_SECONDS: ${EXPORT_MAX_RANGE_SECONDS:-}  # longest window one export may cover (empty = 86400)
       SEED_ADMIN_USERNAME: ${SEED_ADMIN_USERNAME:-admin}
       SEED_ADMIN_PASSWORD: ${SEED_ADMIN_PASSWORD:-}     # seeded by default (setup-env.sh generates it); blank = browser create-admin wizard
       ONVIF_CONFIG_B64: ${ONVIF_CONFIG_B64:-}           # legacy fallback; per-camera ONVIF creds live in the DB now
@@ -207,6 +209,7 @@ services:
       MAIN_REPAIR_TRANSCODE_ENABLED: ${MAIN_REPAIR_TRANSCODE_ENABLED:-}
       SEGMENT_LOW_CACHE_MAX_BYTES: ${SEGMENT_LOW_CACHE_MAX_BYTES:-}
       EXPORT_CACHE_MAX_BYTES: ${EXPORT_CACHE_MAX_BYTES:-}
+      FRAME_PROXY_MAX_CONCURRENCY: ${FRAME_PROXY_MAX_CONCURRENCY:-}   # live-still fetches in flight at once (empty = one per core, 8..32)
       # Behind the bundled Caddy (or any reverse proxy), set TRUST_PROXY=1 so the
       # rate limiter keys on the client IP from X-Forwarded-For instead of the
       # proxy's own address (one bucket for ALL HTTPS users otherwise). Leave

--- a/docs-site/docs/configuration/environment-reference.md
+++ b/docs-site/docs/configuration/environment-reference.md
@@ -115,8 +115,10 @@ value there, the database copy wins and the env value is just the default.
 One honest footnote: a few more `THUMB_*` names exist in the source
 (`THUMB_INTERVAL_SECS`, `THUMB_MAX_ATTEMPTS`, `THUMB_MAX_WIDTH`,
 `THUMB_MIN_WIDTH`, `THUMB_NEAR_BLACK_LUMA`, `THUMB_EXTRACT_TIMEOUT_SECS`) as
-fixed built-in constants (a 4-second preview grid, widths clamped 48-640, a
-12-second extract timeout, and the black-frame retry logic). They are *not*
+fixed built-in constants (a 4-second preview grid, widths clamped 48-640 and
+then snapped to the nearest of 80/160/320/480/640 so the preview cache holds a
+handful of sizes instead of hundreds, a 12-second extract timeout, and the
+black-frame retry logic). They are *not*
 read from the environment and the compose file deliberately does not forward
 them, because forwarding a name implies a tunability that does not exist.
 Setting them in `.env` does nothing, so they don't get rows here.
@@ -178,7 +180,9 @@ See [Hardware decode](/configuration/hardware-decode) for enabling this.
 |---|---|---|
 | `EXPORT_DIR` | `/exports` | its own volume, not under the read-only `/data` mount |
 | `EXPORT_TTL_SECONDS` | `86400` | how long a completed export survives before cleanup |
-| `EXPORT_CACHE_MAX_BYTES` | `21474836480` (20 GiB) | size budget for the on-disk export cache; oldest entries are dropped past it |
+| `EXPORT_CACHE_MAX_BYTES` | `21474836480` (20 GiB) | size budget for the on-disk export cache; oldest entries are dropped past it. In-flight jobs are never deleted, but the space they already occupy counts against this budget, so finished exports are cleared to make room for them |
+| `EXPORT_MAX_CONCURRENT` | `2` | how many export jobs may be queued or running at once. Each job runs one video encode per camera, so this is the main brake on export CPU. A request that arrives while the slots are full gets a "too many requests" answer and should be retried shortly |
+| `EXPORT_MAX_RANGE_SECONDS` | `86400` (1 day) | the longest time window a single export may cover, per camera. Beyond this the request is refused with a clear message rather than starting an encode that would run for hours. Raise it if you genuinely export multi-day ranges; the same limit applies to each clip in a batch export |
 
 ## Streams the server generates on demand
 
@@ -191,6 +195,7 @@ are sized for a phone on a slow link.
 | `MOBILE_STREAM_WIDTH` | `640` | transcode width in pixels, floored at 160 |
 | `MAIN_REPAIR_TRANSCODE_ENABLED` | `false` | opt-in, per-camera full-resolution H.265 to H.264 transcode of a main stream whose SDP has no `fmtp` attribute. Android's video player rejects such a main ("missing attribute fmtp", seen on some Uniview LPR cameras) and otherwise steps down to the H.264 sub in SD. Leave it off and those cameras play in SD on Android; turn it on to get HD, at the cost of recorder CPU while an Android viewer is watching that camera fullscreen. A cheaper copy-only repair does not work for this case, which is why it is a real re-encode and off by default. The cheapest fix of all, when the camera allows it, is to set the camera's main stream to H.264 in its own web UI |
 | `SEGMENT_LOW_CACHE_MAX_BYTES` | `2147483648` (2 GiB) | size budget for the cache of low-resolution playback segments |
+| `FRAME_PROXY_MAX_CONCURRENCY` | scales with cores (one per core, at least 8, at most 32) | how many live camera stills Crumb fetches at once. The low-bandwidth tile walls on the phone apps poll one still per tile per second, so this is what keeps a big wall from queueing. Past the limit a still request is answered with "busy, retry shortly" and the tile keeps its previous image until the next poll |
 
 ## Database backup
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -8,6 +8,107 @@ revisit.
 
 ---
 
+## 2026-09-07, Media routes: bounded waits answering 503, not unbounded queues
+
+**Context.** Every expensive media path (clip and low-bitrate transcodes, the
+filmstrip's single-frame extractions, and now the live-still proxy) gates its
+work behind a shared semaphore. Those acquires were plain
+`acquire_owned().await`, an unbounded queue: once the permits were gone, further
+requests parked indefinitely, holding a connection and never answering. The
+media router also carried neither a request timeout nor a rate limit, both of
+which the JSON routes have had since #17.
+
+**Decision.** Every media semaphore acquire goes through one helper
+(`services/api/src/media_limits.rs::acquire_bounded`) that gives up after a
+per-call-site budget and returns `503` plus `Retry-After`. The media router
+gains its own, much larger rate-limit bucket (burst 1200, 240/s sustained,
+roughly 6x the busiest real client) and a 180 s time-to-response bound.
+
+**Why a timeout is safe over streaming media.** `tower_http`'s `TimeoutLayer`
+bounds only the handler future; response bodies have a separate
+`ResponseBodyTimeoutLayer` that is deliberately not used. Segment downloads,
+export archives, and the open-ended live `stream.mp4` all return headers
+immediately and stream afterwards, so none of them can be cut. The one route
+that legitimately produces for minutes before answering, the on-demand
+DB-vs-disk size verification walk, is mounted outside the timeout for exactly
+that reason.
+
+**Rejected: making the clients wait longer.** Raising the permit counts or the
+wait budgets keeps the failure mode (a request that never answers) and only
+moves the threshold. The clients already treat a failed media fetch as "keep the
+placeholder, poll again", so "busy, retry shortly" is both truthful and the
+behaviour they already handle.
+
+**Rejected: a per-user or per-camera semaphore instead of a global one.** It
+would give fairer degradation, but it multiplies the tuning surface and the
+memory footprint for a system whose realistic worst case is a handful of
+operators. Revisit if a deployment reports one client starving others despite
+the bounded waits.
+
+**Trades knowingly accepted.** Under genuine saturation a scrub thumbnail or a
+wall tile now fails fast instead of eventually arriving; that is the intended
+swap. A camera whose still cannot be fetched is latched for 10 s so subsequent
+polls skip the cold-start retry ladder, which means a camera coming back can be
+up to 10 s late to serve its first still.
+
+**Revisit if:** operators report 503s on the media routes during normal use
+(the budgets or permit counts are too tight), or a deployment large enough to
+need per-principal fairness appears.
+
+---
+
+## 2026-09-07, Filmstrip widths snap to a fixed ladder; export requests are capped
+
+**Context.** The thumbnail width was clamped to 48..640 but otherwise free, and
+it is part of the on-disk cache key, so 593 distinct widths for one instant meant
+593 ffmpeg runs and 593 cache files for what is visually one frame. Separately,
+`POST /export` validated only `start < end`: nothing capped the window, the
+camera count, or duplicates in the camera list, and `filter_camera_ids` is a
+scope filter rather than a de-duplicator (for an admin it returns the list
+verbatim), so `[X, X, X, ...]` ran N sequential full-range encodes all writing
+the same output file with `-y`, counted as one job against
+`EXPORT_MAX_CONCURRENT`.
+
+**Decision.**
+
+- Widths clamp and then snap to `80/160/320/480/640` (nearest, ties down). The
+  buckets are chosen so every width the shipped clients ask for lands on itself:
+  160 (Android and desktop scrub lists), 320 (the Android playback wall), 480
+  (the iOS scrub still, the desktop preview frame, and the `THUMB_PREGEN_WIDTH`
+  default), so no existing or pre-generated cache entry is invalidated.
+- `POST /export` sorts and de-duplicates the camera list, caps it at 50 distinct
+  cameras (the same ceiling `/export/batch` puts on clips, since both fan out to
+  one sequential encode per unit of work), and caps the window with a new
+  `EXPORT_MAX_RANGE_SECONDS` (default 86400, a full day of one camera).
+- Each per-camera encode gets a wall-clock budget derived from the range
+  (4x realtime, floored at 10 minutes, capped at 24 hours) and `kill_on_drop`.
+  A child that wedges now fails the job with a stored error instead of leaving
+  it `Running` forever, which used to consume an `EXPORT_MAX_CONCURRENT` slot
+  permanently until the api was restarted.
+
+**Rejected: quantizing by rounding to a multiple (say 32 px).** It bounds the
+key space too, but it does not guarantee the clients' existing widths are
+fixed points, so the whole warm thumbnail cache (including anything
+pre-generated at 480) would be re-rendered at neighbouring keys on upgrade.
+
+**Rejected: de-duplicating inside `filter_camera_ids`.** That function is the
+RBAC scope filter used by several handlers, including ones that rely on
+comparing the filtered length to the input length to detect a partial-scope
+request. Making it also dedup would silently change those comparisons.
+
+**Rejected: a stall watchdog on ffmpeg progress instead of a wall-clock
+budget.** More precise (it would catch a wedged child in seconds rather than
+hours) and the progress parsing already exists, but it is a larger change to
+the export worker than the failure mode warrants right now.
+
+**Revisit if:** a deployment genuinely exports multi-day ranges and finds the
+default cap or the derived encode budget too tight (both are configurable; the
+budget is not), or if per-camera export throughput makes the 4x realtime factor
+the binding constraint, at which point the stall watchdog becomes the better
+mechanism.
+
+---
+
 ## 2026-08-10, Home Assistant `climate` (thermostat/HVAC setpoint) control is out of scope
 
 **Context.** #442 introduced value-setting HA controls. Light dimming

--- a/services/api/src/cameras.rs
+++ b/services/api/src/cameras.rs
@@ -180,7 +180,7 @@ async fn list_visible_cameras(
 /// * `502` — go2rtc was unreachable, returned a non-2xx status, or the frame
 ///   body could not be read.  Detail is logged at `warn!`, not `error!`, so a
 ///   momentarily unavailable stream doesn't trip 5xx alerting.
-/// * `503` — the still proxy is saturated; retry after the `Retry-After` hint.
+/// * `503`, the still proxy is saturated; retry after the `Retry-After` hint.
 async fn get_camera_frame(
     // Media-read: browsers fetch this still with a scoped `?token=` (see
     // MediaUrls in the clients / admin.html snapshot cache), so it opts into the

--- a/services/api/src/cameras.rs
+++ b/services/api/src/cameras.rs
@@ -43,6 +43,30 @@ use crate::{
     state::AppState,
 };
 
+// ─── live-still proxy tuning ──────────────────────────────────────────────────
+
+/// Attempts made against go2rtc for a still on the normal (camera believed
+/// healthy) path. go2rtc starts producers lazily, so the first fetch for a cold
+/// stream legitimately needs a couple of tries.
+const FRAME_MAX_ATTEMPTS: u32 = 4;
+
+/// Delay between those attempts.
+const FRAME_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(900);
+
+/// Per-attempt upstream timeout on the normal path.
+const FRAME_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Per-attempt upstream timeout on the known-bad fast path. Short: the point is
+/// to answer "not available" quickly and release the permit, not to wait out a
+/// camera that has already failed.
+const FRAME_FAST_FAIL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// How long a camera stays latched as "still unavailable" after a failed fetch.
+/// Longer than the ~1 s poll interval of the low-bandwidth walls (so the latch
+/// actually covers their polls) but short enough that a camera coming back is
+/// served the normal way within a few seconds even if no poll succeeds first.
+const FRAME_UNAVAILABLE_TTL: std::time::Duration = std::time::Duration::from_secs(10);
+
 // ─── route registry ───────────────────────────────────────────────────────────
 
 /// Mount per-camera utility routes.
@@ -132,6 +156,23 @@ async fn list_visible_cameras(
 /// (`GET /media-token`) for per-camera media, so a login credential never lands
 /// in a snapshot URL.
 ///
+/// # Concurrency
+///
+/// The low-bandwidth walls on Android and iOS poll one still per tile roughly
+/// once a second, so this route is the highest-frequency media endpoint there
+/// is. Every fetch takes a permit from the frame-proxy semaphore
+/// (`FRAME_PROXY_MAX_CONCURRENCY`) with a bounded wait: a saturated proxy
+/// answers `503` + `Retry-After` and the tile shows its placeholder until the
+/// next poll, instead of queueing an unbounded pile of connection-holding
+/// requests.
+///
+/// A camera whose still could not be fetched is latched as unavailable for
+/// [`FRAME_UNAVAILABLE_TTL`], and while the latch holds the retry ladder
+/// below collapses to a single quick attempt. That is what keeps a wall pointed
+/// at a camera that is down cheap: the first poll pays the full cold-start
+/// ladder, every poll after it fails in about a second and releases its permit.
+/// A successful fetch clears the latch immediately.
+///
 /// # Errors
 ///
 /// * `401` / `403` — auth / scope failure.
@@ -139,6 +180,7 @@ async fn list_visible_cameras(
 /// * `502` — go2rtc was unreachable, returned a non-2xx status, or the frame
 ///   body could not be read.  Detail is logged at `warn!`, not `error!`, so a
 ///   momentarily unavailable stream doesn't trip 5xx alerting.
+/// * `503` — the still proxy is saturated; retry after the `Retry-After` hint.
 async fn get_camera_frame(
     // Media-read: browsers fetch this still with a scoped `?token=` (see
     // MediaUrls in the clients / admin.html snapshot cache), so it opts into the
@@ -180,12 +222,34 @@ async fn get_camera_frame(
     // percent-encoding, so a plain format string is safe here.
     let upstream_url = format!("{api_base}/api/frame.jpeg?src={}", cam.go2rtc_name);
 
+    // Fast path when the camera is already known not to be producing stills: a
+    // disabled camera, a stream go2rtc has rejected, or one whose last fetch
+    // exhausted the ladder. Each of those means the cold-start retry ladder
+    // below has nothing to wait for, so it only burns a permit.
+    let known_bad = !cam.enabled
+        || state.stream_rejected(&cam.go2rtc_name)
+        || state.frame_recently_unavailable(camera_id);
+    let (max_attempts, request_timeout) = if known_bad {
+        (1, FRAME_FAST_FAIL_TIMEOUT)
+    } else {
+        (FRAME_MAX_ATTEMPTS, FRAME_REQUEST_TIMEOUT)
+    };
+
     let http_client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(5))
+        .timeout(request_timeout)
         .build()
         .map_err(|e| {
             ApiError::Internal(anyhow::anyhow!("frame proxy: build reqwest client: {e}"))
         })?;
+
+    // Bound how many stills are in flight at once. Held across the fetch only;
+    // released on drop when this handler returns.
+    let _permit = crate::media_limits::acquire_bounded(
+        &state.frame_semaphore(),
+        crate::media_limits::FRAME_PROXY_WAIT,
+        "camera still proxy",
+    )
+    .await?;
 
     // P0-GO2RTC (lighter lockdown): Crumb's own go2rtc REST API now requires
     // Basic auth (`local_auth: true` — this call crosses the Docker bridge
@@ -203,12 +267,11 @@ async fn get_camera_frame(
     // returns 500 while the source connects, then succeeds once a keyframe lands.
     // Retry a few times with a short delay so a cold camera loads on first touch
     // instead of leaning on the client to retry (and to keep the error logs quiet).
-    const MAX_ATTEMPTS: u32 = 4;
-    const RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(900);
+    // `max_attempts` is 1 on the known-bad fast path above.
     let mut frame = None;
     let mut last_status: Option<reqwest::StatusCode> = None;
     let mut last_err: Option<String> = None;
-    for attempt in 1..=MAX_ATTEMPTS {
+    for attempt in 1..=max_attempts {
         let mut req = http_client.get(&upstream_url);
         if let Some((ref user, ref pass)) = go2rtc_auth {
             req = req.basic_auth(user, Some(pass));
@@ -236,16 +299,20 @@ async fn get_camera_frame(
             // operator needs when go2rtc is down or the API base is wrong.
             Err(e) => last_err = Some(format!("connect: {:#}", anyhow::Error::new(e))),
         }
-        if attempt < MAX_ATTEMPTS {
-            tokio::time::sleep(RETRY_DELAY).await;
+        if attempt < max_attempts {
+            tokio::time::sleep(FRAME_RETRY_DELAY).await;
         }
     }
-    let bytes = frame.ok_or_else(|| {
-        ApiError::BadGateway(format!(
-            "go2rtc frame ({upstream_url}) unavailable after {MAX_ATTEMPTS} tries (last status {last_status:?}{})",
+    let Some(bytes) = frame else {
+        // Latch the camera so the next poll takes the single-attempt path.
+        state.mark_frame_unavailable(camera_id, FRAME_UNAVAILABLE_TTL);
+        return Err(ApiError::BadGateway(format!(
+            "go2rtc frame ({upstream_url}) unavailable after {max_attempts} tries (last status {last_status:?}{})",
             last_err.map(|e| format!(", {e}")).unwrap_or_default(),
-        ))
-    })?;
+        )));
+    };
+    // Back in service: clear the latch so the full ladder is available again.
+    state.clear_frame_unavailable(camera_id);
 
     Ok((
         StatusCode::OK,

--- a/services/api/src/clips.rs
+++ b/services/api/src/clips.rs
@@ -955,11 +955,14 @@ async fn generate_clip_file(
     out: &FsPath,
     preview: bool,
 ) -> Result<(), ApiError> {
-    let _permit = state
-        .clip_gen_semaphore()
-        .acquire_owned()
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("clip-gen semaphore closed: {e}")))?;
+    // Bounded: at saturation the caller gets 503 + Retry-After rather than
+    // queueing behind every transcode ahead of it with no answer.
+    let _permit = crate::media_limits::acquire_bounded(
+        &state.clip_gen_semaphore(),
+        crate::media_limits::CLIP_GEN_WAIT,
+        "clip transcode",
+    )
+    .await?;
     // Another request may have produced it while we waited for the permit.
     if tokio::fs::metadata(out).await.is_ok() {
         return Ok(());
@@ -1085,11 +1088,14 @@ async fn generate_thumbnail(
 ) -> Result<(), ApiError> {
     // Bound total concurrent ffmpeg fan-out with the same permit the clip.mp4 and
     // low-stream transcodes use, so a cold thumbnail grid can't spawn-storm.
-    let _permit = state
-        .clip_gen_semaphore()
-        .acquire_owned()
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("clip-gen semaphore closed: {e}")))?;
+    // Bounded wait: a saturated queue answers 503 + Retry-After, and the grid
+    // shows a placeholder and retries, rather than hanging on an open request.
+    let _permit = crate::media_limits::acquire_bounded(
+        &state.clip_gen_semaphore(),
+        crate::media_limits::CLIP_GEN_WAIT,
+        "clip thumbnail",
+    )
+    .await?;
     let pool = state.pool();
     let storage_paths = db::storage_path_map(pool)
         .await

--- a/services/api/src/config.rs
+++ b/services/api/src/config.rs
@@ -180,6 +180,16 @@ pub struct ApiConfig {
     /// camera). Default: `2`.
     pub export_max_concurrent: usize,
 
+    /// `EXPORT_MAX_RANGE_SECONDS` -- longest `[start, end]` window a single
+    /// export job may request, per camera.
+    ///
+    /// A job runs one ffmpeg per camera over the whole window, so an unbounded
+    /// range is an unbounded amount of work and output for one request.
+    /// Default: `86400` (a full day of one camera), which is well beyond any
+    /// realistic evidence export while still refusing "year 1000 to 9999".
+    /// Raise it if a deployment genuinely exports multi-day ranges.
+    pub export_max_range_seconds: i64,
+
     /// `CLIP_GEN_MAX_CONCURRENCY` -- max simultaneous on-demand clip transcodes
     /// (the Clips tab). Each play streams one libx264 ffmpeg, paced by the
     /// client's read; the permit is held for the play's lifetime, so this caps
@@ -254,6 +264,18 @@ pub struct ApiConfig {
     /// the recorder while a big box isn't throttled to a fixed handful. Override
     /// to taste.
     pub thumb_extract_max_concurrency: usize,
+
+    /// `FRAME_PROXY_MAX_CONCURRENCY` -- max simultaneous `GET
+    /// /cameras/{id}/frame.jpg` fetches from go2rtc.
+    ///
+    /// The still proxy is network-bound, not CPU-bound (it forwards one JPEG),
+    /// but a request against a camera that is down can hold its slot for the
+    /// whole retry ladder, so it needs a bound of its own rather than sharing
+    /// the CPU-sized thumbnail semaphore. Sized for the low-bandwidth walls that
+    /// drive it: a 16-tile wall polling once a second at ~150 ms per fetch is
+    /// about 3 concurrent, with all 16 tiles able to fire at the same instant.
+    /// Default: one per CPU core, clamped to `[8, 32]`.
+    pub frame_proxy_max_concurrency: usize,
 
     /// `THUMB_CACHE_MAX_BYTES` -- soft byte budget for the filmstrip thumbnail
     /// cache (`{export_dir}/.thumbs`). A periodic sweeper evicts oldest-by-mtime
@@ -467,6 +489,7 @@ impl ApiConfig {
             export_dir: optional_env("EXPORT_DIR", DEFAULT_EXPORT_DIR),
             export_ttl_seconds: parse_env("EXPORT_TTL_SECONDS", 86_400_u64)?,
             export_max_concurrent: parse_env("EXPORT_MAX_CONCURRENT", 2usize)?.max(1),
+            export_max_range_seconds: parse_env("EXPORT_MAX_RANGE_SECONDS", 86_400_i64)?.max(1),
             clip_gen_max_concurrency: parse_env("CLIP_GEN_MAX_CONCURRENCY", 4usize)?.max(1),
             clip_cache_max_bytes: parse_env("CLIP_CACHE_MAX_BYTES", 10_737_418_240_u64)?,
             segment_low_cache_max_bytes: parse_env(
@@ -480,6 +503,11 @@ impl ApiConfig {
             thumb_extract_max_concurrency: parse_env(
                 "THUMB_EXTRACT_MAX_CONCURRENCY",
                 default_thumb_concurrency(),
+            )?
+            .max(1),
+            frame_proxy_max_concurrency: parse_env(
+                "FRAME_PROXY_MAX_CONCURRENCY",
+                default_frame_proxy_concurrency(),
             )?
             .max(1),
             thumb_cache_max_bytes: parse_env("THUMB_CACHE_MAX_BYTES", 21_474_836_480_u64)?,
@@ -530,6 +558,15 @@ fn optional_env_opt(key: &str) -> Option<String> {
 fn default_thumb_concurrency() -> usize {
     let cores = std::thread::available_parallelism().map_or(4, std::num::NonZeroUsize::get);
     (cores / 2).clamp(2, 12)
+}
+
+/// Default concurrency for the live-still proxy. Network-bound rather than
+/// CPU-bound, so it gets a higher floor than [`default_thumb_concurrency`]: one
+/// slot per core, clamped to `[8, 32]`, which keeps a 16-tile low-bandwidth wall
+/// from ever queueing on a healthy install.
+fn default_frame_proxy_concurrency() -> usize {
+    let cores = std::thread::available_parallelism().map_or(4, std::num::NonZeroUsize::get);
+    cores.clamp(8, 32)
 }
 
 fn parse_env<T>(key: &str, default: T) -> Result<T>

--- a/services/api/src/error.rs
+++ b/services/api/src/error.rs
@@ -75,6 +75,15 @@ pub enum ApiError {
     #[error("internal server error")]
     Internal(#[source] anyhow::Error),
 
+    // ── 503 ──────────────────────────────────────────────────────────────────
+    /// A bounded server resource (a media work semaphore) was still full after
+    /// the caller's bounded wait. Renders 503 plus `Retry-After: <secs>` so the
+    /// client backs off and retries instead of holding a connection open in an
+    /// unbounded queue. Distinct from 429 (`TooManyRequestsRetry`), which means
+    /// "you personally sent too much"; this means "the server is busy".
+    #[error("service unavailable: {message}")]
+    ServiceUnavailableRetry { message: String, retry_after: u64 },
+
     // ── 502 ──────────────────────────────────────────────────────────────────
     /// An upstream dependency (e.g. go2rtc, behind the live MSE proxy) was
     /// unreachable or returned an error.  Detail is logged at `warn!` (not
@@ -99,6 +108,7 @@ impl ApiError {
             }
             Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::BadGateway(_) => StatusCode::BAD_GATEWAY,
+            Self::ServiceUnavailableRetry { .. } => StatusCode::SERVICE_UNAVAILABLE,
         }
     }
 
@@ -114,6 +124,7 @@ impl ApiError {
             Self::TooManyRequests(_) | Self::TooManyRequestsRetry { .. } => "Too Many Requests",
             Self::Internal(_) => "Internal Server Error",
             Self::BadGateway(_) => "Bad Gateway",
+            Self::ServiceUnavailableRetry { .. } => "Service Unavailable",
         }
     }
 }
@@ -154,9 +165,15 @@ impl IntoResponse for ApiError {
 
         let mut response = (status, body).into_response();
 
-        // 429 backoff hint: attach `Retry-After: <secs>` so a well-behaved
-        // client (or the login UI) knows how long to wait (issue #127).
-        if let Self::TooManyRequestsRetry { retry_after, .. } = &self {
+        // 429/503 backoff hint: attach `Retry-After: <secs>` so a well-behaved
+        // client (or the login UI) knows how long to wait (issue #127, and the
+        // bounded media-work acquires in `media_limits`).
+        let retry_hint = match &self {
+            Self::TooManyRequestsRetry { retry_after, .. }
+            | Self::ServiceUnavailableRetry { retry_after, .. } => Some(*retry_after),
+            _ => None,
+        };
+        if let Some(retry_after) = retry_hint {
             if let Ok(val) = axum::http::HeaderValue::from_str(&retry_after.to_string()) {
                 response
                     .headers_mut()

--- a/services/api/src/export.rs
+++ b/services/api/src/export.rs
@@ -761,7 +761,7 @@ enum WaitOutcome {
 /// On cancel, SIGKILL + reap the child (so no zombie) and return
 /// [`WaitOutcome::Cancelled`]; this interrupts a long single-camera encode
 /// promptly, not just between cameras. On budget expiry, likewise kill + reap
-/// and return [`WaitOutcome::TimedOut`] so the caller can FAIL the job — a
+/// and return [`WaitOutcome::TimedOut`] so the caller can FAIL the job. A
 /// wedged child must never leave a job `Running` forever, because that
 /// permanently consumes one of `EXPORT_MAX_CONCURRENT` slots.
 async fn wait_or_cancel(

--- a/services/api/src/export.rs
+++ b/services/api/src/export.rs
@@ -82,6 +82,93 @@ const FFMPEG_BIN: &str = "/usr/local/bin/ffmpeg";
 /// Upper bound on clips in a single batch export job (guards ffmpeg fan-out).
 const MAX_BATCH_ITEMS: usize = 50;
 
+/// Upper bound on DISTINCT cameras in a single `POST /export` job.
+///
+/// Both export routes fan out to one sequential ffmpeg run per unit of work, so
+/// they get the same ceiling: `/export/batch` counts clips, `/export` counts
+/// cameras. 50 is far beyond any real evidence export (the largest reference
+/// install has eleven cameras) while still refusing a list that would keep the
+/// single job slot busy for hours.
+const MAX_EXPORT_CAMERAS: usize = 50;
+
+/// Floor on the per-camera ffmpeg wall-clock budget, so a short export still
+/// gets a sane allowance for spin-up, seeking, and a slow disk.
+const EXPORT_FFMPEG_TIMEOUT_FLOOR_SECS: u64 = 600;
+
+/// Wall-clock allowance per second of requested range. 4x realtime is very
+/// forgiving even for a burn-in re-encode; anything slower than that is a wedged
+/// child, not a busy one.
+const EXPORT_FFMPEG_TIMEOUT_FACTOR: u64 = 4;
+
+/// Absolute ceiling on the per-camera ffmpeg budget, whatever the range. Without
+/// it a maximum-range job could hold its slot for days.
+const EXPORT_FFMPEG_TIMEOUT_CEILING_SECS: u64 = 24 * 60 * 60;
+
+/// Wall-clock budget for ONE camera's ffmpeg run over a `range_secs` window.
+///
+/// A child that neither exits nor gets dropped (a read wedged on a stalled
+/// mount, say) used to leave the job `Running` forever, which permanently
+/// consumed one of `EXPORT_MAX_CONCURRENT` slots: after enough of them every
+/// `POST /export` returned 429 until the api was restarted. Bounding the wait
+/// turns that into a `Failed` job with a stored error, which frees the slot and
+/// tells the operator what happened.
+fn export_ffmpeg_timeout(range_secs: i64) -> std::time::Duration {
+    let range = u64::try_from(range_secs.max(0)).unwrap_or(u64::MAX);
+    let scaled = range
+        .saturating_mul(EXPORT_FFMPEG_TIMEOUT_FACTOR)
+        .max(EXPORT_FFMPEG_TIMEOUT_FLOOR_SECS)
+        .min(EXPORT_FFMPEG_TIMEOUT_CEILING_SECS);
+    std::time::Duration::from_secs(scaled)
+}
+
+/// Validate a `POST /export` request's camera list and time range, returning the
+/// cameras to actually export: sorted and de-duplicated.
+///
+/// De-duplication is the load-bearing part. `AuthUser::filter_camera_ids` is a
+/// scope filter, NOT a dedup (for an admin it returns the list verbatim), so a
+/// body repeating one camera N times used to run N sequential full-range ffmpeg
+/// jobs, all writing the SAME `{camera_id}.{ext}` output with `-y`, and all
+/// counted as ONE job against `EXPORT_MAX_CONCURRENT`. Collapsing duplicates
+/// here makes the work proportional to what the caller can actually receive.
+///
+/// Kept pure (no state, no DB) so the caps are unit-testable.
+fn validate_export_cameras_and_range(
+    camera_ids: &[Uuid],
+    start: chrono::DateTime<Utc>,
+    end: chrono::DateTime<Utc>,
+    max_range_seconds: i64,
+) -> Result<Vec<Uuid>, ApiError> {
+    if camera_ids.is_empty() {
+        return Err(ApiError::BadRequest(
+            "camera_ids must contain at least one camera".to_owned(),
+        ));
+    }
+    if start >= end {
+        return Err(ApiError::BadRequest(
+            "start must be strictly before end".to_owned(),
+        ));
+    }
+
+    let range_seconds = (end - start).num_seconds();
+    if range_seconds > max_range_seconds {
+        return Err(ApiError::BadRequest(format!(
+            "export range too large: {range_seconds} seconds requested, max {max_range_seconds} \
+             (raise EXPORT_MAX_RANGE_SECONDS to allow longer exports)"
+        )));
+    }
+
+    let mut distinct = camera_ids.to_vec();
+    distinct.sort_unstable();
+    distinct.dedup();
+    if distinct.len() > MAX_EXPORT_CAMERAS {
+        return Err(ApiError::BadRequest(format!(
+            "too many cameras in one export ({} requested, max {MAX_EXPORT_CAMERAS})",
+            distinct.len()
+        )));
+    }
+    Ok(distinct)
+}
+
 // ─── route registry ───────────────────────────────────────────────────────────
 
 /// Mount export routes onto the root router.
@@ -120,32 +207,25 @@ async fn create_export(
     user.require_export()?;
 
     // ── validate ──────────────────────────────────────────────────────────────
-    if body.camera_ids.is_empty() {
-        return Err(ApiError::BadRequest(
-            "camera_ids must contain at least one camera".to_owned(),
-        ));
-    }
-    if body.start >= body.end {
-        return Err(ApiError::BadRequest(
-            "start must be strictly before end".to_owned(),
-        ));
-    }
+    // Bounds the request BEFORE any work is allocated: non-empty, ordered,
+    // within EXPORT_MAX_RANGE_SECONDS, and at most MAX_EXPORT_CAMERAS DISTINCT
+    // cameras. Returns the de-duplicated camera list.
+    let effective_ids = validate_export_cameras_and_range(
+        &body.camera_ids,
+        body.start,
+        body.end,
+        state.config().export_max_range_seconds,
+    )?;
 
     // Scope: ALL-OR-NOTHING. Reject if ANY requested camera is outside the
     // caller's assigned list, matching /export/batch (create_batch_export) and
     // the archive download — a caller never gets a silently-narrowed partial
     // export they didn't ask for.
-    if let Some(denied) = body
-        .camera_ids
-        .iter()
-        .find(|c| !user.can_access_camera(**c))
-    {
+    if let Some(denied) = effective_ids.iter().find(|c| !user.can_access_camera(**c)) {
         return Err(ApiError::Forbidden(format!(
             "camera {denied} is not in your assigned camera list"
         )));
     }
-    // All accessible now; filter still runs to dedup.
-    let effective_ids = user.filter_camera_ids(&body.camera_ids);
 
     // ── concurrency cap ───────────────────────────────────────────────────────
     // Bound unbounded ffmpeg spawning: refuse new work when too many jobs are
@@ -669,14 +749,23 @@ enum WaitOutcome {
     Finished(std::io::Result<std::process::ExitStatus>),
     /// The cancel token fired; the child was killed + reaped.
     Cancelled,
+    /// The per-camera wall-clock budget elapsed; the child was killed + reaped.
+    /// Carries the budget so the caller can name it in the stored job error.
+    TimedOut(std::time::Duration),
 }
 
-/// Await an ffmpeg `child` while watching `token`. On cancel, SIGKILL + reap the
-/// child (so no zombie) and return [`WaitOutcome::Cancelled`]. This interrupts a
-/// long single-camera encode promptly, not just between cameras.
+/// Await an ffmpeg `child` while watching `token` and a wall-clock `budget`.
+///
+/// On cancel, SIGKILL + reap the child (so no zombie) and return
+/// [`WaitOutcome::Cancelled`]; this interrupts a long single-camera encode
+/// promptly, not just between cameras. On budget expiry, likewise kill + reap
+/// and return [`WaitOutcome::TimedOut`] so the caller can FAIL the job — a
+/// wedged child must never leave a job `Running` forever, because that
+/// permanently consumes one of `EXPORT_MAX_CONCURRENT` slots.
 async fn wait_or_cancel(
     child: &mut tokio::process::Child,
     token: &CancellationToken,
+    budget: std::time::Duration,
 ) -> WaitOutcome {
     tokio::select! {
         res = child.wait() => WaitOutcome::Finished(res),
@@ -684,6 +773,10 @@ async fn wait_or_cancel(
             // `kill()` sends SIGKILL AND reaps the child (awaits its exit).
             let _ = child.kill().await;
             WaitOutcome::Cancelled
+        }
+        () = tokio::time::sleep(budget) => {
+            let _ = child.kill().await;
+            WaitOutcome::TimedOut(budget)
         }
     }
 }
@@ -760,6 +853,8 @@ async fn run_export_job(
     // Pre-compute codec args (same for every camera in the job).
     let codec = build_codec_args(burn_timestamp, include_audio, &video_codec, &container);
     let ext = codec.ext;
+    // Per-camera wall-clock budget, derived from the requested range.
+    let ffmpeg_budget = export_ffmpeg_timeout((end - start).num_seconds());
 
     for (cam_idx, &camera_id) in camera_ids.iter().enumerate() {
         info!(
@@ -878,10 +973,13 @@ async fn run_export_job(
         args.push(output_path.to_string_lossy().into_owned());
 
         // ── e. spawn ffmpeg ───────────────────────────────────────────────────
+        // kill_on_drop reaps the child if this worker task is ever dropped, so a
+        // half-finished encode can't outlive the job that owns it.
         let mut child = match Command::new(FFMPEG_BIN)
             .args(&args)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true)
             .spawn()
         {
             Ok(c) => c,
@@ -919,9 +1017,20 @@ async fn run_export_job(
             });
         }
 
-        let exit_status = match wait_or_cancel(&mut child, &cancel).await {
+        let exit_status = match wait_or_cancel(&mut child, &cancel, ffmpeg_budget).await {
             WaitOutcome::Cancelled => {
                 cancel_job(&state, job_id, &export_dir).await;
+                return;
+            }
+            WaitOutcome::TimedOut(budget) => {
+                fail_job(
+                    &state,
+                    job_id,
+                    format!(
+                        "ffmpeg for camera {camera_id} exceeded its {} s budget and was stopped",
+                        budget.as_secs()
+                    ),
+                );
                 return;
             }
             WaitOutcome::Finished(Ok(s)) => s,
@@ -1089,6 +1198,9 @@ async fn create_batch_export(
     }
 
     // Validate + scope every item up front (fail the whole request on a bad one).
+    // Each item is one ffmpeg run, so each gets the same per-range cap as a
+    // single-camera export.
+    let max_range_seconds = state.config().export_max_range_seconds;
     let mut items: Vec<(Uuid, chrono::DateTime<Utc>, chrono::DateTime<Utc>)> =
         Vec::with_capacity(body.items.len());
     for it in &body.items {
@@ -1096,6 +1208,13 @@ async fn create_batch_export(
             return Err(ApiError::BadRequest(
                 "each clip's start must be strictly before its end".to_owned(),
             ));
+        }
+        let range_seconds = (it.end - it.start).num_seconds();
+        if range_seconds > max_range_seconds {
+            return Err(ApiError::BadRequest(format!(
+                "clip range too large: {range_seconds} seconds requested, max \
+                 {max_range_seconds} (raise EXPORT_MAX_RANGE_SECONDS to allow longer exports)"
+            )));
         }
         user.assert_camera_access(it.camera_id)?;
         items.push((it.camera_id, it.start, it.end));
@@ -1266,10 +1385,13 @@ async fn export_one_clip(
     args.extend(["-progress".to_owned(), "pipe:2".to_owned()]);
     args.push(output_path.to_string_lossy().into_owned());
 
+    // kill_on_drop reaps the child if this worker task is ever dropped, so a
+    // half-finished encode can't outlive the job that owns it.
     let mut child = Command::new(FFMPEG_BIN)
         .args(&args)
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
         .spawn()
         .map_err(|e| format!("spawn ffmpeg for {camera_id}: {e}"))?;
 
@@ -1288,8 +1410,20 @@ async fn export_one_clip(
         });
     }
 
-    let exit_status = match wait_or_cancel(&mut child, token).await {
+    let exit_status = match wait_or_cancel(
+        &mut child,
+        token,
+        export_ffmpeg_timeout((end - start).num_seconds()),
+    )
+    .await
+    {
         WaitOutcome::Cancelled => return Ok(ClipStep::Cancelled),
+        WaitOutcome::TimedOut(budget) => {
+            return Err(format!(
+                "ffmpeg for camera {camera_id} exceeded its {} s budget and was stopped",
+                budget.as_secs()
+            ))
+        }
         WaitOutcome::Finished(Ok(s)) => s,
         WaitOutcome::Finished(Err(e)) => return Err(format!("wait ffmpeg for {camera_id}: {e}")),
     };
@@ -1606,7 +1740,8 @@ mod tests {
         let token = CancellationToken::new();
         token.cancel(); // already cancelled → take the cancel branch immediately
 
-        let outcome = wait_or_cancel(&mut child, &token).await;
+        let outcome =
+            wait_or_cancel(&mut child, &token, std::time::Duration::from_secs(600)).await;
         assert!(matches!(outcome, WaitOutcome::Cancelled));
 
         // Dead AND reaped: try_wait returns Some(exit status), no error/zombie.
@@ -1621,8 +1756,132 @@ mod tests {
             .spawn()
             .expect("spawn true");
         let token = CancellationToken::new(); // not cancelled
-        let outcome = wait_or_cancel(&mut child, &token).await;
+        let outcome =
+            wait_or_cancel(&mut child, &token, std::time::Duration::from_secs(600)).await;
         assert!(matches!(outcome, WaitOutcome::Finished(Ok(s)) if s.success()));
+    }
+
+    /// A child that never exits must be KILLED and REAPED when its wall-clock
+    /// budget elapses, and reported as `TimedOut` so the job fails with a stored
+    /// error instead of sitting `Running` forever and burning a concurrency slot.
+    #[tokio::test]
+    async fn budget_expiry_kills_reaps_and_reports_timeout() {
+        let mut child = tokio::process::Command::new("sleep")
+            .arg("60")
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn sleep stand-in for ffmpeg");
+        let token = CancellationToken::new(); // not cancelled
+
+        let outcome =
+            wait_or_cancel(&mut child, &token, std::time::Duration::from_millis(150)).await;
+        assert!(
+            matches!(outcome, WaitOutcome::TimedOut(_)),
+            "a child that outlives its budget must report TimedOut"
+        );
+        let reaped = child.try_wait().expect("try_wait should not error");
+        assert!(reaped.is_some(), "ffmpeg child was not reaped after timeout");
+    }
+
+    // ── per-camera ffmpeg budget ────────────────────────────────────────────────
+
+    #[test]
+    fn export_ffmpeg_budget_is_floored_scaled_and_capped() {
+        // Short range → the floor, so a 10 s clip still gets spin-up room.
+        assert_eq!(
+            export_ffmpeg_timeout(10).as_secs(),
+            EXPORT_FFMPEG_TIMEOUT_FLOOR_SECS
+        );
+        // Mid range → 4x realtime.
+        assert_eq!(export_ffmpeg_timeout(3600).as_secs(), 3600 * 4);
+        // Maximum range → the absolute ceiling, never unbounded.
+        assert_eq!(
+            export_ffmpeg_timeout(i64::MAX).as_secs(),
+            EXPORT_FFMPEG_TIMEOUT_CEILING_SECS
+        );
+        // Nonsense input is still finite.
+        assert_eq!(
+            export_ffmpeg_timeout(-5).as_secs(),
+            EXPORT_FFMPEG_TIMEOUT_FLOOR_SECS
+        );
+    }
+
+    // ── POST /export validation ─────────────────────────────────────────────────
+
+    /// Helper: a valid one-hour window.
+    fn one_hour() -> (chrono::DateTime<Utc>, chrono::DateTime<Utc>) {
+        let start = Utc::now();
+        (start, start + chrono::Duration::hours(1))
+    }
+
+    #[test]
+    fn export_validation_dedups_and_sorts_the_camera_list() {
+        let (start, end) = one_hour();
+        let a = Uuid::from_u128(1);
+        let b = Uuid::from_u128(2);
+        // The shape that used to run N sequential full-range ffmpeg jobs writing
+        // the SAME output file, all counted as ONE job against the concurrency
+        // cap: one camera repeated many times.
+        let requested = vec![b, a, b, a, b, b, b, b];
+        let out = validate_export_cameras_and_range(&requested, start, end, 86_400)
+            .expect("a duplicated but in-range list is valid");
+        assert_eq!(out, vec![a, b], "duplicates collapse; order is stable");
+    }
+
+    #[test]
+    fn export_validation_rejects_an_over_long_range() {
+        let start = Utc::now();
+        let end = start + chrono::Duration::seconds(86_401);
+        let err = validate_export_cameras_and_range(&[Uuid::from_u128(1)], start, end, 86_400)
+            .expect_err("a range past the cap must be refused");
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert!(
+            err.to_string().contains("range too large"),
+            "message should say why: {err}"
+        );
+        // Exactly at the cap is fine (the bound is inclusive).
+        validate_export_cameras_and_range(
+            &[Uuid::from_u128(1)],
+            start,
+            start + chrono::Duration::seconds(86_400),
+            86_400,
+        )
+        .expect("a range exactly at the cap is allowed");
+    }
+
+    #[test]
+    fn export_validation_rejects_too_many_distinct_cameras() {
+        let (start, end) = one_hour();
+        let too_many: Vec<Uuid> = (0..=u128::try_from(MAX_EXPORT_CAMERAS).unwrap())
+            .map(Uuid::from_u128)
+            .collect();
+        let err = validate_export_cameras_and_range(&too_many, start, end, 86_400)
+            .expect_err("more distinct cameras than the cap must be refused");
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+
+        // The cap counts DISTINCT cameras, so a long list of duplicates passes.
+        let mut duplicated = vec![Uuid::from_u128(7); MAX_EXPORT_CAMERAS * 4];
+        duplicated.push(Uuid::from_u128(8));
+        let out = validate_export_cameras_and_range(&duplicated, start, end, 86_400)
+            .expect("duplicates do not count against the camera cap");
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn export_validation_rejects_empty_and_inverted_ranges() {
+        let (start, end) = one_hour();
+        assert_eq!(
+            validate_export_cameras_and_range(&[], start, end, 86_400)
+                .expect_err("empty camera list")
+                .status(),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            validate_export_cameras_and_range(&[Uuid::from_u128(1)], end, start, 86_400)
+                .expect_err("inverted range")
+                .status(),
+            StatusCode::BAD_REQUEST
+        );
     }
 
     // ── build_codec_args audio handling ─────────────────────────────────────────

--- a/services/api/src/export.rs
+++ b/services/api/src/export.rs
@@ -1740,8 +1740,7 @@ mod tests {
         let token = CancellationToken::new();
         token.cancel(); // already cancelled → take the cancel branch immediately
 
-        let outcome =
-            wait_or_cancel(&mut child, &token, std::time::Duration::from_secs(600)).await;
+        let outcome = wait_or_cancel(&mut child, &token, std::time::Duration::from_secs(600)).await;
         assert!(matches!(outcome, WaitOutcome::Cancelled));
 
         // Dead AND reaped: try_wait returns Some(exit status), no error/zombie.
@@ -1756,8 +1755,7 @@ mod tests {
             .spawn()
             .expect("spawn true");
         let token = CancellationToken::new(); // not cancelled
-        let outcome =
-            wait_or_cancel(&mut child, &token, std::time::Duration::from_secs(600)).await;
+        let outcome = wait_or_cancel(&mut child, &token, std::time::Duration::from_secs(600)).await;
         assert!(matches!(outcome, WaitOutcome::Finished(Ok(s)) if s.success()));
     }
 
@@ -1780,7 +1778,10 @@ mod tests {
             "a child that outlives its budget must report TimedOut"
         );
         let reaped = child.try_wait().expect("try_wait should not error");
-        assert!(reaped.is_some(), "ffmpeg child was not reaped after timeout");
+        assert!(
+            reaped.is_some(),
+            "ffmpeg child was not reaped after timeout"
+        );
     }
 
     // ── per-camera ffmpeg budget ────────────────────────────────────────────────

--- a/services/api/src/export.rs
+++ b/services/api/src/export.rs
@@ -114,10 +114,12 @@ const EXPORT_FFMPEG_TIMEOUT_CEILING_SECS: u64 = 24 * 60 * 60;
 /// tells the operator what happened.
 fn export_ffmpeg_timeout(range_secs: i64) -> std::time::Duration {
     let range = u64::try_from(range_secs.max(0)).unwrap_or(u64::MAX);
-    let scaled = range
-        .saturating_mul(EXPORT_FFMPEG_TIMEOUT_FACTOR)
-        .max(EXPORT_FFMPEG_TIMEOUT_FLOOR_SECS)
-        .min(EXPORT_FFMPEG_TIMEOUT_CEILING_SECS);
+    // The floor is a compile-time constant below the ceiling, so `clamp` cannot
+    // panic here.
+    let scaled = range.saturating_mul(EXPORT_FFMPEG_TIMEOUT_FACTOR).clamp(
+        EXPORT_FFMPEG_TIMEOUT_FLOOR_SECS,
+        EXPORT_FFMPEG_TIMEOUT_CEILING_SECS,
+    );
     std::time::Duration::from_secs(scaled)
 }
 

--- a/services/api/src/export.rs
+++ b/services/api/src/export.rs
@@ -1742,7 +1742,7 @@ mod tests {
         let token = CancellationToken::new();
         token.cancel(); // already cancelled → take the cancel branch immediately
 
-        let outcome = wait_or_cancel(&mut child, &token, std::time::Duration::from_secs(600)).await;
+        let outcome = wait_or_cancel(&mut child, &token, std::time::Duration::from_mins(10)).await;
         assert!(matches!(outcome, WaitOutcome::Cancelled));
 
         // Dead AND reaped: try_wait returns Some(exit status), no error/zombie.
@@ -1757,7 +1757,7 @@ mod tests {
             .spawn()
             .expect("spawn true");
         let token = CancellationToken::new(); // not cancelled
-        let outcome = wait_or_cancel(&mut child, &token, std::time::Duration::from_secs(600)).await;
+        let outcome = wait_or_cancel(&mut child, &token, std::time::Duration::from_mins(10)).await;
         assert!(matches!(outcome, WaitOutcome::Finished(Ok(s)) if s.success()));
     }
 

--- a/services/api/src/filmstrip.rs
+++ b/services/api/src/filmstrip.rs
@@ -609,7 +609,10 @@ mod tests {
     fn quantize_thumb_width_snaps_to_a_bucket_and_clamps() {
         // Out of range in both directions clamps to the ladder's ends.
         assert_eq!(quantize_thumb_width(0), THUMB_WIDTH_BUCKETS[0]);
-        assert_eq!(quantize_thumb_width(THUMB_MIN_WIDTH), THUMB_WIDTH_BUCKETS[0]);
+        assert_eq!(
+            quantize_thumb_width(THUMB_MIN_WIDTH),
+            THUMB_WIDTH_BUCKETS[0]
+        );
         assert_eq!(quantize_thumb_width(u32::MAX), THUMB_MAX_WIDTH);
 
         // Nearest wins.

--- a/services/api/src/filmstrip.rs
+++ b/services/api/src/filmstrip.rs
@@ -81,6 +81,19 @@ pub(crate) const DEFAULT_THUMB_INTERVAL_SECS: i64 = 4;
 const THUMB_MIN_WIDTH: u32 = 48;
 const THUMB_MAX_WIDTH: u32 = 640;
 
+/// The only widths a thumbnail is ever rendered (and cached) at.
+///
+/// Clamping alone left 593 distinct legal widths, and the width is part of the
+/// cache key, so 593 requests for the same instant meant 593 ffmpeg runs and 593
+/// files on disk for what is visually the same frame. Snapping to this ladder
+/// collapses them onto a handful of shared keys. The buckets are chosen so every
+/// width the shipped clients ask for lands on itself and nothing is re-rendered:
+/// 160 (the scrub-list default on Android and desktop), 320 (the Android
+/// playback wall), and 480 (the iOS scrub still, the desktop preview frame, and
+/// the `THUMB_PREGEN_WIDTH` default, so the pre-generated cache stays hot). 80
+/// and 640 bracket the ladder at the clamp bounds.
+const THUMB_WIDTH_BUCKETS: [u32; 5] = [80, 160, 320, 480, 640];
+
 /// Hard ceiling on a single filmstrip window. The endpoint builds one grid
 /// entry per `DEFAULT_THUMB_INTERVAL_SECS`, so an unbounded range would
 /// allocate an enormous Vec (and OOM the process — filmstrip lives on the
@@ -196,10 +209,12 @@ async fn list_filmstrip(
 pub struct FrameQuery {
     /// Timestamp of the frame to serve.
     pub ts: DateTime<Utc>,
-    /// Requested width in pixels (informational for v1 — single resolution stored).
-    /// Parsed from the query for forward-compat but not yet used to resize.
+    /// Requested width in pixels. Clamped to `[THUMB_MIN_WIDTH, THUMB_MAX_WIDTH]`
+    /// and then snapped to [`THUMB_WIDTH_BUCKETS`]; the result is both the scale
+    /// ffmpeg renders at and part of the on-disk cache key. The list endpoint
+    /// above propagates its own `width` into every frame URL it mints, so a
+    /// client picks the width once per strip.
     #[serde(default = "default_thumb_width")]
-    #[allow(dead_code)]
     pub width: u32,
 }
 
@@ -240,7 +255,7 @@ async fn serve_frame(
     let grid_ms = DEFAULT_THUMB_INTERVAL_SECS * 1000;
     let ts_ms = q.ts.timestamp_millis().div_euclid(grid_ms) * grid_ms;
     let snapped_ts = Utc.timestamp_millis_opt(ts_ms).single().unwrap_or(q.ts);
-    let w = q.width.clamp(THUMB_MIN_WIDTH, THUMB_MAX_WIDTH);
+    let w = quantize_thumb_width(q.width);
     let (thumbs_root, frame_path) =
         thumb_frame_path(state.config().thumb_cache_base(), camera_id, ts_ms, w);
     ensure_thumbnail(&state, camera_id, snapped_ts, w).await?;
@@ -333,7 +348,7 @@ pub(crate) async fn ensure_thumbnail(
     snapped_ts: DateTime<Utc>,
     width: u32,
 ) -> Result<PathBuf, ApiError> {
-    let w = width.clamp(THUMB_MIN_WIDTH, THUMB_MAX_WIDTH);
+    let w = quantize_thumb_width(width);
     let (thumbs_root, frame_path) = thumb_frame_path(
         state.config().thumb_cache_base(),
         camera_id,
@@ -401,7 +416,7 @@ async fn extract_thumbnail(
     // In-segment offset (clamped non-negative).
     #[allow(clippy::cast_precision_loss)]
     let offset_secs: f64 = (ts - seg.start_ts).num_milliseconds().max(0) as f64 / 1000.0;
-    let w = width.clamp(THUMB_MIN_WIDTH, THUMB_MAX_WIDTH);
+    let w = quantize_thumb_width(width);
 
     tokio::fs::create_dir_all(thumbs_root)
         .await
@@ -420,12 +435,14 @@ async fn extract_thumbnail(
     // Cap concurrent extractions so a fast multi-camera scrub (each miss is one
     // single-frame ffmpeg) can't spawn a storm, mirroring the `/play` and
     // clip-gen semaphores. The permit is held only for the decode below and
-    // released on drop when this function returns.
-    let _permit = state
-        .thumb_semaphore()
-        .acquire_owned()
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("thumb semaphore closed: {e}")))?;
+    // released on drop when this function returns. Bounded: at saturation the
+    // caller gets 503 + Retry-After rather than parking on the queue forever.
+    let _permit = crate::media_limits::acquire_bounded(
+        &state.thumb_semaphore(),
+        crate::media_limits::THUMB_EXTRACT_WAIT,
+        "thumbnail extraction",
+    )
+    .await?;
 
     let args = thumb_ffmpeg_args(
         offset_secs,
@@ -471,6 +488,22 @@ async fn extract_thumbnail(
 }
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
+
+/// Clamp a requested thumbnail width into range and then snap it to the nearest
+/// entry of [`THUMB_WIDTH_BUCKETS`].
+///
+/// The width is part of the on-disk cache key, so this is what keeps the number
+/// of distinct renditions per instant at five rather than 593. Ties (a width
+/// exactly between two buckets) snap DOWN, which favours the smaller file and,
+/// more importantly, is deterministic: the same request must always resolve to
+/// the same cache key.
+pub(crate) fn quantize_thumb_width(width: u32) -> u32 {
+    let clamped = width.clamp(THUMB_MIN_WIDTH, THUMB_MAX_WIDTH);
+    THUMB_WIDTH_BUCKETS
+        .into_iter()
+        .min_by_key(|b| (b.abs_diff(clamped), *b))
+        .unwrap_or(clamped)
+}
 
 /// Generate timestamp slots across `[start, end)` anchored to a fixed global
 /// grid of `interval_secs`, unfiltered by recorded coverage.
@@ -557,7 +590,49 @@ fn thumb_ffmpeg_args(offset_secs: f64, width: u32, input: &str, output: &str) ->
 
 #[cfg(test)]
 mod tests {
-    use super::thumb_ffmpeg_args;
+    use super::{
+        quantize_thumb_width, thumb_ffmpeg_args, THUMB_MAX_WIDTH, THUMB_MIN_WIDTH,
+        THUMB_WIDTH_BUCKETS,
+    };
+
+    #[test]
+    fn quantize_thumb_width_keeps_every_shipped_client_width_exact() {
+        // The widths the clients actually ask for must land on themselves, or
+        // every existing cached thumbnail (and the pre-generated cache, which
+        // defaults to 480) would be re-rendered at a different key.
+        for w in [160, 320, 480] {
+            assert_eq!(quantize_thumb_width(w), w, "client width {w} must be exact");
+        }
+    }
+
+    #[test]
+    fn quantize_thumb_width_snaps_to_a_bucket_and_clamps() {
+        // Out of range in both directions clamps to the ladder's ends.
+        assert_eq!(quantize_thumb_width(0), THUMB_WIDTH_BUCKETS[0]);
+        assert_eq!(quantize_thumb_width(THUMB_MIN_WIDTH), THUMB_WIDTH_BUCKETS[0]);
+        assert_eq!(quantize_thumb_width(u32::MAX), THUMB_MAX_WIDTH);
+
+        // Nearest wins.
+        assert_eq!(quantize_thumb_width(161), 160);
+        assert_eq!(quantize_thumb_width(300), 320);
+        assert_eq!(quantize_thumb_width(500), 480);
+        assert_eq!(quantize_thumb_width(639), 640);
+
+        // Exact ties snap DOWN, deterministically (240 is 80 from both 160 and
+        // 320): the same request must always resolve to the same cache key.
+        assert_eq!(quantize_thumb_width(240), 160);
+        assert_eq!(quantize_thumb_width(400), 320);
+    }
+
+    #[test]
+    fn quantize_thumb_width_collapses_the_whole_legal_range_onto_the_ladder() {
+        // The point of the quantizer: however many distinct widths a client can
+        // legally ask for, they only ever produce this many cache keys.
+        let mut seen: Vec<u32> = (0..=1000).map(quantize_thumb_width).collect();
+        seen.sort_unstable();
+        seen.dedup();
+        assert_eq!(seen, THUMB_WIDTH_BUCKETS.to_vec());
+    }
 
     #[test]
     fn thumb_ffmpeg_args_forces_mjpeg() {

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -582,12 +582,13 @@ async fn main() -> anyhow::Result<()> {
     // OUTSIDE both timeouts (the 30 s JSON one and the media one). It still
     // takes the media rate-limit bucket, and it is admin-gated by its handler's
     // AuthUser extractor.
-    let heavy_routes = Router::new()
-        .merge(stats::heavy_routes())
-        .layer(axum::middleware::from_fn_with_state(
-            media_rate_limiter.clone(),
-            rate_limit::rate_limit_mw,
-        ));
+    let heavy_routes =
+        Router::new()
+            .merge(stats::heavy_routes())
+            .layer(axum::middleware::from_fn_with_state(
+                media_rate_limiter.clone(),
+                rate_limit::rate_limit_mw,
+            ));
 
     // CORS covers the first argument and deliberately NOT the second (`/auth`).
     // Layers that must cover everything (tracing) go outside the call.

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -467,7 +467,7 @@ async fn main() -> anyhow::Result<()> {
     // high-frequency by nature (a low-bandwidth wall polls one still per tile
     // per second; scrubbing fires filmstrip frames in bursts of dozens), so this
     // is sized with roughly a 6x margin over the busiest real client rather than
-    // as a tight throttle — see `media_limits` for the arithmetic. It is keyed
+    // as a tight throttle, see `media_limits` for the arithmetic. It is keyed
     // exactly like the JSON bucket (TCP peer IP, or the first `X-Forwarded-For`
     // hop under `TRUST_PROXY`).
     let media_rate_limiter = rate_limit::RateLimiter::new(
@@ -549,7 +549,7 @@ async fn main() -> anyhow::Result<()> {
     // download, an export archive, and an open-ended live `stream.mp4` all
     // return their headers immediately and stream afterwards, so none of them
     // can be cut. What it does bound is the routes that produce something before
-    // answering — the on-demand clip and low-bitrate transcodes — which is
+    // answering, the on-demand clip and low-bitrate transcodes, which is
     // exactly the case that could otherwise hang a request indefinitely.
     let media_layers = |r: Router<AppState>| {
         r.layer(TimeoutLayer::with_status_code(

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -95,6 +95,7 @@ mod ffprobe;
 mod filmstrip;
 mod go2rtc;
 mod ha;
+mod media_limits;
 mod metrics;
 mod notifications;
 mod plates;
@@ -462,6 +463,18 @@ async fn main() -> anyhow::Result<()> {
     // touching high-frequency media serving.
     let rate_limiter = rate_limit::RateLimiter::new(240, 4.0);
 
+    // Second, much larger bucket for the media routes. Media serving is
+    // high-frequency by nature (a low-bandwidth wall polls one still per tile
+    // per second; scrubbing fires filmstrip frames in bursts of dozens), so this
+    // is sized with roughly a 6x margin over the busiest real client rather than
+    // as a tight throttle — see `media_limits` for the arithmetic. It is keyed
+    // exactly like the JSON bucket (TCP peer IP, or the first `X-Forwarded-For`
+    // hop under `TRUST_PROXY`).
+    let media_rate_limiter = rate_limit::RateLimiter::new(
+        media_limits::MEDIA_RATE_BURST,
+        media_limits::MEDIA_RATE_REFILL_PER_SEC,
+    );
+
     // JSON/API routes get gzip + a 30s request timeout (bounds DB-heavy endpoints
     // like /timeline + fails slow clients fast). MEDIA routes (segment/video
     // serving, export file downloads, filmstrip JPEGs) are deliberately EXCLUDED:
@@ -526,22 +539,55 @@ async fn main() -> anyhow::Result<()> {
             .merge(updates::routes()),
     );
 
-    let media_routes = Router::new()
-        .merge(playback::routes())
-        .merge(segment_low::routes())
-        .merge(export::routes())
-        .merge(filmstrip::routes())
-        // On-demand DB-vs-disk size verification: a filesystem walk that can run
-        // long on a large archive, so it lives here (no 30 s timeout) not in
-        // json_routes. Admin-gated by its handler's AuthUser extractor.
+    // Media routes get their own (much larger) rate-limit bucket plus a
+    // time-to-response bound. Still NO gzip: it would break 206 range requests
+    // and waste CPU on already-compressed video.
+    //
+    // The timeout is safe over streaming media because `tower_http`'s
+    // `TimeoutLayer` bounds only the handler future, NOT the response body
+    // (body deadlines are a separate `ResponseBodyTimeoutLayer`). A segment
+    // download, an export archive, and an open-ended live `stream.mp4` all
+    // return their headers immediately and stream afterwards, so none of them
+    // can be cut. What it does bound is the routes that produce something before
+    // answering — the on-demand clip and low-bitrate transcodes — which is
+    // exactly the case that could otherwise hang a request indefinitely.
+    let media_layers = |r: Router<AppState>| {
+        r.layer(TimeoutLayer::with_status_code(
+            StatusCode::SERVICE_UNAVAILABLE,
+            media_limits::MEDIA_RESPONSE_TIMEOUT,
+        ))
+        .layer(axum::middleware::from_fn_with_state(
+            media_rate_limiter.clone(),
+            rate_limit::rate_limit_mw,
+        ))
+    };
+
+    let media_routes = media_layers(
+        Router::new()
+            .merge(playback::routes())
+            .merge(segment_low::routes())
+            .merge(export::routes())
+            .merge(filmstrip::routes())
+            // Per-camera JPEG still proxy (authenticated, no gzip).
+            .merge(cameras::routes())
+            // Detection snapshot proxy (authenticated via AuthUser — Bearer or a
+            // scoped ?token=; no gzip).
+            .merge(events::media_routes())
+            // Clip media: generated clip.mp4 + thumbnail.jpg (authenticated; ?token= ok).
+            .merge(clips::media_routes()),
+    );
+
+    // On-demand DB-vs-disk size verification: a filesystem walk that can
+    // legitimately run for minutes on a large archive, so it is deliberately
+    // OUTSIDE both timeouts (the 30 s JSON one and the media one). It still
+    // takes the media rate-limit bucket, and it is admin-gated by its handler's
+    // AuthUser extractor.
+    let heavy_routes = Router::new()
         .merge(stats::heavy_routes())
-        // Per-camera JPEG still proxy (authenticated, no gzip, no timeout).
-        .merge(cameras::routes())
-        // Detection snapshot proxy (authenticated via AuthUser — Bearer or a
-        // scoped ?token=; no gzip, no timeout).
-        .merge(events::media_routes())
-        // Clip media: generated clip.mp4 + thumbnail.jpg (authenticated; ?token= ok).
-        .merge(clips::media_routes());
+        .layer(axum::middleware::from_fn_with_state(
+            media_rate_limiter.clone(),
+            rate_limit::rate_limit_mw,
+        ));
 
     // CORS covers the first argument and deliberately NOT the second (`/auth`).
     // Layers that must cover everything (tracing) go outside the call.
@@ -559,7 +605,8 @@ async fn main() -> anyhow::Result<()> {
             // Prometheus metrics — no auth (no secrets), no rate limit (scraper).
             .merge(metrics::routes())
             .merge(json_routes)
-            .merge(media_routes),
+            .merge(media_routes)
+            .merge(heavy_routes),
         auth_routes,
     )
     // Layers applied outermost-first (LIFO evaluation order in tower).
@@ -989,25 +1036,39 @@ async fn export_ttl_sweeper(state: AppState, ttl_seconds: u64) {
 /// the total exceeds `max_bytes`. Complements the age-based TTL sweep in
 /// [`export_ttl_sweeper`]: age caps how long output lingers, this caps how much
 /// accumulates within a TTL window so a burst of large exports can't fill the
-/// disk. A `Running` job is never touched.
+/// disk.
+///
+/// A `Queued`/`Running` job is never *evicted* (its files are still being
+/// written), but its bytes ARE counted against the budget: they are on the same
+/// disk, and ignoring them let the real total sit above `max_bytes` for as long
+/// as jobs kept running. Counting them just makes the sweeper free more finished
+/// output to make room, which is the intended behaviour.
 async fn sweep_export_budget(state: &AppState, max_bytes: u64) {
     let export_root = state.config().export_dir.clone();
-    // Snapshot finished jobs with their creation time and on-disk size.
+    // Snapshot finished jobs with their creation time and on-disk size, and
+    // separately total up what the in-flight jobs are already occupying.
     let mut finished: Vec<(uuid::Uuid, chrono::DateTime<chrono::Utc>, u64)> = Vec::new();
+    let mut active_bytes: u64 = 0;
     for entry in state.export_jobs() {
         let job = entry.value();
-        if !matches!(
+        let dir = std::path::Path::new(&export_root).join(entry.key().to_string());
+        let size = dir_size_bytes(&dir).await;
+        if matches!(
             job.status,
             dto::ExportStatus::Done | dto::ExportStatus::Failed | dto::ExportStatus::Cancelled
         ) {
-            continue; // never evict a running job
+            finished.push((*entry.key(), job.created_at, size));
+        } else {
+            active_bytes = active_bytes.saturating_add(size);
         }
-        let dir = std::path::Path::new(&export_root).join(entry.key().to_string());
-        let size = dir_size_bytes(&dir).await;
-        finished.push((*entry.key(), job.created_at, size));
     }
 
-    for job_id in plan_export_evictions(finished, max_bytes) {
+    // Shrink the budget the finished jobs get to share by what the in-flight
+    // ones already hold. Saturating to zero means "evict everything finished",
+    // which is the right answer when the live jobs alone are over budget.
+    let finished_budget = max_bytes.saturating_sub(active_bytes);
+
+    for job_id in plan_export_evictions(finished, finished_budget) {
         let dir = std::path::Path::new(&export_root).join(job_id.to_string());
         let removed = match tokio::fs::remove_dir_all(&dir).await {
             Ok(()) => true,

--- a/services/api/src/media_limits.rs
+++ b/services/api/src/media_limits.rs
@@ -97,9 +97,9 @@ pub const MEDIA_RATE_REFILL_PER_SEC: f64 = 240.0;
 /// live `stream.mp4`: those all return their headers immediately and stream
 /// afterwards. What it does bound is the media routes that *produce* something
 /// before answering, the longest being an on-demand clip or low-bitrate
-/// transcode: 120 s of ffmpeg plus a 15 s [`CLIP_GEN_WAIT`]. 180 s clears that
-/// with slack and still guarantees every media request terminates.
-pub const MEDIA_RESPONSE_TIMEOUT: Duration = Duration::from_secs(180);
+/// transcode: 120 s of ffmpeg plus a 15 s [`CLIP_GEN_WAIT`]. Three minutes
+/// clears that with slack and still guarantees every media request terminates.
+pub const MEDIA_RESPONSE_TIMEOUT: Duration = Duration::from_mins(3);
 
 // ─── bounded acquire ──────────────────────────────────────────────────────────
 

--- a/services/api/src/media_limits.rs
+++ b/services/api/src/media_limits.rs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Bounds for the media router: work-semaphore waits and the per-client request
+//! budget.
+//!
+//! # Why
+//!
+//! The media routes (segment serving, filmstrip frames, clip renditions, live
+//! stills, export downloads) each gate their expensive work behind a shared
+//! [`tokio::sync::Semaphore`]. Those acquires used to be plain
+//! `acquire_owned().await`, i.e. an **unbounded** queue: at saturation a request
+//! parked forever holding its connection, never answering, and one busy client
+//! could keep every other viewer waiting with no signal at all.
+//!
+//! [`acquire_bounded`] makes every such acquire time-limited. A caller that does
+//! not get a permit inside its budget gets `503 Service Unavailable` plus a
+//! `Retry-After` hint, so the client backs off and the connection is released.
+//! Answering "busy, try again" is strictly better than an open-ended hang: the
+//! clients already treat a failed media fetch as "show the placeholder and poll
+//! again", which is exactly the desired behaviour under load.
+//!
+//! # Choosing a wait budget
+//!
+//! The budget is per call site, sized against how long the guarded work itself
+//! takes:
+//!
+//! | Budget | Guarded work | Reasoning |
+//! |--------|--------------|-----------|
+//! | [`CLIP_GEN_WAIT`] (15 s) | clip / low-bitrate transcode, clip thumbnail | The transcode itself is capped at 120 s but in practice runs in seconds (a segment is ~4 s of video, a clip window <= 30 s). 15 s absorbs a full queue ahead of us without pinning a connection for the transcode cap. |
+//! | [`THUMB_EXTRACT_WAIT`] (5 s) | single-frame filmstrip ffmpeg | Each extraction is one frame (typically well under a second, hard cap 12 s). Scrubbing fires bursts of dozens, and the useful answer is fast-or-nothing: a scrub thumbnail that arrives after 5 s is already off screen. |
+//! | [`FRAME_PROXY_WAIT`] (5 s) | live JPEG still proxied from go2rtc | Low-bandwidth walls poll each tile about once a second, so a wait longer than a poll interval only builds a backlog. |
+//!
+//! # Per-client request budget
+//!
+//! [`MEDIA_RATE_BURST`] / [`MEDIA_RATE_REFILL_PER_SEC`] size the media router's
+//! own token bucket (a second, much larger bucket than the JSON routes'). See
+//! those constants for the arithmetic against real client polling behaviour.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use crate::error::ApiError;
+
+// ─── work-semaphore wait budgets ──────────────────────────────────────────────
+
+/// Wait budget for the clip-generation semaphore (clip renditions, low-bitrate
+/// segment variants, clip thumbnails). See the module table.
+pub const CLIP_GEN_WAIT: Duration = Duration::from_secs(15);
+
+/// Wait budget for the thumbnail-extraction semaphore (filmstrip frames).
+pub const THUMB_EXTRACT_WAIT: Duration = Duration::from_secs(5);
+
+/// Wait budget for the live-still proxy semaphore (`/cameras/:id/frame.jpg`).
+pub const FRAME_PROXY_WAIT: Duration = Duration::from_secs(5);
+
+/// `Retry-After` seconds sent with the 503. Short: the queue that turned this
+/// caller away drains in seconds, and the clients poll on their own cadence
+/// anyway.
+const RETRY_AFTER_SECS: u64 = 2;
+
+// ─── per-client media request budget ──────────────────────────────────────────
+
+/// Burst capacity of the media router's per-client token bucket.
+///
+/// The heaviest legitimate burst a single client produces is timeline
+/// scrubbing, which fires filmstrip frame requests dozens at a time (call it
+/// 60 for a wide scrub across a full strip). 1200 absorbs twenty such bursts
+/// back to back before a single request is refused.
+pub const MEDIA_RATE_BURST: u32 = 1200;
+
+/// Sustained refill of the media router's per-client token bucket, in requests
+/// per second.
+///
+/// Arithmetic against the real clients:
+///
+/// * Android low-bandwidth wall: 16 tiles polling `frame.jpg` at 1 Hz = 16 req/s
+///   (its adaptive backoff only ever lowers that, to 1 per 5 s per tile).
+/// * iOS low-bandwidth tiles: 16 tiles at one per 1.2 s = about 13 req/s; the
+///   WebRTC backdrop poll is 16 tiles at one per 2 s = 8 req/s.
+/// * Segment playback opens a handful of `/segments/:id` and
+///   `/segments/:id/low.mp4` requests per seek.
+///
+/// A client doing all of that at once sits around 30 to 40 req/s. 240 leaves
+/// roughly a 6x margin, so it never touches a real operator (even several
+/// devices sharing one address behind a proxy that does not set
+/// `X-Forwarded-For`), while still stopping a runaway loop, which produces
+/// thousands per second, well before it can queue meaningful work.
+pub const MEDIA_RATE_REFILL_PER_SEC: f64 = 240.0;
+
+/// Time-to-first-byte budget for the media router.
+///
+/// `tower_http`'s `TimeoutLayer` bounds only the handler future, not the
+/// response body (body timeouts are a separate `ResponseBodyTimeoutLayer`), so
+/// this cannot cut a long segment download, an export archive, or an open-ended
+/// live `stream.mp4`: those all return their headers immediately and stream
+/// afterwards. What it does bound is the media routes that *produce* something
+/// before answering, the longest being an on-demand clip or low-bitrate
+/// transcode: 120 s of ffmpeg plus a 15 s [`CLIP_GEN_WAIT`]. 180 s clears that
+/// with slack and still guarantees every media request terminates.
+pub const MEDIA_RESPONSE_TIMEOUT: Duration = Duration::from_secs(180);
+
+// ─── bounded acquire ──────────────────────────────────────────────────────────
+
+/// Acquire a permit from `sem`, giving up after `wait`.
+///
+/// `what` names the resource in the log line and the client-visible message
+/// (e.g. `"clip transcode"`). On timeout this returns
+/// [`ApiError::ServiceUnavailableRetry`], which renders 503 with a `Retry-After`
+/// header; the caller must simply `?` it and let the request end.
+///
+/// A closed semaphore is impossible in practice (nothing calls `close()`), so it
+/// maps to a 500 exactly as the plain acquires it replaces did.
+pub async fn acquire_bounded(
+    sem: &Arc<Semaphore>,
+    wait: Duration,
+    what: &str,
+) -> Result<OwnedSemaphorePermit, ApiError> {
+    match tokio::time::timeout(wait, Arc::clone(sem).acquire_owned()).await {
+        Ok(Ok(permit)) => Ok(permit),
+        Ok(Err(e)) => Err(ApiError::Internal(anyhow::anyhow!(
+            "{what} semaphore closed: {e}"
+        ))),
+        Err(_) => {
+            tracing::warn!(
+                resource = what,
+                wait_secs = wait.as_secs(),
+                "media work queue saturated, returning 503"
+            );
+            Err(ApiError::ServiceUnavailableRetry {
+                message: format!("{what} queue is saturated; retry shortly"),
+                retry_after: RETRY_AFTER_SECS,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{acquire_bounded, ApiError};
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::sync::Semaphore;
+
+    #[tokio::test]
+    async fn saturated_semaphore_yields_503_within_the_budget() {
+        // Zero permits: nothing can ever be acquired, so this MUST come back as
+        // the 503 path rather than parking forever (the whole point of the
+        // bounded acquire).
+        let sem = Arc::new(Semaphore::new(0));
+        let started = std::time::Instant::now();
+        let err = acquire_bounded(&sem, Duration::from_millis(120), "test work")
+            .await
+            .expect_err("a zero-permit semaphore can never hand out a permit");
+
+        match err {
+            ApiError::ServiceUnavailableRetry {
+                ref message,
+                retry_after,
+            } => {
+                assert!(
+                    message.contains("test work"),
+                    "message should name the resource: {message}"
+                );
+                assert!(retry_after >= 1, "a Retry-After hint must be sent");
+            }
+            other => panic!("expected ServiceUnavailableRetry, got {other:?}"),
+        }
+        assert_eq!(err.status(), axum::http::StatusCode::SERVICE_UNAVAILABLE);
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "the acquire must give up at its budget, not queue forever"
+        );
+    }
+
+    #[tokio::test]
+    async fn free_semaphore_hands_out_a_permit_immediately() {
+        let sem = Arc::new(Semaphore::new(1));
+        let permit = acquire_bounded(&sem, Duration::from_secs(5), "test work")
+            .await
+            .expect("a free semaphore must hand out a permit");
+        assert_eq!(sem.available_permits(), 0);
+        drop(permit);
+        assert_eq!(sem.available_permits(), 1);
+    }
+}

--- a/services/api/src/segment_low.rs
+++ b/services/api/src/segment_low.rs
@@ -147,11 +147,14 @@ async fn get_segment_low(
 /// (rather than `-c copy`) yields a clean, continuous AAC track within the
 /// segment. Cameras with no audio track simply produce no audio (aac is a no-op).
 async fn generate_low_file(state: &AppState, src: &FsPath, out: &FsPath) -> Result<(), ApiError> {
-    let _permit = state
-        .clip_gen_semaphore()
-        .acquire_owned()
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("clip-gen semaphore closed: {e}")))?;
+    // Bounded: at saturation the caller gets 503 + Retry-After rather than
+    // parking on the queue with the connection held open.
+    let _permit = crate::media_limits::acquire_bounded(
+        &state.clip_gen_semaphore(),
+        crate::media_limits::CLIP_GEN_WAIT,
+        "low-bitrate transcode",
+    )
+    .await?;
     // Another request may have produced it while we waited for the permit.
     if tokio::fs::metadata(out).await.is_ok() {
         return Ok(());

--- a/services/api/src/state.rs
+++ b/services/api/src/state.rs
@@ -134,6 +134,23 @@ struct Inner {
     /// Permit count = `config.thumb_extract_max_concurrency`.
     thumb_semaphore: Arc<Semaphore>,
 
+    /// Bounds concurrent `GET /cameras/{id}/frame.jpg` fetches from go2rtc. The
+    /// low-bandwidth walls on Android and iOS poll one still per tile per
+    /// second, and a request against a camera that is down holds its slot for
+    /// the whole retry ladder, so the proxy needs its own bound rather than an
+    /// unbounded fan-out. Permit count = `config.frame_proxy_max_concurrency`.
+    frame_semaphore: Arc<Semaphore>,
+
+    /// Cameras whose live still could not be fetched recently, as a monotonic
+    /// deadline: while `Instant::now() < deadline` the still proxy takes its
+    /// fast path (one quick attempt instead of the full cold-start retry
+    /// ladder), so a wall of tiles pointed at a camera that is down fails in
+    /// well under a second per poll instead of holding a permit for the ladder.
+    /// A successful fetch clears the entry, so a camera that comes back is
+    /// served normally on the very next poll. Memory-only and self-healing: a
+    /// restart just means the first poll after it pays the full ladder again.
+    frame_unavailable_until: DashMap<Uuid, Instant>,
+
     /// Per-key in-flight locks for thumbnail extraction (singleflight). Keyed by
     /// the final cache path; a request serializes on its key so two concurrent
     /// misses on the same slot (e.g. the Phase 1 background writer racing an
@@ -303,6 +320,7 @@ impl AppState {
         let play_semaphore = Arc::new(Semaphore::new(config.playback_max_concurrency));
         let clip_gen_semaphore = Arc::new(Semaphore::new(config.clip_gen_max_concurrency));
         let thumb_semaphore = Arc::new(Semaphore::new(config.thumb_extract_max_concurrency));
+        let frame_semaphore = Arc::new(Semaphore::new(config.frame_proxy_max_concurrency));
 
         // Health-alert maintenance window (issue #46). Off by default; an
         // optional `MAINTENANCE_UNTIL` env (unix seconds) lets a deployment
@@ -328,6 +346,8 @@ impl AppState {
             mainv_needed: DashMap::new(),
             stream_rejected: DashMap::new(),
             thumb_semaphore,
+            frame_semaphore,
+            frame_unavailable_until: DashMap::new(),
             thumb_inflight: DashMap::new(),
             roles_cache: DashMap::new(),
             revoked_jtis: DashMap::new(),
@@ -482,6 +502,45 @@ impl AppState {
     #[inline]
     pub fn thumb_semaphore(&self) -> Arc<Semaphore> {
         Arc::clone(&self.0.thumb_semaphore)
+    }
+
+    /// Clone the live-still proxy concurrency semaphore handle (cheap `Arc`
+    /// clone). Used by `GET /cameras/{id}/frame.jpg` to cap concurrent go2rtc
+    /// still fetches.
+    #[inline]
+    pub fn frame_semaphore(&self) -> Arc<Semaphore> {
+        Arc::clone(&self.0.frame_semaphore)
+    }
+
+    /// Whether `camera_id`'s live still is currently latched as unavailable, so
+    /// the proxy should take its single-attempt fast path. See
+    /// [`frame_unavailable_until`](Inner::frame_unavailable_until).
+    #[inline]
+    pub fn frame_recently_unavailable(&self, camera_id: Uuid) -> bool {
+        self.0
+            .frame_unavailable_until
+            .get(&camera_id)
+            .is_some_and(|until| Instant::now() < *until)
+    }
+
+    /// Latch `camera_id`'s live still as unavailable for `ttl`. Called when a
+    /// still fetch exhausts its attempts.
+    pub fn mark_frame_unavailable(&self, camera_id: Uuid, ttl: Duration) {
+        // Cheap unbounded-growth guard: entries are one per camera, but a
+        // pathological id churn would still be capped.
+        if self.0.frame_unavailable_until.len() > 4096 {
+            self.0.frame_unavailable_until.clear();
+        }
+        self.0
+            .frame_unavailable_until
+            .insert(camera_id, Instant::now() + ttl);
+    }
+
+    /// Clear `camera_id`'s unavailable latch after a successful still fetch, so
+    /// a camera that comes back is served the normal way on the next poll.
+    #[inline]
+    pub fn clear_frame_unavailable(&self, camera_id: Uuid) {
+        self.0.frame_unavailable_until.remove(&camera_id);
     }
 
     /// Get (or create) the singleflight lock for a thumbnail cache key. Callers

--- a/services/api/tests/export_limits.rs
+++ b/services/api/tests/export_limits.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Integration tests for the bounds `POST /export` puts on a single job.
+//!
+//! Two properties, both asserted against the REAL `create_export` handler via
+//! the shared harness (`mod support` `#[path]`-includes the actual `src/`
+//! modules, so this is the shipped validation path, not a mirror of it):
+//!
+//! 1. **A repeated camera produces ONE unit of work.** `filter_camera_ids` is a
+//!    scope filter, not a de-duplicator (for an admin it returns the list
+//!    verbatim), so a body naming the same camera N times used to enqueue N
+//!    sequential full-range ffmpeg runs, all writing the SAME output file with
+//!    `-y`, and all counted as ONE job against `EXPORT_MAX_CONCURRENT`. The job
+//!    must now carry exactly one entry per DISTINCT camera.
+//! 2. **An over-long range is refused up front.** The window is capped by
+//!    `EXPORT_MAX_RANGE_SECONDS` (default 86400) and rejected with `400` before
+//!    any job, directory, or ffmpeg child is allocated.
+
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::option_option)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::items_after_statements)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::manual_let_else)]
+#![allow(clippy::default_trait_access)]
+#![allow(clippy::struct_excessive_bools)]
+#![allow(clippy::match_same_arms)]
+#![allow(clippy::manual_clamp)]
+#![allow(clippy::format_push_string)]
+
+mod support;
+
+use axum::body::to_bytes;
+use axum::http::StatusCode;
+use chrono::Utc;
+use uuid::Uuid;
+
+use support::*;
+
+async fn body_json(resp: axum::http::Response<axum::body::Body>) -> serde_json::Value {
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+}
+
+/// The default `EXPORT_MAX_RANGE_SECONDS` (a full day of one camera). The tests
+/// deliberately do NOT set the env var: it is process-wide and every test binary
+/// shares it, so they assert against the shipped default instead.
+const DEFAULT_MAX_RANGE_SECS: i64 = 86_400;
+
+#[tokio::test]
+async fn duplicated_camera_list_produces_one_job_entry_per_distinct_camera() {
+    let app = TestApp::new().await;
+    let admin = seed_admin(app.pool()).await;
+    let token = login(&app, &admin.username, &admin.password).await;
+
+    let cam_a = seed_camera(app.pool()).await;
+    let cam_b = seed_camera(app.pool()).await;
+
+    let start = Utc::now() - chrono::Duration::minutes(5);
+    let end = Utc::now();
+
+    // The pathological shape: one camera repeated many times, plus a second one
+    // also repeated, in no particular order.
+    let resp = app
+        .send(post_auth_json(
+            "/export",
+            &token,
+            &serde_json::json!({
+                "camera_ids": [cam_b, cam_a, cam_b, cam_a, cam_b, cam_b, cam_b, cam_b],
+                "start": start,
+                "end": end,
+            }),
+        ))
+        .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::ACCEPTED,
+        "a duplicated but in-scope, in-range list is a valid request"
+    );
+
+    let body = body_json(resp).await;
+    let job_id: Uuid = body["job_id"]
+        .as_str()
+        .expect("202 body carries a job_id")
+        .parse()
+        .expect("job_id is a UUID");
+
+    // The job record is inserted BEFORE the worker is spawned, so reading it
+    // here is race-free regardless of what the (ffmpeg-less) worker then does.
+    let job = app
+        .state
+        .export_jobs()
+        .get(&job_id)
+        .map(|r| r.clone())
+        .expect("the job the 202 named must exist");
+
+    let mut expected = vec![cam_a, cam_b];
+    expected.sort_unstable();
+    assert_eq!(
+        job.camera_ids, expected,
+        "eight camera_ids naming two distinct cameras must become two units of \
+         work, not eight ffmpeg runs over the same output file"
+    );
+}
+
+#[tokio::test]
+async fn over_long_export_range_is_rejected_with_400() {
+    let app = TestApp::new().await;
+    let admin = seed_admin(app.pool()).await;
+    let token = login(&app, &admin.username, &admin.password).await;
+    let cam = seed_camera(app.pool()).await;
+
+    let start = Utc::now() - chrono::Duration::days(30);
+    let end = Utc::now();
+
+    let resp = app
+        .send(post_auth_json(
+            "/export",
+            &token,
+            &serde_json::json!({
+                "camera_ids": [cam],
+                "start": start,
+                "end": end,
+            }),
+        ))
+        .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "a 30-day window is past EXPORT_MAX_RANGE_SECONDS and must be refused"
+    );
+    let body = body_json(resp).await;
+    let message = body["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("range too large"),
+        "the 400 should say why it was refused (got: {body:?})"
+    );
+
+    // Nothing was allocated: no job exists for this caller at all.
+    assert_eq!(
+        app.state.export_jobs().len(),
+        0,
+        "an over-range request must be refused BEFORE a job is allocated"
+    );
+
+    // And a window exactly at the cap is still accepted, so the bound is where
+    // it is documented to be rather than somewhere just under it.
+    let ok = app
+        .send(post_auth_json(
+            "/export",
+            &token,
+            &serde_json::json!({
+                "camera_ids": [cam],
+                "start": end - chrono::Duration::seconds(DEFAULT_MAX_RANGE_SECS),
+                "end": end,
+            }),
+        ))
+        .await;
+    assert_eq!(
+        ok.status(),
+        StatusCode::ACCEPTED,
+        "a window exactly at EXPORT_MAX_RANGE_SECONDS must still be accepted"
+    );
+}

--- a/services/api/tests/support/mod.rs
+++ b/services/api/tests/support/mod.rs
@@ -81,6 +81,8 @@ pub mod filmstrip;
 pub mod go2rtc;
 #[path = "../../src/ha.rs"]
 pub mod ha;
+#[path = "../../src/media_limits.rs"]
+pub mod media_limits;
 #[path = "../../src/plates.rs"]
 pub mod plates;
 #[path = "../../src/playback.rs"]


### PR DESCRIPTION
## What changed

The media routes could queue work without limit. Every expensive media path (clip and low-bitrate transcodes, filmstrip frame extraction, the live camera still proxy) waits on a shared work semaphore, and those waits were open-ended: once the permits were gone, a request parked indefinitely, held its connection, and never answered. The media router also carried neither a request timeout nor a rate limit, unlike the JSON routes.

Alongside that, two paths let one request ask for an unbounded amount of work: the filmstrip cache key included an unquantized width, and `POST /export` capped neither the time range nor the camera list.

### Bounded waits on the media router

- New `services/api/src/media_limits.rs`. One helper (`acquire_bounded`) wraps every media semaphore acquire with a per-call-site wait budget. A saturated queue now answers `503` with `Retry-After` instead of hanging. Applied to the clip transcode, the clip thumbnail, the low-bitrate segment transcode, filmstrip extraction, and the still proxy. Budgets: 15 s for the transcodes (which run in seconds in practice), 5 s for a single-frame extraction and for a still (a scrub thumbnail that arrives after 5 s is off screen; a wall tile polls again in about a second).
- The media router gets its own, much larger rate-limit bucket, reusing the existing `rate_limit::RateLimiter` and keyed exactly as the JSON bucket is: burst 1200, 240/s sustained. The busiest real client (a 16-tile low-bandwidth wall at 1 Hz, plus segment fetches, plus a scrub burst) sits near 30 to 40 req/s, so that is roughly a 6x margin, while a runaway loop is still stopped well before it can queue work.
- The media router also gets a 3-minute time-to-response bound. `tower_http`'s `TimeoutLayer` bounds only the handler future, not the response body (body deadlines are a separate `ResponseBodyTimeoutLayer` that is deliberately not used), so segment downloads, export archives, and the open-ended live `stream.mp4` cannot be cut: they return headers immediately and stream afterwards. The one route that legitimately produces for minutes, the on-demand DB-vs-disk size verification walk, is mounted outside the timeout for that reason.

### Filmstrip cache keys

Widths clamp and then snap to `80/160/320/480/640` before entering the cache key, so one instant produces five renditions instead of 593. The buckets are chosen so every width the shipped clients ask for lands on itself (160 for the Android and desktop scrub lists, 320 for the Android playback wall, 480 for the iOS scrub still, the desktop preview frame, and the `THUMB_PREGEN_WIDTH` default), so no warm or pre-generated cache entry is invalidated. The frame route's stale "width is unused" doc comment and `dead_code` attribute are corrected: the width has been honoured since it became part of the cache key.

### Export job sizes

- `POST /export` sorts and de-duplicates its camera list. The RBAC scope filter never did (for an admin it returns the list verbatim), so a body repeating one camera N times ran N sequential full-range encodes, all writing the same output file with `-y`, all counted as one job against `EXPORT_MAX_CONCURRENT`. The misleading "filter still runs to dedup" comment is gone.
- The distinct-camera count is capped at 50, matching what `/export/batch` already caps clips at: both routes fan out to one sequential encode per unit of work, so they get the same ceiling.
- New `EXPORT_MAX_RANGE_SECONDS` (default 86400, a full day of one camera) caps the window with a clear 400. The same cap applies per clip in a batch export.
- Export ffmpeg children get `kill_on_drop(true)` (as the filmstrip and backup children already had) plus a wall-clock budget derived from the range: 4x realtime, floored at 10 minutes, capped at 24 hours. A wedged child now fails the job with a stored error instead of leaving it `Running` forever, which used to consume an `EXPORT_MAX_CONCURRENT` slot permanently until the api was restarted.
- The export byte-budget sweeper now counts in-flight jobs' bytes against the budget (it still never deletes them), so the on-disk total no longer sits above `EXPORT_CACHE_MAX_BYTES` for as long as jobs keep running.

### Live still proxy

`GET /cameras/:id/frame.jpg` goes behind a new frame-proxy semaphore. A camera that is disabled, rejected by go2rtc, or whose last fetch failed is latched for 10 seconds and served by a single quick attempt, so a wall of tiles pointed at a camera that is down fails in about a second per poll instead of roughly 17. A successful fetch clears the latch immediately, so a camera that comes back is served normally on the next poll.

## Operator-visible changes

Three env keys are now documented and forwarded by compose. All have defaults; nothing is required.

| Key | Default | Status |
|---|---|---|
| `EXPORT_MAX_RANGE_SECONDS` | `86400` | new |
| `FRAME_PROXY_MAX_CONCURRENCY` | one per core, clamped 8 to 32 | new |
| `EXPORT_MAX_CONCURRENT` | `2` | already existed, was undocumented and not forwarded |

Updated: `.env.example`, `docker-compose.yml`, `docs-site/docs/configuration/environment-reference.md`. `docs/AI-INSTALL.md` needs no change: it does not enumerate optional tuning keys (same as the existing `EXPORT_CACHE_MAX_BYTES`, `SEGMENT_LOW_CACHE_MAX_BYTES`, and `THUMB_*` keys). Two `docs/DECISIONS.md` entries record the bounded-wait choice and the quantizer plus export caps, with the alternatives rejected and revisit triggers.

Behaviour a client can notice: under genuine saturation a scrub thumbnail, clip, or wall tile now fails fast with 503 plus `Retry-After` instead of eventually arriving. That is the intended trade, and the clients already treat a failed media fetch as "keep the placeholder and poll again". An export naming more than 50 distinct cameras, or a window longer than a day, is refused with a 400 that says why.

## How it was tested

Full gate on the build box against this branch: `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --workspace` against a throwaway Postgres 16, all green.

New tests:

- `media_limits`: a zero-permit semaphore must take the 503 path inside its budget (and not park), and a free semaphore hands out and returns a permit.
- `filmstrip`: the width quantizer keeps 160/320/480 exact, snaps to the nearest bucket, breaks ties deterministically downward, and collapses the whole legal input range onto exactly the five buckets.
- `export`: the range, distinct-camera, dedup, empty and inverted-range validation; the derived ffmpeg budget is floored, scaled and capped; a child that outlives its budget is killed, reaped, and reported as `TimedOut`.
- `services/api/tests/export_limits.rs` (new integration test, the real handler through the shared harness): a duplicated camera list produces one job entry per distinct camera, and an over-range request is 400 with no job allocated, while a window exactly at the cap is still accepted.

Not verified by running: nothing here touches the clients, so no Android, iOS or Flutter build was needed. The saturation behaviour itself is covered by the unit test on the helper rather than by driving a real server to saturation.
